### PR TITLE
Aut 4577/verify mfa handlers lockout refactor

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorHttpMapper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorHttpMapper.java
@@ -14,7 +14,7 @@ public class TrackingErrorHttpMapper {
         ErrorResponse errorResponse = TrackingErrorMapper.toErrorResponse(trackingError);
         int statusCode =
                 switch (trackingError) {
-                    case STORAGE_SERVICE_ERROR -> 500;
+                    case STORAGE_SERVICE_ERROR, INVALID_USER_CONTEXT -> 500;
                 };
         return new ErrorResponseWithStatus(statusCode, errorResponse);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorMapper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorMapper.java
@@ -10,6 +10,7 @@ public class TrackingErrorMapper {
     public static ErrorResponse toErrorResponse(TrackingError trackingError) {
         return switch (trackingError) {
             case STORAGE_SERVICE_ERROR -> ErrorResponse.STORAGE_LAYER_ERROR;
+            case INVALID_USER_CONTEXT -> ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR;
         };
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -498,29 +498,17 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         }
 
         Decision canSendSmsOtpDecision = canSendSmsOtpResult.getSuccess();
-        if (canSendSmsOtpDecision instanceof Decision.TemporarilyLockedOut) {
+        if (canSendSmsOtpDecision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
+            if (temporarilyLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                LOG.info("User is blocked from entering any OTP codes");
+                return Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
+            }
             LOG.info("User is blocked from requesting any OTP codes");
             return Optional.of(ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS);
         } else if (canSendSmsOtpDecision instanceof Decision.IndefinitelyLockedOut) {
             LOG.info("User is indefinitely blocked from requesting OTP codes");
             return Optional.of(ErrorResponse.INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS);
         } else if (!(canSendSmsOtpDecision instanceof Decision.Permitted)) {
-            return Optional.of(ErrorResponse.UNHANDLED_NEGATIVE_DECISION);
-        }
-
-        var canVerifyMfaOtpResult =
-                permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
-        if (canVerifyMfaOtpResult.isFailure()) {
-            DecisionError failure = canVerifyMfaOtpResult.getFailure();
-            LOG.error("Failure to get canVerifyMfaOtp decision due to {}", failure);
-            return Optional.of(DecisionErrorMapper.toErrorResponse(failure));
-        }
-
-        Decision canVerifyMfaOtpDecision = canVerifyMfaOtpResult.getSuccess();
-        if (canVerifyMfaOtpDecision instanceof Decision.TemporarilyLockedOut) {
-            LOG.info("User is blocked from entering any OTP codes");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-        } else if (!(canVerifyMfaOtpDecision instanceof Decision.Permitted)) {
             return Optional.of(ErrorResponse.UNHANDLED_NEGATIVE_DECISION);
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -346,7 +346,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     generateApiGatewayProxyErrorResponse(
                             400, INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS));
         }
-        if (canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+        if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut
+                || canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
             var errorResponse =
                     afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -350,42 +350,51 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         var canSendSmsResult =
                 permissionDecisionManager.canSendSmsOtpNotification(
                         journeyType, permissionContext, lockoutStateHolder);
+
         if (canSendSmsResult.isFailure()) {
             return Optional.of(
                     DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
                             canSendSmsResult.getFailure()));
         }
+
         if (canSendSmsResult.getSuccess() instanceof Decision.IndefinitelyLockedOut) {
             return Optional.of(
                     generateApiGatewayProxyErrorResponse(
                             400, INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS));
         }
-        if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut
-                || canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+
+        if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut reauthLockedOut) {
+            if (reauthLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                LOG.warn(
+                        "Unexpected ReauthLockedOut for verification from canSendSmsOtpNotification");
+                return Optional.of(
+                        generateApiGatewayProxyErrorResponse(
+                                500, ErrorResponse.INTERNAL_SERVER_ERROR));
+            }
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
             var errorResponse =
                     afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;
             return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
         }
 
-        var canVerifyResult =
-                permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
-        if (canVerifyResult.isFailure()) {
-            return Optional.of(
-                    DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
-                            canVerifyResult.getFailure()));
-        }
-        if (canVerifyResult.getSuccess() instanceof Decision.ReauthLockedOut) {
-            LOG.warn(
-                    "Unexpected ReauthLockedOut from canVerifyMfaOtp - "
-                            + "should have been checked in an earlier handler in the journey");
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
-        }
-        if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+        if (canSendSmsResult.getSuccess()
+                instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
+
+            ErrorResponse errorResponse;
+            if (temporarilyLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                errorResponse = TOO_MANY_INVALID_MFA_OTPS_ENTERED;
+            } else {
+                errorResponse =
+                        afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;
+            }
+            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+        }
+
+        if (!(canSendSmsResult.getSuccess() instanceof Decision.Permitted)) {
             return Optional.of(
-                    generateApiGatewayProxyErrorResponse(400, TOO_MANY_INVALID_MFA_OTPS_ENTERED));
+                    generateApiGatewayProxyErrorResponse(
+                            500, ErrorResponse.UNHANDLED_NEGATIVE_DECISION));
         }
 
         return Optional.empty();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -11,13 +11,16 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.frontendapi.errormapper.DecisionErrorHttpMapper;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
@@ -237,12 +240,23 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             var requestSmsMfaMethod = maybeRequestedSmsMfaMethod.get();
             var phoneNumber = requestSmsMfaMethod.getDestination();
 
-            var permissionContext =
+            var permissionContextBuilder =
                     PermissionContext.builder()
                             .withEmailAddress(email)
                             .withE164FormattedPhoneNumber(phoneNumber)
-                            .withAuthSessionItem(userContext.getAuthSession())
-                            .build();
+                            .withAuthSessionItem(userContext.getAuthSession());
+
+            userContext
+                    .getUserProfile()
+                    .ifPresent(
+                            userProfile -> {
+                                permissionContextBuilder.withInternalSubjectId(
+                                        userProfile.getSubjectID());
+                                getRpPairwiseId(userProfile, userContext.getAuthSession())
+                                        .ifPresent(permissionContextBuilder::withRpPairwiseId);
+                            });
+
+            var permissionContext = permissionContextBuilder.build();
             var lockoutStateHolder = new InMemoryLockoutStateHolder();
 
             var maybeResponseIfNotPermitted =
@@ -361,6 +375,13 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
                             canVerifyResult.getFailure()));
         }
+        if (canVerifyResult.getSuccess() instanceof Decision.ReauthLockedOut) {
+            LOG.warn(
+                    "Unexpected ReauthLockedOut from canVerifyMfaOtp - "
+                            + "should have been checked in an earlier handler in the journey");
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+        }
         if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
             return Optional.of(
@@ -368,5 +389,16 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         }
 
         return Optional.empty();
+    }
+
+    private Optional<String> getRpPairwiseId(UserProfile userProfile, AuthSessionItem authSession) {
+        try {
+            return Optional.of(
+                    ClientSubjectHelper.getSubject(userProfile, authSession, authenticationService)
+                            .getValue());
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to derive RP pairwise ID: {}", e.getMessage());
+            return Optional.empty();
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -389,17 +389,11 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 return lockedOut.isFirstTimeLimit()
                         ? Optional.of(ErrorResponse.TOO_MANY_PW_RESET_REQUESTS)
                         : Optional.of(ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST);
+            } else if (lockedOut.forbiddenReason()
+                    == ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT) {
+                LOG.info("Code is blocked for email as user has entered too many invalid OTPs");
+                return Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED);
             }
-        }
-
-        var canVerifyResult =
-                permissionDecisionManager.canVerifyEmailOtp(
-                        JourneyType.PASSWORD_RESET, permissionContext);
-
-        if (canVerifyResult.isSuccess()
-                && canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
-            LOG.info("Code is blocked for email as user has entered too many invalid OTPs");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED);
         }
 
         return Optional.empty();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequest;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequestHandlerResponse;
+import uk.gov.di.authentication.frontendapi.errormapper.DecisionErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.exceptions.SerializationException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -40,7 +41,6 @@ import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSWORD_RESET_REQUESTED;
@@ -327,76 +327,38 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 permissionDecisionManager.canSendEmailOtpNotification(
                         JourneyType.PASSWORD_RESET, permissionContext);
 
-        if (canSendResult.isSuccess()) {
-            var decision = canSendResult.getSuccess();
-            if (decision instanceof Decision.TemporarilyLockedOut lockedOut) {
-                var result = handleTemporarilyLockedOut(lockedOut, permissionContext);
-                if (result.isFailure()) {
-                    return result;
-                }
-            }
-        }
-
-        var userIsAlreadyLockedOutOfPasswordReset =
-                hasUserExceededMaxAllowedRequests(email, userContext);
-        if (userIsAlreadyLockedOutOfPasswordReset.isPresent()) {
+        if (canSendResult.isFailure()) {
             return Result.failure(
-                    generateApiGatewayProxyErrorResponse(
-                            400, userIsAlreadyLockedOutOfPasswordReset.get()));
+                    DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                            canSendResult.getFailure()));
         }
 
-        return Result.success(null);
-    }
-
-    private Result<APIGatewayProxyResponseEvent, Void> handleTemporarilyLockedOut(
-            Decision.TemporarilyLockedOut lockedOut, PermissionContext permissionContext) {
-        if (lockedOut.forbiddenReason()
-                == ForbiddenReason.EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT) {
-            userActionsManager.sentEmailOtpNotification(
-                    JourneyType.PASSWORD_RESET, permissionContext);
-            var errorResponse =
-                    lockedOut.isFirstTimeLimit()
-                            ? ErrorResponse.TOO_MANY_PW_RESET_REQUESTS
-                            : ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST;
-            return Result.failure(generateApiGatewayProxyErrorResponse(400, errorResponse));
-        }
-        return Result.success(null);
-    }
-
-    private Optional<ErrorResponse> hasUserExceededMaxAllowedRequests(
-            String email, UserContext userContext) {
-        LOG.info("Validating Password Reset Count");
-        var permissionContext =
-                PermissionContext.builder()
-                        .withInternalSubjectId(
-                                userContext.getAuthSession().getInternalCommonSubjectId())
-                        .withEmailAddress(email)
-                        .withAuthSessionItem(userContext.getAuthSession())
-                        .build();
-
-        var canSendResult =
-                permissionDecisionManager.canSendEmailOtpNotification(
-                        JourneyType.PASSWORD_RESET, permissionContext);
-
-        if (canSendResult.isSuccess()
-                && canSendResult.getSuccess() instanceof Decision.TemporarilyLockedOut lockedOut) {
-
-            if (lockedOut.forbiddenReason() == ForbiddenReason.BLOCKED_FOR_PW_RESET_REQUEST) {
-                LOG.info("Code is blocked for email as user has requested too many OTPs");
-                return Optional.of(ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST);
-            } else if (lockedOut.forbiddenReason()
+        if (canSendResult.getSuccess() instanceof Decision.TemporarilyLockedOut lockedOut) {
+            if (lockedOut.forbiddenReason()
                     == ForbiddenReason.EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT) {
-                return lockedOut.isFirstTimeLimit()
-                        ? Optional.of(ErrorResponse.TOO_MANY_PW_RESET_REQUESTS)
-                        : Optional.of(ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST);
+                userActionsManager.sentEmailOtpNotification(
+                        JourneyType.PASSWORD_RESET, permissionContext);
+                var errorResponse =
+                        lockedOut.isFirstTimeLimit()
+                                ? ErrorResponse.TOO_MANY_PW_RESET_REQUESTS
+                                : ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST;
+                return Result.failure(generateApiGatewayProxyErrorResponse(400, errorResponse));
+            } else if (lockedOut.forbiddenReason()
+                    == ForbiddenReason.BLOCKED_FOR_PW_RESET_REQUEST) {
+                LOG.info("Code is blocked for email as user has requested too many OTPs");
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                400, ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST));
             } else if (lockedOut.forbiddenReason()
                     == ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT) {
                 LOG.info("Code is blocked for email as user has entered too many invalid OTPs");
-                return Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED);
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                400, ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
             }
         }
 
-        return Optional.empty();
+        return Result.success(null);
     }
 
     private String serialiseNotifyRequest(Object request) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -485,38 +485,21 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                             400, INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS));
         }
 
-        boolean isTemporarilyLockedOutOfSendingNotification =
-                canSendResult.getSuccess() instanceof Decision.TemporarilyLockedOut;
-        if (isTemporarilyLockedOutOfSendingNotification) {
+        if (canSendResult.getSuccess()
+                instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
             auditService.submitAuditEvent(
                     getInvalidCodeAuditEventFromNotificationType(notificationType), auditContext);
-            var errorResponse =
-                    afterActionRecorded
-                            ? getErrorResponseForCodeRequestLimitReached(notificationType)
-                            : getErrorResponseForMaxCodeRequests(notificationType);
+
+            ErrorResponse errorResponse;
+            if (temporarilyLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                errorResponse = getErrorResponseForMaxCodeAttempts(notificationType);
+            } else {
+                errorResponse =
+                        afterActionRecorded
+                                ? getErrorResponseForCodeRequestLimitReached(notificationType)
+                                : getErrorResponseForMaxCodeRequests(notificationType);
+            }
             return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
-        }
-
-        Result<DecisionError, Decision> canVerifyResult =
-                notificationType.isForPhoneNumber()
-                        ? permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext)
-                        : permissionDecisionManager.canVerifyEmailOtp(
-                                journeyType, permissionContext);
-
-        if (canVerifyResult.isFailure()) {
-            return Optional.of(
-                    DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
-                            canVerifyResult.getFailure()));
-        }
-
-        boolean isTemporarilyLockedOutOfVerifyingOtp =
-                canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut;
-        if (isTemporarilyLockedOutOfVerifyingOtp) {
-            auditService.submitAuditEvent(
-                    getInvalidCodeAuditEventFromNotificationType(notificationType), auditContext);
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(
-                            400, getErrorResponseForMaxCodeAttempts(notificationType)));
         }
 
         return Optional.empty();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -10,33 +10,30 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
+import uk.gov.di.authentication.frontendapi.errormapper.ForbiddenReasonErrorMapper;
 import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
-import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
-import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -45,26 +42,26 @@ import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Map.entry;
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
-import static uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder.getReauthFailureReasonFromCountTypes;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.PHONE_NUMBER_NOT_REGISTERED;
-import static uk.gov.di.authentication.shared.entity.JourneyType.PASSWORD_RESET_MFA;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
 import static uk.gov.di.authentication.shared.entity.JourneyType.SIGN_IN;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
@@ -76,8 +73,6 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethodOrDefaultMfaMethod;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT;
@@ -91,9 +86,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoAccountModifiersService accountModifiersService;
-    private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
+    private final PermissionDecisionManager permissionDecisionManager;
     private final TestUserHelper testUserHelper;
 
     protected VerifyCodeHandler(
@@ -103,10 +98,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
             DynamoAccountModifiersService accountModifiersService,
-            AuthenticationAttemptsService authenticationAttemptsService,
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
+            PermissionDecisionManager permissionDecisionManager,
             TestUserHelper testUserHelper) {
         super(
                 VerifyCodeRequest.class,
@@ -117,9 +112,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.accountModifiersService = accountModifiersService;
-        this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
+        this.permissionDecisionManager = permissionDecisionManager;
         this.testUserHelper = testUserHelper;
     }
 
@@ -133,10 +128,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
         this.testUserHelper = new TestUserHelper(configurationService);
     }
 
@@ -147,10 +141,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
         this.testUserHelper = new TestUserHelper(configurationService);
     }
 
@@ -173,7 +166,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         var notificationType = codeRequest.notificationType();
         var journeyType = getJourneyType(codeRequest, notificationType);
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
@@ -194,25 +186,27 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     400, ErrorResponse.EMAIL_HAS_NO_USER_PROFILE);
         }
 
-        if (checkReauthErrorCountsAndEmitReauthFailedAuditEvent(
-                journeyType, subjectId, auditContext, maybeRpPairwiseId))
-            return generateApiGatewayProxyErrorResponse(
-                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
+        var permissionContext =
+                PermissionContext.builder()
+                        .withAuthSessionItem(authSession)
+                        .withEmailAddress(authSession.getEmailAddress())
+                        .withInternalSubjectId(subjectId)
+                        .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
+                        .build();
 
-        if (isCodeBlockedForSession(authSession, codeBlockedKeyPrefix)) {
-            ErrorResponse errorResponse = blockedCodeBehaviour(codeRequest);
-            return generateApiGatewayProxyErrorResponse(400, errorResponse);
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(
-                        notificationType.getMfaMethodType(), journeyType);
-        if (deprecatedCodeRequestType != null
-                && isCodeBlockedForSession(
-                        authSession, CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            ErrorResponse errorResponse = blockedCodeBehaviour(codeRequest);
-            return generateApiGatewayProxyErrorResponse(400, errorResponse);
+        var permissionCheck =
+                checkPermission(
+                        journeyType,
+                        notificationType,
+                        permissionContext,
+                        auditContext,
+                        maybeRpPairwiseId,
+                        false,
+                        codeRequest,
+                        Optional.empty());
+        var initialPermissionError = permissionCheck.errorResponse();
+        if (initialPermissionError.isPresent()) {
+            return initialPermissionError.get();
         }
 
         var retrieveMfaMethods = mfaMethodsService.getMfaMethods(authSession.getEmailAddress());
@@ -260,21 +254,46 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         authSessionService.updateSession(authSession);
 
         if (errorResponse.isPresent()) {
-            handleInvalidVerificationCode(
+            Result<TrackingError, Void> trackingResult = Result.success(null);
+            if (notificationType.isForPhoneNumber()) {
+                trackingResult =
+                        userActionsManager.incorrectSmsOtpReceived(journeyType, permissionContext);
+            } else if (notificationType.isEmail()) {
+                trackingResult =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                journeyType, permissionContext);
+            }
+            if (trackingResult.isFailure()) {
+                LOG.error(
+                        "Failed to record incorrect OTP for {}: {}",
+                        notificationType,
+                        trackingResult.getFailure());
+                return TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                        trackingResult.getFailure());
+            }
+
+            var permissionCheckAfterIncrement =
+                    checkPermission(
+                            journeyType,
+                            notificationType,
+                            permissionContext,
+                            auditContext,
+                            maybeRpPairwiseId,
+                            true,
+                            codeRequest,
+                            maybeRequestedSmsMfaMethod);
+            var permissionErrorResponse = permissionCheckAfterIncrement.errorResponse();
+            if (permissionErrorResponse.isPresent()) {
+                return permissionErrorResponse.get();
+            }
+
+            emitInvalidCodeAuditEvent(
                     codeRequest,
                     journeyType,
-                    notificationType,
-                    subjectId,
-                    errorResponse.get(),
-                    authSession,
                     auditContext,
-                    maybeRequestedSmsMfaMethod);
+                    maybeRequestedSmsMfaMethod,
+                    permissionCheckAfterIncrement.attemptCount());
 
-            if (userHasExceededAllowedAttemptsForReauthenticationJourney(
-                    journeyType, subjectId, auditContext, maybeRpPairwiseId)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
-            }
             return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
         }
 
@@ -283,67 +302,16 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     userContext, authSessionService, authenticationService, configurationService);
         }
 
-        if (notificationType.equals(RESET_PASSWORD_WITH_CODE)) {
-            var mfaCodeRequestType =
-                    CodeRequestType.getCodeRequestType(
-                            CodeRequestType.SupportedCodeType.MFA, PASSWORD_RESET_MFA);
-            // TODO remove temporary ZDD measure to reference existing deprecated keys when
-            //  expired
-            var deprecatedMfaCodeRequestType =
-                    CodeRequestType.getDeprecatedCodeRequestTypeString(
-                            MFAMethodType.SMS, PASSWORD_RESET_MFA);
-
-            if (isCodeBlockedForSession(
-                    authSession, CODE_REQUEST_BLOCKED_KEY_PREFIX + mfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS);
-            }
-            if (deprecatedMfaCodeRequestType != null
-                    && isCodeBlockedForSession(
-                            authSession,
-                            CODE_REQUEST_BLOCKED_KEY_PREFIX + deprecatedMfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS);
-            }
-
-            if (isCodeBlockedForSession(
-                    authSession, CODE_BLOCKED_KEY_PREFIX + mfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-            }
-            if (deprecatedMfaCodeRequestType != null
-                    && isCodeBlockedForSession(
-                            authSession, CODE_BLOCKED_KEY_PREFIX + deprecatedMfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-            }
-        }
-
-        var successProcessingErrorResponse =
-                processSuccessfulCodeRequest(
+        return processSuccessfulCodeRequest(
                         codeRequest,
                         userContext,
-                        subjectId,
                         journeyType,
                         auditContext,
-                        maybeRpPairwiseId,
                         maybeRequestedSmsMfaMethod,
-                        retrievedMfaMethods);
-        if (successProcessingErrorResponse.isPresent()) {
-            return successProcessingErrorResponse.get();
-        }
-
-        return generateEmptySuccessApiGatewayResponse();
-    }
-
-    private boolean userHasExceededAllowedAttemptsForReauthenticationJourney(
-            JourneyType journeyType,
-            String subjectId,
-            AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId) {
-        return journeyType == REAUTHENTICATION
-                && checkReauthErrorCountsAndEmitReauthFailedAuditEvent(
-                        journeyType, subjectId, auditContext, maybeRpPairwiseId);
+                        retrievedMfaMethods,
+                        permissionContext,
+                        permissionCheck.attemptCount())
+                .orElseGet(() -> generateEmptySuccessApiGatewayResponse());
     }
 
     private Optional<String> getCode(
@@ -366,86 +334,125 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         return codeStorageService.getOtpCode(identifier, notificationType);
     }
 
-    private void handleInvalidVerificationCode(
-            VerifyCodeRequest codeRequest,
+    private record PermissionCheckResult(
+            Optional<APIGatewayProxyResponseEvent> errorResponse, int attemptCount) {}
+
+    private PermissionCheckResult checkPermission(
             JourneyType journeyType,
             NotificationType notificationType,
-            String subjectId,
-            ErrorResponse errorResponse,
-            AuthSessionItem authSession,
+            PermissionContext permissionContext,
             AuditContext auditContext,
+            Optional<String> maybeRpPairwiseId,
+            boolean afterActionRecorded,
+            VerifyCodeRequest codeRequest,
             Optional<MFAMethod> maybeRequestedSmsMfaMethod) {
-        if (journeyType == REAUTHENTICATION && notificationType == MFA_SMS) {
-            if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
-                authenticationAttemptsService.createOrIncrementCount(
-                        subjectId,
-                        NowHelper.nowPlus(
-                                        configurationService.getReauthEnterSMSCodeCountTTL(),
-                                        ChronoUnit.SECONDS)
-                                .toInstant()
-                                .getEpochSecond(),
-                        REAUTHENTICATION,
-                        CountType.ENTER_MFA_CODE);
-            }
-        } else {
-            processBlockedCodeSession(
-                    errorResponse,
-                    authSession,
-                    codeRequest,
-                    journeyType,
+        Result<DecisionError, Decision> canVerifyOtpResult =
+                Result.success(new Decision.Permitted(0));
+        if (notificationType.isForPhoneNumber()) {
+            canVerifyOtpResult =
+                    permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
+        } else if (notificationType.isEmail()) {
+            canVerifyOtpResult =
+                    permissionDecisionManager.canVerifyEmailOtp(journeyType, permissionContext);
+        }
+
+        if (canVerifyOtpResult.isFailure()) {
+            LOG.error(
+                    "Failed to check OTP verification permission: {}",
+                    canVerifyOtpResult.getFailure());
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    500, ErrorResponse.INTERNAL_SERVER_ERROR)),
+                    0);
+        }
+
+        var decision = canVerifyOtpResult.getSuccess();
+
+        if (decision instanceof Decision.ReauthLockedOut reauthLockedOut) {
+            ReauthFailureReasons reauthFailureReason =
+                    ForbiddenReasonErrorMapper.toReauthFailureReason(
+                            reauthLockedOut.forbiddenReason());
+
+            auditService.submitAuditEvent(
+                    FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                     auditContext,
-                    maybeRequestedSmsMfaMethod);
+                    ReauthMetadataBuilder.builder(maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
+                            .withAllIncorrectAttemptCounts(reauthLockedOut.detailedCounts())
+                            .withFailureReason(reauthFailureReason)
+                            .build());
+            cloudwatchMetricsService.incrementCounter(
+                    CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            FAILURE_REASON.getValue(),
+                            reauthFailureReason.getValue()));
+
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS)),
+                    reauthLockedOut.attemptCount());
         }
-    }
 
-    private boolean checkReauthErrorCountsAndEmitReauthFailedAuditEvent(
-            JourneyType journeyType,
-            String subjectId,
-            AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            var countsByJourney =
-                    maybeRpPairwiseId.isEmpty()
-                            ? authenticationAttemptsService.getCountsByJourney(
-                                    subjectId, REAUTHENTICATION)
-                            : authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            subjectId, maybeRpPairwiseId.get(), REAUTHENTICATION);
-
-            var countTypesWhereBlocked =
-                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
-                            countsByJourney, configurationService);
-
-            if (!countTypesWhereBlocked.isEmpty()) {
-                ReauthFailureReasons failureReason =
-                        getReauthFailureReasonFromCountTypes(countTypesWhereBlocked);
+        if (decision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
+            LOG.info("User is temporarily locked out from OTP verification");
+            if (afterActionRecorded) {
+                if (maybeRequestedSmsMfaMethod.isPresent()) {
+                    auditContext =
+                            auditContext.withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                            maybeRequestedSmsMfaMethod
+                                                    .get()
+                                                    .getPriority()
+                                                    .toLowerCase()));
+                }
+                // loginFailureCount is hardcoded to 0 because the previous implementation
+                // reset the incorrect attempts counter before reading it for the audit event,
+                // so this field was always emitted as 0 on the max-retries path.
+                var metadataPairArray =
+                        metadataPairs(notificationType, journeyType, codeRequest, 0, true);
                 auditService.submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                        FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
                         auditContext,
-                        ReauthMetadataBuilder.builder(
-                                        maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
-                                .withAllIncorrectAttemptCounts(countsByJourney)
-                                .withFailureReason(failureReason)
-                                .build());
-                cloudwatchMetricsService.incrementCounter(
-                        CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                        Map.of(
-                                ENVIRONMENT.getValue(),
-                                configurationService.getEnvironment(),
-                                FAILURE_REASON.getValue(),
-                                failureReason == null ? "unknown" : failureReason.getValue()));
-                LOG.info(
-                        "Re-authentication locked due to {} counts exceeded.",
-                        countTypesWhereBlocked);
-                return true;
+                        metadataPairArray);
             }
+            var errorResponse = blockedCodeBehaviour(notificationType);
+            return new PermissionCheckResult(
+                    Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse)),
+                    temporarilyLockedOut.attemptCount());
         }
 
-        return false;
+        if (decision instanceof Decision.Permitted permitted) {
+            return new PermissionCheckResult(Optional.empty(), permitted.attemptCount());
+        }
+
+        return new PermissionCheckResult(Optional.empty(), 0);
     }
 
-    private ErrorResponse blockedCodeBehaviour(VerifyCodeRequest codeRequest) {
+    private void emitInvalidCodeAuditEvent(
+            VerifyCodeRequest codeRequest,
+            JourneyType journeyType,
+            AuditContext auditContext,
+            Optional<MFAMethod> maybeRequestedSmsMfaMethod,
+            int loginFailureCount) {
+        var notificationType = codeRequest.notificationType();
+        if (maybeRequestedSmsMfaMethod.isPresent()) {
+            auditContext =
+                    auditContext.withMetadataItem(
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                    maybeRequestedSmsMfaMethod.get().getPriority().toLowerCase()));
+        }
+        var metadataPairArray =
+                metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, true);
+        auditService.submitAuditEvent(
+                FrontendAuditableEvent.AUTH_INVALID_CODE_SENT, auditContext, metadataPairArray);
+    }
+
+    private ErrorResponse blockedCodeBehaviour(NotificationType notificationType) {
         return Map.ofEntries(
                         entry(
                                 VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
@@ -455,41 +462,20 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                                 RESET_PASSWORD_WITH_CODE,
                                 ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED),
                         entry(MFA_SMS, ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED))
-                .get(codeRequest.notificationType());
-    }
-
-    private boolean isCodeBlockedForSession(
-            AuthSessionItem authSession, String codeBlockedKeyPrefix) {
-        return codeStorageService.isBlockedForEmail(
-                authSession.getEmailAddress(), codeBlockedKeyPrefix);
-    }
-
-    private void blockCodeForSession(AuthSessionItem authSession, String codeBlockPrefix) {
-        codeStorageService.saveBlockedForEmail(
-                authSession.getEmailAddress(),
-                codeBlockPrefix,
-                configurationService.getLockoutDuration());
-        LOG.info("Email is blocked");
-    }
-
-    private void resetIncorrectMfaCodeAttemptsCount(AuthSessionItem authSession) {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
-        LOG.info("IncorrectMfaCodeAttemptsCount reset");
+                .get(notificationType);
     }
 
     private Optional<APIGatewayProxyResponseEvent> processSuccessfulCodeRequest(
             VerifyCodeRequest codeRequest,
             UserContext userContext,
-            String subjectId,
             JourneyType journeyType,
             AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId,
             Optional<MFAMethod> maybeRequestedSmsMfaMethod,
-            List<MFAMethod> retrievedMfaMethods) {
+            List<MFAMethod> retrievedMfaMethods,
+            PermissionContext permissionContext,
+            int loginFailureCount) {
         var authSession = userContext.getAuthSession();
         var notificationType = codeRequest.notificationType();
-        int loginFailureCount =
-                codeStorageService.getIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
         var clientId = authSession.getClientId();
         var levelOfConfidence =
                 Optional.ofNullable(authSession.getRequestedLevelOfConfidence()).orElse(NONE);
@@ -507,9 +493,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         String emailAddress = authSession.getEmailAddress();
         String otpCodeIdentifier = emailAddress;
-        MFAMethod smsMfaMethod = null;
         if (notificationType.isForPhoneNumber()) {
-            smsMfaMethod = maybeRequestedSmsMfaMethod.orElseThrow();
+            MFAMethod smsMfaMethod = maybeRequestedSmsMfaMethod.orElseThrow();
             String formattedPhoneNumber =
                     PhoneNumberHelper.formatPhoneNumber(smsMfaMethod.getDestination());
             otpCodeIdentifier = emailAddress.concat(formattedPhoneNumber);
@@ -518,15 +503,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             pair(
                                     AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
                                     smsMfaMethod.getPriority().toLowerCase()));
-        }
 
-        if (notificationType.equals(MFA_SMS)) {
             String countryCode =
-                    Optional.ofNullable(smsMfaMethod)
-                            .flatMap(
-                                    method ->
-                                            PhoneNumberHelper.maybeGetCountry(
-                                                    method.getDestination()))
+                    PhoneNumberHelper.maybeGetCountry(smsMfaMethod.getDestination())
                             .orElse("unknown");
             LOG.info(
                     "MFA code has been successfully verified for MFA type: {}. JourneyType: {}. CountryCode: {}",
@@ -535,13 +514,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     countryCode);
 
             LOG.info("Setting hasVerifiedMfa to true");
-            var permissionContext =
-                    PermissionContext.builder()
-                            .withAuthSessionItem(authSession)
-                            .withEmailAddress(emailAddress)
-                            .withInternalSubjectId(subjectId)
-                            .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
-                            .build();
             var result = userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);
             if (result.isFailure()) {
                 LOG.error("Failed to record correct SMS OTP: {}", result.getFailure());
@@ -562,21 +534,18 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     levelOfConfidence.getValue(),
                     testUserHelper.isTestJourney(authSession.getEmailAddress()),
                     journeyType,
-                    smsMfaMethod != null
-                            ? MFAMethodType.valueOf(smsMfaMethod.getMfaMethodType())
-                            : null,
-                    smsMfaMethod != null
-                            ? PriorityIdentifier.valueOf(smsMfaMethod.getPriority())
-                            : null);
+                    MFAMethodType.valueOf(smsMfaMethod.getMfaMethodType()),
+                    PriorityIdentifier.valueOf(smsMfaMethod.getPriority()));
         }
 
-        if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
-            preserveReauthCountsForAuditIfJourneyIsReauth(
-                    journeyType, subjectId, authSession, maybeRpPairwiseId);
-            clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
-            maybeRpPairwiseId.ifPresentOrElse(
-                    this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
-                    () -> LOG.warn("Unable to clear rp pairwise id reauth counts"));
+        if (notificationType.isEmail()) {
+            var result = userActionsManager.correctEmailOtpReceived(journeyType, permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct email OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
         }
 
         codeStorageService.deleteOtpCode(otpCodeIdentifier, notificationType);
@@ -586,34 +555,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
         return Optional.empty();
-    }
-
-    void preserveReauthCountsForAuditIfJourneyIsReauth(
-            JourneyType journeyType,
-            String subjectId,
-            AuthSessionItem authSession,
-            Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.supportReauthSignoutEnabled()
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            var counts =
-                    maybeRpPairwiseId.isPresent()
-                            ? authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            subjectId, maybeRpPairwiseId.get(), REAUTHENTICATION)
-                            : authenticationAttemptsService.getCountsByJourney(
-                                    subjectId, REAUTHENTICATION);
-            var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
-            authSessionService.updateSession(updatedAuthSession);
-        }
-    }
-
-    void clearReauthErrorCountsForSuccessfullyAuthenticatedUser(String identifier) {
-        Arrays.stream(CountType.values())
-                .forEach(
-                        countType ->
-                                authenticationAttemptsService.deleteCount(
-                                        identifier, REAUTHENTICATION, countType));
     }
 
     private AuditService.MetadataPair[] metadataPairs(
@@ -635,50 +576,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             metadataPairs.add(pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
         }
         return metadataPairs.toArray(AuditService.MetadataPair[]::new);
-    }
-
-    private void processBlockedCodeSession(
-            ErrorResponse errorResponse,
-            AuthSessionItem authSession,
-            VerifyCodeRequest codeRequest,
-            JourneyType journeyType,
-            AuditContext auditContext,
-            Optional<MFAMethod> maybeRequestedSmsMfaMethod) {
-        var notificationType = codeRequest.notificationType();
-        var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        AuditableEvent auditableEvent;
-        switch (errorResponse) {
-            case TOO_MANY_INVALID_MFA_OTPS_ENTERED,
-                    TOO_MANY_INVALID_PW_RESET_CODES_ENTERED,
-                    TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED:
-                if (!configurationService.supportReauthSignoutEnabled()
-                        || journeyType != REAUTHENTICATION) {
-                    blockCodeForSession(authSession, codeBlockedKeyPrefix);
-                }
-                resetIncorrectMfaCodeAttemptsCount(authSession);
-                auditableEvent = FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
-                break;
-            case TOO_MANY_EMAIL_CODES_ENTERED:
-                resetIncorrectMfaCodeAttemptsCount(authSession);
-                auditableEvent = FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
-                break;
-            default:
-                auditableEvent = FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
-                break;
-        }
-        if (maybeRequestedSmsMfaMethod.isPresent()) {
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    maybeRequestedSmsMfaMethod.get().getPriority().toLowerCase()));
-        }
-        var loginFailureCount =
-                codeStorageService.getIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
-        var metadataPairArray =
-                metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, true);
-        auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairArray);
     }
 
     private Optional<String> getOtpCodeForTestClient(NotificationType notificationType) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -251,13 +251,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         var errorResponse =
                 ValidationHelper.validateVerificationCode(
-                        notificationType,
-                        journeyType,
-                        code,
-                        codeRequest.code(),
-                        codeStorageService,
-                        authSession.getEmailAddress(),
-                        configurationService);
+                        notificationType, code, codeRequest.code());
 
         if (errorResponse.stream().anyMatch(ErrorResponse.INVALID_NOTIFICATION_TYPE::equals)) {
             return generateApiGatewayProxyErrorResponse(400, errorResponse.get());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
+import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
@@ -324,15 +325,19 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             }
         }
 
-        processSuccessfulCodeRequest(
-                codeRequest,
-                userContext,
-                subjectId,
-                journeyType,
-                auditContext,
-                maybeRpPairwiseId,
-                maybeRequestedSmsMfaMethod,
-                retrievedMfaMethods);
+        var successProcessingErrorResponse =
+                processSuccessfulCodeRequest(
+                        codeRequest,
+                        userContext,
+                        subjectId,
+                        journeyType,
+                        auditContext,
+                        maybeRpPairwiseId,
+                        maybeRequestedSmsMfaMethod,
+                        retrievedMfaMethods);
+        if (successProcessingErrorResponse.isPresent()) {
+            return successProcessingErrorResponse.get();
+        }
 
         return generateEmptySuccessApiGatewayResponse();
     }
@@ -478,7 +483,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         LOG.info("IncorrectMfaCodeAttemptsCount reset");
     }
 
-    private void processSuccessfulCodeRequest(
+    private Optional<APIGatewayProxyResponseEvent> processSuccessfulCodeRequest(
             VerifyCodeRequest codeRequest,
             UserContext userContext,
             String subjectId,
@@ -537,8 +542,19 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
             LOG.info("Setting hasVerifiedMfa to true");
             var permissionContext =
-                    PermissionContext.builder().withAuthSessionItem(authSession).build();
-            userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);
+                    PermissionContext.builder()
+                            .withAuthSessionItem(authSession)
+                            .withEmailAddress(emailAddress)
+                            .withInternalSubjectId(subjectId)
+                            .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
+                            .build();
+            var result = userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct SMS OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
 
             authSessionService.updateSession(
                     authSession
@@ -575,6 +591,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, false);
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
+        return Optional.empty();
     }
 
     void preserveReauthCountsForAuditIfJourneyIsReauth(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
@@ -54,6 +55,7 @@ import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -246,7 +248,13 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         try {
             String subjectID = userProfileMaybe.map(UserProfile::getSubjectID).orElse(null);
             return verifyCode(
-                    input, codeRequest, userContext, subjectID, maybeRpPairwiseId, userProfile);
+                    input,
+                    codeRequest,
+                    userContext,
+                    subjectID,
+                    maybeRpPairwiseId,
+                    userProfile,
+                    permissionContext);
         } catch (Exception e) {
             LOG.error("Unexpected exception thrown", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.REQUEST_MISSING_PARAMS);
@@ -394,7 +402,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             UserContext userContext,
             String subjectId,
             Optional<String> maybeRpPairwiseId,
-            UserProfile userProfile) {
+            UserProfile userProfile,
+            PermissionContext permissionContext) {
 
         var authSession = userContext.getAuthSession();
         var auditContext =
@@ -491,6 +500,26 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
 
             auditFailure(codeRequest, errorResponse, authSession, auditContext, activeMfaMethod);
+
+            Result<TrackingError, Void> trackingResult = Result.success(null);
+            if (errorResponse.equals(ErrorResponse.INVALID_PHONE_CODE_ENTERED)) {
+                trackingResult =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                codeRequest.getJourneyType(), permissionContext);
+            }
+            if (errorResponse.equals(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED)) {
+                trackingResult =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                codeRequest.getJourneyType(), permissionContext);
+            }
+            if (trackingResult.isFailure()) {
+                LOG.error(
+                        "Failed to record incorrect {} OTP: {}",
+                        codeRequest.getMfaMethodType(),
+                        trackingResult.getFailure());
+                return TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                        trackingResult.getFailure());
+            }
         } else {
             auditSuccess(codeRequest, authSession, auditContext, activeMfaMethod);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -34,14 +33,11 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
-import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -57,9 +53,7 @@ import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -70,7 +64,6 @@ import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
-import static uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder.getReauthFailureReasonFromCountTypes;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
@@ -86,7 +79,6 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.PhoneNumberHelper.formatPhoneNumber;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethodOrDefaultMfaMethod;
 
 public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeRequest>
@@ -97,7 +89,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private final AuditService auditService;
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory;
     private final CloudwatchMetricsService cloudwatchMetricsService;
-    private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
     private final PermissionDecisionManager permissionDecisionManager;
@@ -110,7 +101,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuditService auditService,
             MfaCodeProcessorFactory mfaCodeProcessorFactory,
             CloudwatchMetricsService cloudwatchMetricsService,
-            AuthenticationAttemptsService authenticationAttemptsService,
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
@@ -125,7 +115,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.auditService = auditService;
         this.mfaCodeProcessorFactory = mfaCodeProcessorFactory;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
-        this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
         this.permissionDecisionManager = permissionDecisionManager;
@@ -152,8 +141,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         this.mfaMethodsService,
                         this.testUserHelper);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
@@ -175,8 +162,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         this.mfaMethodsService,
                         this.testUserHelper);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
@@ -240,11 +225,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             return permissionCheck.errorResponse().get();
         }
 
-        if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
-                journeyType, userProfile, auditContext, maybeRpPairwiseId))
-            return generateApiGatewayProxyErrorResponse(
-                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
-
         try {
             String subjectID = userProfileMaybe.map(UserProfile::getSubjectID).orElse(null);
             return verifyCode(
@@ -279,55 +259,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private static boolean userProfileMissingForReauthenticationJourney(
             UserProfile userProfile, JourneyType journeyType) {
         return userProfile == null && journeyType == REAUTHENTICATION;
-    }
-
-    private boolean checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
-            JourneyType journeyType,
-            UserProfile userProfile,
-            AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId) {
-        if (configurationService.isAuthenticationAttemptsServiceEnabled()
-                && REAUTHENTICATION.equals(journeyType)
-                && userProfile != null) {
-            var counts =
-                    maybeRpPairwiseId.isEmpty()
-                            ? authenticationAttemptsService.getCountsByJourney(
-                                    userProfile.getSubjectID(), REAUTHENTICATION)
-                            : authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            userProfile.getSubjectID(),
-                                            maybeRpPairwiseId.get(),
-                                            REAUTHENTICATION);
-            var countTypesWhereLimitExceeded =
-                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
-                            counts, configurationService);
-
-            if (!countTypesWhereLimitExceeded.isEmpty()) {
-                ReauthFailureReasons failureReason =
-                        getReauthFailureReasonFromCountTypes(countTypesWhereLimitExceeded);
-                auditService.submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                        auditContext,
-                        ReauthMetadataBuilder.builder(
-                                        maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
-                                .withAllIncorrectAttemptCounts(counts)
-                                .withFailureReason(failureReason)
-                                .build());
-                cloudwatchMetricsService.incrementCounter(
-                        CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                        Map.of(
-                                ENVIRONMENT.getValue(),
-                                configurationService.getEnvironment(),
-                                FAILURE_REASON.getValue(),
-                                failureReason == null ? "unknown" : failureReason.getValue()));
-
-                LOG.info(
-                        "Re-authentication locked due to {} counts exceeded.",
-                        countTypesWhereLimitExceeded);
-                return true;
-            }
-        }
-        return false;
     }
 
     private record PermissionCheckResult(
@@ -490,29 +421,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         400, ErrorResponse.INVALID_AUTH_APP_SECRET);
             }
 
-            if (errorResponse.equals(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)
-                    || errorResponse.equals(
-                            ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED)) {
-                blockCodeForSessionAndResetCountIfBlockDoesNotExist(
-                        userContext.getAuthSession().getEmailAddress(),
-                        codeRequest.getMfaMethodType(),
-                        codeRequest.getJourneyType());
-            }
-
-            if (isInvalidReauthAuthAppAttempt(errorResponse, codeRequest)
-                    && configurationService.isAuthenticationAttemptsServiceEnabled()
-                    && subjectId != null) {
-                authenticationAttemptsService.createOrIncrementCount(
-                        subjectId,
-                        NowHelper.nowPlus(
-                                        configurationService.getReauthEnterAuthAppCodeCountTTL(),
-                                        ChronoUnit.SECONDS)
-                                .toInstant()
-                                .getEpochSecond(),
-                        REAUTHENTICATION,
-                        CountType.ENTER_MFA_CODE);
-            }
-
             Result<TrackingError, Void> trackingResult = Result.success(null);
             if (errorResponse.equals(ErrorResponse.INVALID_PHONE_CODE_ENTERED)) {
                 trackingResult =
@@ -562,22 +470,14 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                             codeRequest,
                             mfaCodeProcessor,
                             maybeRpPairwiseId,
-                            userProfile);
+                            userProfile,
+                            permissionContext);
             if (successProcessingErrorResponse.isPresent()) {
                 return successProcessingErrorResponse.get();
             }
         }
 
         authSessionService.updateSession(authSession);
-
-        if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
-                codeRequest.getJourneyType(),
-                userContext.getUserProfile().orElse(null),
-                auditContext,
-                maybeRpPairwiseId)) {
-            return generateApiGatewayProxyErrorResponse(
-                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
-        }
 
         return errorResponseMaybe
                 .map(response -> generateApiGatewayProxyErrorResponse(400, response))
@@ -703,18 +603,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             VerifyMfaCodeRequest codeRequest,
             MfaCodeProcessor mfaCodeProcessor,
             Optional<String> maybeRpPairwiseId,
-            UserProfile userProfile) {
+            UserProfile userProfile,
+            PermissionContext permissionContext) {
 
-        if (configurationService.isAuthenticationAttemptsServiceEnabled()
-                && codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP
-                && subjectId != null) {
-            preserveReauthCountsForAuditIfJourneyIsReauth(
-                    codeRequest.getJourneyType(), subjectId, authSession, maybeRpPairwiseId);
-            clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
-            maybeRpPairwiseId.ifPresentOrElse(
-                    this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
-                    () -> LOG.warn("Unable to clear rp pairwise id reauth counts"));
-        }
         mfaCodeProcessor.processSuccessfulCodeRequest(
                 IpAddressHelper.extractIpAddress(input),
                 extractPersistentIdFromHeaders(input.getHeaders()),
@@ -726,13 +617,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
 
         LOG.info("Setting hasVerifiedMfa to true");
-        var permissionContextBuilder =
-                PermissionContext.builder()
-                        .withAuthSessionItem(authSession)
-                        .withEmailAddress(authSession.getEmailAddress())
-                        .withInternalSubjectId(subjectId)
-                        .withRpPairwiseId(maybeRpPairwiseId.orElse(null));
-        var permissionContext = permissionContextBuilder.build();
+
         if (codeRequest.getMfaMethodType() == MFAMethodType.SMS) {
             var result =
                     userActionsManager.correctSmsOtpReceived(
@@ -772,75 +657,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         entry(ErrorResponse.INVALID_PHONE_CODE_ENTERED, AUTH_INVALID_CODE_SENT));
 
         return map.getOrDefault(errorResponse, FrontendAuditableEvent.AUTH_INVALID_CODE_SENT);
-    }
-
-    private void clearReauthErrorCountsForSuccessfullyAuthenticatedUser(String uniqueIdentifier) {
-        Arrays.stream(CountType.values())
-                .forEach(
-                        countType ->
-                                authenticationAttemptsService.deleteCount(
-                                        uniqueIdentifier, REAUTHENTICATION, countType));
-    }
-
-    void preserveReauthCountsForAuditIfJourneyIsReauth(
-            JourneyType journeyType,
-            String subjectId,
-            AuthSessionItem authSession,
-            Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.supportReauthSignoutEnabled()
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            var counts =
-                    maybeRpPairwiseId.isPresent()
-                            ? authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            subjectId, maybeRpPairwiseId.get(), REAUTHENTICATION)
-                            : authenticationAttemptsService.getCountsByJourney(
-                                    subjectId, REAUTHENTICATION);
-            var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
-            authSessionService.updateSession(updatedAuthSession);
-        }
-    }
-
-    private static boolean isInvalidReauthAuthAppAttempt(
-            ErrorResponse errorResponse, VerifyMfaCodeRequest codeRequest) {
-        return errorResponse == ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED
-                && codeRequest.getJourneyType() == REAUTHENTICATION;
-    }
-
-    private void blockCodeForSessionAndResetCountIfBlockDoesNotExist(
-            String emailAddress, MFAMethodType mfaMethodType, JourneyType journeyType) {
-
-        var codeRequestType = CodeRequestType.getCodeRequestType(mfaMethodType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-
-        if (codeStorageService.isBlockedForEmail(emailAddress, codeBlockedKeyPrefix)) {
-            return;
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(mfaMethodType, journeyType);
-        if (codeStorageService.isBlockedForEmail(
-                emailAddress, CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            return;
-        }
-
-        boolean reducedLockout =
-                List.of(CodeRequestType.MFA_REGISTRATION, CodeRequestType.MFA_ACCOUNT_RECOVERY)
-                        .contains(CodeRequestType.getCodeRequestType(mfaMethodType, journeyType));
-        long blockDuration =
-                reducedLockout
-                        ? configurationService.getReducedLockoutDuration()
-                        : configurationService.getLockoutDuration();
-
-        if (!configurationService.supportReauthSignoutEnabled()
-                || journeyType != REAUTHENTICATION) {
-            codeStorageService.saveBlockedForEmail(
-                    emailAddress, codeBlockedKeyPrefix, blockDuration);
-        }
-
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
     private AuditService.MetadataPair[] metadataPairsForEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
+import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
@@ -399,14 +400,18 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         } else {
             auditSuccess(codeRequest, authSession, auditContext, activeMfaMethod);
 
-            processSuccessfulCodeSession(
-                    userContext.getAuthSession(),
-                    input,
-                    subjectId,
-                    codeRequest,
-                    mfaCodeProcessor,
-                    maybeRpPairwiseId,
-                    userProfile);
+            var successProcessingErrorResponse =
+                    processSuccessfulCodeSession(
+                            userContext.getAuthSession(),
+                            input,
+                            subjectId,
+                            codeRequest,
+                            mfaCodeProcessor,
+                            maybeRpPairwiseId,
+                            userProfile);
+            if (successProcessingErrorResponse.isPresent()) {
+                return successProcessingErrorResponse.get();
+            }
         }
 
         authSessionService.updateSession(authSession);
@@ -544,7 +549,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         return ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse();
     }
 
-    private void processSuccessfulCodeSession(
+    private Optional<APIGatewayProxyResponseEvent> processSuccessfulCodeSession(
             AuthSessionItem authSession,
             APIGatewayProxyRequestEvent input,
             String subjectId,
@@ -574,15 +579,28 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
 
         LOG.info("Setting hasVerifiedMfa to true");
-        PermissionContext permissionContext =
-                PermissionContext.builder().withAuthSessionItem(authSession).build();
+        var permissionContextBuilder =
+                PermissionContext.builder()
+                        .withAuthSessionItem(authSession)
+                        .withEmailAddress(authSession.getEmailAddress())
+                        .withInternalSubjectId(subjectId)
+                        .withRpPairwiseId(maybeRpPairwiseId.orElse(null));
+        var permissionContext = permissionContextBuilder.build();
         if (codeRequest.getMfaMethodType() == MFAMethodType.SMS) {
-            userActionsManager.correctSmsOtpReceived(
-                    codeRequest.getJourneyType(), permissionContext);
+            var result =
+                    userActionsManager.correctSmsOtpReceived(
+                            codeRequest.getJourneyType(), permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct SMS OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
         } else if (codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP) {
             userActionsManager.correctAuthAppOtpReceived(
                     codeRequest.getJourneyType(), permissionContext);
         }
+        return Optional.empty();
     }
 
     private FrontendAuditableEvent errorResponseAsFrontendAuditableEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -874,10 +874,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
             case AUTH_INVALID_CODE_SENT, AUTH_CODE_VERIFIED -> {
                 if (auditableEvent.equals(AUTH_INVALID_CODE_SENT)) {
-                    // TODO: Remove divide by 2 once lockout logic is removed from processors.
-                    // Currently both the processor (via ValidationHelper) and UserActionsManager
-                    // increment the count, causing double-counting.
-                    metadataPairs.add(pair("loginFailureCount", failureCount / 2));
+                    metadataPairs.add(pair("loginFailureCount", failureCount));
                 }
 
                 metadataPairs.add(pair("MFACodeEntered", codeRequest.getCode()));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -597,8 +597,15 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                 result.getFailure()));
             }
         } else if (codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP) {
-            userActionsManager.correctAuthAppOtpReceived(
-                    codeRequest.getJourneyType(), permissionContext);
+            var result =
+                    userActionsManager.correctAuthAppOtpReceived(
+                            codeRequest.getJourneyType(), permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct Auth App OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
         }
         return Optional.empty();
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
+import uk.gov.di.authentication.frontendapi.errormapper.ForbiddenReasonErrorMapper;
 import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
@@ -49,7 +50,9 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
 import java.time.temporal.ChronoUnit;
@@ -95,6 +98,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
+    private final PermissionDecisionManager permissionDecisionManager;
     private final TestUserHelper testUserHelper;
 
     public VerifyMfaCodeHandler(
@@ -108,6 +112,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
+            PermissionDecisionManager permissionDecisionManager,
             TestUserHelper testUserHelper) {
         super(
                 VerifyMfaCodeRequest.class,
@@ -121,6 +126,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
+        this.permissionDecisionManager = permissionDecisionManager;
         this.testUserHelper = testUserHelper;
     }
 
@@ -147,6 +153,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
 
     public VerifyMfaCodeHandler(
@@ -169,6 +176,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
 
     @Override
@@ -209,6 +217,26 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (userProfileMissingForReauthenticationJourney(userProfile, journeyType))
             return generateApiGatewayProxyErrorResponse(
                     400, ErrorResponse.EMAIL_HAS_NO_USER_PROFILE);
+
+        var permissionContext =
+                PermissionContext.builder()
+                        .withAuthSessionItem(authSession)
+                        .withEmailAddress(authSession.getEmailAddress())
+                        .withInternalSubjectId(
+                                userProfileMaybe.map(UserProfile::getSubjectID).orElse(null))
+                        .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
+                        .build();
+
+        var maybeResponseIfNotPermitted =
+                getResponseIfNotPermitted(
+                        journeyType,
+                        codeRequest.getMfaMethodType(),
+                        permissionContext,
+                        auditContext,
+                        maybeRpPairwiseId);
+        if (maybeResponseIfNotPermitted.isPresent()) {
+            return maybeResponseIfNotPermitted.get();
+        }
 
         if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
                 journeyType, userProfile, auditContext, maybeRpPairwiseId))
@@ -292,6 +320,72 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
         }
         return false;
+    }
+
+    private Optional<APIGatewayProxyResponseEvent> getResponseIfNotPermitted(
+            JourneyType journeyType,
+            MFAMethodType mfaMethodType,
+            PermissionContext permissionContext,
+            AuditContext auditContext,
+            Optional<String> maybeRpPairwiseId) {
+        var canVerifyOtpResult =
+                permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
+
+        if (canVerifyOtpResult.isFailure()) {
+            LOG.error(
+                    "Failed to check MFA OTP verification permission: {}",
+                    canVerifyOtpResult.getFailure());
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+        }
+
+        var decision = canVerifyOtpResult.getSuccess();
+
+        if (decision instanceof Decision.ReauthLockedOut reauthLockedOut) {
+            ReauthFailureReasons reauthFailureReason =
+                    ForbiddenReasonErrorMapper.toReauthFailureReason(
+                            reauthLockedOut.forbiddenReason());
+
+            auditService.submitAuditEvent(
+                    FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                    auditContext,
+                    ReauthMetadataBuilder.builder(maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
+                            .withAllIncorrectAttemptCounts(reauthLockedOut.detailedCounts())
+                            .withFailureReason(reauthFailureReason)
+                            .build());
+            cloudwatchMetricsService.incrementCounter(
+                    CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            FAILURE_REASON.getValue(),
+                            reauthFailureReason.getValue()));
+
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(
+                            400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+        }
+
+        if (decision instanceof Decision.TemporarilyLockedOut) {
+            LOG.info("User is temporarily locked out from MFA OTP verification");
+            auditService.submitAuditEvent(
+                    AUTH_CODE_MAX_RETRIES_REACHED,
+                    auditContext,
+                    pair("mfa-type", mfaMethodType.getValue()),
+                    pair("account-recovery", journeyType == JourneyType.ACCOUNT_RECOVERY),
+                    pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, journeyType),
+                    pair(
+                            AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT,
+                            configurationService.getCodeMaxRetries()),
+                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"));
+            var errorResponse =
+                    mfaMethodType == MFAMethodType.AUTH_APP
+                            ? ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED
+                            : ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED;
+            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+        }
+
+        return Optional.empty();
     }
 
     private APIGatewayProxyResponseEvent verifyCode(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -229,15 +229,15 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
                         .build();
 
-        var maybeResponseIfNotPermitted =
-                getResponseIfNotPermitted(
+        var permissionCheck =
+                checkPermission(
                         journeyType,
                         codeRequest.getMfaMethodType(),
                         permissionContext,
                         auditContext,
                         maybeRpPairwiseId);
-        if (maybeResponseIfNotPermitted.isPresent()) {
-            return maybeResponseIfNotPermitted.get();
+        if (permissionCheck.errorResponse().isPresent()) {
+            return permissionCheck.errorResponse().get();
         }
 
         if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
@@ -330,7 +330,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         return false;
     }
 
-    private Optional<APIGatewayProxyResponseEvent> getResponseIfNotPermitted(
+    private record PermissionCheckResult(
+            Optional<APIGatewayProxyResponseEvent> errorResponse, int attemptCount) {}
+
+    private PermissionCheckResult checkPermission(
             JourneyType journeyType,
             MFAMethodType mfaMethodType,
             PermissionContext permissionContext,
@@ -343,8 +346,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             LOG.error(
                     "Failed to check MFA OTP verification permission: {}",
                     canVerifyOtpResult.getFailure());
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    500, ErrorResponse.INTERNAL_SERVER_ERROR)),
+                    0);
         }
 
         var decision = canVerifyOtpResult.getSuccess();
@@ -369,12 +375,14 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                             FAILURE_REASON.getValue(),
                             reauthFailureReason.getValue()));
 
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(
-                            400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS)),
+                    reauthLockedOut.attemptCount());
         }
 
-        if (decision instanceof Decision.TemporarilyLockedOut) {
+        if (decision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
             LOG.info("User is temporarily locked out from MFA OTP verification");
             auditService.submitAuditEvent(
                     AUTH_CODE_MAX_RETRIES_REACHED,
@@ -390,10 +398,16 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     mfaMethodType == MFAMethodType.AUTH_APP
                             ? ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED
                             : ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED;
-            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+            return new PermissionCheckResult(
+                    Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse)),
+                    temporarilyLockedOut.attemptCount());
         }
 
-        return Optional.empty();
+        if (decision instanceof Decision.Permitted permitted) {
+            return new PermissionCheckResult(Optional.empty(), permitted.attemptCount());
+        }
+
+        return new PermissionCheckResult(Optional.empty(), 0);
     }
 
     private APIGatewayProxyResponseEvent verifyCode(
@@ -499,8 +513,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         CountType.ENTER_MFA_CODE);
             }
 
-            auditFailure(codeRequest, errorResponse, authSession, auditContext, activeMfaMethod);
-
             Result<TrackingError, Void> trackingResult = Result.success(null);
             if (errorResponse.equals(ErrorResponse.INVALID_PHONE_CODE_ENTERED)) {
                 trackingResult =
@@ -520,6 +532,25 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 return TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
                         trackingResult.getFailure());
             }
+
+            var permissionCheckAfterIncrement =
+                    checkPermission(
+                            codeRequest.getJourneyType(),
+                            codeRequest.getMfaMethodType(),
+                            permissionContext,
+                            auditContext,
+                            maybeRpPairwiseId);
+            if (permissionCheckAfterIncrement.errorResponse().isPresent()) {
+                return permissionCheckAfterIncrement.errorResponse().get();
+            }
+
+            auditFailure(
+                    codeRequest,
+                    errorResponse,
+                    authSession,
+                    auditContext,
+                    activeMfaMethod,
+                    permissionCheckAfterIncrement.attemptCount());
         } else {
             auditSuccess(codeRequest, authSession, auditContext, activeMfaMethod);
 
@@ -567,11 +598,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuditContext auditContext,
             Optional<MFAMethod> activeMfaMethod) {
         var metadataPairs =
-                metadataPairsForEvent(
-                        AUTH_CODE_VERIFIED,
-                        authSession.getEmailAddress(),
-                        codeRequest,
-                        activeMfaMethod);
+                metadataPairsForEvent(AUTH_CODE_VERIFIED, codeRequest, activeMfaMethod, 0);
         auditService.submitAuditEvent(AUTH_CODE_VERIFIED, auditContext, metadataPairs);
     }
 
@@ -580,14 +607,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             ErrorResponse errorResponse,
             AuthSessionItem authSession,
             AuditContext auditContext,
-            Optional<MFAMethod> activeMfaMethod) {
+            Optional<MFAMethod> activeMfaMethod,
+            int failureCount) {
         var auditableEvent = errorResponseAsFrontendAuditableEvent(errorResponse);
         var metadataPairs =
-                metadataPairsForEvent(
-                        auditableEvent,
-                        authSession.getEmailAddress(),
-                        codeRequest,
-                        activeMfaMethod);
+                metadataPairsForEvent(auditableEvent, codeRequest, activeMfaMethod, failureCount);
         auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairs);
     }
 
@@ -821,9 +845,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     private AuditService.MetadataPair[] metadataPairsForEvent(
             FrontendAuditableEvent auditableEvent,
-            String email,
             VerifyMfaCodeRequest codeRequest,
-            Optional<MFAMethod> activeMfaMethod) {
+            Optional<MFAMethod> activeMfaMethod,
+            int failureCount) {
         var methodType = codeRequest.getMfaMethodType();
         var metadataPairs = new ArrayList<AuditService.MetadataPair>();
         metadataPairs.add(pair("mfa-type", methodType.getValue()));
@@ -850,8 +874,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
             case AUTH_INVALID_CODE_SENT, AUTH_CODE_VERIFIED -> {
                 if (auditableEvent.equals(AUTH_INVALID_CODE_SENT)) {
-                    var failureCount = codeStorageService.getIncorrectMfaCodeAttemptsCount(email);
-                    metadataPairs.add(pair("loginFailureCount", failureCount));
+                    // TODO: Remove divide by 2 once lockout logic is removed from processors.
+                    // Currently both the processor (via ValidationHelper) and UserActionsManager
+                    // increment the count, causing double-counting.
+                    metadataPairs.add(pair("loginFailureCount", failureCount / 2));
                 }
 
                 metadataPairs.add(pair("MFACodeEntered", codeRequest.getCode()));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -4,7 +4,6 @@ import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -36,7 +35,6 @@ import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVER
 import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
@@ -50,7 +48,6 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
-            int maxRetries,
             CodeRequest codeRequest,
             AuditService auditService,
             DynamoAccountModifiersService accountModifiersService,
@@ -58,7 +55,6 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
         super(
                 userContext,
                 codeStorageService,
-                maxRetries,
                 authenticationService,
                 auditService,
                 accountModifiersService,
@@ -70,38 +66,11 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
     @Override
     public Optional<ErrorResponse> validateCode() {
-        var codeRequestType =
-                CodeRequestType.getCodeRequestType(AUTH_APP, codeRequest.getJourneyType());
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-
         var nonRegistrationJourneyTypes =
                 List.of(
                         JourneyType.SIGN_IN,
                         JourneyType.PASSWORD_RESET_MFA,
                         JourneyType.REAUTHENTICATION);
-
-        if (isCodeBlockedForSession(codeBlockedKeyPrefix)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED);
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(
-                        AUTH_APP, codeRequest.getJourneyType());
-        if (isCodeBlockedForSession(CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED);
-        }
-
-        if (codeRequestType.getJourneyType() != JourneyType.REAUTHENTICATION) {
-            incrementRetryCount();
-        }
-
-        if (hasExceededRetryLimit()) {
-            LOG.info("Exceeded code retry limit");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED);
-        }
 
         var authAppSecret =
                 nonRegistrationJourneyTypes.contains(codeRequest.getJourneyType())
@@ -122,8 +91,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             LOG.info("Auth code is not valid");
             return Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED);
         }
-        LOG.info("Auth code valid. Resetting code request count");
-        resetCodeIncorrectEntryCount();
+        LOG.info("Auth code valid");
 
         return Optional.empty();
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -23,7 +23,6 @@ public abstract class MfaCodeProcessor {
     protected final Logger LOG = LogManager.getLogger(this.getClass());
     public final CodeStorageService codeStorageService;
     public final DynamoAccountModifiersService accountModifiersService;
-    private final int maxRetries;
     public final String emailAddress;
     private final UserContext userContext;
     protected final AuthenticationService authenticationService;
@@ -33,7 +32,6 @@ public abstract class MfaCodeProcessor {
     MfaCodeProcessor(
             UserContext userContext,
             CodeStorageService codeStorageService,
-            int maxRetries,
             AuthenticationService authenticationService,
             AuditService auditService,
             DynamoAccountModifiersService accountModifiersService,
@@ -41,28 +39,10 @@ public abstract class MfaCodeProcessor {
         this.emailAddress = userContext.getAuthSession().getEmailAddress();
         this.userContext = userContext;
         this.codeStorageService = codeStorageService;
-        this.maxRetries = maxRetries;
         this.authenticationService = authenticationService;
         this.auditService = auditService;
         this.accountModifiersService = accountModifiersService;
         this.mfaMethodsService = mfaMethodsService;
-    }
-
-    boolean isCodeBlockedForSession(String codeBlockedKeyPrefix) {
-        return codeStorageService.isBlockedForEmail(emailAddress, codeBlockedKeyPrefix);
-    }
-
-    boolean hasExceededRetryLimit() {
-        LOG.info("Max retries: {}", maxRetries);
-        return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress) >= maxRetries;
-    }
-
-    void incrementRetryCount() {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
-    }
-
-    void resetCodeIncorrectEntryCount() {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
     void submitAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.frontendapi.validation;
 
 import uk.gov.di.authentication.entity.CodeRequest;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -12,7 +11,6 @@ import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.List;
 import java.util.Optional;
 
 public class MfaCodeProcessorFactory {
@@ -45,24 +43,16 @@ public class MfaCodeProcessorFactory {
     public Optional<MfaCodeProcessor> getMfaCodeProcessor(
             MFAMethodType mfaMethodType, CodeRequest codeRequest, UserContext userContext) {
         return switch (mfaMethodType) {
-            case AUTH_APP -> {
-                int codeMaxRetries =
-                        List.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY)
-                                        .contains(codeRequest.getJourneyType())
-                                ? configurationService.getIncreasedCodeMaxRetries()
-                                : configurationService.getCodeMaxRetries();
-                yield Optional.of(
-                        new AuthAppCodeProcessor(
-                                userContext,
-                                codeStorageService,
-                                configurationService,
-                                authenticationService,
-                                codeMaxRetries,
-                                codeRequest,
-                                auditService,
-                                accountModifiersService,
-                                mfaMethodsService));
-            }
+            case AUTH_APP -> Optional.of(
+                    new AuthAppCodeProcessor(
+                            userContext,
+                            codeStorageService,
+                            configurationService,
+                            authenticationService,
+                            codeRequest,
+                            auditService,
+                            accountModifiersService,
+                            mfaMethodsService));
             case SMS -> Optional.of(
                     new PhoneNumberCodeProcessor(
                             codeStorageService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -122,14 +122,7 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
         var errorResponse =
                 ValidationHelper.validateVerificationCode(
-                        notificationType,
-                        journeyType,
-                        storedCode,
-                        codeRequest.getCode(),
-                        codeStorageService,
-                        emailAddress,
-                        configurationService,
-                        false);
+                        notificationType, storedCode, codeRequest.getCode());
 
         if (errorResponse.isEmpty()) {
             codeStorageService.deleteOtpCode(codeIdentifier, notificationType);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -6,7 +6,6 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PhoneNumberRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -34,7 +33,6 @@ import java.util.UUID;
 
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
@@ -59,7 +57,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         super(
                 userContext,
                 codeStorageService,
-                configurationService.getCodeMaxRetries(),
                 authenticationService,
                 auditService,
                 dynamoAccountModifiersService,
@@ -89,7 +86,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         super(
                 userContext,
                 codeStorageService,
-                configurationService.getCodeMaxRetries(),
                 authenticationService,
                 auditService,
                 dynamoAccountModifiersService,
@@ -114,23 +110,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         ? NotificationType.MFA_SMS
                         : NotificationType.VERIFY_PHONE_NUMBER;
 
-        var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-
-        if (isCodeBlockedForSession(codeBlockedKeyPrefix)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED);
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(
-                        notificationType.getMfaMethodType(), journeyType);
-        if (isCodeBlockedForSession(CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED);
-        }
-
         boolean isTestClient = testUserHelper.isTestJourney(userContext);
 
         var formattedPhoneNumber =
@@ -149,7 +128,8 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         codeRequest.getCode(),
                         codeStorageService,
                         emailAddress,
-                        configurationService);
+                        configurationService,
+                        false);
 
         if (errorResponse.isEmpty()) {
             codeStorageService.deleteOtpCode(codeIdentifier, notificationType);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -215,8 +215,6 @@ class LoginHandlerTest {
                 .thenReturn(Result.success(new Decision.Permitted(0)));
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
         handler =
                 new LoginHandler(
                         configurationService,
@@ -1265,8 +1263,6 @@ class LoginHandlerTest {
 
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -1274,7 +1270,6 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(200));
 
         verify(permissionDecisionManager).canSendSmsOtpNotification(any(), any());
-        verify(permissionDecisionManager).canVerifyMfaOtp(any(), any());
     }
 
     @ParameterizedTest
@@ -1292,7 +1287,6 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(200));
 
         verify(permissionDecisionManager, never()).canSendSmsOtpNotification(any(), any());
-        verify(permissionDecisionManager, never()).canVerifyMfaOtp(any(), any());
     }
 
     private static Stream<Arguments> validMfaMethodsWithExpectedBlock() {
@@ -1333,21 +1327,13 @@ class LoginHandlerTest {
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
 
-        if (expectedError == ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS) {
-            when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.TemporarilyLockedOut(null, 0, null, false)));
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(0)));
-        } else {
-            when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(0)));
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.TemporarilyLockedOut(null, 0, null, false)));
-        }
+        ForbiddenReason reason =
+                expectedError == ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS
+                        ? ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT
+                        : ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
+                .thenReturn(
+                        Result.success(new Decision.TemporarilyLockedOut(reason, 0, null, false)));
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -1370,8 +1356,6 @@ class LoginHandlerTest {
                                 new Decision.IndefinitelyLockedOut(
                                         ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
                                         10)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -945,6 +945,31 @@ class MfaHandlerTest {
         verify(sqsClient, never()).send(any());
     }
 
+    @Test
+    void shouldReturn500WhenCanVerifyMfaOtpReturnsReauthLockedOut() {
+        usingValidSession();
+
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.ReauthLockedOut(
+                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                        6,
+                                        Instant.now(),
+                                        false,
+                                        java.util.Map.of(),
+                                        List.of())));
+
+        var body = format("{ \"email\": \"%s\"}", EMAIL);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+        verify(sqsClient, never()).send(any());
+    }
+
     @ParameterizedTest
     @MethodSource("mfaJourneyTypes")
     void shouldReturn400WhenInternationalSendLimitServiceBlocks(JourneyType journeyType) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -756,6 +756,36 @@ class MfaHandlerTest {
                                 .withMetadataItem(pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
+    @Test
+    void shouldReturn400IfUserIsBlockedFromRequestingMfaCodesWithReauthLockedOut() {
+        usingValidSession();
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.ReauthLockedOut(
+                                        ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
+                                        6,
+                                        Instant.now(),
+                                        false,
+                                        java.util.Map.of(),
+                                        List.of())));
+
+        var body =
+                format(
+                        "{ \"email\": \"%s\", \"journeyType\": \"%s\"}",
+                        EMAIL, JourneyType.REAUTHENTICATION);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasJsonBody(BLOCKED_FOR_SENDING_MFA_OTPS));
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(FrontendAuditableEvent.AUTH_MFA_INVALID_CODE_REQUEST),
+                        any(AuditContext.class));
+    }
+
     @ParameterizedTest
     @MethodSource("smsJourneyTypes")
     void shouldReturn400IfUserIsBlockedFromAttemptingMfaCodes(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -212,8 +212,6 @@ class MfaHandlerTest {
 
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActionsManager.sentSmsOtpNotification(any(), any(), any()))
                 .thenReturn(Result.success(null));
 
@@ -792,7 +790,7 @@ class MfaHandlerTest {
             JourneyType journeyType, boolean reauthEnabled) {
         usingValidSession();
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(reauthEnabled);
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new Decision.TemporarilyLockedOut(
@@ -930,26 +928,10 @@ class MfaHandlerTest {
     }
 
     @Test
-    void shouldReturn500WhenCanVerifyMfaOtpReturnsError() {
+    void shouldReturn500WhenCanSendSmsOtpNotificationReturnsReauthLockedOut() {
         usingValidSession();
 
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
-
-        var body = format("{ \"email\": \"%s\"}", EMAIL);
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(500));
-        verify(sqsClient, never()).send(any());
-    }
-
-    @Test
-    void shouldReturn500WhenCanVerifyMfaOtpReturnsReauthLockedOut() {
-        usingValidSession();
-
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new Decision.ReauthLockedOut(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -165,8 +165,6 @@ class ResetPasswordRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(6);
         when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActionsManager.sentEmailOtpNotification(any(), any()))
                 .thenReturn(Result.success(null));
     }
@@ -469,7 +467,7 @@ class ResetPasswordRequestHandlerTest {
         @Test
         void shouldReturn400IfUserIsBlockedFromEnteringAnyMoreInvalidPasswordResetsOTPs() {
             usingSessionWithPasswordResetCount(0);
-            when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+            when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
                     .thenReturn(
                             Result.success(
                                     new Decision.TemporarilyLockedOut(
@@ -501,8 +499,6 @@ class ResetPasswordRequestHandlerTest {
                                             6,
                                             Instant.now(),
                                             true)));
-            when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(0)));
 
             var result = handler.handleRequest(validEvent, context);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 
 import java.time.Instant;
@@ -488,9 +489,7 @@ class ResetPasswordRequestHandlerTest {
         void shouldReturn400IfUserIsNewlyBlockedFromEnteringAnyMoreInvalidPasswordResetsOTPs() {
             when(configurationService.getCodeMaxRetries()).thenReturn(6);
             usingSessionWithPasswordResetCount(5);
-            // First call returns permitted, second call (after increment) returns locked out
             when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(5)))
                     .thenReturn(
                             Result.success(
                                     new Decision.TemporarilyLockedOut(
@@ -504,6 +503,18 @@ class ResetPasswordRequestHandlerTest {
 
             assertEquals(400, result.getStatusCode());
             assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PW_RESET_REQUESTS));
+            verifyNoInteractions(awsSqsClient);
+        }
+
+        @Test
+        void shouldReturn500IfPermissionCheckFails() {
+            usingSessionWithPasswordResetCount(0);
+            when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
+                    .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+            var result = handler.handleRequest(validEvent, context);
+
+            assertEquals(500, result.getStatusCode());
             verifyNoInteractions(awsSqsClient);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -1372,18 +1372,8 @@ class SendNotificationHandlerTest {
             }
 
             @Test
-            void shouldReturn400IfUserIsBlockedFromEnteringRegistrationEmailOtpCodes() {
+            void shouldAllowRegistrationEmailOtpRequestEvenWhenVerificationBlockExists() {
                 usingValidSession();
-                when(permissionDecisionManager.canVerifyEmailOtp(
-                                eq(REGISTRATION), any(PermissionContext.class)))
-                        .thenReturn(
-                                Result.success(
-                                        new Decision.TemporarilyLockedOut(
-                                                ForbiddenReason
-                                                        .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
-                                                6,
-                                                Instant.now(),
-                                                false)));
 
                 var body =
                         format(
@@ -1393,17 +1383,13 @@ class SendNotificationHandlerTest {
 
                 var result = handler.handleRequest(event, context);
 
-                assertEquals(400, result.getStatusCode());
-                assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED));
-                verifyNoInteractions(emailSqsClient);
-                verify(auditService)
-                        .submitAuditEvent(AUTH_EMAIL_INVALID_CODE_REQUEST, auditContext);
+                assertEquals(204, result.getStatusCode());
             }
 
             @Test
             void shouldReturn400IfUserIsBlockedFromEnteringAccountRecoveryEmailOtpCodes() {
                 usingValidSession();
-                when(permissionDecisionManager.canVerifyEmailOtp(
+                when(permissionDecisionManager.canSendEmailOtpNotification(
                                 eq(JourneyType.ACCOUNT_RECOVERY), any(PermissionContext.class)))
                         .thenReturn(
                                 Result.success(
@@ -1436,7 +1422,7 @@ class SendNotificationHandlerTest {
 
             @Test
             void shouldReturn400IfUserIsBlockedFromEnteringPhoneOtpCodes() {
-                when(permissionDecisionManager.canVerifyMfaOtp(
+                when(permissionDecisionManager.canSendSmsOtpNotification(
                                 eq(REGISTRATION), any(PermissionContext.class)))
                         .thenReturn(
                                 Result.success(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -49,6 +49,7 @@ import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -225,6 +226,8 @@ class VerifyCodeHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
     }
 
     @Test
@@ -1202,6 +1205,8 @@ class VerifyCodeHandlerTest {
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
         when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
 
         // Act
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -1210,6 +1215,25 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verify(userActionsManager)
                 .correctSmsOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectSmsOtpReceivedReturnsInvalidUserContext() {
+        // Arrange
+        when(codeStorageService.getOtpCode(
+                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
+                .thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        // Act
+        var result = makeCallWithCode(CODE, MFA_SMS.toString());
+
+        // Assert
+        assertThat(result, hasStatus(500));
     }
 
     private void withReauthTurnedOn() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -33,12 +33,10 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -48,17 +46,19 @@ import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
+import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
+import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -102,8 +102,6 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASS
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
@@ -135,7 +133,6 @@ class VerifyCodeHandlerTest {
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final String TEST_SUBJECT_ID = "test-subject-id";
     private static final long CODE_EXPIRY_TIME = 900;
-    private static final long LOCKOUT_DURATION = 799;
     private static final int MAX_RETRIES = 6;
     private final Context context = mock(Context.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -158,11 +155,11 @@ class VerifyCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final DynamoAccountModifiersService accountModifiersService =
             mock(DynamoAccountModifiersService.class);
-    private final AuthenticationAttemptsService authenticationAttemptsService =
-            mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
     private final TestUserHelper testUserHelper = mock(TestUserHelper.class);
 
     private final AuditContext AUDIT_CONTEXT =
@@ -204,10 +201,10 @@ class VerifyCodeHandlerTest {
                         auditService,
                         cloudwatchMetricsService,
                         accountModifiersService,
-                        authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
+                        permissionDecisionManager,
                         testUserHelper);
 
         when(authenticationService.getUserProfileFromEmail(EMAIL))
@@ -228,6 +225,16 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(authSession));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
+        when(userActionsManager.correctEmailOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectEmailOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
     }
 
     @Test
@@ -292,7 +299,6 @@ class VerifyCodeHandlerTest {
                                 emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                                         ? "ACCOUNT_RECOVERY"
                                         : "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -326,7 +332,6 @@ class VerifyCodeHandlerTest {
                                 emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                                         ? "ACCOUNT_RECOVERY"
                                         : "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -362,7 +367,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         eq(FrontendAuditableEvent.AUTH_INVALID_CODE_SENT),
-                        any(AuditContext.class),
+                        eq(AUDIT_CONTEXT),
                         metadataCaptor.capture());
 
         List<AuditService.MetadataPair> expected =
@@ -377,8 +382,6 @@ class VerifyCodeHandlerTest {
 
         assertTrue(expected.containsAll(actual));
         assertTrue(actual.containsAll(expected));
-
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -415,7 +418,6 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -451,25 +453,26 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
-    void
-            shouldReturnMaxReachedAndNotSetBlockWhenRegistrationEmailCodeAttemptsExceedMaxRetryCount() {
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+    void shouldReturnMaxReachedAndSetBlockWhenRegistrationEmailCodeAttemptsExceedMaxRetryCount() {
         when(codeStorageService.getOtpCode(EMAIL, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
+
         var result = makeCallWithCode(INVALID_CODE, VERIFY_EMAIL.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED));
         verifyNoInteractions(accountModifiersService);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-        verify(codeStorageService, never())
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, LOCKOUT_DURATION);
+        verify(userActionsManager).incorrectEmailOtpReceived(eq(JourneyType.REGISTRATION), any());
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
@@ -477,13 +480,16 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenAccountRecoveryEmailCodeIsBlocked() {
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
+        when(permissionDecisionManager.canVerifyEmailOtp(
+                        eq(JourneyType.ACCOUNT_RECOVERY), any(PermissionContext.class)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name());
 
@@ -491,13 +497,16 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED));
         verifyNoInteractions(accountModifiersService);
         verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenPasswordResetEmailCodeIsBlocked() {
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_PASSWORD_RESET;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
+        when(permissionDecisionManager.canVerifyEmailOtp(
+                        eq(JourneyType.PASSWORD_RESET), any(PermissionContext.class)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, RESET_PASSWORD_WITH_CODE.name());
 
@@ -505,15 +514,17 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
         verifyNoInteractions(accountModifiersService);
         verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndNotSetBlockWhenSignInCodeIsBlocked(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any(PermissionContext.class)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, MFA_SMS.name(), journeyType);
 
@@ -521,48 +532,26 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED));
         verifyNoInteractions(accountModifiersService);
         verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @Test
-    void shouldReturnMaxReachedAndNotSetBlockWhenSignInCodeIsBlockedUsingDeprecatedKey() {
-        JourneyType journeyType = JourneyType.SIGN_IN;
-
-        var codeBlockedKeyPrefix =
-                CODE_BLOCKED_KEY_PREFIX
-                        + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                MFAMethodType.SMS, journeyType);
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
-
-        var result = makeCallWithCode(CODE, MFA_SMS.name(), journeyType);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED));
-        verifyNoInteractions(accountModifiersService);
-        verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
     void
             shouldReturnMaxReachedAndSetBlockWhenAccountRecoveryEmailCodeAttemptsExceedMaxRetryCount() {
-        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
-
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(false);
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED));
-        verify(codeStorageService)
-                .saveBlockedForEmail(EMAIL, codeBlockedKeyPrefix, LOCKOUT_DURATION);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+        verify(userActionsManager)
+                .incorrectEmailOtpReceived(eq(JourneyType.ACCOUNT_RECOVERY), any());
         verifyNoInteractions(accountModifiersService);
         verify(auditService)
                 .submitAuditEvent(
@@ -571,7 +560,6 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name()),
                         pair("account-recovery", true),
                         pair("journey-type", "ACCOUNT_RECOVERY"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -583,8 +571,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
         when(accountModifiersService.isAccountRecoveryBlockPresent(anyString())).thenReturn(true);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
@@ -637,7 +625,6 @@ class VerifyCodeHandlerTest {
                         journeyType != null ? journeyType : JourneyType.SIGN_IN,
                         MFAMethodType.SMS,
                         PriorityIdentifier.DEFAULT);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -647,8 +634,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD, BACKUP_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
         when(accountModifiersService.isAccountRecoveryBlockPresent(anyString())).thenReturn(true);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
@@ -677,7 +664,6 @@ class VerifyCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("loginFailureCount", MAX_RETRIES - 1),
                         pair("MFACodeEntered", "123456"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -685,13 +671,12 @@ class VerifyCodeHandlerTest {
         when(codeStorageService.getOtpCode(
                         EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
                 .thenReturn(Optional.of(CODE));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
         when(accountModifiersService.isAccountRecoveryBlockPresent(INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(false);
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        withReauthTurnedOn();
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -736,11 +721,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
         when(accountModifiersService.isAccountRecoveryBlockPresent(INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(false);
-        withReauthTurnedOn();
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
 
@@ -762,8 +744,9 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString());
 
@@ -802,15 +785,19 @@ class VerifyCodeHandlerTest {
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenSignInExceedMaxRetryCount(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        withReauthTurnedOn();
-        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(
                         EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+        if (journeyType != REAUTHENTICATION) {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(0)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+        }
 
         var result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString(), journeyType);
 
@@ -821,57 +808,52 @@ class VerifyCodeHandlerTest {
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_MFA_CODE_ENTERED));
         }
 
-        if (codeRequestType != CodeRequestType.MFA_REAUTHENTICATION) {
-            verify(codeStorageService)
-                    .saveBlockedForEmail(
-                            EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, LOCKOUT_DURATION);
-        }
+        verify(userActionsManager).incorrectSmsOtpReceived(any(), any());
 
         verifyNoInteractions(accountModifiersService);
 
         if (journeyType != REAUTHENTICATION) {
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                            AUDIT_CONTEXT.withMetadataItem(pair("mfa-method", "default")),
+                            AUDIT_CONTEXT.withMetadataItem(
+                                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
                             pair("notification-type", MFA_SMS.name()),
                             pair("account-recovery", false),
                             pair(
                                     "journey-type",
                                     journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
                             pair("mfa-type", MFAMethodType.SMS.getValue()),
-                            pair("loginFailureCount", MAX_RETRIES + 1),
-                            pair("MFACodeEntered", "6543221"),
+                            pair("loginFailureCount", 0),
+                            pair("MFACodeEntered", INVALID_CODE),
                             pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
         }
     }
 
     @Test
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenPasswordResetExceedMaxRetryCount() {
-        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(EMAIL, RESET_PASSWORD_WITH_CODE))
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(INVALID_CODE, RESET_PASSWORD_WITH_CODE.toString());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
-        verify(codeStorageService)
-                .saveBlockedForEmail(
-                        EMAIL,
-                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_PASSWORD_RESET,
-                        LOCKOUT_DURATION);
+        verify(userActionsManager).incorrectEmailOtpReceived(eq(JourneyType.PASSWORD_RESET), any());
         verifyNoInteractions(accountModifiersService);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                        AUDIT_CONTEXT.withMetadataItem(pair("mfa-method", "default")),
+                        AUDIT_CONTEXT.withMetadataItem(
+                                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
                         pair("notification-type", RESET_PASSWORD_WITH_CODE.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "PASSWORD_RESET"));
@@ -903,145 +885,16 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
     }
 
-    private static Stream<Arguments> expectedMfaCodeBlocks() {
-        return Stream.of(
-                Arguments.of(
-                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.MFA_PW_RESET_MFA,
-                        ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED),
-                Arguments.of(
-                        CODE_BLOCKED_KEY_PREFIX + "PW_RESET_MFA_" + MFAMethodType.SMS,
-                        ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED),
-                Arguments.of(
-                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.MFA_PW_RESET_MFA,
-                        ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS),
-                Arguments.of(
-                        CODE_REQUEST_BLOCKED_KEY_PREFIX + "PW_RESET_MFA_" + MFAMethodType.SMS,
-                        ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS));
-    }
-
-    @ParameterizedTest
-    @MethodSource("expectedMfaCodeBlocks")
-    void shouldReturn400ForValidResetPasswordRequestWhenUserHasAnMFACodeBlock(
-            String blockKeyPrefix, ErrorResponse expectedError) {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-        when(testUserHelper.isTestJourney(any(UserContext.class))).thenReturn(true);
-        when(configurationService.getTestClientVerifyEmailOTP())
-                .thenReturn(Optional.of(TEST_CLIENT_CODE));
-        when(codeStorageService.getOtpCode(
-                        TEST_CLIENT_EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()),
-                        RESET_PASSWORD_WITH_CODE))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(TEST_CLIENT_EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.isBlockedForEmail(TEST_CLIENT_EMAIL, blockKeyPrefix))
-                .thenReturn(true);
-
-        authSession.setEmailAddress(TEST_CLIENT_EMAIL);
-        authSession.setClientId(TEST_CLIENT_ID);
-        String body =
-                format(
-                        "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
-                        TEST_CLIENT_CODE, RESET_PASSWORD_WITH_CODE);
-        APIGatewayProxyResponseEvent result = makeCallWithCode(body, Optional.of(authSession));
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(expectedError));
-    }
-
-    @Test
-    void shouldNotCheckForMFACodeBlocksOnANonePasswordResetJourney() {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-        when(configurationService.getTestClientVerifyEmailOTP())
-                .thenReturn(Optional.of(TEST_CLIENT_CODE));
-        when(codeStorageService.getOtpCode(
-                        TEST_CLIENT_EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(TEST_CLIENT_EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-
-        authSession.setEmailAddress(TEST_CLIENT_EMAIL);
-        authSession.setClientId(TEST_CLIENT_ID);
-        String body =
-                format(
-                        "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
-                        TEST_CLIENT_CODE, SIGN_IN);
-        makeCallWithCode(body, Optional.of(authSession));
-
-        verify(codeStorageService, never())
-                .isBlockedForEmail(
-                        TEST_CLIENT_EMAIL,
-                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.MFA_PW_RESET_MFA);
-    }
-
-    @ParameterizedTest
-    @MethodSource("codeRequestTypes")
-    void shouldDeleteCountOnSuccessfulSMSCodeRequest(
-            CodeRequestType codeRequestType, JourneyType journeyType) {
-        when(codeStorageService.getOtpCode(
-                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        withReauthTurnedOn();
-        var existingCounts = Map.of(ENTER_EMAIL, 5, ENTER_PASSWORD, 1);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        any(), any(), eq(REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-        when(configurationService.getInternalSectorUri()).thenReturn("http://" + SECTOR_HOST);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        var result = makeCallWithCode(CODE, MFA_SMS.toString(), journeyType);
-
-        List.of(TEST_SUBJECT_ID, expectedPairwiseId)
-                .forEach(
-                        identifier ->
-                                verify(
-                                                authenticationAttemptsService,
-                                                times(CountType.values().length))
-                                        .deleteCount(
-                                                eq(identifier),
-                                                eq(JourneyType.REAUTHENTICATION),
-                                                any()));
-
-        if (journeyType == REAUTHENTICATION) {
-            verify(authSessionService, atLeastOnce())
-                    .updateSession(
-                            argThat(
-                                    s ->
-                                            s.getPreservedReauthCountsForAuditMap()
-                                                    .equals(existingCounts)));
-        } else {
-            verify(authSessionService, never())
-                    .updateSession(
-                            argThat(
-                                    s ->
-                                            Objects.equals(
-                                                    s.getPreservedReauthCountsForAuditMap(),
-                                                    existingCounts)));
-        }
-
-        assertThat(result, hasStatus(204));
-    }
-
     @Test
     void shouldIncrementEnterMFAAuthenticationAttemptCountOnFailedReauthenticationAttempt() {
-        long ttl = 120L;
-        withReauthTurnedOn();
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(ttl);
-        MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class);
-        mockedNowHelperClass
-                .when(() -> NowHelper.nowPlus(ttl, ChronoUnit.SECONDS))
-                .thenReturn(Date.from(Instant.parse("2099-01-01T00:00:00.00Z")));
 
         var result = makeCallWithCode(INVALID_CODE, MFA_SMS.name(), REAUTHENTICATION);
 
-        verify(authenticationAttemptsService, times(1))
-                .createOrIncrementCount(
-                        TEST_SUBJECT_ID, 4070908800L, REAUTHENTICATION, ENTER_MFA_CODE);
+        verify(userActionsManager).incorrectSmsOtpReceived(eq(REAUTHENTICATION), any());
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.INVALID_MFA_CODE_ENTERED));
-        mockedNowHelperClass.close();
     }
 
     private static Stream<Arguments> reauthCountTypesAndMetadata() {
@@ -1076,10 +929,29 @@ class VerifyCodeHandlerTest {
             String expectedFailureReason) {
         try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
                 Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            withReauthTurnedOn();
-            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                            any(), any(), eq(REAUTHENTICATION)))
-                    .thenReturn(Map.of(countType, MAX_RETRIES));
+            var detailedCounts = Map.of(countType, MAX_RETRIES);
+            var forbiddenReason =
+                    switch (countType) {
+                        case ENTER_EMAIL -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT;
+                        case ENTER_PASSWORD -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT;
+                        case ENTER_MFA_CODE,
+                                ENTER_AUTH_APP_CODE,
+                                ENTER_SMS_CODE,
+                                ENTER_EMAIL_CODE -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+                    };
+            when(permissionDecisionManager.canVerifyMfaOtp(eq(REAUTHENTICATION), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            forbiddenReason,
+                                            MAX_RETRIES,
+                                            Instant.now(),
+                                            false,
+                                            detailedCounts,
+                                            List.of(countType))));
             when(configurationService.getInternalSectorUri())
                     .thenReturn("https://test.account.gov.uk");
             Subject subject = new Subject(TEST_SUBJECT_ID);
@@ -1204,7 +1076,6 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
 
@@ -1225,7 +1096,6 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
 
@@ -1236,9 +1106,69 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(500));
     }
 
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+    @Test
+    void shouldReturn500WhenCorrectEmailOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(EMAIL, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
+        when(userActionsManager.correctEmailOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        var result = makeCallWithCode(CODE, VERIFY_EMAIL.name());
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenIncorrectSmsOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(
+                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
+                .thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        var result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString());
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenIncorrectEmailOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(EMAIL, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
+        when(userActionsManager.incorrectEmailOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        var result = makeCallWithCode(INVALID_CODE, VERIFY_EMAIL.name());
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenCanVerifyEmailOtpReturnsFailure() {
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+        var result = makeCallWithCode(CODE, VERIFY_EMAIL.name());
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    void shouldReturn500WhenCanVerifyMfaOtpReturnsFailure() {
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+        var result = makeCallWithCode(CODE, MFA_SMS.name());
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
     }
 
     @Nested
@@ -1255,7 +1185,6 @@ class VerifyCodeHandlerTest {
                     .thenReturn(Optional.of(CODE));
             when(mfaMethodsService.getMfaMethods(EMAIL))
                     .thenReturn(Result.success(List.of(INTERNATIONAL_SMS_METHOD)));
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
             authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -215,6 +215,8 @@ class VerifyMfaCodeHandlerTest {
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
+        when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -1649,6 +1651,8 @@ class VerifyMfaCodeHandlerTest {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var codeRequest =
@@ -1662,5 +1666,27 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verify(userActionsManager)
                 .correctAuthAppOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectAuthAppOtpReceivedReturnsInvalidUserContext()
+            throws Json.JsonException {
+        // Arrange
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+        authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, AUTH_APP_SECRET);
+
+        // Act
+        var result = makeCallWithCode(codeRequest);
+
+        // Assert
+        assertThat(result, hasStatus(500));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -1042,10 +1042,8 @@ class VerifyMfaCodeHandlerTest {
                             : AUTH_APP_SECRET;
             when(authAppCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-            // TODO: Change back to 3 once processor lockout logic is removed (divide-by-2
-            // workaround removed)
             when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(6)));
+                    .thenReturn(Result.success(new Decision.Permitted(3)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1234,10 +1232,8 @@ class VerifyMfaCodeHandlerTest {
                     .thenReturn(Optional.of(phoneNumberCodeProcessor));
             when(phoneNumberCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-            // TODO: Change back to 3 once processor lockout logic is removed (divide-by-2
-            // workaround removed)
             when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(6)));
+                    .thenReturn(Result.success(new Decision.Permitted(3)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -14,13 +13,11 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetType;
-import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
@@ -28,7 +25,6 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -37,13 +33,11 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -57,16 +51,14 @@ import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
+import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -77,11 +69,9 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -99,14 +89,11 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_METHOD_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_RESET_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_COMPLETED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_INITIATED;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
@@ -114,7 +101,6 @@ import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
@@ -177,8 +163,6 @@ class VerifyMfaCodeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final AuthenticationAttemptsService authenticationAttemptsService =
-            mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
@@ -211,17 +195,17 @@ class VerifyMfaCodeHandlerTest {
 
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
         when(configurationService.getEnvironment()).thenReturn("test");
-        when(configurationService.getLockoutDuration()).thenReturn(900L);
-        when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
         when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
         when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
@@ -234,7 +218,6 @@ class VerifyMfaCodeHandlerTest {
                         auditService,
                         mfaCodeProcessorFactory,
                         cloudwatchMetricsService,
-                        authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
@@ -274,9 +257,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -351,9 +331,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -396,9 +373,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -440,9 +414,6 @@ class VerifyMfaCodeHandlerTest {
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -502,9 +473,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -570,9 +538,6 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(204));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
                     pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
@@ -906,124 +871,6 @@ class VerifyMfaCodeHandlerTest {
             verifyNoInteractions(cloudwatchMetricsService);
         }
 
-        private static Stream<Arguments> blockedCodeForAuthAppOTPEnteredTooManyTimes() {
-            return Stream.of(
-                    Arguments.of(
-                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
-                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
-                    Arguments.of(JourneyType.SIGN_IN, CodeRequestType.MFA_SIGN_IN),
-                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
-                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
-        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            withReauthTurnedOn();
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
-            var authAppSecret =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            if (journeyType.equals(REAUTHENTICATION)) {
-                verify(codeStorageService, never())
-                        .saveBlockedForEmail(
-                                eq(EMAIL),
-                                eq(CODE_BLOCKED_KEY_PREFIX + codeRequestType),
-                                anyLong());
-            } else {
-                long expectedCodeBlockedTime =
-                        (journeyType.equals(REGISTRATION) || journeyType.equals(ACCOUNT_RECOVERY))
-                                ? 300L
-                                : 900L;
-                verify(codeStorageService)
-                        .saveBlockedForEmail(
-                                EMAIL,
-                                CODE_BLOCKED_KEY_PREFIX + codeRequestType,
-                                expectedCodeBlockedTime);
-                verifyNoInteractions(authenticationAttemptsService);
-            }
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @EnumSource(JourneyType.class)
-        void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists(
-                JourneyType journeyType) throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            when(codeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                    .thenReturn(true);
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
-            var authAppSecret =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
-
-            if (!CodeRequestType.isValidCodeRequestType(
-                    CodeRequestType.SupportedCodeType.getFromMfaMethodType(
-                            codeRequest.getMfaMethodType()),
-                    codeRequest.getJourneyType())) {
-                return;
-            }
-
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
         @ParameterizedTest
         @EnumSource(JourneyType.class)
         void shouldReturn400WhenUserEnteredInvalidAuthAppOtpCode(JourneyType journeyType)
@@ -1037,7 +884,8 @@ class VerifyMfaCodeHandlerTest {
                             : AUTH_APP_SECRET;
             when(authAppCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(3)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1058,11 +906,7 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
                     ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
@@ -1090,124 +934,6 @@ class VerifyMfaCodeHandlerTest {
             assertTrue(actual.containsAll(expected));
         }
 
-        private static Stream<Arguments> blockedCodeForInvalidPhoneNumberTooManyTimes() {
-            return Stream.of(
-                    Arguments.of(
-                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
-                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
-                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
-                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
-        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            withReauthTurnedOn();
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_SMS_METHOD)));
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            long blockTime = 900L;
-            if (List.of(CodeRequestType.MFA_REGISTRATION, CodeRequestType.MFA_ACCOUNT_RECOVERY)
-                    .contains(codeRequestType)) {
-                blockTime = 300L;
-            }
-            if (journeyType != REAUTHENTICATION) {
-                verify(codeStorageService)
-                        .saveBlockedForEmail(
-                                EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, blockTime);
-            }
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
-        void shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExists(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            var codeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_SMS_METHOD)));
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        @Test
-        void
-                shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExistsWithDeprecatedPrefix()
-                        throws Json.JsonException {
-            JourneyType journeyType = JourneyType.PASSWORD_RESET_MFA;
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            var codeBlockedPrefix =
-                    CODE_BLOCKED_KEY_PREFIX
-                            + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                    MFAMethodType.SMS, journeyType);
-            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-        }
-
         private static Stream<Arguments> invalidOtpSmsJourneyTypesWithMfaNotificationType() {
             return Stream.of(
                     Arguments.of(JourneyType.SIGN_IN, MFA_SMS.name()),
@@ -1226,7 +952,8 @@ class VerifyMfaCodeHandlerTest {
                     .thenReturn(Optional.of(phoneNumberCodeProcessor));
             when(phoneNumberCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(3)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1252,9 +979,6 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
@@ -1313,182 +1037,8 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_SECRET));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(auditService);
             verifyNoInteractions(cloudwatchMetricsService);
-        }
-    }
-
-    @Test
-    void shouldIncrementMFAAuthenticationAttemptsCountIfIncorrectCodeEntered()
-            throws Json.JsonException {
-        long ttl = 3600L;
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(ttl);
-        MockedStatic<NowHelper> mockedNowHelperClass = mockStatic(NowHelper.class);
-        mockedNowHelperClass
-                .when(() -> NowHelper.nowPlus(ttl, ChronoUnit.SECONDS))
-                .thenReturn(Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-        makeCallWithCode(codeRequest);
-
-        verify(authenticationAttemptsService, times(1))
-                .createOrIncrementCount(
-                        TEST_SUBJECT_ID, 1704067200L, REAUTHENTICATION, ENTER_MFA_CODE);
-
-        mockedNowHelperClass.close();
-    }
-
-    @Test
-    void
-            shouldDeleteAuthAppAuthenticationAttemptsCountAndStoreCountsInSessionIfCorrectCodeEnteredForReauthJourney()
-                    throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, CODE, JourneyType.REAUTHENTICATION, null);
-        makeCallWithCode(codeRequest);
-
-        List.of(TEST_SUBJECT_ID, expectedRpPairwiseSubjectId)
-                .forEach(
-                        identifier ->
-                                verify(
-                                                authenticationAttemptsService,
-                                                times(CountType.values().length))
-                                        .deleteCount(
-                                                eq(identifier),
-                                                eq(JourneyType.REAUTHENTICATION),
-                                                any()));
-
-        verify(authSessionService, atLeastOnce())
-                .updateSession(
-                        argThat(
-                                s ->
-                                        s.getPreservedReauthCountsForAuditMap()
-                                                .equals(existingCounts)));
-    }
-
-    @Test
-    void
-            shouldDeleteAuthAppAuthenticationAttemptsCountAndNotStoreCountsInSessionIfCorrectCodeEnteredForSigninJourney()
-                    throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
-        makeCallWithCode(codeRequest);
-
-        verify(authenticationAttemptsService, times(1))
-                .deleteCount(TEST_SUBJECT_ID, JourneyType.REAUTHENTICATION, ENTER_MFA_CODE);
-
-        verify(authSessionService, never())
-                .updateSession(
-                        argThat(
-                                s ->
-                                        Objects.equals(
-                                                s.getPreservedReauthCountsForAuditMap(),
-                                                existingCounts)));
-    }
-
-    private static Stream<Arguments> reauthCountTypesAndMetadata() {
-        return Stream.of(
-                Arguments.arguments(
-                        ENTER_EMAIL,
-                        MAX_RETRIES,
-                        0,
-                        0,
-                        ReauthFailureReasons.INCORRECT_EMAIL.getValue()),
-                Arguments.arguments(
-                        ENTER_PASSWORD,
-                        0,
-                        MAX_RETRIES,
-                        0,
-                        ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
-                Arguments.arguments(
-                        ENTER_MFA_CODE,
-                        0,
-                        0,
-                        MAX_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()));
-    }
-
-    @ParameterizedTest
-    @MethodSource("reauthCountTypesAndMetadata")
-    void shouldReturnErrorIfUserHasTooManyReauthAttemptCountsOfAnyType(
-            CountType countType,
-            int expectedEmailAttemptCount,
-            int expectedPasswordAttemptCount,
-            int expectedOtpAttemptCount,
-            String expectedFailureReason)
-            throws Json.JsonException {
-        try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
-                Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                            any(), any(), eq(REAUTHENTICATION)))
-                    .thenReturn(Map.of(countType, MAX_RETRIES));
-            when(configurationService.getInternalSectorUri())
-                    .thenReturn("https://test.account.gov.uk");
-            Subject subject = new Subject(TEST_SUBJECT_ID);
-            mockedClientSubjectHelperClass
-                    .when(
-                            () ->
-                                    ClientSubjectHelper.getSubject(
-                                            eq(userProfile),
-                                            any(AuthSessionItem.class),
-                                            any(AuthenticationService.class)))
-                    .thenReturn(subject);
-
-            var codeRequest =
-                    new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-            var result = makeCallWithCode(codeRequest);
-
-            verify(auditService, times(1))
-                    .submitAuditEvent(
-                            FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                            AUDIT_CONTEXT,
-                            pair("rpPairwiseId", subject.getValue()),
-                            pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
-                            pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
-                            pair("incorrect_otp_code_attempt_count", expectedOtpAttemptCount),
-                            pair("failure-reason", expectedFailureReason));
-            verify(cloudwatchMetricsService)
-                    .incrementCounter(
-                            CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                            Map.of(
-                                    ENVIRONMENT.getValue(),
-                                    configurationService.getEnvironment(),
-                                    FAILURE_REASON.getValue(),
-                                    expectedFailureReason));
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
         }
     }
 
@@ -1502,11 +1052,6 @@ class VerifyMfaCodeHandlerTest {
     private void assertAuditEventSubmittedWithMetadata(
             AuditableEvent event, AuditService.MetadataPair... pairs) {
         verify(auditService).submitAuditEvent(event, AUDIT_CONTEXT, pairs);
-    }
-
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
     }
 
     @Test
@@ -1583,9 +1128,6 @@ class VerifyMfaCodeHandlerTest {
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(phoneNumberCodeProcessor)
                 .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-        verify(codeStorageService, never())
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
         boolean isAccountRecoveryJourney = journeyType.equals(ACCOUNT_RECOVERY);
 
@@ -1700,7 +1242,7 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Nested
-    class LockoutChecks {
+    class PermissionHandling {
 
         @Test
         void shouldReturn400WithAuthAppErrorWhenTemporarilyLockedOut() throws Json.JsonException {
@@ -1794,6 +1336,249 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
             verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        private boolean hasExpectedPermissionContext(PermissionContext pc) {
+            return EMAIL.equals(pc.emailAddress())
+                    && SUBJECT_ID.equals(pc.internalSubjectId())
+                    && expectedRpPairwiseSubjectId.equals(pc.rpPairwiseId());
+        }
+
+        @Test
+        void shouldCallIncorrectSmsOtpReceivedWhenSmsCodeIsInvalid() throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS,
+                            CODE,
+                            JourneyType.SIGN_IN,
+                            DEFAULT_SMS_METHOD.getDestination());
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            verify(userActionsManager)
+                    .incorrectSmsOtpReceived(
+                            eq(JourneyType.SIGN_IN), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldCallIncorrectSmsOtpReceivedWithSubjectIdForReauth() throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS,
+                            CODE,
+                            REAUTHENTICATION,
+                            DEFAULT_SMS_METHOD.getDestination());
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            verify(userActionsManager)
+                    .incorrectSmsOtpReceived(
+                            eq(REAUTHENTICATION), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldCallIncorrectAuthAppOtpReceivedWhenAuthAppCodeIsInvalid()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            verify(userActionsManager)
+                    .incorrectAuthAppOtpReceived(
+                            eq(JourneyType.SIGN_IN), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldReturn400WithLockoutErrorWhenAuthAppCodeBecomesBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            // First check passes (not blocked), second check after increment returns blocked
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+        }
+
+        @Test
+        void shouldReturn400WithLockoutErrorWhenSmsCodeBecomesBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            // First check passes (not blocked), second check after increment returns blocked
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.SMS,
+                                    CODE,
+                                    JourneyType.SIGN_IN,
+                                    DEFAULT_SMS_METHOD.getDestination()));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+        }
+
+        @Test
+        void shouldReturn400WithReauthLockedOutWhenAuthAppCodeBecomesReauthBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            ForbiddenReason
+                                                    .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                            MAX_RETRIES,
+                                            Instant.now(),
+                                            false,
+                                            detailedCounts,
+                                            List.of(ENTER_MFA_CODE))));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            verify(userActionsManager).incorrectAuthAppOtpReceived(any(), any());
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
+        }
+
+        @Test
+        void shouldReturn500WhenIncorrectSmsOtpReceivedFails() throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS,
+                            CODE,
+                            JourneyType.SIGN_IN,
+                            DEFAULT_SMS_METHOD.getDestination());
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(500));
+        }
+
+        @Test
+        void shouldReturn500WhenIncorrectAuthAppOtpReceivedFails() throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(500));
         }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -1495,6 +1495,50 @@ class VerifyMfaCodeHandlerTest {
         }
 
         @Test
+        void shouldReturn400WithReauthLockedOutWhenAuthAppCodeBecomesReauthBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            ForbiddenReason
+                                                    .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                            MAX_RETRIES,
+                                            Instant.now(),
+                                            false,
+                                            detailedCounts,
+                                            List.of(ENTER_MFA_CODE))));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            verify(userActionsManager).incorrectAuthAppOtpReceived(any(), any());
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
+        }
+
+        @Test
         void shouldReturn500WhenIncorrectSmsOtpReceivedFails() throws Json.JsonException {
             when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                     .thenReturn(Optional.of(phoneNumberCodeProcessor));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -13,11 +14,13 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetType;
+import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
@@ -25,6 +28,7 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -33,11 +37,13 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
+import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -55,10 +61,13 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -69,9 +78,11 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -89,11 +100,14 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_METHOD_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_RESET_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_COMPLETED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_INITIATED;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
@@ -101,6 +115,7 @@ import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
@@ -163,6 +178,8 @@ class VerifyMfaCodeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
+    private final AuthenticationAttemptsService authenticationAttemptsService =
+            mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
@@ -195,7 +212,11 @@ class VerifyMfaCodeHandlerTest {
 
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
         when(configurationService.getEnvironment()).thenReturn("test");
+        when(configurationService.getLockoutDuration()).thenReturn(900L);
+        when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
+        when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
+        when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
@@ -218,6 +239,7 @@ class VerifyMfaCodeHandlerTest {
                         auditService,
                         mfaCodeProcessorFactory,
                         cloudwatchMetricsService,
+                        authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
@@ -257,6 +279,9 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -331,6 +356,9 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -373,6 +401,9 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -414,6 +445,9 @@ class VerifyMfaCodeHandlerTest {
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -473,6 +507,9 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -538,6 +575,9 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(204));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
                     pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
@@ -871,6 +911,124 @@ class VerifyMfaCodeHandlerTest {
             verifyNoInteractions(cloudwatchMetricsService);
         }
 
+        private static Stream<Arguments> blockedCodeForAuthAppOTPEnteredTooManyTimes() {
+            return Stream.of(
+                    Arguments.of(
+                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
+                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
+                    Arguments.of(JourneyType.SIGN_IN, CodeRequestType.MFA_SIGN_IN),
+                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
+                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
+        }
+
+        @ParameterizedTest
+        @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
+        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
+                JourneyType journeyType, CodeRequestType codeRequestType)
+                throws Json.JsonException {
+            withReauthTurnedOn();
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            when(mfaMethodsService.getMfaMethods(any()))
+                    .thenReturn(
+                            Result.success(
+                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
+                                            ? List.of()
+                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
+            var authAppSecret =
+                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
+                                    .contains(journeyType)
+                            ? null
+                            : AUTH_APP_SECRET;
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            if (journeyType.equals(REAUTHENTICATION)) {
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(
+                                eq(EMAIL),
+                                eq(CODE_BLOCKED_KEY_PREFIX + codeRequestType),
+                                anyLong());
+            } else {
+                long expectedCodeBlockedTime =
+                        (journeyType.equals(REGISTRATION) || journeyType.equals(ACCOUNT_RECOVERY))
+                                ? 300L
+                                : 900L;
+                verify(codeStorageService)
+                        .saveBlockedForEmail(
+                                EMAIL,
+                                CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                                expectedCodeBlockedTime);
+                verifyNoInteractions(authenticationAttemptsService);
+            }
+            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+            verifyNoInteractions(cloudwatchMetricsService);
+            assertAuditEventSubmittedWithMetadata(
+                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
+                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
+                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
+                    pair("journey-type", journeyType),
+                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
+                    pair("mfa-method", "default"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(JourneyType.class)
+        void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists(
+                JourneyType journeyType) throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            when(codeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
+                    .thenReturn(true);
+            when(mfaMethodsService.getMfaMethods(any()))
+                    .thenReturn(
+                            Result.success(
+                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
+                                            ? List.of()
+                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
+            var authAppSecret =
+                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
+                                    .contains(journeyType)
+                            ? null
+                            : AUTH_APP_SECRET;
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
+
+            if (!CodeRequestType.isValidCodeRequestType(
+                    CodeRequestType.SupportedCodeType.getFromMfaMethodType(
+                            codeRequest.getMfaMethodType()),
+                    codeRequest.getJourneyType())) {
+                return;
+            }
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verifyNoInteractions(cloudwatchMetricsService);
+            verifyNoInteractions(authenticationAttemptsService);
+            assertAuditEventSubmittedWithMetadata(
+                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
+                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
+                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
+                    pair("journey-type", journeyType),
+                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
+                    pair("mfa-method", "default"));
+        }
+
         @ParameterizedTest
         @EnumSource(JourneyType.class)
         void shouldReturn400WhenUserEnteredInvalidAuthAppOtpCode(JourneyType journeyType)
@@ -884,8 +1042,10 @@ class VerifyMfaCodeHandlerTest {
                             : AUTH_APP_SECRET;
             when(authAppCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            // TODO: Change back to 3 once processor lockout logic is removed (divide-by-2
+            // workaround removed)
             when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(3)));
+                    .thenReturn(Result.success(new Decision.Permitted(6)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -906,7 +1066,11 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
+            verifyNoInteractions(authenticationAttemptsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
                     ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
@@ -934,6 +1098,124 @@ class VerifyMfaCodeHandlerTest {
             assertTrue(actual.containsAll(expected));
         }
 
+        private static Stream<Arguments> blockedCodeForInvalidPhoneNumberTooManyTimes() {
+            return Stream.of(
+                    Arguments.of(
+                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
+                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
+                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
+                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
+        }
+
+        @ParameterizedTest
+        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
+        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
+                JourneyType journeyType, CodeRequestType codeRequestType)
+                throws Json.JsonException {
+            withReauthTurnedOn();
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            when(mfaMethodsService.getMfaMethods(any()))
+                    .thenReturn(
+                            Result.success(
+                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
+                                            ? List.of()
+                                            : List.of(DEFAULT_SMS_METHOD)));
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            long blockTime = 900L;
+            if (List.of(CodeRequestType.MFA_REGISTRATION, CodeRequestType.MFA_ACCOUNT_RECOVERY)
+                    .contains(codeRequestType)) {
+                blockTime = 300L;
+            }
+            if (journeyType != REAUTHENTICATION) {
+                verify(codeStorageService)
+                        .saveBlockedForEmail(
+                                EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, blockTime);
+            }
+            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+            verifyNoInteractions(cloudwatchMetricsService);
+            assertAuditEventSubmittedWithMetadata(
+                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
+                    pair("mfa-type", MFAMethodType.SMS.getValue()),
+                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
+                    pair("journey-type", journeyType),
+                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
+                    pair("mfa-method", "default"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
+        void shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExists(
+                JourneyType journeyType, CodeRequestType codeRequestType)
+                throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            var codeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
+            when(mfaMethodsService.getMfaMethods(any()))
+                    .thenReturn(
+                            Result.success(
+                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
+                                            ? List.of()
+                                            : List.of(DEFAULT_SMS_METHOD)));
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+            verifyNoInteractions(cloudwatchMetricsService);
+            assertAuditEventSubmittedWithMetadata(
+                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
+                    pair("mfa-type", MFAMethodType.SMS.getValue()),
+                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
+                    pair("journey-type", journeyType),
+                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
+                    pair("mfa-method", "default"));
+        }
+
+        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
+        @Test
+        void
+                shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExistsWithDeprecatedPrefix()
+                        throws Json.JsonException {
+            JourneyType journeyType = JourneyType.PASSWORD_RESET_MFA;
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            var codeBlockedPrefix =
+                    CODE_BLOCKED_KEY_PREFIX
+                            + CodeRequestType.getDeprecatedCodeRequestTypeString(
+                                    MFAMethodType.SMS, journeyType);
+            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+        }
+
         private static Stream<Arguments> invalidOtpSmsJourneyTypesWithMfaNotificationType() {
             return Stream.of(
                     Arguments.of(JourneyType.SIGN_IN, MFA_SMS.name()),
@@ -952,8 +1234,10 @@ class VerifyMfaCodeHandlerTest {
                     .thenReturn(Optional.of(phoneNumberCodeProcessor));
             when(phoneNumberCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            // TODO: Change back to 3 once processor lockout logic is removed (divide-by-2
+            // workaround removed)
             when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(3)));
+                    .thenReturn(Result.success(new Decision.Permitted(6)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -979,6 +1263,9 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
@@ -1037,8 +1324,182 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_SECRET));
+            verify(codeStorageService, never())
+                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(auditService);
             verifyNoInteractions(cloudwatchMetricsService);
+        }
+    }
+
+    @Test
+    void shouldIncrementMFAAuthenticationAttemptsCountIfIncorrectCodeEntered()
+            throws Json.JsonException {
+        long ttl = 3600L;
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        withReauthTurnedOn();
+        when(authAppCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+        when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(ttl);
+        MockedStatic<NowHelper> mockedNowHelperClass = mockStatic(NowHelper.class);
+        mockedNowHelperClass
+                .when(() -> NowHelper.nowPlus(ttl, ChronoUnit.SECONDS))
+                .thenReturn(Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
+        makeCallWithCode(codeRequest);
+
+        verify(authenticationAttemptsService, times(1))
+                .createOrIncrementCount(
+                        TEST_SUBJECT_ID, 1704067200L, REAUTHENTICATION, ENTER_MFA_CODE);
+
+        mockedNowHelperClass.close();
+    }
+
+    @Test
+    void
+            shouldDeleteAuthAppAuthenticationAttemptsCountAndStoreCountsInSessionIfCorrectCodeEnteredForReauthJourney()
+                    throws Json.JsonException {
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        withReauthTurnedOn();
+        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+
+        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
+        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
+                .thenReturn(existingCounts);
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, CODE, JourneyType.REAUTHENTICATION, null);
+        makeCallWithCode(codeRequest);
+
+        List.of(TEST_SUBJECT_ID, expectedRpPairwiseSubjectId)
+                .forEach(
+                        identifier ->
+                                verify(
+                                                authenticationAttemptsService,
+                                                times(CountType.values().length))
+                                        .deleteCount(
+                                                eq(identifier),
+                                                eq(JourneyType.REAUTHENTICATION),
+                                                any()));
+
+        verify(authSessionService, atLeastOnce())
+                .updateSession(
+                        argThat(
+                                s ->
+                                        s.getPreservedReauthCountsForAuditMap()
+                                                .equals(existingCounts)));
+    }
+
+    @Test
+    void
+            shouldDeleteAuthAppAuthenticationAttemptsCountAndNotStoreCountsInSessionIfCorrectCodeEnteredForSigninJourney()
+                    throws Json.JsonException {
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        withReauthTurnedOn();
+        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+
+        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
+        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
+                .thenReturn(existingCounts);
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+        makeCallWithCode(codeRequest);
+
+        verify(authenticationAttemptsService, times(1))
+                .deleteCount(TEST_SUBJECT_ID, JourneyType.REAUTHENTICATION, ENTER_MFA_CODE);
+
+        verify(authSessionService, never())
+                .updateSession(
+                        argThat(
+                                s ->
+                                        Objects.equals(
+                                                s.getPreservedReauthCountsForAuditMap(),
+                                                existingCounts)));
+    }
+
+    private static Stream<Arguments> reauthCountTypesAndMetadata() {
+        return Stream.of(
+                Arguments.arguments(
+                        ENTER_EMAIL,
+                        MAX_RETRIES,
+                        0,
+                        0,
+                        ReauthFailureReasons.INCORRECT_EMAIL.getValue()),
+                Arguments.arguments(
+                        ENTER_PASSWORD,
+                        0,
+                        MAX_RETRIES,
+                        0,
+                        ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
+                Arguments.arguments(
+                        ENTER_MFA_CODE,
+                        0,
+                        0,
+                        MAX_RETRIES,
+                        ReauthFailureReasons.INCORRECT_OTP.getValue()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("reauthCountTypesAndMetadata")
+    void shouldReturnErrorIfUserHasTooManyReauthAttemptCountsOfAnyType(
+            CountType countType,
+            int expectedEmailAttemptCount,
+            int expectedPasswordAttemptCount,
+            int expectedOtpAttemptCount,
+            String expectedFailureReason)
+            throws Json.JsonException {
+        try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
+                Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
+            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
+            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                            any(), any(), eq(REAUTHENTICATION)))
+                    .thenReturn(Map.of(countType, MAX_RETRIES));
+            when(configurationService.getInternalSectorUri())
+                    .thenReturn("https://test.account.gov.uk");
+            Subject subject = new Subject(TEST_SUBJECT_ID);
+            mockedClientSubjectHelperClass
+                    .when(
+                            () ->
+                                    ClientSubjectHelper.getSubject(
+                                            eq(userProfile),
+                                            any(AuthSessionItem.class),
+                                            any(AuthenticationService.class)))
+                    .thenReturn(subject);
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
+            var result = makeCallWithCode(codeRequest);
+
+            verify(auditService, times(1))
+                    .submitAuditEvent(
+                            FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                            AUDIT_CONTEXT,
+                            pair("rpPairwiseId", subject.getValue()),
+                            pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
+                            pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
+                            pair("incorrect_otp_code_attempt_count", expectedOtpAttemptCount),
+                            pair("failure-reason", expectedFailureReason));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                            Map.of(
+                                    ENVIRONMENT.getValue(),
+                                    configurationService.getEnvironment(),
+                                    FAILURE_REASON.getValue(),
+                                    expectedFailureReason));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
         }
     }
 
@@ -1052,6 +1513,11 @@ class VerifyMfaCodeHandlerTest {
     private void assertAuditEventSubmittedWithMetadata(
             AuditableEvent event, AuditService.MetadataPair... pairs) {
         verify(auditService).submitAuditEvent(event, AUDIT_CONTEXT, pairs);
+    }
+
+    private void withReauthTurnedOn() {
+        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
+        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
     }
 
     @Test
@@ -1128,6 +1594,9 @@ class VerifyMfaCodeHandlerTest {
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(phoneNumberCodeProcessor)
                 .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
         boolean isAccountRecoveryJourney = journeyType.equals(ACCOUNT_RECOVERY);
 
@@ -1421,121 +1890,6 @@ class VerifyMfaCodeHandlerTest {
             verify(userActionsManager)
                     .incorrectAuthAppOtpReceived(
                             eq(JourneyType.SIGN_IN), argThat(this::hasExpectedPermissionContext));
-        }
-
-        @Test
-        void shouldReturn400WithLockoutErrorWhenAuthAppCodeBecomesBlockedByThisRequest()
-                throws Json.JsonException {
-            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-            when(mfaMethodsService.getMfaMethods(EMAIL))
-                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
-                    .thenReturn(Result.success(null));
-            // First check passes (not blocked), second check after increment returns blocked
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(5)))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.TemporarilyLockedOut(
-                                            null, MAX_RETRIES, Instant.now(), false)));
-
-            var result =
-                    makeCallWithCode(
-                            new VerifyMfaCodeRequest(
-                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
-                            any(AuditContext.class),
-                            any(AuditService.MetadataPair[].class));
-        }
-
-        @Test
-        void shouldReturn400WithLockoutErrorWhenSmsCodeBecomesBlockedByThisRequest()
-                throws Json.JsonException {
-            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-            when(mfaMethodsService.getMfaMethods(EMAIL))
-                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
-                    .thenReturn(Result.success(null));
-            // First check passes (not blocked), second check after increment returns blocked
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(5)))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.TemporarilyLockedOut(
-                                            null, MAX_RETRIES, Instant.now(), false)));
-
-            var result =
-                    makeCallWithCode(
-                            new VerifyMfaCodeRequest(
-                                    MFAMethodType.SMS,
-                                    CODE,
-                                    JourneyType.SIGN_IN,
-                                    DEFAULT_SMS_METHOD.getDestination()));
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
-                            any(AuditContext.class),
-                            any(AuditService.MetadataPair[].class));
-        }
-
-        @Test
-        void shouldReturn400WithReauthLockedOutWhenAuthAppCodeBecomesReauthBlockedByThisRequest()
-                throws Json.JsonException {
-            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-            when(mfaMethodsService.getMfaMethods(EMAIL))
-                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
-                    .thenReturn(Result.success(null));
-            var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(5)))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.ReauthLockedOut(
-                                            ForbiddenReason
-                                                    .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
-                                            MAX_RETRIES,
-                                            Instant.now(),
-                                            false,
-                                            detailedCounts,
-                                            List.of(ENTER_MFA_CODE))));
-
-            var result =
-                    makeCallWithCode(
-                            new VerifyMfaCodeRequest(
-                                    MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
-            verify(userActionsManager).incorrectAuthAppOtpReceived(any(), any());
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
-                            any(AuditContext.class),
-                            any(AuditService.MetadataPair[].class));
-            verify(cloudwatchMetricsService)
-                    .incrementCounter(
-                            eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -14,13 +13,11 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetType;
-import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
@@ -28,7 +25,6 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -37,13 +33,11 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -61,13 +55,10 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -78,11 +69,9 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -100,14 +89,11 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_METHOD_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_RESET_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_COMPLETED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_INITIATED;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
@@ -115,7 +101,6 @@ import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
@@ -178,8 +163,6 @@ class VerifyMfaCodeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final AuthenticationAttemptsService authenticationAttemptsService =
-            mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
@@ -212,11 +195,7 @@ class VerifyMfaCodeHandlerTest {
 
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
         when(configurationService.getEnvironment()).thenReturn("test");
-        when(configurationService.getLockoutDuration()).thenReturn(900L);
-        when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
@@ -239,7 +218,6 @@ class VerifyMfaCodeHandlerTest {
                         auditService,
                         mfaCodeProcessorFactory,
                         cloudwatchMetricsService,
-                        authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
@@ -279,9 +257,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -356,9 +331,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -401,9 +373,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -445,9 +414,6 @@ class VerifyMfaCodeHandlerTest {
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -507,9 +473,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -575,9 +538,6 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(204));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
                     pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
@@ -911,124 +871,6 @@ class VerifyMfaCodeHandlerTest {
             verifyNoInteractions(cloudwatchMetricsService);
         }
 
-        private static Stream<Arguments> blockedCodeForAuthAppOTPEnteredTooManyTimes() {
-            return Stream.of(
-                    Arguments.of(
-                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
-                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
-                    Arguments.of(JourneyType.SIGN_IN, CodeRequestType.MFA_SIGN_IN),
-                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
-                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
-        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            withReauthTurnedOn();
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
-            var authAppSecret =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            if (journeyType.equals(REAUTHENTICATION)) {
-                verify(codeStorageService, never())
-                        .saveBlockedForEmail(
-                                eq(EMAIL),
-                                eq(CODE_BLOCKED_KEY_PREFIX + codeRequestType),
-                                anyLong());
-            } else {
-                long expectedCodeBlockedTime =
-                        (journeyType.equals(REGISTRATION) || journeyType.equals(ACCOUNT_RECOVERY))
-                                ? 300L
-                                : 900L;
-                verify(codeStorageService)
-                        .saveBlockedForEmail(
-                                EMAIL,
-                                CODE_BLOCKED_KEY_PREFIX + codeRequestType,
-                                expectedCodeBlockedTime);
-                verifyNoInteractions(authenticationAttemptsService);
-            }
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @EnumSource(JourneyType.class)
-        void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists(
-                JourneyType journeyType) throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            when(codeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                    .thenReturn(true);
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
-            var authAppSecret =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
-
-            if (!CodeRequestType.isValidCodeRequestType(
-                    CodeRequestType.SupportedCodeType.getFromMfaMethodType(
-                            codeRequest.getMfaMethodType()),
-                    codeRequest.getJourneyType())) {
-                return;
-            }
-
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
         @ParameterizedTest
         @EnumSource(JourneyType.class)
         void shouldReturn400WhenUserEnteredInvalidAuthAppOtpCode(JourneyType journeyType)
@@ -1064,11 +906,7 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
                     ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
@@ -1094,124 +932,6 @@ class VerifyMfaCodeHandlerTest {
 
             assertTrue(expected.containsAll(actual));
             assertTrue(actual.containsAll(expected));
-        }
-
-        private static Stream<Arguments> blockedCodeForInvalidPhoneNumberTooManyTimes() {
-            return Stream.of(
-                    Arguments.of(
-                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
-                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
-                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
-                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
-        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            withReauthTurnedOn();
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_SMS_METHOD)));
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            long blockTime = 900L;
-            if (List.of(CodeRequestType.MFA_REGISTRATION, CodeRequestType.MFA_ACCOUNT_RECOVERY)
-                    .contains(codeRequestType)) {
-                blockTime = 300L;
-            }
-            if (journeyType != REAUTHENTICATION) {
-                verify(codeStorageService)
-                        .saveBlockedForEmail(
-                                EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, blockTime);
-            }
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
-        void shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExists(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            var codeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_SMS_METHOD)));
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        @Test
-        void
-                shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExistsWithDeprecatedPrefix()
-                        throws Json.JsonException {
-            JourneyType journeyType = JourneyType.PASSWORD_RESET_MFA;
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            var codeBlockedPrefix =
-                    CODE_BLOCKED_KEY_PREFIX
-                            + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                    MFAMethodType.SMS, journeyType);
-            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         }
 
         private static Stream<Arguments> invalidOtpSmsJourneyTypesWithMfaNotificationType() {
@@ -1259,9 +979,6 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
@@ -1320,182 +1037,8 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_SECRET));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(auditService);
             verifyNoInteractions(cloudwatchMetricsService);
-        }
-    }
-
-    @Test
-    void shouldIncrementMFAAuthenticationAttemptsCountIfIncorrectCodeEntered()
-            throws Json.JsonException {
-        long ttl = 3600L;
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(ttl);
-        MockedStatic<NowHelper> mockedNowHelperClass = mockStatic(NowHelper.class);
-        mockedNowHelperClass
-                .when(() -> NowHelper.nowPlus(ttl, ChronoUnit.SECONDS))
-                .thenReturn(Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-        makeCallWithCode(codeRequest);
-
-        verify(authenticationAttemptsService, times(1))
-                .createOrIncrementCount(
-                        TEST_SUBJECT_ID, 1704067200L, REAUTHENTICATION, ENTER_MFA_CODE);
-
-        mockedNowHelperClass.close();
-    }
-
-    @Test
-    void
-            shouldDeleteAuthAppAuthenticationAttemptsCountAndStoreCountsInSessionIfCorrectCodeEnteredForReauthJourney()
-                    throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, CODE, JourneyType.REAUTHENTICATION, null);
-        makeCallWithCode(codeRequest);
-
-        List.of(TEST_SUBJECT_ID, expectedRpPairwiseSubjectId)
-                .forEach(
-                        identifier ->
-                                verify(
-                                                authenticationAttemptsService,
-                                                times(CountType.values().length))
-                                        .deleteCount(
-                                                eq(identifier),
-                                                eq(JourneyType.REAUTHENTICATION),
-                                                any()));
-
-        verify(authSessionService, atLeastOnce())
-                .updateSession(
-                        argThat(
-                                s ->
-                                        s.getPreservedReauthCountsForAuditMap()
-                                                .equals(existingCounts)));
-    }
-
-    @Test
-    void
-            shouldDeleteAuthAppAuthenticationAttemptsCountAndNotStoreCountsInSessionIfCorrectCodeEnteredForSigninJourney()
-                    throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
-        makeCallWithCode(codeRequest);
-
-        verify(authenticationAttemptsService, times(1))
-                .deleteCount(TEST_SUBJECT_ID, JourneyType.REAUTHENTICATION, ENTER_MFA_CODE);
-
-        verify(authSessionService, never())
-                .updateSession(
-                        argThat(
-                                s ->
-                                        Objects.equals(
-                                                s.getPreservedReauthCountsForAuditMap(),
-                                                existingCounts)));
-    }
-
-    private static Stream<Arguments> reauthCountTypesAndMetadata() {
-        return Stream.of(
-                Arguments.arguments(
-                        ENTER_EMAIL,
-                        MAX_RETRIES,
-                        0,
-                        0,
-                        ReauthFailureReasons.INCORRECT_EMAIL.getValue()),
-                Arguments.arguments(
-                        ENTER_PASSWORD,
-                        0,
-                        MAX_RETRIES,
-                        0,
-                        ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
-                Arguments.arguments(
-                        ENTER_MFA_CODE,
-                        0,
-                        0,
-                        MAX_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()));
-    }
-
-    @ParameterizedTest
-    @MethodSource("reauthCountTypesAndMetadata")
-    void shouldReturnErrorIfUserHasTooManyReauthAttemptCountsOfAnyType(
-            CountType countType,
-            int expectedEmailAttemptCount,
-            int expectedPasswordAttemptCount,
-            int expectedOtpAttemptCount,
-            String expectedFailureReason)
-            throws Json.JsonException {
-        try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
-                Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                            any(), any(), eq(REAUTHENTICATION)))
-                    .thenReturn(Map.of(countType, MAX_RETRIES));
-            when(configurationService.getInternalSectorUri())
-                    .thenReturn("https://test.account.gov.uk");
-            Subject subject = new Subject(TEST_SUBJECT_ID);
-            mockedClientSubjectHelperClass
-                    .when(
-                            () ->
-                                    ClientSubjectHelper.getSubject(
-                                            eq(userProfile),
-                                            any(AuthSessionItem.class),
-                                            any(AuthenticationService.class)))
-                    .thenReturn(subject);
-
-            var codeRequest =
-                    new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-            var result = makeCallWithCode(codeRequest);
-
-            verify(auditService, times(1))
-                    .submitAuditEvent(
-                            FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                            AUDIT_CONTEXT,
-                            pair("rpPairwiseId", subject.getValue()),
-                            pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
-                            pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
-                            pair("incorrect_otp_code_attempt_count", expectedOtpAttemptCount),
-                            pair("failure-reason", expectedFailureReason));
-            verify(cloudwatchMetricsService)
-                    .incrementCounter(
-                            CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                            Map.of(
-                                    ENVIRONMENT.getValue(),
-                                    configurationService.getEnvironment(),
-                                    FAILURE_REASON.getValue(),
-                                    expectedFailureReason));
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
         }
     }
 
@@ -1509,11 +1052,6 @@ class VerifyMfaCodeHandlerTest {
     private void assertAuditEventSubmittedWithMetadata(
             AuditableEvent event, AuditService.MetadataPair... pairs) {
         verify(auditService).submitAuditEvent(event, AUDIT_CONTEXT, pairs);
-    }
-
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
     }
 
     @Test
@@ -1590,9 +1128,6 @@ class VerifyMfaCodeHandlerTest {
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(phoneNumberCodeProcessor)
                 .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-        verify(codeStorageService, never())
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
         boolean isAccountRecoveryJourney = journeyType.equals(ACCOUNT_RECOVERY);
 
@@ -1886,6 +1421,77 @@ class VerifyMfaCodeHandlerTest {
             verify(userActionsManager)
                     .incorrectAuthAppOtpReceived(
                             eq(JourneyType.SIGN_IN), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldReturn400WithLockoutErrorWhenAuthAppCodeBecomesBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            // First check passes (not blocked), second check after increment returns blocked
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+        }
+
+        @Test
+        void shouldReturn400WithLockoutErrorWhenSmsCodeBecomesBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            // First check passes (not blocked), second check after increment returns blocked
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.SMS,
+                                    CODE,
+                                    JourneyType.SIGN_IN,
+                                    DEFAULT_SMS_METHOD.getDestination()));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -52,7 +52,11 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
+import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
@@ -178,6 +182,8 @@ class VerifyMfaCodeHandlerTest {
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
     private final TestUserHelper testUserHelper = mock(TestUserHelper.class);
 
     @RegisterExtension
@@ -217,6 +223,8 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Result.success(null));
         when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -230,6 +238,7 @@ class VerifyMfaCodeHandlerTest {
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
+                        permissionDecisionManager,
                         testUserHelper);
     }
 
@@ -1688,5 +1697,103 @@ class VerifyMfaCodeHandlerTest {
 
         // Assert
         assertThat(result, hasStatus(500));
+    }
+
+    @Nested
+    class LockoutChecks {
+
+        @Test
+        void shouldReturn400WithAuthAppErrorWhenTemporarilyLockedOut() throws Json.JsonException {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        @Test
+        void shouldReturn400WithSmsErrorWhenTemporarilyLockedOut() throws Json.JsonException {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.SMS, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        @Test
+        void shouldReturn400WhenReauthLockedOut() throws Json.JsonException {
+            var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            ForbiddenReason
+                                                    .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                            MAX_RETRIES,
+                                            Instant.now(),
+                                            false,
+                                            detailedCounts,
+                                            List.of(ENTER_MFA_CODE))));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        @Test
+        void shouldReturn500WhenPermissionDecisionManagerFails() throws Json.JsonException {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(500));
+            assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -53,6 +53,7 @@ import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -212,6 +213,8 @@ class VerifyMfaCodeHandlerTest {
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -1593,6 +1596,8 @@ class VerifyMfaCodeHandlerTest {
         when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var codeRequest =
@@ -1609,6 +1614,33 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verify(userActionsManager)
                 .correctSmsOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectSmsOtpReceivedReturnsInvalidUserContext()
+            throws Json.JsonException {
+        // Arrange
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(phoneNumberCodeProcessor));
+        when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+        authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        CODE,
+                        JourneyType.SIGN_IN,
+                        DEFAULT_SMS_METHOD.getDestination());
+
+        // Act
+        var result = makeCallWithCode(codeRequest);
+
+        // Assert
+        assertThat(result, hasStatus(500));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -56,7 +55,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
@@ -84,7 +82,6 @@ class AuthAppCodeProcessorTest {
     private static final String IP_ADDRESS = "123.123.123.123";
     private static final String INTERNAL_SUB_ID = "urn:fdc:gov.uk:2022:" + IdGenerator.generate();
     private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
-    private final int MAX_RETRIES = 5;
 
     private final AuditContext auditContext =
             new AuditContext(
@@ -124,15 +121,10 @@ class AuthAppCodeProcessorTest {
 
     private static Stream<Arguments> validatorParams() {
         return Stream.of(
-                Arguments.of(JourneyType.SIGN_IN, null, CodeRequestType.MFA_SIGN_IN),
-                Arguments.of(
-                        JourneyType.PASSWORD_RESET_MFA, null, CodeRequestType.MFA_PW_RESET_MFA),
-                Arguments.of(
-                        JourneyType.REGISTRATION,
-                        AUTH_APP_SECRET,
-                        CodeRequestType.MFA_REGISTRATION),
-                Arguments.of(
-                        JourneyType.REAUTHENTICATION, null, CodeRequestType.MFA_REAUTHENTICATION));
+                Arguments.of(JourneyType.SIGN_IN, null),
+                Arguments.of(JourneyType.PASSWORD_RESET_MFA, null),
+                Arguments.of(JourneyType.REGISTRATION, AUTH_APP_SECRET),
+                Arguments.of(JourneyType.REAUTHENTICATION, null));
     }
 
     @ParameterizedTest
@@ -150,19 +142,14 @@ class AuthAppCodeProcessorTest {
 
     private static Stream<Arguments> validatorParamsWithoutRegistrationJourney() {
         return Stream.of(
-                Arguments.of(JourneyType.SIGN_IN, null, CodeRequestType.MFA_SIGN_IN),
-                Arguments.of(
-                        JourneyType.PASSWORD_RESET_MFA, null, CodeRequestType.MFA_PW_RESET_MFA),
-                Arguments.of(
-                        JourneyType.REAUTHENTICATION, null, CodeRequestType.MFA_REAUTHENTICATION));
+                Arguments.of(JourneyType.SIGN_IN),
+                Arguments.of(JourneyType.PASSWORD_RESET_MFA),
+                Arguments.of(JourneyType.REAUTHENTICATION));
     }
 
     @ParameterizedTest
     @MethodSource("validatorParamsWithoutRegistrationJourney")
     void returnsNoErrorOnValidAuthCodeForMigratedUser(JourneyType journeyType) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
         var userCredentials =
                 new UserCredentials()
                         .withMfaMethods(List.of(DEFAULT_AUTH_APP_METHOD, BACKUP_SMS_METHOD));
@@ -185,7 +172,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -197,9 +183,6 @@ class AuthAppCodeProcessorTest {
     @ParameterizedTest
     @MethodSource("validatorParamsWithoutRegistrationJourney")
     void returnsNoErrorOnValidAuthCodeToBackupMethodForMigratedUser(JourneyType journeyType) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
         var userCredentials =
                 new UserCredentials()
                         .withMfaMethods(List.of(BACKUP_AUTH_APP_METHOD, DEFAULT_SMS_METHOD));
@@ -222,7 +205,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -231,60 +213,7 @@ class AuthAppCodeProcessorTest {
         assertEquals(Optional.empty(), authAppCodeProcessor.validateCode());
     }
 
-    @ParameterizedTest
-    @MethodSource("validatorParams")
-    void returnsCorrectErrorWhenCodeBlockedForEmailAddress(
-            JourneyType journeyType, String authAppSecret, CodeRequestType codeRequestType) {
-        setUpBlockedUser(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, "000000", journeyType, authAppSecret),
-                codeRequestType);
-
-        assertEquals(
-                Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED),
-                authAppCodeProcessor.validateCode());
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @Test
-    void returnsCorrectErrorWhenCodeBlockedForEmailAddressWithDeprecatedPrefix() {
-        JourneyType journeyType = JourneyType.SIGN_IN;
-        when(mockCodeStorageService.isBlockedForEmail(
-                        EMAIL,
-                        CODE_BLOCKED_KEY_PREFIX
-                                + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                        MFAMethodType.AUTH_APP, journeyType)))
-                .thenReturn(true);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        MAX_RETRIES,
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, "000000", journeyType, "credential"),
-                        mockAuditService,
-                        mockAccountModifiersService,
-                        mockMfaMethodsService);
-
-        assertEquals(
-                Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED),
-                authAppCodeProcessor.validateCode());
-    }
-
-    @ParameterizedTest
-    @MethodSource("validatorParams")
-    void returnsCorrectErrorWhenRetryLimitExceeded(JourneyType journeyType, String authAppSecret) {
-        setUpRetryLimitExceededUser(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, "000000", journeyType, authAppSecret));
-
-        assertEquals(
-                Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED),
-                authAppCodeProcessor.validateCode());
-    }
+    // Lockout checks are now done by PermissionDecisionManager in the handler, not the processor
 
     @ParameterizedTest
     @MethodSource("validatorParams")
@@ -531,44 +460,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
-                        codeRequest,
-                        mockAuditService,
-                        mockAccountModifiersService,
-                        mockMfaMethodsService);
-    }
-
-    private void setUpBlockedUser(CodeRequest codeRequest, CodeRequestType codeRequestType) {
-        when(mockCodeStorageService.isBlockedForEmail(
-                        EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(true);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        MAX_RETRIES,
-                        codeRequest,
-                        mockAuditService,
-                        mockAccountModifiersService,
-                        mockMfaMethodsService);
-    }
-
-    private void setUpRetryLimitExceededUser(CodeRequest codeRequest) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -576,8 +467,6 @@ class AuthAppCodeProcessorTest {
     }
 
     private void setUpNoAuthCodeForUser(CodeRequest codeRequest) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
         when(mockDynamoService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn(new UserCredentials().withMfaMethods(List.of()));
 
@@ -587,7 +476,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -595,9 +483,6 @@ class AuthAppCodeProcessorTest {
     }
 
     private void setUpValidAuthCode(CodeRequest codeRequest) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
         var mfaMethod =
                 new MFAMethod()
                         .withMfaMethodType(MFAMethodType.AUTH_APP.name())
@@ -612,7 +497,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -63,7 +63,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.UK_NOTIFY_MOBILE_TEST_NUMBER;
@@ -111,7 +110,6 @@ class PhoneNumberCodeProcessorTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getCodeMaxRetries()).thenReturn(3);
         when(userContext.getTxmaAuditEncoded()).thenReturn(TXMA_ENCODED_HEADER_VALUE);
 
         var userCredentials =
@@ -218,97 +216,6 @@ class PhoneNumberCodeProcessorTest {
                 .deleteOtpCode(
                         CommonTestVariables.EMAIL.concat(CommonTestVariables.UK_MOBILE_NUMBER),
                         notificationType);
-    }
-
-    @Test
-    void shouldReturnErrorWhenInvalidRegistrationPhoneNumberCodeUsedTooManyTimes() {
-        setUpPhoneNumberCodeRetryLimitExceeded(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        REGISTRATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER));
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)));
-    }
-
-    @Test
-    void shouldReturnErrorWhenInvalidMfaPhoneNumberCodeUsedTooManyTimes() {
-        setUpPhoneNumberCodeRetryLimitExceeded(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        JourneyType.PASSWORD_RESET_MFA,
-                        CommonTestVariables.UK_MOBILE_NUMBER));
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED)));
-    }
-
-    @Test
-    void shouldReturnErrorWhenInvalidReauthenticateMfaPhoneNumberCodeUsedTooManyTimes() {
-        setUpPhoneNumberCodeRetryLimitExceeded(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        JourneyType.REAUTHENTICATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER));
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED)));
-    }
-
-    @ParameterizedTest
-    @MethodSource("codeRequestTypes")
-    void shouldReturnErrorWhenUserIsBlockedFromEnteringRegistrationPhoneNumberCodes(
-            CodeRequestType codeRequestType, JourneyType journeyType) {
-        setUpBlockedPhoneNumberCode(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)));
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @Test
-    void
-            shouldReturnErrorWhenUserIsBlockedFromEnteringRegistrationPhoneNumberCodesWithDeprecatedPrefix() {
-        var codeRequestType = CodeRequestType.MFA_PW_RESET_MFA;
-        var journeyType = JourneyType.PASSWORD_RESET_MFA;
-        var mfaMethodType = MFAMethodType.SMS;
-
-        setUpBlockedPhoneNumberCode(
-                new VerifyMfaCodeRequest(
-                        mfaMethodType,
-                        INVALID_CODE,
-                        journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
-
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(false);
-
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL,
-                        CODE_BLOCKED_KEY_PREFIX
-                                + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                        mfaMethodType, journeyType)))
-                .thenReturn(true);
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)));
     }
 
     @Test
@@ -606,60 +513,6 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
                         NotificationType.MFA_SMS))
                 .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(false);
-        phoneNumberCodeProcessor =
-                new PhoneNumberCodeProcessor(
-                        codeStorageService,
-                        userContext,
-                        configurationService,
-                        codeRequest,
-                        authenticationService,
-                        auditService,
-                        accountModifiersService,
-                        sqsClient,
-                        mfaMethodsService,
-                        testUserHelper);
-    }
-
-    public void setUpPhoneNumberCodeRetryLimitExceeded(CodeRequest codeRequest) {
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(CommonTestVariables.EMAIL))
-                .thenReturn(6);
-        when(userContext.getAuthSession()).thenReturn(authSession);
-        when(configurationService.isTestClientsEnabled()).thenReturn(false);
-        when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
-                        NotificationType.VERIFY_PHONE_NUMBER))
-                .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-        phoneNumberCodeProcessor =
-                new PhoneNumberCodeProcessor(
-                        codeStorageService,
-                        userContext,
-                        configurationService,
-                        codeRequest,
-                        authenticationService,
-                        auditService,
-                        accountModifiersService,
-                        sqsClient,
-                        mfaMethodsService,
-                        testUserHelper);
-    }
-
-    public void setUpBlockedPhoneNumberCode(
-            CodeRequest codeRequest, CodeRequestType codeRequestType) {
-        when(userContext.getAuthSession()).thenReturn(authSession);
-        when(configurationService.isTestClientsEnabled()).thenReturn(false);
-        when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
-                        NotificationType.VERIFY_PHONE_NUMBER))
-                .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(true);
         phoneNumberCodeProcessor =
                 new PhoneNumberCodeProcessor(
                         codeStorageService,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -150,6 +150,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             var response =
                     makeRequest(
@@ -197,6 +199,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
 
@@ -354,6 +358,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             var response =
                     makeRequest(
@@ -401,6 +407,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -8,11 +8,13 @@ import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
@@ -258,6 +260,28 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .withAttribute(USER_PHONE, UK_MOBILE_NUMBER)
                                 .withAttribute(EXTENSIONS_MFA_METHOD, "default")
                                 .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")));
+    }
+
+    @Test
+    void shouldClearIncorrectEmailOtpBlockWhenNewCodeRequestedForRegistration() {
+        var codeBlockedKeyPrefix =
+                CodeStorageService.CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_REGISTRATION;
+        redis.blockMfaCodesForEmail(EMAIL, codeBlockedKeyPrefix);
+
+        assertThat(redis.isBlockedMfaCodesForEmail(EMAIL, codeBlockedKeyPrefix), equalTo(true));
+
+        var response =
+                makeRequest(
+                        Optional.of(
+                                new SendNotificationRequest(
+                                        EMAIL,
+                                        NotificationType.VERIFY_EMAIL,
+                                        JourneyType.REGISTRATION)),
+                        constructFrontendHeaders(SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(204));
+        assertThat(redis.isBlockedMfaCodesForEmail(EMAIL, codeBlockedKeyPrefix), equalTo(false));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -17,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -24,6 +26,7 @@ import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegration
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
+import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 
 import java.util.List;
 import java.util.Map;
@@ -39,18 +42,33 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_MFA_RESET_REQUESTED;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REAUTH_FAILED;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertAuditEventExpectations;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_ACCOUNT_RECOVERY;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_LOGIN_FAILURE_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MAX_SMS_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_CODE_ENTERED;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_METHOD;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_RESET_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.FAILURE_REASON;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_EMAIL_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_OTP_CODE_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_PASSWORD_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.RP_PAIRWISE_ID;
 
 public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -103,7 +121,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @ParameterizedTest
@@ -129,7 +164,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @ParameterizedTest
@@ -153,7 +205,23 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.INVALID_EMAIL_CODE_ENTERED));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @ParameterizedTest
@@ -182,8 +250,32 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response2, hasStatus(400));
         assertThat(response2, hasJsonBody(ErrorResponse.INVALID_EMAIL_CODE_ENTERED));
 
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_INVALID_CODE_SENT));
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name()),
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @Test
@@ -210,7 +302,14 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(false));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, VERIFY_EMAIL.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, JourneyType.REGISTRATION.name())));
     }
 
     @Test
@@ -263,7 +362,17 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE,
+                                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.ACCOUNT_RECOVERY.name())));
     }
 
     @Test
@@ -289,7 +398,17 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE,
+                                        RESET_PASSWORD_WITH_CODE.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.PASSWORD_RESET.name())));
     }
 
     private static Stream<JourneyType> journeyTypes() {
@@ -324,7 +443,22 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, "0")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")
+                                .withAttribute(
+                                        EXTENSIONS_MAX_SMS_COUNT,
+                                        String.valueOf(
+                                                ConfigurationService.getInstance()
+                                                        .getCodeMaxRetries()))
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
     }
 
     @Test
@@ -348,6 +482,62 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(null));
+    }
+
+    @Test
+    void shouldEmitAuthReauthFailedWhenMfaSmsAttemptsExceededDuringReauthentication() {
+        setUpTestWithSignUp(sessionId);
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
+        userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
+
+        var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+        byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
+        String rpPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(), RP_SECTOR_HOST, salt);
+
+        var internalCommonSubjectId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(),
+                        INTERNAl_SECTOR_HOST,
+                        SaltHelper.generateNewSalt());
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
+
+        var maxRetries = ConfigurationService.getInstance().getCodeMaxRetries();
+        var ttl = NowHelper.now().toInstant().plusSeconds(600).getEpochSecond();
+        for (int i = 0; i < maxRetries; i++) {
+            authCodeExtension.createOrIncrementCount(
+                    userProfile.getSubjectID(),
+                    ttl,
+                    JourneyType.REAUTHENTICATION,
+                    CountType.ENTER_MFA_CODE);
+        }
+
+        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
+        var codeRequest = new VerifyCodeRequest(MFA_SMS, code, JourneyType.REAUTHENTICATION, null);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_REAUTH_FAILED)
+                                .withAttribute(INCORRECT_EMAIL_ATTEMPT_COUNT, "0")
+                                .withAttribute(INCORRECT_PASSWORD_ATTEMPT_COUNT, "0")
+                                .withAttribute(
+                                        INCORRECT_OTP_CODE_ATTEMPT_COUNT,
+                                        String.valueOf(maxRetries))
+                                .withAttribute(FAILURE_REASON, "incorrect_otp")
+                                .withAttribute(RP_PAIRWISE_ID, rpPairwiseId)));
     }
 
     @ParameterizedTest
@@ -376,7 +566,21 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(204));
 
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        journeyType != null
+                                                ? journeyType.name()
+                                                : JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(MFAMethodType.SMS));
@@ -448,8 +652,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        journeyType != null
+                                                ? journeyType.name()
+                                                : JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(MFAMethodType.SMS));
@@ -476,7 +696,19 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(204));
         var authSession = authSessionExtension.getSession(sessionId).orElseThrow();
         assertThat(authSession.getInternalCommonSubjectId(), notNullValue());
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.PASSWORD_RESET_MFA.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(MFAMethodType.SMS));
@@ -509,7 +741,18 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(true));
         if (journeyType != JourneyType.REAUTHENTICATION) {
-            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
+            assertAuditEventExpectations(
+                    txmaAuditQueue,
+                    List.of(
+                            new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                    .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                    .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                    .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                    .withAttribute(
+                                            EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                    .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 1)
+                                    .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                    .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")));
         }
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
@@ -554,8 +797,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_MFA_RESET_REQUESTED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_MFA_RESET_REQUESTED)
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.ACCOUNT_RECOVERY.name())
+                                .withAttribute(EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "7")
+                                .withAttribute(
+                                        EXTENSIONS_MFA_RESET_TYPE, "FORCED_INTERNATIONAL_NUMBERS"),
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     @Test
@@ -585,7 +844,17 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     private ConfigurationService forcedMfaResetEnabledConfigurationService() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -61,6 +61,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     public static final String CLIENT_NAME = "test-client-name";
     private static final Subject SUBJECT = new Subject();
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
+    private static final String RP_SECTOR_HOST = "test.com";
     private String sessionId;
 
     @RegisterExtension
@@ -357,6 +358,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithoutSignUp(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
@@ -429,6 +431,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithoutSignUp(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -279,7 +279,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     }
 
     @Test
-    void shouldReturnMaxReachedButNotSetBlockWhenVerifyEmailCodeAttemptsExceedMaxRetryCount() {
+    void shouldReturnMaxReachedAndSetBlockWhenVerifyEmailCodeAttemptsExceedMaxRetryCount() {
         setUpTestWithoutSignUp(sessionId);
         for (int i = 0; i < ConfigurationService.getInstance().getCodeMaxRetries(); i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
@@ -301,7 +301,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED));
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
-                equalTo(false));
+                equalTo(true));
         assertAuditEventExpectations(
                 txmaAuditQueue,
                 List.of(
@@ -463,6 +463,12 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @Test
     void shouldReturnMaxReachedAndSingalLogoutWhenReauthSmsCodeAttemptsExceedMaxRetryCount() {
+        var internalCommonSubjectId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithSignUp(sessionId);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         for (int i = 0; i < 5; i++) {
@@ -724,6 +730,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithSignUp(sessionId);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
-import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 import uk.gov.di.authentication.sharedtest.helper.AuthAppStub;
 
 import java.time.Duration;
@@ -37,7 +38,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,14 +50,27 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_MFA_RESET_REQUESTED;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REAUTH_FAILED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertAuditEventExpectations;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.ATTEMPT_NO_FAILED_AT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_ACCOUNT_RECOVERY;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_LOGIN_FAILURE_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_CODE_ENTERED;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_METHOD;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.FAILURE_REASON;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_EMAIL_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_OTP_CODE_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_PASSWORD_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.RP_PAIRWISE_ID;
 
 class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String EMAIL_ADDRESS = "test@test.com";
@@ -86,8 +99,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private String sessionId;
 
     @RegisterExtension
-    protected static final AuthenticationAttemptsStoreExtension authCodeExtension =
-            new AuthenticationAttemptsStoreExtension();
+    protected static final AuthenticationAttemptsStoreExtension
+            authenticationAttemptsStoreExtension = new AuthenticationAttemptsStoreExtension();
 
     @RegisterExtension
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
@@ -139,7 +152,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -171,7 +192,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
     }
 
@@ -229,8 +258,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -259,8 +296,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.getMfaMethod(EMAIL_ADDRESS).size(), equalTo(1));
@@ -301,8 +346,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
 
         var retrievedMfaMethods = userStore.getMfaMethod(EMAIL_ADDRESS);
@@ -346,10 +399,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertTrue(mfaMethod.isMethodVerified());
         assertInstanceOf(UUID.class, UUID.fromString(mfaMethod.getMfaIdentifier()));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
     }
 
     @Test
@@ -366,8 +426,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
 
@@ -448,8 +516,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
 
@@ -485,10 +561,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        List<AuditableEvent> expectedAuditableEvents =
-                List.of(AUTH_CODE_VERIFIED, AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED);
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, expectedAuditableEvents, true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -521,12 +603,22 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        List<AuditableEvent> expectedAuditableEvents =
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
+        var codeVerifiedExpectation =
+                new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                        .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                        .withAttribute(
+                                EXTENSIONS_ACCOUNT_RECOVERY, String.valueOf(isAccountRecovery))
+                        .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                        .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                        .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code);
+        List<AuditEventExpectation> expectedAuditableEvents =
                 nonRegistrationJourneyTypes.contains(journeyType)
-                        ? singletonList(AUTH_CODE_VERIFIED)
-                        : List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP);
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, expectedAuditableEvents, true);
+                        ? List.of(codeVerifiedExpectation)
+                        : List.of(
+                                codeVerifiedExpectation,
+                                new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP));
+        assertAuditEventExpectations(txmaAuditQueue, expectedAuditableEvents);
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(
@@ -555,9 +647,20 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
+        assertThat(response, hasStatus(400));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         if (isAccountVerified) {
@@ -583,9 +686,20 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, invalidCode)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         if (isAccountVerified) {
@@ -593,6 +707,32 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     userStore.getMfaMethod(EMAIL_ADDRESS).get(0).getCredentialValue(),
                     equalTo(AUTH_APP_SECRET_BASE_32));
         }
+    }
+
+    @Test
+    void shouldIncludeLoginFailureCountInAuthInvalidCodeSentForSignIn() {
+        setUpAuthAppRequest(JourneyType.SIGN_IN);
+        String invalidCode = AUTH_APP_STUB.getAuthAppOneTimeCode("O5ZG63THFVZWKY3SMV2A====");
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, invalidCode, JourneyType.SIGN_IN);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "SIGN_IN")
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 1)
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, invalidCode)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
     }
 
     @ParameterizedTest
@@ -613,7 +753,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, invalidCode)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(true));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -636,7 +784,14 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.AUTH_APP_METHOD_NOT_FOUND));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     @Test
@@ -676,7 +831,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.AUTH_APP_METHOD_NOT_FOUND));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         if (isAccountVerified) {
@@ -700,10 +863,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new VerifyMfaCodeRequest(
                         MFAMethodType.AUTH_APP, code, journeyType, profileInformation);
 
-        var codeRequestType =
-                CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        redis.blockMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix);
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+            var maxRetries = ConfigurationService.getInstance().getCodeMaxRetries();
+            createMfaAttempts(userProfile.getSubjectID(), maxRetries);
+        } else {
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
+            var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+            redis.blockMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix);
+        }
 
         var response =
                 makeRequest(
@@ -712,8 +881,49 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_MAX_RETRIES_REACHED));
+
+        ErrorResponse expectedError;
+        List<AuditEventExpectation> expectedAuditEvents;
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            expectedError = ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS;
+            var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+            byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
+            String rpPairwiseId =
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            userProfile.getSubjectID(), SECTOR_IDENTIFIER_HOST, salt);
+            expectedAuditEvents =
+                    List.of(
+                            new AuditEventExpectation(AUTH_REAUTH_FAILED)
+                                    .withAttribute(INCORRECT_EMAIL_ATTEMPT_COUNT, "0")
+                                    .withAttribute(INCORRECT_PASSWORD_ATTEMPT_COUNT, "0")
+                                    .withAttribute(
+                                            INCORRECT_OTP_CODE_ATTEMPT_COUNT,
+                                            String.valueOf(
+                                                    ConfigurationService.getInstance()
+                                                            .getCodeMaxRetries()))
+                                    .withAttribute(FAILURE_REASON, "incorrect_otp")
+                                    .withAttribute(RP_PAIRWISE_ID, rpPairwiseId));
+        } else {
+            expectedError = ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED;
+            expectedAuditEvents =
+                    List.of(
+                            new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                    .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                    .withAttribute(
+                                            EXTENSIONS_ACCOUNT_RECOVERY,
+                                            String.valueOf(
+                                                    journeyType == JourneyType.ACCOUNT_RECOVERY))
+                                    .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                    .withAttribute(
+                                            ATTEMPT_NO_FAILED_AT,
+                                            ConfigurationService.getInstance().getCodeMaxRetries())
+                                    .withAttribute(EXTENSIONS_MFA_METHOD, "default"));
+        }
+
+        assertThat(response, hasJsonBody(expectedError));
+        assertAuditEventExpectations(txmaAuditQueue, expectedAuditEvents);
+
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
@@ -808,10 +1018,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(
                 redis.getMfaCode(EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER),
@@ -840,10 +1057,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertTrue(
                 userStore
@@ -870,10 +1094,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertTrue(
                 userStore
@@ -899,10 +1130,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.getPhoneNumberForUser(EMAIL_ADDRESS).get(), equalTo(PHONE_NUMBER));
         assertTrue(userStore.isPhoneNumberVerified(EMAIL_ADDRESS));
@@ -924,10 +1162,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAuthAppEnabled(EMAIL_ADDRESS), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.getPhoneNumberForUser(EMAIL_ADDRESS).get(), equalTo(PHONE_NUMBER));
@@ -953,13 +1198,27 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
-
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 1)
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")));
 
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
@@ -984,12 +1243,25 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")));
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));
@@ -1019,13 +1291,25 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_MAX_RETRIES_REACHED));
-
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(
+                                        ATTEMPT_NO_FAILED_AT,
+                                        ConfigurationService.getInstance().getCodeMaxRetries())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));
@@ -1058,26 +1342,42 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue,
-                List.of(
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_CODE_MAX_RETRIES_REACHED));
         var isAccountVerified =
                 List.of(JourneyType.ACCOUNT_RECOVERY, JourneyType.REAUTHENTICATION)
                         .contains(journeyType);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 List.of(JourneyType.ACCOUNT_RECOVERY, JourneyType.REAUTHENTICATION)
                                 .contains(journeyType)
                         ? PHONE_NUMBER
                         : null;
+        var invalidCodeExpectation =
+                new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                        .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                        .withAttribute(
+                                EXTENSIONS_ACCOUNT_RECOVERY, String.valueOf(isAccountRecovery))
+                        .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                        .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")
+                        .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                        .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER");
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));
@@ -1128,8 +1428,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_MFA_RESET_REQUESTED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REAUTHENTICATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_MFA_RESET_REQUESTED)));
     }
 
     @Test
@@ -1169,8 +1478,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_MFA_RESET_REQUESTED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "SIGN_IN")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_MFA_RESET_REQUESTED)));
     }
 
     @Test
@@ -1194,7 +1511,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REAUTHENTICATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     @Test
@@ -1223,10 +1549,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
     }
 
     private ConfigurationService forcedMfaResetEnabledConfigurationService() {
@@ -1255,6 +1588,56 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 return true;
             }
         };
+    }
+
+    @Test
+    void shouldEmitAuthReauthFailedWhenOtpAttemptsExceededDuringReauthentication() {
+        var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+        byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
+        String rpPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(), SECTOR_IDENTIFIER_HOST, salt);
+
+        userStore.setAccountVerified(EMAIL_ADDRESS);
+        userStore.addMfaMethod(
+                EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
+
+        var maxRetries = ConfigurationService.getInstance().getCodeMaxRetries();
+        createMfaAttempts(userProfile.getSubjectID(), maxRetries);
+
+        var code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, code, JourneyType.REAUTHENTICATION);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_REAUTH_FAILED)
+                                .withAttribute(INCORRECT_EMAIL_ATTEMPT_COUNT, "0")
+                                .withAttribute(INCORRECT_PASSWORD_ATTEMPT_COUNT, "0")
+                                .withAttribute(
+                                        INCORRECT_OTP_CODE_ATTEMPT_COUNT,
+                                        String.valueOf(maxRetries))
+                                .withAttribute(FAILURE_REASON, "incorrect_otp")
+                                .withAttribute(RP_PAIRWISE_ID, rpPairwiseId)));
+    }
+
+    private void createMfaAttempts(String identifier, int count) {
+        var ttl = NowHelper.now().toInstant().plusSeconds(600).getEpochSecond();
+        for (int i = 0; i < count; i++) {
+            authenticationAttemptsStoreExtension.createOrIncrementCount(
+                    identifier, ttl, JourneyType.REAUTHENTICATION, CountType.ENTER_MFA_CODE);
+        }
     }
 
     private void setupUser(String sessionId, String email, boolean mfaMethodsMigrated) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
@@ -16,6 +16,10 @@ public interface AuditTestConstants {
     String EXTENSIONS_JOURNEY_TYPE = "extensions.journey-type";
     String EXTENSIONS_MFA_TYPE = "extensions.mfa-type";
     String EXTENSIONS_MFA_METHOD = "extensions.mfa-method";
+    String EXTENSIONS_ACCOUNT_RECOVERY = "extensions.account-recovery";
+    String EXTENSIONS_LOGIN_FAILURE_COUNT = "extensions.loginFailureCount";
+    String EXTENSIONS_NOTIFICATION_TYPE = "extensions.notification-type";
+    String EXTENSIONS_MFA_CODE_ENTERED = "extensions.MFACodeEntered";
     String USER_EMAIL_FIELD = "user.email";
     String USER_PHONE = "user.phone";
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
@@ -20,6 +20,9 @@ public interface AuditTestConstants {
     String EXTENSIONS_LOGIN_FAILURE_COUNT = "extensions.loginFailureCount";
     String EXTENSIONS_NOTIFICATION_TYPE = "extensions.notification-type";
     String EXTENSIONS_MFA_CODE_ENTERED = "extensions.MFACodeEntered";
+    String EXTENSIONS_MAX_SMS_COUNT = "extensions.MaxSmsCount";
     String USER_EMAIL_FIELD = "user.email";
+    String EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE = "extensions.phone_number_country_code";
+    String EXTENSIONS_MFA_RESET_TYPE = "extensions.mfaResetType";
     String USER_PHONE = "user.phone";
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -38,7 +38,6 @@ class AuthAppStubTest {
                         mock(CodeStorageService.class),
                         configurationService,
                         mock(DynamoService.class),
-                        99999,
                         mock(CodeRequest.class),
                         mock(AuditService.class),
                         mock(DynamoAccountModifiersService.class),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -8,10 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,7 +19,6 @@ import java.util.regex.Pattern;
 import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE;
 import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.MOBILE;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
-import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 
 public class ValidationHelper {
     private static final Logger LOG = LogManager.getLogger(ValidationHelper.class);
@@ -138,39 +134,9 @@ public class ValidationHelper {
     }
 
     public static Optional<ErrorResponse> validateVerificationCode(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            Optional<String> code,
-            String input,
-            CodeStorageService codeStorageService,
-            String emailAddress,
-            ConfigurationService configurationService) {
-        return validateVerificationCode(
-                notificationType,
-                journeyType,
-                code,
-                input,
-                codeStorageService,
-                emailAddress,
-                configurationService,
-                true);
-    }
-
-    public static Optional<ErrorResponse> validateVerificationCode(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            Optional<String> code,
-            String input,
-            CodeStorageService codeStorageService,
-            String emailAddress,
-            ConfigurationService configurationService,
-            boolean incrementCountOnFailure) {
+            NotificationType notificationType, Optional<String> code, String input) {
 
         if (code.filter(input::equals).isPresent()) {
-            if (journeyType != JourneyType.REAUTHENTICATION) {
-                codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
-            }
-
             switch (notificationType) {
                 case MFA_SMS:
                 case VERIFY_EMAIL:
@@ -182,49 +148,11 @@ public class ValidationHelper {
             return Optional.of(ErrorResponse.INVALID_NOTIFICATION_TYPE);
         }
 
-        return getErrorResponse(
-                notificationType,
-                journeyType,
-                codeStorageService,
-                emailAddress,
-                configurationService,
-                incrementCountOnFailure);
+        return getErrorResponse(notificationType);
     }
 
     private static @NotNull Optional<ErrorResponse> getErrorResponse(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            CodeStorageService codeStorageService,
-            String emailAddress,
-            ConfigurationService configurationService,
-            boolean incrementCountOnFailure) {
-        if (incrementCountOnFailure && journeyType != JourneyType.REAUTHENTICATION) {
-            if (configurationService.supportAccountCreationTTL()
-                    && notificationType == VERIFY_EMAIL) {
-                codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(
-                        emailAddress);
-            } else {
-                codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
-            }
-
-            if (codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress)
-                    >= configurationService.getCodeMaxRetries()) {
-                switch (notificationType) {
-                    case MFA_SMS:
-                        return Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-                    case VERIFY_EMAIL:
-                        return Optional.of(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED);
-                    case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
-                        return Optional.of(
-                                ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED);
-                    case VERIFY_PHONE_NUMBER:
-                        return Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED);
-                    case RESET_PASSWORD_WITH_CODE:
-                        return Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED);
-                }
-            }
-        }
-
+            NotificationType notificationType) {
         switch (notificationType) {
             case MFA_SMS:
                 return Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -145,6 +145,26 @@ public class ValidationHelper {
             CodeStorageService codeStorageService,
             String emailAddress,
             ConfigurationService configurationService) {
+        return validateVerificationCode(
+                notificationType,
+                journeyType,
+                code,
+                input,
+                codeStorageService,
+                emailAddress,
+                configurationService,
+                true);
+    }
+
+    public static Optional<ErrorResponse> validateVerificationCode(
+            NotificationType notificationType,
+            JourneyType journeyType,
+            Optional<String> code,
+            String input,
+            CodeStorageService codeStorageService,
+            String emailAddress,
+            ConfigurationService configurationService,
+            boolean incrementCountOnFailure) {
 
         if (code.filter(input::equals).isPresent()) {
             if (journeyType != JourneyType.REAUTHENTICATION) {
@@ -167,7 +187,8 @@ public class ValidationHelper {
                 journeyType,
                 codeStorageService,
                 emailAddress,
-                configurationService);
+                configurationService,
+                incrementCountOnFailure);
     }
 
     private static @NotNull Optional<ErrorResponse> getErrorResponse(
@@ -175,8 +196,9 @@ public class ValidationHelper {
             JourneyType journeyType,
             CodeStorageService codeStorageService,
             String emailAddress,
-            ConfigurationService configurationService) {
-        if (journeyType != JourneyType.REAUTHENTICATION) {
+            ConfigurationService configurationService,
+            boolean incrementCountOnFailure) {
+        if (incrementCountOnFailure && journeyType != JourneyType.REAUTHENTICATION) {
             if (configurationService.supportAccountCreationTTL()
                     && notificationType == VERIFY_EMAIL) {
                 codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -57,8 +57,8 @@ public class CodeStorageService {
                 configurationService.getLockoutCountTTL());
     }
 
-    public void increaseIncorrectMfaCodeAttemptsCountAccountCreation(String email) {
-        increaseCount(
+    public int increaseIncorrectMfaCodeAttemptsCountAccountCreation(String email) {
+        return increaseCount(
                 email,
                 MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX,
                 configurationService.getAccountCreationLockoutCountTTL());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -50,8 +50,8 @@ public class CodeStorageService {
         this.redisConnectionService = redisConnectionService;
     }
 
-    public void increaseIncorrectMfaCodeAttemptsCount(String email) {
-        increaseCount(
+    public int increaseIncorrectMfaCodeAttemptsCount(String email) {
+        return increaseCount(
                 email,
                 MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX,
                 configurationService.getLockoutCountTTL());

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Optional;
@@ -24,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
@@ -366,42 +363,42 @@ class ValidationHelperTest {
                 arguments(
                         VERIFY_EMAIL,
                         JourneyType.PASSWORD_RESET,
-                        Optional.of(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_EMAIL_CODE_ENTERED),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
                         JourneyType.REGISTRATION,
-                        Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         MFA_SMS,
                         JourneyType.PASSWORD_RESET_MFA,
-                        Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
                         JourneyType.PASSWORD_RESET,
-                        Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PW_RESET_CODE),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
                         JourneyType.PASSWORD_RESET_MFA,
-                        Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
                         INVALID_CODE,
                         100,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
                         JourneyType.PASSWORD_RESET_MFA,
-                        Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
                         INVALID_CODE,
                         100,
                         STORED_VALID_CODE));
@@ -417,61 +414,8 @@ class ValidationHelperTest {
             int previousAttempts,
             Optional<String> storedCode) {
 
-        var codeStorageService = mock(CodeStorageService.class);
-
-        // This simulates the Redis increment counter's side effect which isn't captured
-        previousAttempts++;
-
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS))
-                .thenReturn(previousAttempts);
-
-        when(configurationServiceMock.getCodeMaxRetries()).thenReturn(5);
-        when(configurationServiceMock.supportAccountCreationTTL()).thenReturn(false);
-
         assertEquals(
                 expectedResult,
-                ValidationHelper.validateVerificationCode(
-                        notificationType,
-                        journeyType,
-                        storedCode,
-                        input,
-                        codeStorageService,
-                        EMAIL_ADDRESS,
-                        configurationServiceMock));
-    }
-
-    @ParameterizedTest
-    @MethodSource("validateCodeTestParameters")
-    void shouldIncreaseRetryCountWithCorrectTTL(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            Optional<ErrorResponse> expectedResult,
-            String input,
-            int previousAttempts,
-            Optional<String> storedCode) {
-
-        var codeStorageService = mock(CodeStorageService.class);
-
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS)).thenReturn(1);
-        when(configurationServiceMock.getCodeMaxRetries()).thenReturn(5);
-        when(configurationServiceMock.supportAccountCreationTTL()).thenReturn(true);
-
-        ValidationHelper.validateVerificationCode(
-                notificationType,
-                journeyType,
-                Optional.empty(),
-                input,
-                codeStorageService,
-                EMAIL_ADDRESS,
-                configurationServiceMock);
-
-        if (journeyType != JourneyType.REAUTHENTICATION) {
-            if (notificationType == VERIFY_EMAIL) {
-                verify(codeStorageService)
-                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL_ADDRESS);
-            } else {
-                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS);
-            }
-        }
+                ValidationHelper.validateVerificationCode(notificationType, storedCode, input));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -312,17 +312,36 @@ class CodeStorageServiceTest {
     }
 
     @Test
-    void shouldIncrementCountForIncorrectMfaCodeAttemptsCountAccountCreation() {
+    void shouldCreateCountAndReturnOneForIncorrectMfaCodeAttemptsCountAccountCreation() {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
-                .thenReturn(String.valueOf(0));
+                .thenReturn(null);
 
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
+        int count =
+                codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
 
+        assertThat(count, is(1));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
                         String.valueOf(1),
+                        ACCOUNT_CREATION_CODE_EXPIRY_TIME);
+    }
+
+    @Test
+    void shouldIncrementCountAndReturnNewValueForIncorrectMfaCodeAttemptsCountAccountCreation() {
+        when(redisConnectionService.getValue(
+                        RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
+                .thenReturn(String.valueOf(3));
+
+        int count =
+                codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
+
+        assertThat(count, is(4));
+        verify(redisConnectionService)
+                .saveWithExpiry(
+                        RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
+                        String.valueOf(4),
                         ACCOUNT_CREATION_CODE_EXPIRY_TIME);
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -284,8 +284,10 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(null);
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
+        int count = codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
+
+        assertThat(count, is(1));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
@@ -298,8 +300,10 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(String.valueOf(3));
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
+        int count = codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
+
+        assertThat(count, is(4));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -161,14 +161,20 @@ public class PermissionDecisionManager implements PermissionDecisions {
         if (getCodeStorageService()
                 .isBlockedForEmail(
                         permissionContext.emailAddress(), codeAttemptsBlockedKeyPrefix)) {
+            int attemptCount =
+                    getCodeStorageService()
+                            .getIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
             return Result.success(
                     createTemporarilyLockedOut(
                             ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
-                            0,
+                            attemptCount,
                             false));
         }
 
-        return Result.success(new Decision.Permitted(0));
+        int attemptCount =
+                getCodeStorageService()
+                        .getIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        return Result.success(new Decision.Permitted(attemptCount));
     }
 
     @Override

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -289,6 +289,21 @@ public class PermissionDecisionManager implements PermissionDecisions {
     @Override
     public Result<DecisionError, Decision> canVerifyMfaOtp(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (permissionContext == null) {
+            return Result.failure(DecisionError.INVALID_USER_CONTEXT);
+        }
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            if (permissionContext.internalSubjectIds() == null
+                    || permissionContext.rpPairwiseId() == null) {
+                return Result.failure(DecisionError.INVALID_USER_CONTEXT);
+            }
+            return this.checkForAnyReauthLockout(
+                    permissionContext.internalSubjectIds(),
+                    permissionContext.rpPairwiseId(),
+                    CountType.ENTER_MFA_CODE);
+        }
+
         if (permissionContext.emailAddress() == null) {
             return Result.failure(DecisionError.INVALID_USER_CONTEXT);
         }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -106,6 +106,16 @@ public class PermissionDecisionManager implements PermissionDecisions {
             return Result.success(createTemporarilyLockedOut(reason, 0, false));
         }
 
+        if (journeyType != JourneyType.REGISTRATION) {
+            var canVerifyResult = canVerifyEmailOtp(journeyType, permissionContext);
+            if (canVerifyResult.isFailure()) {
+                return canVerifyResult;
+            }
+            if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+                return canVerifyResult;
+            }
+        }
+
         // PASSWORD_RESET has additional count-based check.
         //
         // This exists because ResetPasswordRequestHandler used to do one check of the count
@@ -283,6 +293,14 @@ public class PermissionDecisionManager implements PermissionDecisions {
                                 configurationService.getCodeMaxRetries(),
                                 Instant.ofEpochSecond(ttl),
                                 false));
+            }
+
+            var canVerifyResult = canVerifyMfaOtp(journeyType, permissionContext);
+            if (canVerifyResult.isFailure()) {
+                return canVerifyResult;
+            }
+            if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+                return canVerifyResult;
             }
 
             return Result.success(new Decision.Permitted(0));

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -335,7 +335,10 @@ public class PermissionDecisionManager implements PermissionDecisions {
                                 false));
             }
 
-            return Result.success(new Decision.Permitted(0));
+            int attemptCount =
+                    getCodeStorageService()
+                            .getIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+            return Result.success(new Decision.Permitted(attemptCount));
         } catch (RuntimeException e) {
             LOG.error("Could not retrieve MFA code block details.", e);
             return Result.failure(DecisionError.STORAGE_SERVICE_ERROR);

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
@@ -235,11 +236,13 @@ public class PermissionDecisionManager implements PermissionDecisions {
                 && lockoutStateHolder.isReauthSmsOtpLimitExceeded()) {
             LOG.info("Reauth user exceeded SMS OTP limit (from InMemoryLockoutStateHolder)");
             return Result.success(
-                    new Decision.TemporarilyLockedOut(
+                    new Decision.ReauthLockedOut(
                             ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
                             configurationService.getCodeMaxRetries(),
                             Instant.now(),
-                            false));
+                            false,
+                            Map.of(),
+                            List.of()));
         }
 
         try {

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -301,15 +301,27 @@ public class PermissionDecisionManager implements PermissionDecisions {
                                     CODE_BLOCKED_KEY_PREFIX + codeRequestType);
 
             // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-            var deprecatedCodeRequestType =
+            var deprecatedSmsCodeRequestType =
                     CodeRequestType.getDeprecatedCodeRequestTypeString(
                             MFAMethodType.SMS, journeyType);
-            if (deprecatedCodeRequestType != null) {
+            if (deprecatedSmsCodeRequestType != null) {
                 long deprecatedTtl =
                         getCodeStorageService()
                                 .getTTL(
                                         permissionContext.emailAddress(),
-                                        CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType);
+                                        CODE_BLOCKED_KEY_PREFIX + deprecatedSmsCodeRequestType);
+                ttl = Math.max(ttl, deprecatedTtl);
+            }
+
+            var deprecatedAuthAppCodeRequestType =
+                    CodeRequestType.getDeprecatedCodeRequestTypeString(
+                            MFAMethodType.AUTH_APP, journeyType);
+            if (deprecatedAuthAppCodeRequestType != null) {
+                long deprecatedTtl =
+                        getCodeStorageService()
+                                .getTTL(
+                                        permissionContext.emailAddress(),
+                                        CODE_BLOCKED_KEY_PREFIX + deprecatedAuthAppCodeRequestType);
                 ttl = Math.max(ttl, deprecatedTtl);
             }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -120,6 +120,15 @@ public class UserActionsManager implements UserActions {
             return Result.success(null);
         }
 
+        if (journeyType == JourneyType.REGISTRATION) {
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(SupportedCodeType.EMAIL, journeyType);
+            getCodeStorageService()
+                    .deleteBlockForEmail(
+                            permissionContext.emailAddress(),
+                            CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType);
+        }
+
         var updatedSession =
                 permissionContext
                         .authSessionItem()

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
@@ -382,8 +383,42 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        if (permissionContext == null) {
+            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+        }
+        var authSession = permissionContext.authSessionItem();
+        if (authSession == null) {
+            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+        }
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            // TODO remove comment
+            // rpPairwiseId is optional in handlers - may not be present for email OTP verification
+            // but should be present for SMS verification
+            var internalSubjectId = permissionContext.internalSubjectId();
+            var rpPairwiseId = permissionContext.rpPairwiseId();
+            if (internalSubjectId == null || rpPairwiseId == null) {
+                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+            }
+
+            for (String identifier : List.of(internalSubjectId, rpPairwiseId)) {
+                for (CountType countType : CountType.values()) {
+                    getAuthenticationAttemptsService()
+                            .deleteCount(identifier, JourneyType.REAUTHENTICATION, countType);
+                }
+            }
+        } else {
+            if (permissionContext.emailAddress() == null) {
+                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+            }
+
+            getCodeStorageService()
+                    .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        }
+
+        var updatedSession = authSession.withHasVerifiedMfa(true);
         getAuthSessionService().updateSession(updatedSession);
+
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -383,43 +383,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        if (permissionContext == null) {
-            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
-        }
-        var authSession = permissionContext.authSessionItem();
-        if (authSession == null) {
-            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
-        }
-
-        if (journeyType == JourneyType.REAUTHENTICATION) {
-            // TODO remove comment
-            // rpPairwiseId is optional in handlers - may not be present for email OTP verification
-            // but should be present for SMS verification
-            var internalSubjectId = permissionContext.internalSubjectId();
-            var rpPairwiseId = permissionContext.rpPairwiseId();
-            if (internalSubjectId == null || rpPairwiseId == null) {
-                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
-            }
-
-            for (String identifier : List.of(internalSubjectId, rpPairwiseId)) {
-                for (CountType countType : CountType.values()) {
-                    getAuthenticationAttemptsService()
-                            .deleteCount(identifier, JourneyType.REAUTHENTICATION, countType);
-                }
-            }
-        } else {
-            if (permissionContext.emailAddress() == null) {
-                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
-            }
-
-            getCodeStorageService()
-                    .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
-        }
-
-        var updatedSession = authSession.withHasVerifiedMfa(true);
-        getAuthSessionService().updateSession(updatedSession);
-
-        return Result.success(null);
+        return correctMfaOtpReceived(journeyType, permissionContext);
     }
 
     @Override
@@ -477,8 +441,44 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        return correctMfaOtpReceived(journeyType, permissionContext);
+    }
+
+    private Result<TrackingError, Void> correctMfaOtpReceived(
+            JourneyType journeyType, PermissionContext permissionContext) {
+        if (permissionContext == null) {
+            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+        }
+        var authSession = permissionContext.authSessionItem();
+        if (authSession == null) {
+            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+        }
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            var internalSubjectId = permissionContext.internalSubjectId();
+            var rpPairwiseId = permissionContext.rpPairwiseId();
+            if (internalSubjectId == null || rpPairwiseId == null) {
+                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+            }
+
+            for (String identifier : List.of(internalSubjectId, rpPairwiseId)) {
+                for (CountType countType : CountType.values()) {
+                    getAuthenticationAttemptsService()
+                            .deleteCount(identifier, JourneyType.REAUTHENTICATION, countType);
+                }
+            }
+        } else {
+            if (permissionContext.emailAddress() == null) {
+                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+            }
+
+            getCodeStorageService()
+                    .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        }
+
+        var updatedSession = authSession.withHasVerifiedMfa(true);
         getAuthSessionService().updateSession(updatedSession);
+
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -466,6 +466,17 @@ public class UserActionsManager implements UserActions {
                 return Result.failure(TrackingError.INVALID_USER_CONTEXT);
             }
 
+            if (configurationService.supportReauthSignoutEnabled()
+                    && configurationService.isAuthenticationAttemptsServiceEnabled()) {
+                var counts =
+                        getAuthenticationAttemptsService()
+                                .getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                                        internalSubjectId,
+                                        rpPairwiseId,
+                                        JourneyType.REAUTHENTICATION);
+                authSession = authSession.withPreservedReauthCountsForAuditMap(counts);
+            }
+
             for (String identifier : List.of(internalSubjectId, rpPairwiseId)) {
                 for (CountType countType : CountType.values()) {
                     getAuthenticationAttemptsService()

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -155,6 +155,66 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectEmailOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        /*
+         * REAUTHENTICATION journey type: Currently a no-op.
+         *
+         * AuthenticationAttemptsService supports tracking email OTP attempts via
+         * CountType.ENTER_EMAIL_CODE (wired into ReauthAuthenticationAttemptsHelper),
+         * but this is not currently used.
+         *
+         * Previously, ValidationHelper.getErrorResponse() explicitly skipped count
+         * increment when journeyType was REAUTHENTICATION, expecting
+         * authenticationAttemptsService to be used instead (as done for MFA_SMS).
+         *
+         * However, email OTP notifications (VERIFY_EMAIL, RESET_PASSWORD_WITH_CODE, etc.)
+         * are never sent with journeyType=REAUTHENTICATION. Even during a reauth flow,
+         * RESET_PASSWORD_WITH_CODE uses PASSWORD_RESET as the journey type because the
+         * frontend does not send a journeyType, so the backend defaults based on
+         * notification type.
+         *
+         * When lockout data storage is consolidated, consider what should happen for
+         * password reset sub-journeys within a reauthentication flow, and whether the
+         * existing CountType.ENTER_EMAIL_CODE should be utilised.
+         */
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            return Result.success(null);
+        }
+
+        int updatedCount;
+        if (configurationService.supportAccountCreationTTL()
+                && journeyType == JourneyType.REGISTRATION) {
+            updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCountAccountCreation(
+                                    permissionContext.emailAddress());
+        } else {
+            updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCount(
+                                    permissionContext.emailAddress());
+        }
+        if (updatedCount >= configurationService.getCodeMaxRetries()) {
+            LOG.info("Setting block for email as user has exceeded max email OTP retries");
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(
+                            CodeRequestType.SupportedCodeType.EMAIL, journeyType);
+
+            boolean reducedLockout =
+                    journeyType == JourneyType.REGISTRATION
+                            || journeyType == JourneyType.ACCOUNT_RECOVERY;
+            long blockDuration =
+                    reducedLockout
+                            ? configurationService.getReducedLockoutDuration()
+                            : configurationService.getLockoutDuration();
+
+            getCodeStorageService()
+                    .saveBlockedForEmail(
+                            permissionContext.emailAddress(),
+                            CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                            blockDuration);
+            getCodeStorageService()
+                    .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        }
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -413,7 +413,12 @@ public class UserActionsManager implements UserActions {
                     getCodeStorageService()
                             .increaseIncorrectMfaCodeAttemptsCount(
                                     permissionContext.emailAddress());
-            if (updatedCount >= configurationService.getCodeMaxRetries()) {
+            int maxRetries =
+                    (journeyType == JourneyType.REGISTRATION
+                                    || journeyType == JourneyType.ACCOUNT_RECOVERY)
+                            ? configurationService.getIncreasedCodeMaxRetries()
+                            : configurationService.getCodeMaxRetries();
+            if (updatedCount >= maxRetries) {
                 var codeRequestType =
                         CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
                 LOG.info("Setting block for email as user has exceeded max MFA code retries");

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -329,6 +330,52 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            try {
+                getAuthenticationAttemptsService()
+                        .createOrIncrementCount(
+                                permissionContext.internalSubjectId(),
+                                NowHelper.nowPlus(
+                                                configurationService
+                                                        .getReauthEnterAuthAppCodeCountTTL(),
+                                                ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond(),
+                                journeyType,
+                                CountType.ENTER_MFA_CODE);
+            } catch (RuntimeException e) {
+                LOG.error(
+                        "Failed to store incorrect Auth App OTP count in AuthenticationAttemptsService",
+                        e);
+                return Result.failure(TrackingError.STORAGE_SERVICE_ERROR);
+            }
+        } else {
+            var updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCount(
+                                    permissionContext.emailAddress());
+            if (updatedCount >= configurationService.getCodeMaxRetries()) {
+                var codeRequestType =
+                        CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
+                LOG.info("Setting block for email as user has exceeded max MFA code retries");
+
+                boolean reducedLockout =
+                        journeyType == JourneyType.REGISTRATION
+                                || journeyType == JourneyType.ACCOUNT_RECOVERY;
+                long blockDuration =
+                        reducedLockout
+                                ? configurationService.getReducedLockoutDuration()
+                                : configurationService.getLockoutDuration();
+
+                getCodeStorageService()
+                        .saveBlockedForEmail(
+                                permissionContext.emailAddress(),
+                                CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                                blockDuration);
+                getCodeStorageService()
+                        .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+            }
+        }
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -269,6 +269,52 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            try {
+                getAuthenticationAttemptsService()
+                        .createOrIncrementCount(
+                                permissionContext.internalSubjectId(),
+                                NowHelper.nowPlus(
+                                                configurationService
+                                                        .getReauthEnterSMSCodeCountTTL(),
+                                                ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond(),
+                                journeyType,
+                                CountType.ENTER_MFA_CODE);
+            } catch (RuntimeException e) {
+                LOG.error(
+                        "Failed to store incorrect SMS OTP count in AuthenticationAttemptsService",
+                        e);
+                return Result.failure(TrackingError.STORAGE_SERVICE_ERROR);
+            }
+        } else {
+            var updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCount(
+                                    permissionContext.emailAddress());
+            if (updatedCount >= configurationService.getCodeMaxRetries()) {
+                var codeRequestType =
+                        CodeRequestType.getCodeRequestType(SupportedCodeType.MFA, journeyType);
+                LOG.info("Setting block for email as user has exceeded max MFA code retries");
+
+                boolean reducedLockout =
+                        journeyType == JourneyType.REGISTRATION
+                                || journeyType == JourneyType.ACCOUNT_RECOVERY;
+                long blockDuration =
+                        reducedLockout
+                                ? configurationService.getReducedLockoutDuration()
+                                : configurationService.getLockoutDuration();
+
+                getCodeStorageService()
+                        .saveBlockedForEmail(
+                                permissionContext.emailAddress(),
+                                CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                                blockDuration);
+                getCodeStorageService()
+                        .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+            }
+        }
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReason.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReason.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.userpermissions.entity;
 
+import java.util.Set;
+
 public enum ForbiddenReason {
     EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT,
     EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT,
@@ -7,5 +9,14 @@ public enum ForbiddenReason {
     EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
     EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT,
     EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
-    EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+    EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+
+    private static final Set<ForbiddenReason> EXCEEDED_OTP_SUBMISSION_LIMIT_REASONS =
+            Set.of(
+                    EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                    EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT);
+
+    public boolean hasExceededOtpSubmissionLimit() {
+        return EXCEEDED_OTP_SUBMISSION_LIMIT_REASONS.contains(this);
+    }
 }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/TrackingError.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/TrackingError.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.userpermissions.entity;
 
 public enum TrackingError {
-    STORAGE_SERVICE_ERROR
+    STORAGE_SERVICE_ERROR,
+    INVALID_USER_CONTEXT
 }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -288,6 +288,7 @@ class PermissionDecisionManagerTest {
             var codeAttemptsBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
             when(codeStorageService.isBlockedForEmail(EMAIL, codeAttemptsBlockedKeyPrefix))
                     .thenReturn(false);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(5);
 
             var result =
                     permissionDecisionManager.canVerifyEmailOtp(
@@ -299,7 +300,7 @@ class PermissionDecisionManagerTest {
                             Decision.Permitted.class,
                             result.getSuccess(),
                             "Expected Permitted decision");
-            assertEquals(0, decision.attemptCount());
+            assertEquals(5, decision.attemptCount());
         }
 
         @Test
@@ -311,6 +312,7 @@ class PermissionDecisionManagerTest {
             var codeAttemptsBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
             when(codeStorageService.isBlockedForEmail(EMAIL, codeAttemptsBlockedKeyPrefix))
                     .thenReturn(true);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(5);
 
             var result =
                     permissionDecisionManager.canVerifyEmailOtp(
@@ -325,6 +327,7 @@ class PermissionDecisionManagerTest {
             assertEquals(
                     ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
                     lockedOut.forbiddenReason());
+            assertEquals(5, lockedOut.attemptCount());
         }
 
         @Test

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -768,6 +768,42 @@ class PermissionDecisionManagerTest {
             assertTrue(result.isFailure());
             assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
         }
+
+        @Test
+        void shouldReturnLockedOutWhenAuthAppDeprecatedKeyIsBlocked() {
+            var userContext = createUserContext(0);
+            long blockTtl = 1234567890L;
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
+                    .thenReturn(0L);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
+                    .thenReturn(0L);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
+                    .thenReturn(blockTtl);
+
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+            assertTrue(result.isSuccess());
+            assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+        }
+
+        @Test
+        void shouldReturnLockedOutWhenSmsDeprecatedKeyIsBlocked() {
+            var userContext = createUserContext(0);
+            long blockTtl = 1234567890L;
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
+                    .thenReturn(0L);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
+                    .thenReturn(blockTtl);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
+                    .thenReturn(0L);
+
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+            assertTrue(result.isSuccess());
+            assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+        }
     }
 
     @Nested

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -724,20 +724,46 @@ class PermissionDecisionManagerTest {
     class CanVerifyMfaOtp {
 
         @Test
-        void shouldReturnPermittedWhenNotBlocked() {
-            var userContext = createUserContext(0);
-            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+        void shouldReturnErrorWhenPermissionContextIsNull() {
+            var result = permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, null);
 
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
-
-            assertTrue(result.isSuccess());
-            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
-            assertEquals(0, decision.attemptCount());
+            assertTrue(result.isFailure());
+            assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
         }
 
-        @Test
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldReturnErrorWhenEmailAddressIsNull() {
+                var userContext =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-id")
+                                .withAuthSessionItem(new AuthSessionItem())
+                                .build();
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnPermittedWhenNotBlocked() {
+                var userContext = createUserContext(0);
+                when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isSuccess());
+                var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                assertEquals(0, decision.attemptCount());
+            }
+
+            @Test
         void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
             var userContext = createUserContext(0);
             when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
@@ -752,53 +778,140 @@ class PermissionDecisionManagerTest {
         }
 
         @Test
-        void shouldReturnLockedOutWhenBlocked() {
-            var userContext = createUserContext(0);
-            long blockTtl = 1234567890L;
-            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(blockTtl);
+            void shouldReturnLockedOutWhenBlocked() {
+                var userContext = createUserContext(0);
+                long blockTtl = 1234567890L;
+                when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(blockTtl);
 
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
-            assertTrue(result.isSuccess());
-            var lockedOut =
-                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
-            assertEquals(
-                    ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
-                    lockedOut.forbiddenReason());
-            assertEquals(6, lockedOut.attemptCount());
+                assertTrue(result.isSuccess());
+                var lockedOut =
+                        assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+                assertEquals(
+                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                        lockedOut.forbiddenReason());
+                assertEquals(6, lockedOut.attemptCount());
+            }
+
+            @Test
+            void shouldReturnStorageErrorWhenExceptionThrown() {
+                var userContext = createUserContext(0);
+                doThrow(new RuntimeException("Storage error"))
+                        .when(codeStorageService)
+                        .getTTL(eq(EMAIL), anyString());
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnLockedOutWhenAuthAppDeprecatedKeyIsBlocked() {
+                var userContext = createUserContext(0);
+                long blockTtl = 1234567890L;
+                when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
+                        .thenReturn(0L);
+                when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
+                        .thenReturn(0L);
+                when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
+                        .thenReturn(blockTtl);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isSuccess());
+                assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            }
         }
 
-        @Test
-        void shouldReturnStorageErrorWhenExceptionThrown() {
-            var userContext = createUserContext(0);
-            doThrow(new RuntimeException("Storage error"))
-                    .when(codeStorageService)
-                    .getTTL(eq(EMAIL), anyString());
+        @Nested
+        class ReauthenticationJourney {
 
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+            @Test
+            void shouldReturnErrorWhenInternalSubjectIdIsNull() {
+                var userContext =
+                        PermissionContext.builder()
+                                .withRpPairwiseId("pairwise")
+                                .withEmailAddress(EMAIL)
+                                .withAuthSessionItem(new AuthSessionItem())
+                                .build();
 
-            assertTrue(result.isFailure());
-            assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
-        }
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
 
-        @Test
-        void shouldReturnLockedOutWhenAuthAppDeprecatedKeyIsBlocked() {
-            var userContext = createUserContext(0);
-            long blockTtl = 1234567890L;
-            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
-                    .thenReturn(0L);
-            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
-                    .thenReturn(0L);
-            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
-                    .thenReturn(blockTtl);
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+            }
 
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+            @Test
+            void shouldReturnErrorWhenRpPairwiseIdIsNull() {
+                var userContext =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-id")
+                                .withEmailAddress(EMAIL)
+                                .withAuthSessionItem(new AuthSessionItem())
+                                .build();
 
-            assertTrue(result.isSuccess());
-            assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnPermittedWhenNotBlocked() {
+                var userContext = createUserContext(0);
+                var identifiers = new ArrayList<String>();
+                identifiers.add(userContext.internalSubjectId());
+                identifiers.add(userContext.rpPairwiseId());
+                when(authenticationAttemptsService.getCountsByJourneyForIdentifiers(
+                                identifiers, JourneyType.REAUTHENTICATION))
+                        .thenReturn(Map.of(CountType.ENTER_MFA_CODE, 2));
+                when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+                when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+                when(configurationService.getCodeMaxRetries()).thenReturn(5);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isSuccess());
+                var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                assertEquals(2, decision.attemptCount());
+            }
+
+            @Test
+            void shouldReturnReauthLockedOutWhenMfaCountExceeded() {
+                var userContext = createUserContext(0);
+                var identifiers = new ArrayList<String>();
+                identifiers.add(userContext.internalSubjectId());
+                identifiers.add(userContext.rpPairwiseId());
+                when(authenticationAttemptsService.getCountsByJourneyForIdentifiers(
+                                identifiers, JourneyType.REAUTHENTICATION))
+                        .thenReturn(Map.of(CountType.ENTER_MFA_CODE, 6));
+                when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+                when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+                when(configurationService.getCodeMaxRetries()).thenReturn(5);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isSuccess());
+                var lockedOut =
+                        assertInstanceOf(Decision.ReauthLockedOut.class, result.getSuccess());
+                assertEquals(
+                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                        lockedOut.forbiddenReason());
+                assertEquals(6, lockedOut.attemptCount());
+            }
         }
 
         @Test

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -753,7 +753,7 @@ class PermissionDecisionManagerTest {
             void shouldReturnPermittedWhenNotBlocked() {
                 var userContext = createUserContext(0);
                 when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+                when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
 
                 var result =
                         permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
@@ -764,20 +764,20 @@ class PermissionDecisionManagerTest {
             }
 
             @Test
-        void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
-            var userContext = createUserContext(0);
-            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+            void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
+                var userContext = createUserContext(0);
+                when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+                when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
 
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
 
-            assertTrue(result.isSuccess());
-            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
-            assertEquals(3, decision.attemptCount());
-        }
+                assertTrue(result.isSuccess());
+                var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                assertEquals(3, decision.attemptCount());
+            }
 
-        @Test
+            @Test
             void shouldReturnLockedOutWhenBlocked() {
                 var userContext = createUserContext(0);
                 long blockTtl = 1234567890L;

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -728,6 +728,7 @@ class PermissionDecisionManagerTest {
         void shouldReturnPermittedWhenNotBlocked() {
             var userContext = createUserContext(0);
             when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
 
             var result =
                     permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
@@ -735,6 +736,20 @@ class PermissionDecisionManagerTest {
             assertTrue(result.isSuccess());
             var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
             assertEquals(0, decision.attemptCount());
+        }
+
+        @Test
+        void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
+            var userContext = createUserContext(0);
+            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+            assertTrue(result.isSuccess());
+            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+            assertEquals(3, decision.attemptCount());
         }
 
         @Test

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -690,7 +690,7 @@ class PermissionDecisionManagerTest {
         }
 
         @Test
-        void shouldReturnLockedOutWhenInMemoryLockoutStateHolderIsSet() {
+        void shouldReturnReauthLockedOutWhenInMemoryLockoutStateHolderIsSet() {
             var userContext = createUserContext(0);
             var lockoutStateHolder = new InMemoryLockoutStateHolder();
             lockoutStateHolder.setReauthSmsOtpLimitExceeded();
@@ -700,8 +700,7 @@ class PermissionDecisionManagerTest {
                             JourneyType.REAUTHENTICATION, userContext, lockoutStateHolder);
 
             assertTrue(result.isSuccess());
-            var lockedOut =
-                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            var lockedOut = assertInstanceOf(Decision.ReauthLockedOut.class, result.getSuccess());
             assertEquals(
                     ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
                     lockedOut.forbiddenReason());

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -172,6 +173,37 @@ class PermissionDecisionManagerTest {
                                 ? ForbiddenReason.BLOCKED_FOR_PW_RESET_REQUEST
                                 : ForbiddenReason.EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT;
                 assertEquals(expectedReason, lockedOut.forbiddenReason());
+            }
+
+            @ParameterizedTest
+            @EnumSource(
+                    value = JourneyType.class,
+                    names = {"REGISTRATION", "ACCOUNT_RECOVERY", "PASSWORD_RESET"})
+            void shouldReturnVerificationBlockForAllJourneysExceptRegistration(
+                    JourneyType journeyType) {
+                var userContext = createUserContext(0);
+                var codeRequestType =
+                        CodeRequestType.getCodeRequestType(
+                                CodeRequestType.SupportedCodeType.EMAIL, journeyType);
+                when(codeStorageService.isBlockedForEmail(
+                                EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
+                        .thenReturn(true);
+
+                var result =
+                        permissionDecisionManager.canSendEmailOtpNotification(
+                                journeyType, userContext);
+
+                assertTrue(result.isSuccess());
+                if (journeyType == JourneyType.REGISTRATION) {
+                    assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                } else {
+                    var lockedOut =
+                            assertInstanceOf(
+                                    Decision.TemporarilyLockedOut.class, result.getSuccess());
+                    assertEquals(
+                            ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                            lockedOut.forbiddenReason());
+                }
             }
         }
 
@@ -720,6 +752,29 @@ class PermissionDecisionManagerTest {
 
             assertTrue(result.isSuccess());
             assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+                value = JourneyType.class,
+                names = {"SIGN_IN", "REGISTRATION", "PASSWORD_RESET_MFA"})
+        void shouldReturnLockedOutWhenVerificationBlockExists(JourneyType journeyType) {
+            var userContext = createUserContext(0);
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(
+                            CodeRequestType.SupportedCodeType.MFA, journeyType);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
+                    .thenReturn(300L);
+
+            var result =
+                    permissionDecisionManager.canSendSmsOtpNotification(journeyType, userContext);
+
+            assertTrue(result.isSuccess());
+            var lockedOut =
+                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            assertEquals(
+                    ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                    lockedOut.forbiddenReason());
         }
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -588,6 +588,107 @@ class UserActionsManagerTest {
     }
 
     @Nested
+    class IncorrectSmsOtpReceived {
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldIncrementCount() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWhenMaxRetriesReached() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        SupportedCodeType.MFA, JourneyType.SIGN_IN);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @ParameterizedTest
+            @MethodSource("reducedLockoutJourneyTypes")
+            void shouldUseReducedLockoutDurationForReducedLockoutJourneys(JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(journeyType, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        SupportedCodeType.MFA, journeyType);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                assertTrue(result.isSuccess());
+            }
+
+            static Stream<JourneyType> reducedLockoutJourneyTypes() {
+                return Stream.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY);
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldIncrementCountViaAuthAttemptsService() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(120L);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authenticationAttemptsService)
+                        .createOrIncrementCount(
+                                eq("subject-123"),
+                                anyLong(),
+                                eq(JourneyType.REAUTHENTICATION),
+                                eq(CountType.ENTER_MFA_CODE));
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthAttemptsServiceThrows() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(120L);
+                doThrow(new RuntimeException("Storage error"))
+                        .when(authenticationAttemptsService)
+                        .createOrIncrementCount(anyString(), anyLong(), any(), any());
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.STORAGE_SERVICE_ERROR, result.getFailure());
+            }
+        }
+    }
+
+    @Nested
     class NoOpMethods {
 
         @Test
@@ -612,8 +713,6 @@ class UserActionsManagerTest {
                     userActionsManager.correctPasswordReceived(journeyType, context).isSuccess());
             assertTrue(userActionsManager.passwordReset(journeyType, context).isSuccess());
             assertTrue(userActionsManager.sentSmsOtpNotification(journeyType, context).isSuccess());
-            assertTrue(
-                    userActionsManager.incorrectSmsOtpReceived(journeyType, context).isSuccess());
             assertTrue(userActionsManager.correctSmsOtpReceived(journeyType, context).isSuccess());
             assertTrue(
                     userActionsManager

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -70,6 +70,7 @@ class UserActionsManagerTest {
                         authSessionService,
                         authenticationAttemptsService);
         when(configurationService.getCodeMaxRetries()).thenReturn(6);
+        when(configurationService.getIncreasedCodeMaxRetries()).thenReturn(999999);
         when(configurationService.getLockoutDuration()).thenReturn(900L);
     }
 
@@ -993,8 +994,24 @@ class UserActionsManagerTest {
 
             @ParameterizedTest
             @MethodSource("reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes")
+            void shouldAllowSignificantlyHigherAttemptsForRegistrationAndAccountRecovery(
+                    JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL))
+                        .thenReturn(999998);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                journeyType, permissionContext);
+
+                verify(codeStorageService, never()).saveBlockedForEmail(any(), any(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @ParameterizedTest
+            @MethodSource("reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes")
             void shouldUseReducedLockoutDurationForReducedLockoutJourneys(JourneyType journeyType) {
-                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL))
+                        .thenReturn(999999);
                 when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
 
                 var result =

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.entity.CodeRequestType.SupportedCodeType;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -624,7 +625,7 @@ class UserActionsManagerTest {
             }
 
             @ParameterizedTest
-            @MethodSource("reducedLockoutJourneyTypes")
+            @MethodSource("reducedIncorrectSmsOtpReceivedLockoutJourneyTypes")
             void shouldUseReducedLockoutDurationForReducedLockoutJourneys(JourneyType journeyType) {
                 when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
                 when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
@@ -640,7 +641,7 @@ class UserActionsManagerTest {
                 assertTrue(result.isSuccess());
             }
 
-            static Stream<JourneyType> reducedLockoutJourneyTypes() {
+            static Stream<JourneyType> reducedIncorrectSmsOtpReceivedLockoutJourneyTypes() {
                 return Stream.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY);
             }
         }
@@ -680,6 +681,108 @@ class UserActionsManagerTest {
 
                 var result =
                         userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.STORAGE_SERVICE_ERROR, result.getFailure());
+            }
+        }
+    }
+
+    @Nested
+    class IncorrectAuthAppOtpReceived {
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldIncrementCount() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWhenMaxRetriesReached() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @ParameterizedTest
+            @MethodSource("reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes")
+            void shouldUseReducedLockoutDurationForReducedLockoutJourneys(JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                journeyType, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        MFAMethodType.AUTH_APP, journeyType);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                assertTrue(result.isSuccess());
+            }
+
+            static Stream<JourneyType> reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes() {
+                return Stream.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY);
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldIncrementCountViaAuthAttemptsService() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(120L);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authenticationAttemptsService)
+                        .createOrIncrementCount(
+                                eq("subject-123"),
+                                anyLong(),
+                                eq(JourneyType.REAUTHENTICATION),
+                                eq(CountType.ENTER_MFA_CODE));
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthAttemptsServiceThrows() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(120L);
+                doThrow(new RuntimeException("Storage error"))
+                        .when(authenticationAttemptsService)
+                        .createOrIncrementCount(anyString(), anyLong(), any(), any());
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
                                 JourneyType.REAUTHENTICATION, context);
 
                 assertTrue(result.isFailure());

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -266,6 +266,18 @@ class UserActionsManagerTest {
                                 .getCodeRequestCount(notificationType, journeyType));
                 assertTrue(result.isSuccess());
             }
+
+            @Test
+            void shouldClearIncorrectEmailOtpBlockWhenNewCodeRequestedForRegistration() {
+                userActionsManager.sentEmailOtpNotification(
+                        JourneyType.REGISTRATION, permissionContext);
+
+                verify(codeStorageService)
+                        .deleteBlockForEmail(
+                                EMAIL,
+                                CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                        + CodeRequestType.EMAIL_REGISTRATION);
+            }
         }
 
         @Nested

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.userpermissions.entity.InMemoryLockoutStateHolde
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -514,6 +515,52 @@ class UserActionsManagerTest {
                 }
                 verify(codeStorageService, never())
                         .deleteIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldPreserveReauthCountsForAuditWhenFeatureFlagsEnabled() {
+                when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+                when(configurationService.isAuthenticationAttemptsServiceEnabled())
+                        .thenReturn(true);
+                var counts = Map.of(CountType.ENTER_PASSWORD, 2, CountType.ENTER_SMS_CODE, 1);
+                when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                                "subject-123", "rp-pairwise-456", JourneyType.REAUTHENTICATION))
+                        .thenReturn(counts);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+                verify(authSessionService).updateSession(captor.capture());
+                assertEquals(counts, captor.getValue().getPreservedReauthCountsForAuditMap());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldNotPreserveReauthCountsWhenFeatureFlagsDisabled() {
+                when(configurationService.supportReauthSignoutEnabled()).thenReturn(false);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authenticationAttemptsService, never())
+                        .getCountsByJourneyForSubjectIdAndRpPairwiseId(any(), any(), any());
                 assertTrue(result.isSuccess());
             }
         }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -704,19 +704,153 @@ class UserActionsManagerTest {
 
     @Nested
     class CorrectAuthAppOtpReceived {
-        @Test
-        void correctAuthAppOtpReceivedShouldSetHasVerifiedMfaToTrue() {
-            // Arrange
-            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
-            // Act
-            var result = userActionsManager.correctAuthAppOtpReceived(null, permissionContext);
+        @Nested
+        class SharedValidation {
 
-            // Assert
-            verify(authSessionService).updateSession(captor.capture());
-            AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
-            assertTrue(result.isSuccess());
+            @Test
+            void shouldReturnErrorWhenPermissionContextIsNull() {
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(JourneyType.SIGN_IN, null);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthSessionItemIsNull() {
+                var context = PermissionContext.builder().withEmailAddress(EMAIL).build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldReturnErrorWhenInternalSubjectIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenRpPairwiseIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearAllReauthCountsForBothIdentifiers() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                for (CountType countType : CountType.values()) {
+                    verify(authenticationAttemptsService)
+                            .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
+                    verify(authenticationAttemptsService)
+                            .deleteCount(
+                                    "rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+                }
+                verify(codeStorageService, never())
+                        .deleteIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldReturnErrorWhenEmailAddressIsNull() {
+                var authSessionWithoutEmail = new AuthSessionItem().withSessionId(SESSION_ID);
+                var context =
+                        PermissionContext.builder()
+                                .withAuthSessionItem(authSessionWithoutEmail)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearIncorrectMfaCodeAttemptsCount() {
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
         }
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -413,19 +413,150 @@ class UserActionsManagerTest {
 
     @Nested
     class CorrectSmsOtpReceived {
-        @Test
-        void correctSmsOtpReceivedShouldSetHasVerifiedMfaToTrue() {
-            // Arrange
-            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
-            // Act
-            var result = userActionsManager.correctSmsOtpReceived(null, permissionContext);
+        @Nested
+        class SharedValidation {
 
-            // Assert
-            verify(authSessionService).updateSession(captor.capture());
-            AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
-            assertTrue(result.isSuccess());
+            @Test
+            void shouldReturnErrorWhenPermissionContextIsNull() {
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, null);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthSessionItemIsNull() {
+                var context = PermissionContext.builder().withEmailAddress(EMAIL).build();
+
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldReturnErrorWhenInternalSubjectIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenRpPairwiseIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearAllReauthCountsForBothIdentifiers() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                for (CountType countType : CountType.values()) {
+                    verify(authenticationAttemptsService)
+                            .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
+                    verify(authenticationAttemptsService)
+                            .deleteCount(
+                                    "rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+                }
+                verify(codeStorageService, never())
+                        .deleteIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldReturnErrorWhenEmailAddressIsNull() {
+                var authSessionWithoutEmail = new AuthSessionItem().withSessionId(SESSION_ID);
+                var context =
+                        PermissionContext.builder()
+                                .withAuthSessionItem(authSessionWithoutEmail)
+                                .build();
+
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearIncorrectMfaCodeAttemptsCount() {
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
         }
     }
 
@@ -977,7 +1108,6 @@ class UserActionsManagerTest {
                     userActionsManager.correctPasswordReceived(journeyType, context).isSuccess());
             assertTrue(userActionsManager.passwordReset(journeyType, context).isSuccess());
             assertTrue(userActionsManager.sentSmsOtpNotification(journeyType, context).isSuccess());
-            assertTrue(userActionsManager.correctSmsOtpReceived(journeyType, context).isSuccess());
             assertTrue(
                     userActionsManager
                             .incorrectAuthAppOtpReceived(journeyType, context)

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
@@ -792,6 +793,168 @@ class UserActionsManagerTest {
     }
 
     @Nested
+    class IncorrectEmailOtpReceived {
+
+        @Nested
+        class PasswordResetAndAccountRecoveryJourneys {
+
+            @ParameterizedTest
+            @EnumSource(
+                    value = JourneyType.class,
+                    names = {"PASSWORD_RESET", "ACCOUNT_RECOVERY"})
+            void shouldIncrementCount(JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                journeyType, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(anyString(), anyString(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithStandardLockoutForPasswordReset() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.PASSWORD_RESET, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.PASSWORD_RESET);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithReducedLockoutForAccountRecovery() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.ACCOUNT_RECOVERY, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.ACCOUNT_RECOVERY);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class RegistrationJourney {
+
+            @Test
+            void shouldIncrementCountUsingAccountCreationMethodWhenConfigEnabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(true);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL))
+                        .thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                verify(codeStorageService)
+                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL);
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(anyString(), anyString(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldIncrementCountUsingStandardMethodWhenConfigDisabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(false);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(anyString());
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(anyString(), anyString(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithReducedLockoutWhenConfigEnabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(true);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL))
+                        .thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.REGISTRATION);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithReducedLockoutWhenConfigDisabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(false);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.REGISTRATION);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldDoNothingForReauthentication() {
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REAUTHENTICATION, permissionContext);
+
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(anyString());
+                verify(authenticationAttemptsService, never())
+                        .createOrIncrementCount(anyString(), anyLong(), any(), any());
+                assertTrue(result.isSuccess());
+            }
+        }
+    }
+
+    @Nested
     class NoOpMethods {
 
         @Test
@@ -805,8 +968,6 @@ class UserActionsManagerTest {
                             .isSuccess());
             assertTrue(
                     userActionsManager.sentEmailOtpNotification(journeyType, context).isSuccess());
-            assertTrue(
-                    userActionsManager.incorrectEmailOtpReceived(journeyType, context).isSuccess());
             assertTrue(
                     userActionsManager.correctEmailOtpReceived(journeyType, context).isSuccess());
             assertTrue(

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReasonTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReasonTest.java
@@ -1,9 +1,10 @@
 package uk.gov.di.authentication.userpermissions.entity;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ForbiddenReasonTest {
 
@@ -38,5 +39,28 @@ class ForbiddenReasonTest {
         // Then
         assertNotNull(result);
         assertEquals("EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT", result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ForbiddenReason.class,
+            names = {
+                "EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT",
+                "EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT"
+            })
+    void hasExceededOtpSubmissionLimitReturnsTrueForOtpSubmissionReasons(ForbiddenReason reason) {
+        assertTrue(reason.hasExceededOtpSubmissionLimit());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ForbiddenReason.class,
+            names = {
+                "EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT",
+                "EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT"
+            },
+            mode = EnumSource.Mode.EXCLUDE)
+    void hasExceededOtpSubmissionLimitReturnsFalseForOtherReasons(ForbiddenReason reason) {
+        assertFalse(reason.hasExceededOtpSubmissionLimit());
     }
 }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/TrackingErrorTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/TrackingErrorTest.java
@@ -9,5 +9,6 @@ class TrackingErrorTest {
     @Test
     void shouldHaveCorrectEnumValues() {
         assertEquals("STORAGE_SERVICE_ERROR", TrackingError.STORAGE_SERVICE_ERROR.name());
+        assertEquals("INVALID_USER_CONTEXT", TrackingError.INVALID_USER_CONTEXT.name());
     }
 }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] All commits contain one or more `Co-authored-by` lines where pairing or mobbing has taken place

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
