### PR TITLE
BAU: reduce nesting by introducing s3 client helper

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/S3ClientHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/S3ClientHelper.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.URI;
+
+public class S3ClientHelper {
+    private S3ClientHelper() {
+        /* This utility class should not be instantiated */
+    }
+
+    public static S3Client createLocalstackS3Client(
+            ConfigurationService configurationService, String endpointOverride) {
+        var fakeCredentials = AwsBasicCredentials.create("FAKEACCESSKEY", "FAKESECRETKEY");
+        var s3Configuration = S3Configuration.builder().pathStyleAccessEnabled(true).build();
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpointOverride))
+                .region(Region.of(configurationService.getAwsRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(fakeCredentials))
+                .serviceConfiguration(s3Configuration)
+                .build();
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/S3ClientHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/S3ClientHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.helpers;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -23,6 +24,13 @@ public class S3ClientHelper {
                 .region(Region.of(configurationService.getAwsRegion()))
                 .credentialsProvider(StaticCredentialsProvider.create(fakeCredentials))
                 .serviceConfiguration(s3Configuration)
+                .build();
+    }
+
+    public static S3Client createDefaultS3Client(ConfigurationService configurationService) {
+        return S3Client.builder()
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                .region(Region.of(configurationService.getAwsRegion()))
                 .build();
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ADJWKSHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ADJWKSHandler.java
@@ -6,15 +6,14 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
+import static uk.gov.di.authentication.frontendapi.helpers.S3ClientHelper.createDefaultS3Client;
 import static uk.gov.di.authentication.frontendapi.helpers.S3ClientHelper.createLocalstackS3Client;
 
 public class ADJWKSHandler implements RequestHandler<Object, Void> {
@@ -42,17 +41,7 @@ public class ADJWKSHandler implements RequestHandler<Object, Void> {
                 configurationService
                         .getLocalstackEndpointUri()
                         .map(endpoint -> createLocalstackS3Client(configurationService, endpoint))
-                        .orElseGet(
-                                () ->
-                                        S3Client.builder()
-                                                .credentialsProvider(
-                                                        DefaultCredentialsProvider.builder()
-                                                                .build())
-                                                .region(
-                                                        Region.of(
-                                                                configurationService
-                                                                        .getAwsRegion()))
-                                                .build());
+                        .orElseGet(() -> createDefaultS3Client(configurationService));
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ADJWKSHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ADJWKSHandler.java
@@ -6,19 +6,16 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
-import java.net.URI;
+import static uk.gov.di.authentication.frontendapi.helpers.S3ClientHelper.createLocalstackS3Client;
 
 public class ADJWKSHandler implements RequestHandler<Object, Void> {
     private final ConfigurationService configurationService;
@@ -44,24 +41,7 @@ public class ADJWKSHandler implements RequestHandler<Object, Void> {
         this.s3Client =
                 configurationService
                         .getLocalstackEndpointUri()
-                        .map(
-                                endpoint ->
-                                        S3Client.builder()
-                                                .endpointOverride(URI.create(endpoint))
-                                                .region(
-                                                        Region.of(
-                                                                configurationService
-                                                                        .getAwsRegion()))
-                                                .credentialsProvider(
-                                                        StaticCredentialsProvider.create(
-                                                                AwsBasicCredentials.create(
-                                                                        "FAKEACCESSKEY",
-                                                                        "FAKESECRETKEY")))
-                                                .serviceConfiguration(
-                                                        S3Configuration.builder()
-                                                                .pathStyleAccessEnabled(true)
-                                                                .build())
-                                                .build())
+                        .map(endpoint -> createLocalstackS3Client(configurationService, endpoint))
                         .orElseGet(
                                 () ->
                                         S3Client.builder()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCJWKSHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCJWKSHandler.java
@@ -6,20 +6,18 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
-import java.net.URI;
 import java.util.List;
+
+import static uk.gov.di.authentication.frontendapi.helpers.S3ClientHelper.createLocalstackS3Client;
 
 public class AMCJWKSHandler implements RequestHandler<Object, Void> {
     private final ConfigurationService configurationService;
@@ -45,24 +43,7 @@ public class AMCJWKSHandler implements RequestHandler<Object, Void> {
         this.s3Client =
                 configurationService
                         .getLocalstackEndpointUri()
-                        .map(
-                                endpoint ->
-                                        S3Client.builder()
-                                                .endpointOverride(URI.create(endpoint))
-                                                .region(
-                                                        Region.of(
-                                                                configurationService
-                                                                        .getAwsRegion()))
-                                                .credentialsProvider(
-                                                        StaticCredentialsProvider.create(
-                                                                AwsBasicCredentials.create(
-                                                                        "FAKEACCESSKEY",
-                                                                        "FAKESECRETKEY")))
-                                                .serviceConfiguration(
-                                                        S3Configuration.builder()
-                                                                .pathStyleAccessEnabled(true)
-                                                                .build())
-                                                .build())
+                        .map(endpoint -> createLocalstackS3Client(configurationService, endpoint))
                         .orElseGet(
                                 () ->
                                         S3Client.builder()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCJWKSHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCJWKSHandler.java
@@ -6,9 +6,7 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -17,6 +15,7 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.util.List;
 
+import static uk.gov.di.authentication.frontendapi.helpers.S3ClientHelper.createDefaultS3Client;
 import static uk.gov.di.authentication.frontendapi.helpers.S3ClientHelper.createLocalstackS3Client;
 
 public class AMCJWKSHandler implements RequestHandler<Object, Void> {
@@ -44,17 +43,7 @@ public class AMCJWKSHandler implements RequestHandler<Object, Void> {
                 configurationService
                         .getLocalstackEndpointUri()
                         .map(endpoint -> createLocalstackS3Client(configurationService, endpoint))
-                        .orElseGet(
-                                () ->
-                                        S3Client.builder()
-                                                .credentialsProvider(
-                                                        DefaultCredentialsProvider.builder()
-                                                                .build())
-                                                .region(
-                                                        Region.of(
-                                                                configurationService
-                                                                        .getAwsRegion()))
-                                                .build());
+                        .orElseGet(() -> createDefaultS3Client(configurationService));
     }
 
     @Override


### PR DESCRIPTION
I ran a query to find where we had the most nesting in the frontend api, and besides the VerifyMfaCodeHandler which is currently being refactored as part of the lockouts refactor, these two jwks handlers had the most indentation.

This pulls out some common code for constructing s3 clients, and in doing so increases the readability of these simple handlers by removing a lot of nesting.