### PR TITLE
AUT-4577: Prepare for verify code handler lockout refactors

### DIFF
--- a/ci/cloudformation/auth/function/mfa.yaml
+++ b/ci/cloudformation/auth/function/mfa.yaml
@@ -98,6 +98,7 @@ Resources:
             !Ref AWS::NoValue,
           ]
         - !Ref DynamoInternationalNumberSendCountReadAccessPolicy
+        - !Ref DynamoAuthenticationAttemptReadPolicy
       ProvisionedConcurrencyConfig: !If
         - EnableProvisionedConcurrency
         - ProvisionedConcurrentExecutions:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorHttpMapper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorHttpMapper.java
@@ -14,7 +14,7 @@ public class TrackingErrorHttpMapper {
         ErrorResponse errorResponse = TrackingErrorMapper.toErrorResponse(trackingError);
         int statusCode =
                 switch (trackingError) {
-                    case STORAGE_SERVICE_ERROR -> 500;
+                    case STORAGE_SERVICE_ERROR, INVALID_USER_CONTEXT -> 500;
                 };
         return new ErrorResponseWithStatus(statusCode, errorResponse);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorMapper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/TrackingErrorMapper.java
@@ -10,6 +10,7 @@ public class TrackingErrorMapper {
     public static ErrorResponse toErrorResponse(TrackingError trackingError) {
         return switch (trackingError) {
             case STORAGE_SERVICE_ERROR -> ErrorResponse.STORAGE_LAYER_ERROR;
+            case INVALID_USER_CONTEXT -> ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR;
         };
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -11,13 +11,16 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.frontendapi.errormapper.DecisionErrorHttpMapper;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
@@ -237,12 +240,23 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             var requestSmsMfaMethod = maybeRequestedSmsMfaMethod.get();
             var phoneNumber = requestSmsMfaMethod.getDestination();
 
-            var permissionContext =
+            var permissionContextBuilder =
                     PermissionContext.builder()
                             .withEmailAddress(email)
                             .withE164FormattedPhoneNumber(phoneNumber)
-                            .withAuthSessionItem(userContext.getAuthSession())
-                            .build();
+                            .withAuthSessionItem(userContext.getAuthSession());
+
+            userContext
+                    .getUserProfile()
+                    .ifPresent(
+                            userProfile -> {
+                                permissionContextBuilder.withInternalSubjectId(
+                                        userProfile.getSubjectID());
+                                getRpPairwiseId(userProfile, userContext.getAuthSession())
+                                        .ifPresent(permissionContextBuilder::withRpPairwiseId);
+                            });
+
+            var permissionContext = permissionContextBuilder.build();
             var lockoutStateHolder = new InMemoryLockoutStateHolder();
 
             var maybeResponseIfNotPermitted =
@@ -360,6 +374,13 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
                             canVerifyResult.getFailure()));
         }
+        if (canVerifyResult.getSuccess() instanceof Decision.ReauthLockedOut) {
+            LOG.warn(
+                    "Unexpected ReauthLockedOut from canVerifyMfaOtp - "
+                            + "should have been checked in an earlier handler in the journey");
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+        }
         if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
             return Optional.of(
@@ -367,5 +388,16 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         }
 
         return Optional.empty();
+    }
+
+    private Optional<String> getRpPairwiseId(UserProfile userProfile, AuthSessionItem authSession) {
+        try {
+            return Optional.of(
+                    ClientSubjectHelper.getSubject(userProfile, authSession, authenticationService)
+                            .getValue());
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to derive RP pairwise ID: {}", e.getMessage());
+            return Optional.empty();
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -360,7 +360,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     generateApiGatewayProxyErrorResponse(
                             400, INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS));
         }
-        if (canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+        if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut
+                || canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
             var errorResponse =
                     afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -915,6 +915,31 @@ class MfaHandlerTest {
         verify(sqsClient, never()).send(any());
     }
 
+    @Test
+    void shouldReturn500WhenCanVerifyMfaOtpReturnsReauthLockedOut() {
+        usingValidSession();
+
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.ReauthLockedOut(
+                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                        6,
+                                        Instant.now(),
+                                        false,
+                                        java.util.Map.of(),
+                                        List.of())));
+
+        var body = format("{ \"email\": \"%s\"}", EMAIL);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+        verify(sqsClient, never()).send(any());
+    }
+
     @ParameterizedTest
     @MethodSource("mfaJourneyTypes")
     void shouldReturn400WhenInternationalSendLimitServiceBlocks(JourneyType journeyType) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -756,6 +756,36 @@ class MfaHandlerTest {
                                 .withMetadataItem(pair("mfa-type", MFAMethodType.SMS.getValue())));
     }
 
+    @Test
+    void shouldReturn400IfUserIsBlockedFromRequestingMfaCodesWithReauthLockedOut() {
+        usingValidSession();
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.ReauthLockedOut(
+                                        ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
+                                        6,
+                                        Instant.now(),
+                                        false,
+                                        java.util.Map.of(),
+                                        List.of())));
+
+        var body =
+                format(
+                        "{ \"email\": \"%s\", \"journeyType\": \"%s\"}",
+                        EMAIL, JourneyType.REAUTHENTICATION);
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasJsonBody(BLOCKED_FOR_SENDING_MFA_OTPS));
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(FrontendAuditableEvent.AUTH_MFA_INVALID_CODE_REQUEST),
+                        any(AuditContext.class));
+    }
+
     @ParameterizedTest
     @MethodSource("smsJourneyTypes")
     void shouldReturn400IfUserIsBlockedFromAttemptingMfaCodes(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -150,6 +150,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             var response =
                     makeRequest(
@@ -197,6 +199,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
 
@@ -354,6 +358,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             var response =
                     makeRequest(
@@ -401,6 +407,8 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             var authenticatedSessionId = IdGenerator.generate();
             authSessionStore.addSession(authenticatedSessionId);
             authSessionStore.addEmailToSession(authenticatedSessionId, USER_EMAIL);
+            authSessionStore.addRpSectorIdentifierHostToSession(
+                    authenticatedSessionId, "test.account.gov.uk");
 
             aUserHasEnteredAnOTPIncorrectlyTheMaximumAllowedTimes(authenticatedSessionId);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -17,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -24,6 +26,7 @@ import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegration
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
+import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 
 import java.util.List;
 import java.util.Map;
@@ -39,18 +42,33 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_MFA_RESET_REQUESTED;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REAUTH_FAILED;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertAuditEventExpectations;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_ACCOUNT_RECOVERY;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_LOGIN_FAILURE_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MAX_SMS_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_CODE_ENTERED;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_METHOD;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_RESET_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.FAILURE_REASON;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_EMAIL_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_OTP_CODE_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_PASSWORD_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.RP_PAIRWISE_ID;
 
 public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -61,6 +79,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     public static final String CLIENT_NAME = "test-client-name";
     private static final Subject SUBJECT = new Subject();
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
+    private static final String RP_SECTOR_HOST = "test.com";
     private String sessionId;
 
     @RegisterExtension
@@ -102,7 +121,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @ParameterizedTest
@@ -128,7 +164,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @ParameterizedTest
@@ -152,7 +205,23 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.INVALID_EMAIL_CODE_ENTERED));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @ParameterizedTest
@@ -181,8 +250,32 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response2, hasStatus(400));
         assertThat(response2, hasJsonBody(ErrorResponse.INVALID_EMAIL_CODE_ENTERED));
 
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_INVALID_CODE_SENT));
+        var expectedJourneyType =
+                emailNotificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES
+                        ? JourneyType.ACCOUNT_RECOVERY
+                        : JourneyType.REGISTRATION;
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name()),
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, emailNotificationType.name())
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(
+                                                expectedJourneyType
+                                                        == JourneyType.ACCOUNT_RECOVERY))
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, expectedJourneyType.name())));
     }
 
     @Test
@@ -209,7 +302,14 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(false));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, VERIFY_EMAIL.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE, JourneyType.REGISTRATION.name())));
     }
 
     @Test
@@ -262,7 +362,17 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE,
+                                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.ACCOUNT_RECOVERY.name())));
     }
 
     @Test
@@ -288,7 +398,17 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE,
+                                        RESET_PASSWORD_WITH_CODE.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.PASSWORD_RESET.name())));
     }
 
     private static Stream<JourneyType> journeyTypes() {
@@ -323,7 +443,22 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_MAX_RETRIES_REACHED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, "0")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")
+                                .withAttribute(
+                                        EXTENSIONS_MAX_SMS_COUNT,
+                                        String.valueOf(
+                                                ConfigurationService.getInstance()
+                                                        .getCodeMaxRetries()))
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
     }
 
     @Test
@@ -347,6 +482,62 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(null));
+    }
+
+    @Test
+    void shouldEmitAuthReauthFailedWhenMfaSmsAttemptsExceededDuringReauthentication() {
+        setUpTestWithSignUp(sessionId);
+        userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
+        userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");
+
+        var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+        byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
+        String rpPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(), RP_SECTOR_HOST, salt);
+
+        var internalCommonSubjectId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(),
+                        INTERNAl_SECTOR_HOST,
+                        SaltHelper.generateNewSalt());
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
+
+        var maxRetries = ConfigurationService.getInstance().getCodeMaxRetries();
+        var ttl = NowHelper.now().toInstant().plusSeconds(600).getEpochSecond();
+        for (int i = 0; i < maxRetries; i++) {
+            authCodeExtension.createOrIncrementCount(
+                    userProfile.getSubjectID(),
+                    ttl,
+                    JourneyType.REAUTHENTICATION,
+                    CountType.ENTER_MFA_CODE);
+        }
+
+        var code = redis.generateAndSaveMfaCode(EMAIL_ADDRESS.concat(PHONE_NUMBER), 900);
+        var codeRequest = new VerifyCodeRequest(MFA_SMS, code, JourneyType.REAUTHENTICATION, null);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_REAUTH_FAILED)
+                                .withAttribute(INCORRECT_EMAIL_ATTEMPT_COUNT, "0")
+                                .withAttribute(INCORRECT_PASSWORD_ATTEMPT_COUNT, "0")
+                                .withAttribute(
+                                        INCORRECT_OTP_CODE_ATTEMPT_COUNT,
+                                        String.valueOf(maxRetries))
+                                .withAttribute(FAILURE_REASON, "incorrect_otp")
+                                .withAttribute(RP_PAIRWISE_ID, rpPairwiseId)));
     }
 
     @ParameterizedTest
@@ -374,7 +565,21 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(204));
 
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        journeyType != null
+                                                ? journeyType.name()
+                                                : JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(MFAMethodType.SMS));
@@ -445,8 +650,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        journeyType != null
+                                                ? journeyType.name()
+                                                : JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(MFAMethodType.SMS));
@@ -473,7 +694,19 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(204));
         var authSession = authSessionExtension.getSession(sessionId).orElseThrow();
         assertThat(authSession.getInternalCommonSubjectId(), notNullValue());
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.PASSWORD_RESET_MFA.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
                 equalTo(MFAMethodType.SMS));
@@ -506,7 +739,18 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(true));
         if (journeyType != JourneyType.REAUTHENTICATION) {
-            assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
+            assertAuditEventExpectations(
+                    txmaAuditQueue,
+                    List.of(
+                            new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                    .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                    .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                    .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                    .withAttribute(
+                                            EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                    .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 1)
+                                    .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                    .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")));
         }
         assertThat(
                 authSessionExtension.getSession(sessionId).get().getVerifiedMfaMethodType(),
@@ -551,8 +795,24 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_MFA_RESET_REQUESTED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_MFA_RESET_REQUESTED)
+                                .withAttribute(
+                                        EXTENSIONS_JOURNEY_TYPE,
+                                        JourneyType.ACCOUNT_RECOVERY.name())
+                                .withAttribute(EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "7")
+                                .withAttribute(
+                                        EXTENSIONS_MFA_RESET_TYPE, "FORCED_INTERNATIONAL_NUMBERS"),
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     @Test
@@ -582,7 +842,17 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.name())
+                                .withAttribute(EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 0)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     private ConfigurationService forcedMfaResetEnabledConfigurationService() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
-import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
+import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthenticationAttemptsStoreExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 import uk.gov.di.authentication.sharedtest.helper.AuthAppStub;
 
 import java.time.Duration;
@@ -37,7 +38,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,14 +50,27 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_MFA_RESET_REQUESTED;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REAUTH_FAILED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsSubmittedWithMatchingNames;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertAuditEventExpectations;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.ATTEMPT_NO_FAILED_AT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_ACCOUNT_RECOVERY;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_LOGIN_FAILURE_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_CODE_ENTERED;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_METHOD;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.FAILURE_REASON;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_EMAIL_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_OTP_CODE_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.INCORRECT_PASSWORD_ATTEMPT_COUNT;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.RP_PAIRWISE_ID;
 
 class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String EMAIL_ADDRESS = "test@test.com";
@@ -86,8 +99,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private String sessionId;
 
     @RegisterExtension
-    protected static final AuthenticationAttemptsStoreExtension authCodeExtension =
-            new AuthenticationAttemptsStoreExtension();
+    protected static final AuthenticationAttemptsStoreExtension
+            authenticationAttemptsStoreExtension = new AuthenticationAttemptsStoreExtension();
 
     @RegisterExtension
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
@@ -139,7 +152,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -171,7 +192,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
     }
 
@@ -229,8 +258,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -259,8 +296,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.getMfaMethod(EMAIL_ADDRESS).size(), equalTo(1));
@@ -301,8 +346,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
 
         var retrievedMfaMethods = userStore.getMfaMethod(EMAIL_ADDRESS);
@@ -346,10 +399,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertTrue(mfaMethod.isMethodVerified());
         assertInstanceOf(UUID.class, UUID.fromString(mfaMethod.getMfaIdentifier()));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
     }
 
     @Test
@@ -366,8 +426,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
 
@@ -448,8 +516,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP), true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
 
@@ -485,10 +561,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        List<AuditableEvent> expectedAuditableEvents =
-                List.of(AUTH_CODE_VERIFIED, AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED);
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, expectedAuditableEvents, true);
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED)));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -521,12 +603,22 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        List<AuditableEvent> expectedAuditableEvents =
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
+        var codeVerifiedExpectation =
+                new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                        .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                        .withAttribute(
+                                EXTENSIONS_ACCOUNT_RECOVERY, String.valueOf(isAccountRecovery))
+                        .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                        .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                        .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code);
+        List<AuditEventExpectation> expectedAuditableEvents =
                 nonRegistrationJourneyTypes.contains(journeyType)
-                        ? singletonList(AUTH_CODE_VERIFIED)
-                        : List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_AUTH_APP);
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, expectedAuditableEvents, true);
+                        ? List.of(codeVerifiedExpectation)
+                        : List.of(
+                                codeVerifiedExpectation,
+                                new AuditEventExpectation(AUTH_UPDATE_PROFILE_AUTH_APP));
+        assertAuditEventExpectations(txmaAuditQueue, expectedAuditableEvents);
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(
@@ -555,9 +647,20 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
+        assertThat(response, hasStatus(400));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         if (isAccountVerified) {
@@ -583,9 +686,20 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, invalidCode)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         if (isAccountVerified) {
@@ -593,6 +707,32 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     userStore.getMfaMethod(EMAIL_ADDRESS).get(0).getCredentialValue(),
                     equalTo(AUTH_APP_SECRET_BASE_32));
         }
+    }
+
+    @Test
+    void shouldIncludeLoginFailureCountInAuthInvalidCodeSentForSignIn() {
+        setUpAuthAppRequest(JourneyType.SIGN_IN);
+        String invalidCode = AUTH_APP_STUB.getAuthAppOneTimeCode("O5ZG63THFVZWKY3SMV2A====");
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, invalidCode, JourneyType.SIGN_IN);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "SIGN_IN")
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 1)
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, invalidCode)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
     }
 
     @ParameterizedTest
@@ -613,7 +753,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, invalidCode)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(accountModifiersStore.isBlockPresent(internalCommonSubjectId), equalTo(true));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(true));
@@ -636,7 +784,14 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.AUTH_APP_METHOD_NOT_FOUND));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     @Test
@@ -676,7 +831,15 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.AUTH_APP_METHOD_NOT_FOUND));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_INVALID_CODE_SENT));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         if (isAccountVerified) {
@@ -700,10 +863,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new VerifyMfaCodeRequest(
                         MFAMethodType.AUTH_APP, code, journeyType, profileInformation);
 
-        var codeRequestType =
-                CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        redis.blockMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix);
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+            var maxRetries = ConfigurationService.getInstance().getCodeMaxRetries();
+            createMfaAttempts(userProfile.getSubjectID(), maxRetries);
+        } else {
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
+            var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+            redis.blockMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix);
+        }
 
         var response =
                 makeRequest(
@@ -712,8 +881,49 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_MAX_RETRIES_REACHED));
+
+        ErrorResponse expectedError;
+        List<AuditEventExpectation> expectedAuditEvents;
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            expectedError = ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS;
+            var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+            byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
+            String rpPairwiseId =
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            userProfile.getSubjectID(), SECTOR_IDENTIFIER_HOST, salt);
+            expectedAuditEvents =
+                    List.of(
+                            new AuditEventExpectation(AUTH_REAUTH_FAILED)
+                                    .withAttribute(INCORRECT_EMAIL_ATTEMPT_COUNT, "0")
+                                    .withAttribute(INCORRECT_PASSWORD_ATTEMPT_COUNT, "0")
+                                    .withAttribute(
+                                            INCORRECT_OTP_CODE_ATTEMPT_COUNT,
+                                            String.valueOf(
+                                                    ConfigurationService.getInstance()
+                                                            .getCodeMaxRetries()))
+                                    .withAttribute(FAILURE_REASON, "incorrect_otp")
+                                    .withAttribute(RP_PAIRWISE_ID, rpPairwiseId));
+        } else {
+            expectedError = ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED;
+            expectedAuditEvents =
+                    List.of(
+                            new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                    .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                    .withAttribute(
+                                            EXTENSIONS_ACCOUNT_RECOVERY,
+                                            String.valueOf(
+                                                    journeyType == JourneyType.ACCOUNT_RECOVERY))
+                                    .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                    .withAttribute(
+                                            ATTEMPT_NO_FAILED_AT,
+                                            ConfigurationService.getInstance().getCodeMaxRetries())
+                                    .withAttribute(EXTENSIONS_MFA_METHOD, "default"));
+        }
+
+        assertThat(response, hasJsonBody(expectedError));
+        assertAuditEventExpectations(txmaAuditQueue, expectedAuditEvents);
+
         var isAccountVerified = accountVerifiedJourneyTypes.contains(journeyType);
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
         assertThat(userStore.isAuthAppVerified(EMAIL_ADDRESS), equalTo(isAccountVerified));
@@ -808,10 +1018,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(
                 redis.getMfaCode(EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER),
@@ -840,10 +1057,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertTrue(
                 userStore
@@ -870,10 +1094,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertTrue(
                 userStore
@@ -899,10 +1130,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.getPhoneNumberForUser(EMAIL_ADDRESS).get(), equalTo(PHONE_NUMBER));
         assertTrue(userStore.isPhoneNumberVerified(EMAIL_ADDRESS));
@@ -924,10 +1162,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
         assertThat(userStore.isAuthAppEnabled(EMAIL_ADDRESS), equalTo(false));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
         assertThat(userStore.getPhoneNumberForUser(EMAIL_ADDRESS).get(), equalTo(PHONE_NUMBER));
@@ -953,13 +1198,27 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
-
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_LOGIN_FAILURE_COUNT, 1)
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")));
 
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
@@ -984,12 +1243,25 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_INVALID_CODE_SENT));
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(
+                                        EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")));
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));
@@ -1019,13 +1291,25 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_MAX_RETRIES_REACHED));
-
         var isAccountVerified = journeyType.equals(JourneyType.ACCOUNT_RECOVERY);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 journeyType.equals(JourneyType.ACCOUNT_RECOVERY) ? PHONE_NUMBER : null;
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(
+                                        ATTEMPT_NO_FAILED_AT,
+                                        ConfigurationService.getInstance().getCodeMaxRetries())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));
@@ -1058,26 +1342,42 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue,
-                List.of(
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_INVALID_CODE_SENT,
-                        AUTH_CODE_MAX_RETRIES_REACHED));
         var isAccountVerified =
                 List.of(JourneyType.ACCOUNT_RECOVERY, JourneyType.REAUTHENTICATION)
                         .contains(journeyType);
+        var isAccountRecovery = journeyType == JourneyType.ACCOUNT_RECOVERY;
         var expectedPhoneNumber =
                 List.of(JourneyType.ACCOUNT_RECOVERY, JourneyType.REAUTHENTICATION)
                                 .contains(journeyType)
                         ? PHONE_NUMBER
                         : null;
+        var invalidCodeExpectation =
+                new AuditEventExpectation(AUTH_INVALID_CODE_SENT)
+                        .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                        .withAttribute(
+                                EXTENSIONS_ACCOUNT_RECOVERY, String.valueOf(isAccountRecovery))
+                        .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                        .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, "123456")
+                        .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                        .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER");
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        invalidCodeExpectation,
+                        new AuditEventExpectation(AUTH_CODE_MAX_RETRIES_REACHED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(
+                                        EXTENSIONS_ACCOUNT_RECOVERY,
+                                        String.valueOf(isAccountRecovery))
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, journeyType.name())
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")));
         assertThat(
                 userStore.getPhoneNumberForUser(EMAIL_ADDRESS).orElse(null),
                 equalTo(expectedPhoneNumber));
@@ -1128,8 +1428,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_MFA_RESET_REQUESTED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REAUTHENTICATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_MFA_RESET_REQUESTED)));
     }
 
     @Test
@@ -1169,8 +1478,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
-                txmaAuditQueue, List.of(AUTH_CODE_VERIFIED, AUTH_MFA_RESET_REQUESTED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "AUTH_APP")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "SIGN_IN")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_MFA_RESET_REQUESTED)));
     }
 
     @Test
@@ -1194,7 +1511,16 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(AUTH_CODE_VERIFIED));
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "false")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REAUTHENTICATION")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code)));
     }
 
     @Test
@@ -1223,10 +1549,17 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertTxmaAuditEventsSubmittedWithMatchingNames(
+        assertAuditEventExpectations(
                 txmaAuditQueue,
-                List.of(AUTH_CODE_VERIFIED, AUTH_UPDATE_PROFILE_PHONE_NUMBER),
-                true);
+                List.of(
+                        new AuditEventExpectation(AUTH_CODE_VERIFIED)
+                                .withAttribute(EXTENSIONS_MFA_TYPE, "SMS")
+                                .withAttribute(EXTENSIONS_ACCOUNT_RECOVERY, "true")
+                                .withAttribute(EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_RECOVERY")
+                                .withAttribute(EXTENSIONS_MFA_METHOD, "default")
+                                .withAttribute(EXTENSIONS_NOTIFICATION_TYPE, "VERIFY_PHONE_NUMBER")
+                                .withAttribute(EXTENSIONS_MFA_CODE_ENTERED, code),
+                        new AuditEventExpectation(AUTH_UPDATE_PROFILE_PHONE_NUMBER)));
     }
 
     private ConfigurationService forcedMfaResetEnabledConfigurationService() {
@@ -1255,6 +1588,56 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 return true;
             }
         };
+    }
+
+    @Test
+    void shouldEmitAuthReauthFailedWhenOtpAttemptsExceededDuringReauthentication() {
+        var userProfile = userStore.getUserProfileFromEmail(EMAIL_ADDRESS).orElseThrow();
+        byte[] salt = userStore.addSalt(EMAIL_ADDRESS);
+        String rpPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(), SECTOR_IDENTIFIER_HOST, salt);
+
+        userStore.setAccountVerified(EMAIL_ADDRESS);
+        userStore.addMfaMethod(
+                EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
+
+        var maxRetries = ConfigurationService.getInstance().getCodeMaxRetries();
+        createMfaAttempts(userProfile.getSubjectID(), maxRetries);
+
+        var code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, code, JourneyType.REAUTHENTICATION);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+
+        assertAuditEventExpectations(
+                txmaAuditQueue,
+                List.of(
+                        new AuditEventExpectation(AUTH_REAUTH_FAILED)
+                                .withAttribute(INCORRECT_EMAIL_ATTEMPT_COUNT, "0")
+                                .withAttribute(INCORRECT_PASSWORD_ATTEMPT_COUNT, "0")
+                                .withAttribute(
+                                        INCORRECT_OTP_CODE_ATTEMPT_COUNT,
+                                        String.valueOf(maxRetries))
+                                .withAttribute(FAILURE_REASON, "incorrect_otp")
+                                .withAttribute(RP_PAIRWISE_ID, rpPairwiseId)));
+    }
+
+    private void createMfaAttempts(String identifier, int count) {
+        var ttl = NowHelper.now().toInstant().plusSeconds(600).getEpochSecond();
+        for (int i = 0; i < count; i++) {
+            authenticationAttemptsStoreExtension.createOrIncrementCount(
+                    identifier, ttl, JourneyType.REAUTHENTICATION, CountType.ENTER_MFA_CODE);
+        }
     }
 
     private void setupUser(String sessionId, String email, boolean mfaMethodsMigrated) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
@@ -16,6 +16,10 @@ public interface AuditTestConstants {
     String EXTENSIONS_JOURNEY_TYPE = "extensions.journey-type";
     String EXTENSIONS_MFA_TYPE = "extensions.mfa-type";
     String EXTENSIONS_MFA_METHOD = "extensions.mfa-method";
+    String EXTENSIONS_ACCOUNT_RECOVERY = "extensions.account-recovery";
+    String EXTENSIONS_LOGIN_FAILURE_COUNT = "extensions.loginFailureCount";
+    String EXTENSIONS_NOTIFICATION_TYPE = "extensions.notification-type";
+    String EXTENSIONS_MFA_CODE_ENTERED = "extensions.MFACodeEntered";
     String USER_EMAIL_FIELD = "user.email";
     String USER_PHONE = "user.phone";
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
@@ -20,6 +20,9 @@ public interface AuditTestConstants {
     String EXTENSIONS_LOGIN_FAILURE_COUNT = "extensions.loginFailureCount";
     String EXTENSIONS_NOTIFICATION_TYPE = "extensions.notification-type";
     String EXTENSIONS_MFA_CODE_ENTERED = "extensions.MFACodeEntered";
+    String EXTENSIONS_MAX_SMS_COUNT = "extensions.MaxSmsCount";
     String USER_EMAIL_FIELD = "user.email";
+    String EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE = "extensions.phone_number_country_code";
+    String EXTENSIONS_MFA_RESET_TYPE = "extensions.mfaResetType";
     String USER_PHONE = "user.phone";
 }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -160,14 +160,20 @@ public class PermissionDecisionManager implements PermissionDecisions {
         if (getCodeStorageService()
                 .isBlockedForEmail(
                         permissionContext.emailAddress(), codeAttemptsBlockedKeyPrefix)) {
+            int attemptCount =
+                    getCodeStorageService()
+                            .getIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
             return Result.success(
                     createTemporarilyLockedOut(
                             ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
-                            0,
+                            attemptCount,
                             false));
         }
 
-        return Result.success(new Decision.Permitted(0));
+        int attemptCount =
+                getCodeStorageService()
+                        .getIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        return Result.success(new Decision.Permitted(attemptCount));
     }
 
     @Override
@@ -335,7 +341,10 @@ public class PermissionDecisionManager implements PermissionDecisions {
                                 false));
             }
 
-            return Result.success(new Decision.Permitted(0));
+            int attemptCount =
+                    getCodeStorageService()
+                            .getIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+            return Result.success(new Decision.Permitted(attemptCount));
         } catch (RuntimeException e) {
             LOG.error("Could not retrieve MFA code block details.", e);
             return Result.failure(DecisionError.STORAGE_SERVICE_ERROR);

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
@@ -241,11 +242,13 @@ public class PermissionDecisionManager implements PermissionDecisions {
                 && lockoutStateHolder.isReauthSmsOtpLimitExceeded()) {
             LOG.info("Reauth user exceeded SMS OTP limit (from InMemoryLockoutStateHolder)");
             return Result.success(
-                    new Decision.TemporarilyLockedOut(
+                    new Decision.ReauthLockedOut(
                             ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
                             configurationService.getCodeMaxRetries(),
                             Instant.now(),
-                            false));
+                            false,
+                            Map.of(),
+                            List.of()));
         }
 
         try {

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -292,6 +292,21 @@ public class PermissionDecisionManager implements PermissionDecisions {
     @Override
     public Result<DecisionError, Decision> canVerifyMfaOtp(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (permissionContext == null) {
+            return Result.failure(DecisionError.INVALID_USER_CONTEXT);
+        }
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            if (permissionContext.internalSubjectIds() == null
+                    || permissionContext.rpPairwiseId() == null) {
+                return Result.failure(DecisionError.INVALID_USER_CONTEXT);
+            }
+            return this.checkForAnyReauthLockout(
+                    permissionContext.internalSubjectIds(),
+                    permissionContext.rpPairwiseId(),
+                    CountType.ENTER_MFA_CODE);
+        }
+
         if (permissionContext.emailAddress() == null) {
             return Result.failure(DecisionError.INVALID_USER_CONTEXT);
         }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -301,15 +301,27 @@ public class PermissionDecisionManager implements PermissionDecisions {
                                     CODE_BLOCKED_KEY_PREFIX + codeRequestType);
 
             // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-            var deprecatedCodeRequestType =
+            var deprecatedSmsCodeRequestType =
                     CodeRequestType.getDeprecatedCodeRequestTypeString(
                             MFAMethodType.SMS, journeyType);
-            if (deprecatedCodeRequestType != null) {
+            if (deprecatedSmsCodeRequestType != null) {
                 long deprecatedTtl =
                         getCodeStorageService()
                                 .getTTL(
                                         permissionContext.emailAddress(),
-                                        CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType);
+                                        CODE_BLOCKED_KEY_PREFIX + deprecatedSmsCodeRequestType);
+                ttl = Math.max(ttl, deprecatedTtl);
+            }
+
+            var deprecatedAuthAppCodeRequestType =
+                    CodeRequestType.getDeprecatedCodeRequestTypeString(
+                            MFAMethodType.AUTH_APP, journeyType);
+            if (deprecatedAuthAppCodeRequestType != null) {
+                long deprecatedTtl =
+                        getCodeStorageService()
+                                .getTTL(
+                                        permissionContext.emailAddress(),
+                                        CODE_BLOCKED_KEY_PREFIX + deprecatedAuthAppCodeRequestType);
                 ttl = Math.max(ttl, deprecatedTtl);
             }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/TrackingError.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/TrackingError.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.userpermissions.entity;
 
 public enum TrackingError {
-    STORAGE_SERVICE_ERROR
+    STORAGE_SERVICE_ERROR,
+    INVALID_USER_CONTEXT
 }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -768,6 +768,42 @@ class PermissionDecisionManagerTest {
             assertTrue(result.isFailure());
             assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
         }
+
+        @Test
+        void shouldReturnLockedOutWhenAuthAppDeprecatedKeyIsBlocked() {
+            var userContext = createUserContext(0);
+            long blockTtl = 1234567890L;
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
+                    .thenReturn(0L);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
+                    .thenReturn(0L);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
+                    .thenReturn(blockTtl);
+
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+            assertTrue(result.isSuccess());
+            assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+        }
+
+        @Test
+        void shouldReturnLockedOutWhenSmsDeprecatedKeyIsBlocked() {
+            var userContext = createUserContext(0);
+            long blockTtl = 1234567890L;
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
+                    .thenReturn(0L);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
+                    .thenReturn(blockTtl);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
+                    .thenReturn(0L);
+
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+            assertTrue(result.isSuccess());
+            assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+        }
     }
 
     @Nested

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -288,6 +288,7 @@ class PermissionDecisionManagerTest {
             var codeAttemptsBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
             when(codeStorageService.isBlockedForEmail(EMAIL, codeAttemptsBlockedKeyPrefix))
                     .thenReturn(false);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(5);
 
             var result =
                     permissionDecisionManager.canVerifyEmailOtp(
@@ -299,7 +300,7 @@ class PermissionDecisionManagerTest {
                             Decision.Permitted.class,
                             result.getSuccess(),
                             "Expected Permitted decision");
-            assertEquals(0, decision.attemptCount());
+            assertEquals(5, decision.attemptCount());
         }
 
         @Test
@@ -311,6 +312,7 @@ class PermissionDecisionManagerTest {
             var codeAttemptsBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
             when(codeStorageService.isBlockedForEmail(EMAIL, codeAttemptsBlockedKeyPrefix))
                     .thenReturn(true);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(5);
 
             var result =
                     permissionDecisionManager.canVerifyEmailOtp(
@@ -325,6 +327,7 @@ class PermissionDecisionManagerTest {
             assertEquals(
                     ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
                     lockedOut.forbiddenReason());
+            assertEquals(5, lockedOut.attemptCount());
         }
 
         @Test
@@ -728,6 +731,7 @@ class PermissionDecisionManagerTest {
         void shouldReturnPermittedWhenNotBlocked() {
             var userContext = createUserContext(0);
             when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
 
             var result =
                     permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
@@ -735,6 +739,20 @@ class PermissionDecisionManagerTest {
             assertTrue(result.isSuccess());
             var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
             assertEquals(0, decision.attemptCount());
+        }
+
+        @Test
+        void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
+            var userContext = createUserContext(0);
+            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+
+            var result =
+                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+            assertTrue(result.isSuccess());
+            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+            assertEquals(3, decision.attemptCount());
         }
 
         @Test

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -728,81 +728,194 @@ class PermissionDecisionManagerTest {
     class CanVerifyMfaOtp {
 
         @Test
-        void shouldReturnPermittedWhenNotBlocked() {
-            var userContext = createUserContext(0);
-            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
-
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
-
-            assertTrue(result.isSuccess());
-            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
-            assertEquals(0, decision.attemptCount());
-        }
-
-        @Test
-        void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
-            var userContext = createUserContext(0);
-            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
-
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
-
-            assertTrue(result.isSuccess());
-            var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
-            assertEquals(3, decision.attemptCount());
-        }
-
-        @Test
-        void shouldReturnLockedOutWhenBlocked() {
-            var userContext = createUserContext(0);
-            long blockTtl = 1234567890L;
-            when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(blockTtl);
-
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
-
-            assertTrue(result.isSuccess());
-            var lockedOut =
-                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
-            assertEquals(
-                    ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
-                    lockedOut.forbiddenReason());
-            assertEquals(6, lockedOut.attemptCount());
-        }
-
-        @Test
-        void shouldReturnStorageErrorWhenExceptionThrown() {
-            var userContext = createUserContext(0);
-            doThrow(new RuntimeException("Storage error"))
-                    .when(codeStorageService)
-                    .getTTL(eq(EMAIL), anyString());
-
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+        void shouldReturnErrorWhenPermissionContextIsNull() {
+            var result = permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, null);
 
             assertTrue(result.isFailure());
-            assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
+            assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
         }
 
-        @Test
-        void shouldReturnLockedOutWhenAuthAppDeprecatedKeyIsBlocked() {
-            var userContext = createUserContext(0);
-            long blockTtl = 1234567890L;
-            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
-                    .thenReturn(0L);
-            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
-                    .thenReturn(0L);
-            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
-                    .thenReturn(blockTtl);
+        @Nested
+        class StandardJourneys {
 
-            var result =
-                    permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+            @Test
+            void shouldReturnErrorWhenEmailAddressIsNull() {
+                var userContext =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-id")
+                                .withAuthSessionItem(new AuthSessionItem())
+                                .build();
 
-            assertTrue(result.isSuccess());
-            assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnPermittedWhenNotBlocked() {
+                var userContext = createUserContext(0);
+                when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+                when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isSuccess());
+                var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                assertEquals(0, decision.attemptCount());
+            }
+
+            @Test
+            void shouldReturnPermittedWithAttemptCountWhenNotBlocked() {
+                var userContext = createUserContext(0);
+                when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(0L);
+                when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isSuccess());
+                var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                assertEquals(3, decision.attemptCount());
+            }
+
+            @Test
+            void shouldReturnLockedOutWhenBlocked() {
+                var userContext = createUserContext(0);
+                long blockTtl = 1234567890L;
+                when(codeStorageService.getTTL(eq(EMAIL), anyString())).thenReturn(blockTtl);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isSuccess());
+                var lockedOut =
+                        assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+                assertEquals(
+                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                        lockedOut.forbiddenReason());
+                assertEquals(6, lockedOut.attemptCount());
+            }
+
+            @Test
+            void shouldReturnStorageErrorWhenExceptionThrown() {
+                var userContext = createUserContext(0);
+                doThrow(new RuntimeException("Storage error"))
+                        .when(codeStorageService)
+                        .getTTL(eq(EMAIL), anyString());
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.STORAGE_SERVICE_ERROR, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnLockedOutWhenAuthAppDeprecatedKeyIsBlocked() {
+                var userContext = createUserContext(0);
+                long blockTtl = 1234567890L;
+                when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "MFA_SIGN_IN"))
+                        .thenReturn(0L);
+                when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "SMS_SIGN_IN"))
+                        .thenReturn(0L);
+                when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + "AUTH_APP_SIGN_IN"))
+                        .thenReturn(blockTtl);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(JourneyType.SIGN_IN, userContext);
+
+                assertTrue(result.isSuccess());
+                assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldReturnErrorWhenInternalSubjectIdIsNull() {
+                var userContext =
+                        PermissionContext.builder()
+                                .withRpPairwiseId("pairwise")
+                                .withEmailAddress(EMAIL)
+                                .withAuthSessionItem(new AuthSessionItem())
+                                .build();
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenRpPairwiseIdIsNull() {
+                var userContext =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-id")
+                                .withEmailAddress(EMAIL)
+                                .withAuthSessionItem(new AuthSessionItem())
+                                .build();
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isFailure());
+                assertEquals(DecisionError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnPermittedWhenNotBlocked() {
+                var userContext = createUserContext(0);
+                var identifiers = new ArrayList<String>();
+                identifiers.add(userContext.internalSubjectId());
+                identifiers.add(userContext.rpPairwiseId());
+                when(authenticationAttemptsService.getCountsByJourneyForIdentifiers(
+                                identifiers, JourneyType.REAUTHENTICATION))
+                        .thenReturn(Map.of(CountType.ENTER_MFA_CODE, 2));
+                when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+                when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+                when(configurationService.getCodeMaxRetries()).thenReturn(5);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isSuccess());
+                var decision = assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                assertEquals(2, decision.attemptCount());
+            }
+
+            @Test
+            void shouldReturnReauthLockedOutWhenMfaCountExceeded() {
+                var userContext = createUserContext(0);
+                var identifiers = new ArrayList<String>();
+                identifiers.add(userContext.internalSubjectId());
+                identifiers.add(userContext.rpPairwiseId());
+                when(authenticationAttemptsService.getCountsByJourneyForIdentifiers(
+                                identifiers, JourneyType.REAUTHENTICATION))
+                        .thenReturn(Map.of(CountType.ENTER_MFA_CODE, 6));
+                when(configurationService.getMaxEmailReAuthRetries()).thenReturn(5);
+                when(configurationService.getMaxPasswordRetries()).thenReturn(5);
+                when(configurationService.getCodeMaxRetries()).thenReturn(5);
+
+                var result =
+                        permissionDecisionManager.canVerifyMfaOtp(
+                                JourneyType.REAUTHENTICATION, userContext);
+
+                assertTrue(result.isSuccess());
+                var lockedOut =
+                        assertInstanceOf(Decision.ReauthLockedOut.class, result.getSuccess());
+                assertEquals(
+                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                        lockedOut.forbiddenReason());
+                assertEquals(6, lockedOut.attemptCount());
+            }
         }
 
         @Test

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -693,7 +693,7 @@ class PermissionDecisionManagerTest {
         }
 
         @Test
-        void shouldReturnLockedOutWhenInMemoryLockoutStateHolderIsSet() {
+        void shouldReturnReauthLockedOutWhenInMemoryLockoutStateHolderIsSet() {
             var userContext = createUserContext(0);
             var lockoutStateHolder = new InMemoryLockoutStateHolder();
             lockoutStateHolder.setReauthSmsOtpLimitExceeded();
@@ -703,8 +703,7 @@ class PermissionDecisionManagerTest {
                             JourneyType.REAUTHENTICATION, userContext, lockoutStateHolder);
 
             assertTrue(result.isSuccess());
-            var lockedOut =
-                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            var lockedOut = assertInstanceOf(Decision.ReauthLockedOut.class, result.getSuccess());
             assertEquals(
                     ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
                     lockedOut.forbiddenReason());

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/TrackingErrorTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/TrackingErrorTest.java
@@ -9,5 +9,6 @@ class TrackingErrorTest {
     @Test
     void shouldHaveCorrectEnumValues() {
         assertEquals("STORAGE_SERVICE_ERROR", TrackingError.STORAGE_SERVICE_ERROR.name());
+        assertEquals("INVALID_USER_CONTEXT", TrackingError.INVALID_USER_CONTEXT.name());
     }
 }


### PR DESCRIPTION
## What

This PR extends `PermissionDecisionManager` and the integration test suite to prepare for the upcoming lockout refactoring of `VerifyCodeHandler` and `VerifyMfaCodeHandler`.

The verify code handlers are about to have their inline lockout logic replaced with `PermissionDecisionManager` and `UserActionsManager`. These preparatory changes ensure the manager classes have the capabilities the handlers will need, and that the integration tests will catch any unintended changes to audit event payloads during the refactor.

### Things to note

- The `AUTH_APP` deprecated key fix addresses a gap that is practically harmless (old-format blocks have long expired) but is included to maintain correctness during the lift-and-shift. We're not trying to change behaviour, just move it.
- `MfaHandler` now returns a 500 if `canVerifyMfaOtp` returns `ReauthLockedOut`, because reauth locks should have been caught by an earlier handler in the journey. This is a defensive guard, not an expected path. `canVerifyMfaOtp` serves reauth lockouts now as it will be needed in the upcoming verify code handler refactors.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] All commits contain one or more `Co-authored-by` lines where pairing or mobbing has taken place

## Related PRs

The next PR is https://github.com/govuk-one-login/authentication-api/pull/8173
