### PR TITLE
AUT-5350: Deleting TSD assume role for Account deletion process

### DIFF
--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -940,53 +940,6 @@ Resources:
       TargetKeyId: !Ref TestIdTokenSigningKey
 
   # ----------------
-  # TSD Account Deletion role
-  # ----------------
-  InvokeAccountDeletionLambdaPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Condition: ShouldCreateAccountDeletionPolicy
-    Properties:
-      ManagedPolicyName: manual-account-deletion-user-policy
-      Path: /control-tower/am/
-      Description: Policy for use in Control Tower to be attached to the role assumed by support users to perform account deletions
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: permitInvokeLambda
-            Effect: Allow
-            Action:
-              - lambda:InvokeFunction
-              - lambda:GetFunctionConfiguration
-            Resource:
-              - !GetAtt ManuallyDeleteAccountFunction.Arn
-
-  AccountDeletionRole:
-    Type: AWS::IAM::Role
-    Condition: ShouldCreateAccountDeletionPolicy
-    Properties:
-      RoleName: !Sub ${AWS::StackName}-support-account-deletion-role
-      Path: /runbooks/
-      Description: Role for support users to perform account deletions using lambda exec action
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-            Action: sts:AssumeRole
-            Condition:
-              StringLike:
-                aws:PrincipalArn: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
-      ManagedPolicyArns:
-        - !Ref InvokeAccountDeletionLambdaPolicy
-      PermissionsBoundary:
-        !If [
-          UsePermissionsBoundary,
-          !Ref PermissionsBoundary,
-          !Ref AWS::NoValue,
-        ]
-
-  # ----------------
   # Managed policies
   # ----------------
 


### PR DESCRIPTION
## What

AUt-5350: Deleting TSD assume role for Account deletion process due to path change will be created again with  runbook path 

## How to review

1. Code Review
