### PR TITLE
AUT-5340: Generate access tokens in generic way

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenConfig.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenConfig.java
@@ -1,4 +1,4 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
 public record AccessTokenConfig(
-        String accessTokenName, AMCDownstreamScope scope, String audience, String signingKey) {}
+        String accessTokenName, AccessTokenScope scope, String audience, String signingKey) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenScope.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public interface AMCDownstreamScope {
+public interface AccessTokenScope {
 
     String getValue();
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountDataScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountDataScope.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public enum AccountDataScope implements AMCDownstreamScope {
+public enum AccountDataScope implements AccessTokenScope {
     PASSKEY_CREATE("passkey-create");
 
     private final String value;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountManagementScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountManagementScope.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public enum AccountManagementScope implements AMCDownstreamScope {
+public enum AccountManagementScope implements AccessTokenScope {
     ACCOUNT_DELETE("account-delete");
 
     private final String value;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenConfig;
 import uk.gov.di.authentication.frontendapi.entity.amc.TransportJWTConfig;
 import uk.gov.di.authentication.frontendapi.errormapper.AMCFailureHttpMapper;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
+import uk.gov.di.authentication.frontendapi.services.AccessTokenConstructorService;
 import uk.gov.di.authentication.frontendapi.services.JwtService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -73,7 +74,10 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                 new AMCService(
                         configurationService,
                         new NowHelper.NowClock(Clock.systemUTC()),
-                        new JwtService(new KmsConnectionService(configurationService)));
+                        new JwtService(new KmsConnectionService(configurationService)),
+                        new AccessTokenConstructorService(
+                                new JwtService(new KmsConnectionService(configurationService)),
+                                configurationService));
         this.dynamoAmcStateService = new DynamoAmcStateService(configurationService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.frontendapi.entity.amc.AMCCallbackRequest;
 import uk.gov.di.authentication.frontendapi.entity.amc.TokenResponseError;
 import uk.gov.di.authentication.frontendapi.errormapper.AMCFailureHttpMapper;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
+import uk.gov.di.authentication.frontendapi.services.AccessTokenConstructorService;
 import uk.gov.di.authentication.frontendapi.services.JwtService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -54,7 +55,10 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
                 new AMCService(
                         configurationService,
                         new NowHelper.NowClock(Clock.systemUTC()),
-                        new JwtService(new KmsConnectionService(configurationService)));
+                        new JwtService(new KmsConnectionService(configurationService)),
+                        new AccessTokenConstructorService(
+                                new JwtService(new KmsConnectionService(configurationService)),
+                                configurationService));
         this.dynamoAmcStateService = new DynamoAmcStateService(configurationService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -6,7 +6,6 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
@@ -21,7 +20,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizationUrlAndCookie;
-import uk.gov.di.authentication.frontendapi.entity.amc.AMCDownstreamScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenConfig;
@@ -48,16 +46,19 @@ public class AMCService {
     private final ConfigurationService configurationService;
     private final NowHelper.NowClock nowClock;
     private final JwtService jwtService;
+    private final AccessTokenConstructorService accessTokenConstructorService;
     private static final Logger LOG = LogManager.getLogger(AMCService.class);
     private static final Long CLIENT_ASSERTION_LIFETIME = 5L;
 
     public AMCService(
             ConfigurationService configurationService,
             NowHelper.NowClock nowClock,
-            JwtService jwtService) {
+            JwtService jwtService,
+            AccessTokenConstructorService accessTokenConstructorService) {
         this.configurationService = configurationService;
         this.nowClock = nowClock;
         this.jwtService = jwtService;
+        this.accessTokenConstructorService = accessTokenConstructorService;
     }
 
     public Result<AMCFailureReason, AMCAuthorizationUrlAndCookie> buildAuthorizationResult(
@@ -206,14 +207,18 @@ public class AMCService {
 
         for (AccessTokenConfig config : configs) {
             var result =
-                    createAccessToken(
-                            internalPairwiseSubject,
-                            config.scope(),
-                            authSessionItem,
-                            issueTime,
-                            expiryDate,
-                            config.audience(),
-                            config.signingKey());
+                    accessTokenConstructorService
+                            .createSignedAccessToken(
+                                    internalPairwiseSubject,
+                                    config.scope(),
+                                    authSessionItem,
+                                    issueTime,
+                                    expiryDate,
+                                    config.audience(),
+                                    configurationService.getAuthIssuerClaim(),
+                                    configurationService.getAMCClientId(),
+                                    config.signingKey())
+                            .mapFailure(this::mapJwtFailureReason);
 
             if (result.isFailure()) {
                 return Result.failure(result.getFailure());
@@ -222,39 +227,6 @@ public class AMCService {
             accessTokens.put(config.accessTokenName(), result.getSuccess());
         }
         return Result.success(accessTokens);
-    }
-
-    private Result<AMCFailureReason, BearerAccessToken> createAccessToken(
-            String internalPairwiseSubject,
-            AMCDownstreamScope scope,
-            AuthSessionItem authSessionItem,
-            Date issueTime,
-            Date expiryDate,
-            String audience,
-            String signingKey) {
-        var claims =
-                new JWTClaimsSet.Builder()
-                        .claim("scope", scope.getValue())
-                        .issuer(configurationService.getAuthIssuerClaim())
-                        .audience(audience)
-                        .expirationTime(expiryDate)
-                        .issueTime(issueTime)
-                        .notBeforeTime(issueTime)
-                        .subject(internalPairwiseSubject)
-                        .claim("client_id", configurationService.getAMCClientId())
-                        .claim("sid", authSessionItem.getSessionId())
-                        .jwtID(UUID.randomUUID().toString())
-                        .build();
-
-        return jwtService
-                .signJWT(claims, signingKey)
-                .map(
-                        signedJWT ->
-                                new BearerAccessToken(
-                                        signedJWT.serialize(),
-                                        configurationService.getSessionExpiry(),
-                                        new Scope(scope.getValue())))
-                .mapFailure(this::mapJwtFailureReason);
     }
 
     private JWTAuthenticationClaimsSet buildClientAssertionJwt() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorService.java
@@ -1,0 +1,62 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenScope;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Date;
+import java.util.UUID;
+
+public class AccessTokenConstructorService {
+
+    private final JwtService jwtService;
+    private final ConfigurationService configurationService;
+
+    public AccessTokenConstructorService(
+            JwtService jwtService, ConfigurationService configurationService) {
+        this.jwtService = jwtService;
+        this.configurationService = configurationService;
+    }
+
+    public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
+            String internalPairwiseSubject,
+            AccessTokenScope scope,
+            AuthSessionItem authSessionItem,
+            Date issueTime,
+            Date expiryDate,
+            String audience,
+            String issuer,
+            String clientId,
+            String signingKey) {
+        var claims =
+                new JWTClaimsSet.Builder()
+                        .claim("scope", scope.getValue())
+                        .issuer(issuer)
+                        .audience(audience)
+                        .expirationTime(expiryDate)
+                        .issueTime(issueTime)
+                        .notBeforeTime(issueTime)
+                        .subject(internalPairwiseSubject)
+                        .claim("client_id", clientId)
+                        .claim("sid", authSessionItem.getSessionId())
+                        .jwtID(UUID.randomUUID().toString())
+                        .build();
+
+        return jwtService
+                .signJWT(claims, signingKey)
+                .map(signedJWT -> signedJwtToAccessToken(signedJWT, scope));
+    }
+
+    private BearerAccessToken signedJwtToAccessToken(SignedJWT signedJWT, AccessTokenScope scope) {
+        return new BearerAccessToken(
+                signedJWT.serialize(),
+                configurationService.getSessionExpiry(),
+                new Scope(scope.getValue()));
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -25,12 +25,14 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,10 +42,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
-import uk.gov.di.authentication.frontendapi.entity.amc.AMCDownstreamScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenConfig;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccountDataScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccountManagementScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.JourneyOutcomeError;
@@ -135,22 +137,23 @@ class AMCServiceTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final JwtService jwtService = mock(JwtService.class);
+    private final AccessTokenConstructorService accessTokenConstructorService =
+            mock(AccessTokenConstructorService.class);
     private ECKey accessTokenKey;
     private ECKey otherAccessTokenKey;
     private ECKey compositeJWTKey;
 
     @BeforeEach
     void setup() throws Exception {
-        amcService = new AMCService(configurationService, NOW_CLOCK, jwtService);
+        amcService =
+                new AMCService(
+                        configurationService, NOW_CLOCK, jwtService, accessTokenConstructorService);
         accessTokenKey = new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         compositeJWTKey = new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         otherAccessTokenKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
-        mockJwtSigning(
-                Map.of(
-                        ACCESS_TOKEN_KEY_ALIAS, accessTokenKey,
-                        COMPOSITE_JWT_KEY_ALIAS, compositeJWTKey,
-                        OTHER_ACCESS_TOKEN_KEY_ALIAS, otherAccessTokenKey));
+        mockJwtSigning(Map.of(COMPOSITE_JWT_KEY_ALIAS, compositeJWTKey));
+        mockAccessTokenCreation();
         mockJwtEncryption();
         authSessionItem =
                 new AuthSessionItem()
@@ -274,7 +277,6 @@ class AMCServiceTest {
 
         @Test
         void shouldReturnFailureWhenSignatureTranscodingFails() {
-
             when(jwtService.signJWT(any(JWTClaimsSet.class), any(String.class)))
                     .thenReturn(Result.failure(JwtFailureReason.TRANSCODING_ERROR));
 
@@ -318,7 +320,42 @@ class AMCServiceTest {
             when(jwtService.signJWT(any(), any())).thenReturn(Result.failure(signingFailureReason));
 
             AMCService serviceWithMockJwt =
-                    new AMCService(configurationService, NOW_CLOCK, jwtService);
+                    new AMCService(
+                            configurationService,
+                            NOW_CLOCK,
+                            jwtService,
+                            accessTokenConstructorService);
+
+            var result =
+                    serviceWithMockJwt.buildAuthorizationResult(
+                            INTERNAL_PAIRWISE_ID,
+                            AMCScope.ACCOUNT_DELETE,
+                            authSessionItem,
+                            PUBLIC_SUBJECT,
+                            REDIRECT_URI,
+                            ACCESS_TOKEN_CONFIG,
+                            TEST_PUBLIC_ENCRYPTION_KEY,
+                            STATE);
+
+            assertTrue(result.isFailure());
+            assertEquals(expectedFailureReason, result.getFailure());
+        }
+
+        @ParameterizedTest
+        @MethodSource("jwtFailureReasonsToAMCFailureReasons")
+        void shouldMapJwtFailureReasonsFromCreateSignedAccessTokenToAMCFailureReason(
+                JwtFailureReason jwtFailureReason, AMCFailureReason expectedFailureReason) {
+            var externalApiAccessTokenService = mock(AccessTokenConstructorService.class);
+            when(externalApiAccessTokenService.createSignedAccessToken(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(Result.failure(jwtFailureReason));
+
+            AMCService serviceWithMockJwt =
+                    new AMCService(
+                            configurationService,
+                            NOW_CLOCK,
+                            jwtService,
+                            externalApiAccessTokenService);
 
             var result =
                     serviceWithMockJwt.buildAuthorizationResult(
@@ -367,7 +404,7 @@ class AMCServiceTest {
         }
 
         private void assertAccessTokenClaims(
-                AMCDownstreamScope expectedScope,
+                AccessTokenScope expectedScope,
                 String expectedAudience,
                 JWTClaimsSet accessTokenClaims) {
             assertAll(
@@ -566,6 +603,59 @@ class AMCServiceTest {
                             } catch (JOSEException | ParseException e) {
                                 throw new RuntimeException(e);
                             }
+                        });
+    }
+
+    private void mockAccessTokenCreation() {
+        when(accessTokenConstructorService.createSignedAccessToken(
+                        any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenAnswer(
+                        invocation -> {
+                            String internalPairwiseSubject = invocation.getArgument(0);
+                            AccessTokenScope scope = invocation.getArgument(1);
+                            AuthSessionItem session = invocation.getArgument(2);
+                            Date issueTime = invocation.getArgument(3);
+                            Date expiryDate = invocation.getArgument(4);
+                            String audience = invocation.getArgument(5);
+                            String issuer = invocation.getArgument(6);
+                            String clientId = invocation.getArgument(7);
+                            String signingKeyAlias = invocation.getArgument(8);
+
+                            ECKey key =
+                                    Map.of(
+                                                    ACCESS_TOKEN_KEY_ALIAS, accessTokenKey,
+                                                    OTHER_ACCESS_TOKEN_KEY_ALIAS,
+                                                            otherAccessTokenKey)
+                                            .get(signingKeyAlias);
+
+                            var claims =
+                                    new JWTClaimsSet.Builder()
+                                            .claim("scope", scope.getValue())
+                                            .issuer(issuer)
+                                            .audience(audience)
+                                            .expirationTime(expiryDate)
+                                            .issueTime(issueTime)
+                                            .notBeforeTime(issueTime)
+                                            .subject(internalPairwiseSubject)
+                                            .claim("client_id", clientId)
+                                            .claim("sid", session.getSessionId())
+                                            .jwtID(UUID.randomUUID().toString())
+                                            .build();
+
+                            SignedJWT signedJWT =
+                                    new SignedJWT(
+                                            new JWSHeader.Builder(JWSAlgorithm.ES256)
+                                                    .type(com.nimbusds.jose.JOSEObjectType.JWT)
+                                                    .keyID(key.getKeyID())
+                                                    .build(),
+                                            claims);
+                            signedJWT.sign(new ECDSASigner(key));
+
+                            return Result.success(
+                                    new BearerAccessToken(
+                                            signedJWT.serialize(),
+                                            3600L,
+                                            new Scope(scope.getValue())));
                         });
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorServiceTest.java
@@ -1,0 +1,159 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenScope;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccountDataScope;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccountManagementScope;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_PAIRWISE_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
+
+class AccessTokenConstructorServiceTest {
+
+    private static final String AUDIENCE = "https://api.example.com";
+    private static final String ISSUER = "https://signin.account.gov.uk/";
+    private static final String AMC_CLIENT_ID = "amc-client-id";
+    private static final String SIGNING_KEY_ALIAS = "test-key-alias";
+    private static final long SESSION_EXPIRY = 3600L;
+
+    private static final Instant NOW_INSTANT = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    private static final Date NOW = Date.from(NOW_INSTANT);
+    private static final Date EXPIRY = Date.from(NOW_INSTANT.plus(5, ChronoUnit.MINUTES));
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final JwtService jwtService = mock(JwtService.class);
+
+    private AccessTokenConstructorService accessTokenConstructorService;
+    private AuthSessionItem authSessionItem;
+    private ECKey signingKey;
+
+    @BeforeEach
+    void setup() throws Exception {
+        accessTokenConstructorService =
+                new AccessTokenConstructorService(jwtService, configurationService);
+
+        when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
+        mockJwtSigning();
+        signingKey = new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
+        authSessionItem =
+                new AuthSessionItem()
+                        .withClientId(CLIENT_ID)
+                        .withSessionId(SESSION_ID)
+                        .withEmailAddress(EMAIL);
+    }
+
+    private static Stream<Arguments> validScopes() {
+        return Stream.of(
+                Arguments.of(AccountDataScope.PASSKEY_CREATE, "passkey-create"),
+                Arguments.of(AccountManagementScope.ACCOUNT_DELETE, "account-delete"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validScopes")
+    void shouldCreateAndSignAccessTokenWithValidScope(
+            AccessTokenScope accessTokenScope, String expectedScope)
+            throws ParseException, JOSEException {
+        // Arrange
+        // Act
+        var result =
+                accessTokenConstructorService.createSignedAccessToken(
+                        INTERNAL_PAIRWISE_ID,
+                        accessTokenScope,
+                        authSessionItem,
+                        NOW,
+                        EXPIRY,
+                        AUDIENCE,
+                        ISSUER,
+                        AMC_CLIENT_ID,
+                        SIGNING_KEY_ALIAS);
+
+        // Assert
+        assertTrue(result.isSuccess());
+        var token = result.getSuccess();
+        var signedJWT = SignedJWT.parse(token.getValue());
+        var claims = signedJWT.getJWTClaimsSet();
+
+        assertTrue(signedJWT.verify(new ECDSAVerifier(signingKey.toECPublicKey())));
+        assertEquals(expectedScope, claims.getClaim("scope"));
+        assertEquals(ISSUER, claims.getIssuer());
+        assertEquals(AUDIENCE, claims.getAudience().get(0));
+        assertEquals(INTERNAL_PAIRWISE_ID, claims.getSubject());
+        assertEquals(AMC_CLIENT_ID, claims.getClaim("client_id"));
+        assertEquals(SESSION_ID, claims.getClaim("sid"));
+        assertEquals(NOW, claims.getIssueTime());
+        assertEquals(EXPIRY, claims.getExpirationTime());
+        assertEquals(NOW, claims.getNotBeforeTime());
+    }
+
+    @Test
+    void shouldReturnJwtFailureReasonIfThereIsSigningFailure() {
+        // Arrange
+        when(jwtService.signJWT(any(JWTClaimsSet.class), any(String.class)))
+                .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+        // Act
+        var result =
+                accessTokenConstructorService.createSignedAccessToken(
+                        INTERNAL_PAIRWISE_ID,
+                        AccountDataScope.PASSKEY_CREATE,
+                        authSessionItem,
+                        NOW,
+                        EXPIRY,
+                        AUDIENCE,
+                        ISSUER,
+                        AMC_CLIENT_ID,
+                        SIGNING_KEY_ALIAS);
+
+        // Assert
+        assertTrue(result.isFailure());
+        assertEquals(JwtFailureReason.SIGNING_ERROR, result.getFailure());
+    }
+
+    private void mockJwtSigning() {
+        when(jwtService.signJWT(any(JWTClaimsSet.class), any(String.class)))
+                .thenAnswer(
+                        invocation -> {
+                            JWTClaimsSet claims = invocation.getArgument(0);
+                            var jwsBuilder =
+                                    new JWSHeader.Builder(JWSAlgorithm.ES256)
+                                            .type(JOSEObjectType.JWT)
+                                            .keyID(signingKey.getKeyID())
+                                            .build();
+                            SignedJWT signedJWT = new SignedJWT(jwsBuilder, claims);
+                            signedJWT.sign(new ECDSASigner(signingKey));
+                            return Result.success(signedJWT);
+                        });
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/CommonTestVariables.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/CommonTestVariables.java
@@ -32,6 +32,8 @@ public class CommonTestVariables {
     public static final String PUBLIC_SUBJECT_ID = "public-subject-id";
     public static final String JOURNEY_ID = "journey-id";
     public static final String TEST_OTP_CODE = "123456";
+    public static final String INTERNAL_PAIRWISE_ID =
+            "urn:fdc:gov.uk:2022:xH7hrtJCgdi2NEF7TXcOC6SMz8DohdoLo9hWqQMWPRk";
     public static final Map<String, String> VALID_HEADERS =
             Map.ofEntries(
                     Map.entry(


### PR DESCRIPTION
## What

- Add `AccessTokenConstructorService`. Currently, this is used to build the ADAPI access token that we will be sending as a claim when we authorize with AMC and when we make direct calls to the ADAPI from internal-api. However, this should be extendable to constructing other access tokens in the future
- Use this new service when making the access tokens in the AMCAuthorize request

## How to review

1. Code review
2. Deploy to dev env and run through a create passkey journey


