### PR TITLE
Ato 2500/add further catch coverage on invoke

### DIFF
--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/logging/LogEventMatcher.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/logging/LogEventMatcher.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.sharedtest.logging;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -33,6 +34,28 @@ public class LogEventMatcher {
             @Override
             protected boolean matchesSafely(LogEvent item) {
                 var message = item.getMessage().getFormattedMessage();
+
+                return Arrays.stream(values).anyMatch(message::contains);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a log event with message containing [" + Arrays.asList(values) + "]");
+            }
+        };
+    }
+
+    public static Matcher<LogEvent> withLevelAndMessageContaining(Level level, String... values) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(LogEvent item) {
+                var message = item.getMessage().getFormattedMessage();
+
+                if (!item.getLevel().equals(level)) {
+                    return false;
+                }
 
                 return Arrays.stream(values).anyMatch(message::contains);
             }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
@@ -44,6 +45,7 @@ public class ClientSignatureValidationService {
 
     private static final Logger LOG = LogManager.getLogger(ClientSignatureValidationService.class);
     private static final String TOKEN_PATH = "token";
+    public static final String MISSING = "missing";
 
     private final OidcAPI oidcAPI;
     private final ConfigurationService configurationService;
@@ -202,7 +204,26 @@ public class ClientSignatureValidationService {
                             .build();
             return awsLambda.invoke(request);
         } catch (LambdaException e) {
-            LOG.error("LambdaException thrown while invoking FetchJwksFunction");
+            var errorMessage =
+                    Optional.ofNullable(e.awsErrorDetails())
+                            .map(AwsErrorDetails::errorMessage)
+                            .orElse(MISSING);
+
+            var errorCode =
+                    Optional.ofNullable(e.awsErrorDetails())
+                            .map(AwsErrorDetails::errorCode)
+                            .orElse(MISSING);
+
+            var requestId = Optional.ofNullable(e.requestId()).orElse(MISSING);
+
+            LOG.error(
+                    "LambdaException thrown while invoking FetchJwksFunction: {}\n Error code: {}\n Request ID: {}",
+                    errorMessage,
+                    errorCode,
+                    requestId);
+            throw new JwksException(e.getMessage());
+        } catch (Exception e) {
+            LOG.error("Exception thrown while invoking FetchJwksFunction: ", e);
             throw new JwksException(e.getMessage());
         }
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationServiceTest.java
@@ -14,19 +14,24 @@ import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.Nonce;
+import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+import software.amazon.awssdk.services.lambda.model.LambdaException;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
+import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -39,10 +44,13 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.nimbusds.jose.JWSAlgorithm.RS256;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withLevelAndMessageContaining;
 import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class ClientSignatureValidationServiceTest {
@@ -62,6 +70,10 @@ class ClientSignatureValidationServiceTest {
 
     private ClientRegistry client;
     private KeyPair keyPair;
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(ClientSignatureValidationService.class);
 
     @BeforeEach
     void setup() {
@@ -185,6 +197,42 @@ class ClientSignatureValidationServiceTest {
             assertThrows(
                     JwksException.class,
                     () -> clientSignatureValidationService.validate(signedJWT, client));
+        }
+
+        @Test
+        void shouldLogAndThrowJwksExceptionWhenInvokeReturnsLambdaException() {
+            when(lambdaClient.invoke((InvokeRequest) ArgumentMatchers.any()))
+                    .thenThrow(LambdaException.class);
+            var signedJWT = generateSignedJWT(keyPair.getPrivate());
+
+            assertThrows(
+                    JwksException.class,
+                    () -> clientSignatureValidationService.validate(signedJWT, client));
+
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withLevelAndMessageContaining(
+                                    Level.ERROR,
+                                    "LambdaException thrown while invoking FetchJwksFunction")));
+        }
+
+        @Test
+        void shouldLogAndThrowJwksExceptionWhenInvokeReturnsException() {
+            when(lambdaClient.invoke((InvokeRequest) ArgumentMatchers.any()))
+                    .thenThrow(SdkClientException.class);
+            var signedJWT = generateSignedJWT(keyPair.getPrivate());
+
+            assertThrows(
+                    JwksException.class,
+                    () -> clientSignatureValidationService.validate(signedJWT, client));
+
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withLevelAndMessageContaining(
+                                    Level.ERROR,
+                                    "Exception thrown while invoking FetchJwksFunction")));
         }
 
         @Test


### PR DESCRIPTION
### Wider context of change
As part of the P2 yesterday, we realised we weren't catching all the errors AWS returns. This catches and adds some additional detail to logging

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
