### PR TITLE
BAU: Fix CVE-2026-2332 jetty vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ subprojects {
                     }
 
                     add(conf.name, 'org.eclipse.jetty:jetty-http:[12.0.33,12.1.0)') {
-                        because 'CVE-2026-2332 is fixed in org.eclipse.jetty:jetty-http:12.0.33 and higher'
+                        because 'CVE-2026-2332 is fixed in org.eclipse.jetty:jetty-http:12.0.33'
                     }
 
                     // Jackson constraints

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -7,6 +7,12 @@ group = "uk.gov.di.authentication.local"
 version = "unspecified"
 
 dependencies {
+    constraints {
+        implementation('org.eclipse.jetty:jetty-http:[12.1.7,)') {
+            because 'CVE-2026-2332 is fixed in org.eclipse.jetty:jetty-http:12.1.7 and higher'
+        }
+    }
+
     implementation libs.javalin,
             libs.bundles.awsDynamoDb,
             libs.awsKms,


### PR DESCRIPTION


## What

Fix dependabot alert [here](https://github.com/govuk-one-login/authentication-api/security/dependabot/98)

## How to review

1. Code review

## Checklist

