### PR TITLE
BAU: Reword checklist items for better applicability

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/auth_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/auth_template.md
@@ -29,7 +29,7 @@ When deprecating session data, split the work into two PRs:
 2. After any sessions containing that data have expired, remove the value’s definition.
 -->
 
-- [ ] Deployment of this PR will not break active user journeys
+- [ ] Assessed the impact on active user sessions and confirmed no breaking changes
 
 <!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨
 
@@ -39,7 +39,7 @@ Check with counterparts to see if changes need to be made in the other team's co
 In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
 -->
 
-- [ ] Impact on orch and auth mutual dependencies has been checked.
+- [ ] Orch and Auth mutual dependencies have been checked for breaking changes
 
 <!-- Changes required to stub-orchestration?
 
@@ -47,7 +47,7 @@ If the contract between Orch and Auth has changed then this may need to be refle
 
 -->
 
-- [ ] No changes required or changes have been made to stub-orchestration.
+- [ ] Stub-orchestration has been updated (or no changes required)
 
 <!-- UCD Review
 When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.
@@ -59,7 +59,7 @@ Contact UCD colleagues in the Authentication team to identify the best way to ap
 Delete this item if this PR does not need a UCD review.
 -->
 
-- [ ] A UCD review has been performed.
+- [ ] A UCD review has been performed (or no review required)
 
 <!-- Pairing
 We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.
@@ -67,7 +67,7 @@ We want to make sure ensemble commits are correctly attributed to the contributo
 See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
 -->
 
-- [ ] All commits contain one or more `Co-authored-by` lines where pairing or mobbing has taken place
+- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)
 
 ## Related PRs
 


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Reword checklist items for better applicability

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Static Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys **- Markdown file changes only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked. **- Markdown file changes only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration. **- Markdown file changes only**