### PR TITLE
ATO-2508: Use default credentials provider, not Environment variable based

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
@@ -1,5 +1,6 @@
 package uk.gov.di.accountmanagement.services;
 
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -21,9 +22,10 @@ public class AwsSnsClient {
         var builder =
                 SnsClient.builder()
                         .region(Region.of(region))
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create());
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build());
         if (endpointUri != null && !endpointUri.isEmpty()) {
-            builder.endpointOverride(URI.create(endpointUri));
+            builder.endpointOverride(URI.create(endpointUri))
+                    .credentialsProvider(EnvironmentVariableCredentialsProvider.create());
         }
         this.snsClient = builder.build();
         this.topicArn = topicArn;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
@@ -2,6 +2,7 @@ package uk.gov.di.accountmanagement.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -24,9 +25,10 @@ public class AwsSnsClient {
         var builder =
                 SnsClient.builder()
                         .region(Region.of(region))
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create());
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build());
         if (endpointUri != null && !endpointUri.isEmpty()) {
-            builder.endpointOverride(URI.create(endpointUri));
+            builder.endpointOverride(URI.create(endpointUri))
+                    .credentialsProvider(EnvironmentVariableCredentialsProvider.create());
         }
         this.snsClient = builder.build();
         this.topicArn = topicArn;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -14,7 +14,7 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
@@ -63,7 +63,7 @@ public class ClientSignatureValidationService {
         this.lambdaClient =
                 LambdaClient.builder()
                         .region(Region.of(configurationService.getAwsRegion()))
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .build();
         this.oidcAPI = new OidcAPI(configurationService);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -13,7 +13,7 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
@@ -59,7 +59,7 @@ public class ClientSignatureValidationService {
         this.lambdaClient =
                 LambdaClient.builder()
                         .region(Region.of(configurationService.getAwsRegion()))
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
                         .build();
         this.oidcAPI = new OidcAPI(configurationService);
     }


### PR DESCRIPTION
### Wider context of change

We previously enabled snapstart on the token handler[1] which started throwing errors due to the usage of EnvironmentVariableCredentialsProvider.

When using Snapstart[2], the environment variables based credentials are not set in the lambda environment, as these would have likely expired due to the cached execution environment.

When explicitly setting EnvironmentVariableCredentialsProvider here, we overide the default credential provider chain[3] lambda uses, which means lambda only tries to use the Environment variables to invoke the SDK client, causing exceptions to be thrown because the env vars are not set when Snapstart is enabled.

The fix here is to use the Default Credential provider class, as there is no real benefit to us overriding the default here. This means that once snapstart is re-enabled, we will no longer throw an exception here.

[1] - https://github.com/govuk-one-login/authentication-api/pull/8168
[2] - https://docs.aws.amazon.com/lambda/latest/dg/snapstart-activate.html#snapstart-credentials
[3] - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html

### What’s changed
- Removes any usages of EnvironmentVariableCredentialsProvider with DefaultCredentialsProvider in client signature validation service. 
- Also removes it from a service in the an SNS service in account management

### Manual testing:
- This is really quite unlikely to break anything as the DefaultCredentialsProvider is more expansive than the EnvironmentVariableCredentialsProvider however I will test that our JWKS fetching is unaffected by this:

- Deploy to dev and configure stub for JWKS (deployed these [stub](https://github.com/govuk-one-login/relying-party-stub/pull/793) changes alongside this)
- Run through a journey and confirm the fetch jwks handler is invoked and a full journey is unaffected
- Saw the fetch JWKS handler was invoked fine 
- Saw the public key cache was populated fin
- Also deployed to auth dev and checked using the bulk account deletion handler and was fine

- I think I scanned through the codebase and saw that we're not using EnvironmentVariableCredentialsProvider anywhere outside of code that is called in integration tests, but would be good for someone to pull the branch down and confirm this!

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
