### PR TITLE
AUT-5381: Disable bulk email sender schedule

### DIFF
--- a/ci/terraform/utils/production.tfvars
+++ b/ci/terraform/utils/production.tfvars
@@ -13,11 +13,11 @@ bulk_user_email_max_audience_load_user_batch_size = 10000
 bulk_user_email_type                              = "INTERNATIONAL_NUMBERS_FORCED_MFA_RESET_BULK_EMAIL"
 bulk_user_email_audience_load_pause_duration      = 300000
 
-bulk_user_email_send_schedule_enabled    = true
+bulk_user_email_send_schedule_enabled    = false
 bulk_user_email_send_schedule_expression = "cron(* 8-14 17 4 ? 2026)"
-bulk_user_email_email_sending_enabled    = true
-bulk_user_email_batch_size               = 107
-bulk_user_email_send_mode                = "DELIVERY_RECEIPT_TEMPORARY_FAILURE_RETRIES"
+bulk_user_email_email_sending_enabled    = false
+bulk_user_email_batch_size               = 0
+bulk_user_email_send_mode                = "PENDING"
 bulk_user_email_sender_type              = "INTERNATIONAL_NUMBERS_FORCED_MFA_RESET"
 
 # Logging


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Disables the bulk user email sender schedule AND sending by this lambda.
- Resets the batch size AND the sender mode back to the default for new email campaigns (`PENDING` mode).

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Static Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Switch lambda send mode - https://github.com/govuk-one-login/authentication-api/pull/8203