### PR TITLE
AUT-5385: Ignore gradle major version 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       default-days: 7
     open-pull-requests-limit: 100
     ignore:
+      - dependency-name: "gradle"
+        versions: ["[9.0,)"]
       - dependency-name: "com.nimbusds:oauth2-oidc-sdk"
       - dependency-name: "org.junit*:*"
         update-types: ["version-update:semver-patch"]


### PR DESCRIPTION


## What

Ignore gradle major version 9

Gradle upgrades cannot just be merged and require a ticket, so setting to ignore until the work is complete.  This should be removed when the v9 upgrade is complete.

See https://govukverify.atlassian.net/browse/AUT-5385

## How to review

1. Code Review

## Related PRs

Will be closed: https://github.com/govuk-one-login/authentication-api/pull/8087