### PR TITLE
Aut 5321/account data api authorizer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -277,7 +277,7 @@
         "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java",
         "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 125,
         "is_secret": false
       }
     ],
@@ -307,7 +307,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 121,
         "is_secret": false
       },
       {
@@ -315,7 +315,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 155,
         "is_secret": false
       },
       {
@@ -323,7 +323,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 189,
         "is_secret": false
       },
       {
@@ -331,7 +331,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 197,
         "is_secret": false
       },
       {
@@ -339,7 +339,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 205,
         "is_secret": false
       },
       {
@@ -347,7 +347,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 213,
         "is_secret": false
       },
       {
@@ -355,7 +355,7 @@
         "filename": "ci/cloudformation/account-data/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 213,
+        "line_number": 221,
         "is_secret": false
       }
     ],
@@ -365,7 +365,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 399,
+        "line_number": 393,
         "is_secret": false
       },
       {
@@ -373,7 +373,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 558,
+        "line_number": 544,
         "is_secret": false
       },
       {
@@ -381,7 +381,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 638,
+        "line_number": 622,
         "is_secret": false
       },
       {
@@ -389,7 +389,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 646,
+        "line_number": 630,
         "is_secret": false
       },
       {
@@ -397,7 +397,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 654,
+        "line_number": 638,
         "is_secret": false
       },
       {
@@ -405,7 +405,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 662,
+        "line_number": 646,
         "is_secret": false
       },
       {
@@ -413,7 +413,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 654,
         "is_secret": false
       },
       {
@@ -421,7 +421,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 2840,
+        "line_number": 2825,
         "is_secret": false
       }
     ],
@@ -451,7 +451,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 384,
+        "line_number": 376,
         "is_secret": false
       },
       {
@@ -459,7 +459,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 633,
+        "line_number": 618,
         "is_secret": false
       },
       {
@@ -467,7 +467,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 726,
+        "line_number": 709,
         "is_secret": false
       },
       {
@@ -475,7 +475,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 734,
+        "line_number": 717,
         "is_secret": false
       },
       {
@@ -483,7 +483,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 742,
+        "line_number": 725,
         "is_secret": false
       },
       {
@@ -491,7 +491,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 750,
+        "line_number": 733,
         "is_secret": false
       },
       {
@@ -499,7 +499,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 758,
+        "line_number": 741,
         "is_secret": false
       },
       {
@@ -507,7 +507,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 2722,
+        "line_number": 2705,
         "is_secret": false
       }
     ],
@@ -881,7 +881,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java",
         "hashed_secret": "3c452d118b5dbfad5feb4c9be02ad0f8dd6a38ac",
         "is_verified": false,
-        "line_number": 68,
+        "line_number": 65,
         "is_secret": false
       }
     ],
@@ -901,7 +901,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java",
         "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 92,
         "is_secret": false
       }
     ],
@@ -911,7 +911,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java",
         "hashed_secret": "e7451a5d89d2e9e5f35668721904c877cfb39d08",
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 48,
         "is_secret": false
       }
     ],
@@ -1247,7 +1247,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "69c1b96f46e66e1100392a01d2437152b949a74d",
         "is_verified": false,
-        "line_number": 412,
+        "line_number": 464,
         "is_secret": false
       },
       {
@@ -1255,7 +1255,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "9ac2a39cf66fae8a32a979917e2f426c5674a28b",
         "is_verified": false,
-        "line_number": 412,
+        "line_number": 464,
         "is_secret": false
       },
       {
@@ -1263,7 +1263,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "a303cce93958d7697653352052cc6f999313c4ad",
         "is_verified": false,
-        "line_number": 412,
+        "line_number": 464,
         "is_secret": false
       },
       {
@@ -1271,7 +1271,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "e8d63aecdc6bc83b9429e94a4ae06eecab59923b",
         "is_verified": false,
-        "line_number": 412,
+        "line_number": 464,
         "is_secret": false
       }
     ],
@@ -1301,7 +1301,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java",
         "hashed_secret": "251c10082a6308fe3731846101d52f254a84491a",
         "is_verified": false,
-        "line_number": 2141,
+        "line_number": 2142,
         "is_secret": false
       }
     ],
@@ -1547,29 +1547,6 @@
         "is_secret": false
       }
     ],
-    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
-        "hashed_secret": "633b6d73dcfc71676b365534a6b1edff7775f84e",
-        "is_verified": false,
-        "line_number": 81
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
-        "hashed_secret": "747ddc98b5f9c1c5155a501872a7f37831bcfdf8",
-        "is_verified": false,
-        "line_number": 82
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
-        "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
-        "is_verified": false,
-        "line_number": 89
-      }
-    ],
     "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java": [
       {
         "type": "Base64 High Entropy String",
@@ -1601,6 +1578,50 @@
         "hashed_secret": "dd888a796666370b9523ef44581c34e19372116a",
         "is_verified": false,
         "line_number": 798,
+        "is_secret": false
+      }
+    ],
+    "python-utils/scripts/create_encrypting_key_from_jwks.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "python-utils/scripts/create_encrypting_key_from_jwks.py",
+        "hashed_secret": "8ed498ae5227a1732b22eb062e19b81641613f29",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "python-utils/scripts/create_encrypting_key_from_jwks.py",
+        "hashed_secret": "3732e91c621d2bfb0392f23ccdf62534f9bbf453",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "python-utils/scripts/create_signing_key_from_jwks.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
+        "hashed_secret": "ff1fe68fcd51bee4b399a28fc5f2131bbdac2b91",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
+        "hashed_secret": "59c70048939981b2c93600f44c21fd7929820cce",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
+        "hashed_secret": "7311a4913a0cc1042f392865bb031519d00ccf8d",
+        "is_verified": false,
+        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -1886,128 +1907,23 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 148,
         "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "2fadaec2edd927e80cfb2e94a26fed24a1ce0d22",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "6630a415701f2a22d266ef5ff84ce87a71541c38",
-        "is_verified": false,
-        "line_number": 182
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "6d638ce73bc18e3d490992a2edbd25aabe2ae88c",
-        "is_verified": false,
-        "line_number": 216
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "f8ff6c162942955ce28332f99a00d66152b26df9",
-        "is_verified": false,
-        "line_number": 217
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "0a6660bfb8f15c4996cd4ff06318129c8862c28e",
-        "is_verified": false,
-        "line_number": 218
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "f43c1b313513e120a1c7f1b2e16c4e588a447c7b",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "2599084e2fdd2597f08300eb2094a699200b41e2",
-        "is_verified": false,
-        "line_number": 255
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "2a36be9af46cd27c5f1b20aa020887c1fccaa8ae",
-        "is_verified": false,
-        "line_number": 256
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "d2b22571923d78d2ec43c00b0ab37c26cf31dc0a",
-        "is_verified": false,
-        "line_number": 290
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "202abfba0a5645bdd42c4365448acbccd996fa4b",
-        "is_verified": false,
-        "line_number": 291
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "d151606c5a71f1a890ed49e96a05aca41d78430f",
-        "is_verified": false,
-        "line_number": 292
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 296,
+        "line_number": 258,
         "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "67357ea9e9105423bfc88d8e24dd80c4ac213a7b",
-        "is_verified": false,
-        "line_number": 326
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "563ca8e169d3eec2259de50e53b964c8c66fbcb3",
-        "is_verified": false,
-        "line_number": 327
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "template.yaml",
-        "hashed_secret": "d5e506d3f6850724c006f45e4dd68b14615d1532",
-        "is_verified": false,
-        "line_number": 328
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 341,
+        "line_number": 294,
         "is_secret": false
       },
       {
@@ -2015,7 +1931,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 349,
+        "line_number": 302,
         "is_secret": false
       },
       {
@@ -2023,7 +1939,7 @@
         "filename": "template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 357,
+        "line_number": 310,
         "is_secret": false
       },
       {
@@ -2031,7 +1947,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 374,
+        "line_number": 327,
         "is_secret": false
       },
       {
@@ -2039,7 +1955,7 @@
         "filename": "template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 382,
+        "line_number": 335,
         "is_secret": false
       },
       {
@@ -2047,7 +1963,7 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 6955,
+        "line_number": 6943,
         "is_secret": false
       },
       {
@@ -2055,7 +1971,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5b2a69401d414f203d94880132858cc997e8c0eb",
         "is_verified": false,
-        "line_number": 7423,
+        "line_number": 7411,
         "is_secret": false
       }
     ]

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/AuthorizeException.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/AuthorizeException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.accountdata.entity;
+
+public class AuthorizeException extends RuntimeException {
+    public AuthorizeException(String e) {
+        super(e);
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/UnauthorizedException.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.accountdata.entity;
+
+public class UnauthorizedException extends RuntimeException {
+    private static final String UNAUTHORIZED_STRING = "Unauthorized";
+
+    public UnauthorizedException() {
+        super(UNAUTHORIZED_STRING);
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -1,0 +1,57 @@
+package uk.gov.di.authentication.accountdata.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.util.DateUtils;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+
+import java.util.Date;
+
+public class AuthorizeHandler
+        implements RequestHandler<APIGatewayCustomAuthorizerEvent, APIGatewayProxyResponseEvent> {
+    private static final Logger LOG = LogManager.getLogger(AuthorizeHandler.class);
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayCustomAuthorizerEvent apiGatewayCustomAuthorizerEvent, Context context) {
+        var token = apiGatewayCustomAuthorizerEvent.getAuthorizationToken();
+        try {
+            var accessToken = AccessToken.parse(token, AccessTokenType.BEARER);
+            var signedAccessToken = SignedJWT.parse(accessToken.getValue());
+            var claimsSet = signedAccessToken.getJWTClaimsSet();
+            var accessTokenValidationResult = validateAccessTokenExpiryTime(claimsSet);
+
+            if (accessTokenValidationResult.isFailure()) {
+                throw accessTokenValidationResult.getFailure();
+            }
+
+            return new APIGatewayProxyResponseEvent().withStatusCode(200);
+        } catch (ParseException | java.text.ParseException e) {
+            throw new RuntimeException("TODO");
+        }
+    }
+
+    private Result<UnauthorizedException, Void> validateAccessTokenExpiryTime(JWTClaimsSet claimsSet) {
+        Date currentDateTime = NowHelper.now();
+        if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 0)) {
+            LOG.warn(
+                    "Access Token expires at: {}. CurrentDateTime is: {}",
+                    claimsSet.getExpirationTime(),
+                    currentDateTime);
+            return Result.failure(new UnauthorizedException());
+        } else {
+            return Result.success(null);
+        }
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -76,13 +76,14 @@ public class AuthorizeHandler
     }
 
     private Result<UnauthorizedException, Void> verifySignature(SignedJWT signedJWT) {
+        var failure = Result.<UnauthorizedException, Void>failure(new UnauthorizedException());
         try {
             var maybeJwk =
                     jwksService.retrieveJwkFromURLWithKeyId(signedJWT.getHeader().getKeyID());
 
             if (maybeJwk.isFailure()) {
                 LOG.warn("Error retrieving jwks key: {}", maybeJwk.getFailure());
-                return Result.failure(new UnauthorizedException());
+                return failure;
             }
             var jwk = maybeJwk.getSuccess();
             var algorithm = signedJWT.getHeader().getAlgorithm();
@@ -92,16 +93,17 @@ public class AuthorizeHandler
                 verifier = new ECDSAVerifier(jwk.toECKey());
             } else {
                 LOG.error("Unsupported signature algorithm: {}", algorithm);
-                return Result.failure(new UnauthorizedException());
+                return failure;
             }
 
             if (!signedJWT.verify(verifier)) {
-                return Result.failure(new UnauthorizedException());
+                return failure;
             } else {
                 return Result.success(null);
             }
         } catch (JOSEException e) {
-            throw new RuntimeException("TODO");
+            LOG.error("Error verifying signature: {}", e.getMessage());
+            return failure;
         }
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -91,7 +91,8 @@ public class AuthorizeHandler
             if (JWSAlgorithm.ES256.equals(algorithm)) {
                 verifier = new ECDSAVerifier(jwk.toECKey());
             } else {
-                throw new RuntimeException("TODO");
+                LOG.error("Unsupported signature algorithm: {}", algorithm);
+                return Result.failure(new UnauthorizedException());
             }
 
             if (!signedJWT.verify(verifier)) {

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -70,7 +70,8 @@ public class AuthorizeHandler
             var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
             return getAllowExecuteApiPolicyForSubject(subject, methodArn);
         } catch (ParseException | java.text.ParseException e) {
-            throw new RuntimeException("TODO");
+            LOG.warn("Unable to parse Access Token {}", e.getMessage());
+            throw new UnauthorizedException();
         }
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -4,6 +4,10 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.util.DateUtils;
@@ -12,15 +16,37 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
+import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.net.MalformedURLException;
 import java.util.Date;
 
 public class AuthorizeHandler
         implements RequestHandler<APIGatewayCustomAuthorizerEvent, APIGatewayProxyResponseEvent> {
     private static final Logger LOG = LogManager.getLogger(AuthorizeHandler.class);
+    private RemoteJwksService jwksService;
+
+    public AuthorizeHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public AuthorizeHandler(ConfigurationService configurationService) {
+        try {
+            this.jwksService = new RemoteJwksService(configurationService.getAccountDataJwksUrl());
+        } catch (MalformedURLException e) {
+            LOG.error("Unable to initialise authorize handler, malformed account data jwks url");
+            throw new AuthorizeException(e.getMessage());
+        }
+    }
+
+    public AuthorizeHandler(RemoteJwksService jwksService) {
+        this.jwksService = jwksService;
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
@@ -30,10 +56,13 @@ public class AuthorizeHandler
             var accessToken = AccessToken.parse(token, AccessTokenType.BEARER);
             var signedAccessToken = SignedJWT.parse(accessToken.getValue());
             var claimsSet = signedAccessToken.getJWTClaimsSet();
-            var accessTokenValidationResult = validateAccessTokenExpiryTime(claimsSet);
 
-            if (accessTokenValidationResult.isFailure()) {
-                throw accessTokenValidationResult.getFailure();
+            var maybeValidationFailure =
+                    validateAccessTokenExpiryTime(claimsSet)
+                            .flatMap(success -> verifySignature(signedAccessToken));
+
+            if (maybeValidationFailure.isFailure()) {
+                throw maybeValidationFailure.getFailure();
             }
 
             return new APIGatewayProxyResponseEvent().withStatusCode(200);
@@ -42,7 +71,37 @@ public class AuthorizeHandler
         }
     }
 
-    private Result<UnauthorizedException, Void> validateAccessTokenExpiryTime(JWTClaimsSet claimsSet) {
+    private Result<UnauthorizedException, Void> verifySignature(SignedJWT signedJWT) {
+        try {
+            var maybeJwk =
+                    jwksService.retrieveJwkFromURLWithKeyId(signedJWT.getHeader().getKeyID());
+
+            if (maybeJwk.isFailure()) {
+                LOG.warn("Error retrieving jwks key: {}", maybeJwk.getFailure());
+                return Result.failure(new UnauthorizedException());
+            }
+            var jwk = maybeJwk.getSuccess();
+            var algorithm = signedJWT.getHeader().getAlgorithm();
+
+            JWSVerifier verifier;
+            if (JWSAlgorithm.ES256.equals(algorithm)) {
+                verifier = new ECDSAVerifier(jwk.toECKey());
+            } else {
+                throw new RuntimeException("TODO");
+            }
+
+            if (!signedJWT.verify(verifier)) {
+                return Result.failure(new UnauthorizedException());
+            } else {
+                return Result.success(null);
+            }
+        } catch (JOSEException e) {
+            throw new RuntimeException("TODO");
+        }
+    }
+
+    private Result<UnauthorizedException, Void> validateAccessTokenExpiryTime(
+            JWTClaimsSet claimsSet) {
         Date currentDateTime = NowHelper.now();
         if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 0)) {
             LOG.warn(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -58,16 +58,16 @@ public class AuthorizeHandler
             var signedAccessToken = SignedJWT.parse(accessToken.getValue());
             var claimsSet = signedAccessToken.getJWTClaimsSet();
 
-            var maybeValidatedClaims =
+            var validatedClaimsResult =
                     validateAccessTokenExpiryTime(claimsSet)
                             .flatMap(success -> verifySignature(signedAccessToken))
                             .flatMap(success -> validateClaimsSet(claimsSet));
 
-            if (maybeValidatedClaims.isFailure()) {
-                throw maybeValidatedClaims.getFailure();
+            if (validatedClaimsResult.isFailure()) {
+                throw validatedClaimsResult.getFailure();
             }
 
-            var subject = maybeValidatedClaims.getSuccess().getSubject();
+            var subject = validatedClaimsResult.getSuccess().getSubject();
             var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
             return getAllowExecuteApiPolicyForSubject(subject, methodArn);
         } catch (ParseException | java.text.ParseException e) {
@@ -79,14 +79,14 @@ public class AuthorizeHandler
     private Result<UnauthorizedException, Void> verifySignature(SignedJWT signedJWT) {
         var failure = Result.<UnauthorizedException, Void>failure(new UnauthorizedException());
         try {
-            var maybeJwk =
+            var jwkResult =
                     jwksService.retrieveJwkFromURLWithKeyId(signedJWT.getHeader().getKeyID());
 
-            if (maybeJwk.isFailure()) {
-                LOG.warn("Error retrieving jwks key: {}", maybeJwk.getFailure());
+            if (jwkResult.isFailure()) {
+                LOG.warn("Error retrieving jwks key: {}", jwkResult.getFailure());
                 return failure;
             }
-            var jwk = maybeJwk.getSuccess();
+            var jwk = jwkResult.getSuccess();
             var algorithm = signedJWT.getHeader().getAlgorithm();
 
             JWSVerifier verifier;

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -58,15 +58,16 @@ public class AuthorizeHandler
             var signedAccessToken = SignedJWT.parse(accessToken.getValue());
             var claimsSet = signedAccessToken.getJWTClaimsSet();
 
-            var maybeValidationFailure =
+            var maybeValidatedClaims =
                     validateAccessTokenExpiryTime(claimsSet)
-                            .flatMap(success -> verifySignature(signedAccessToken));
+                            .flatMap(success -> verifySignature(signedAccessToken))
+                            .flatMap(success -> validateClaimsSet(claimsSet));
 
-            if (maybeValidationFailure.isFailure()) {
-                throw maybeValidationFailure.getFailure();
+            if (maybeValidatedClaims.isFailure()) {
+                throw maybeValidatedClaims.getFailure();
             }
 
-            var subject = signedAccessToken.getJWTClaimsSet().getSubject();
+            var subject = maybeValidatedClaims.getSuccess().getSubject();
             var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
             return getAllowExecuteApiPolicyForSubject(subject, methodArn);
         } catch (ParseException | java.text.ParseException e) {
@@ -119,6 +120,14 @@ public class AuthorizeHandler
         } else {
             return Result.success(null);
         }
+    }
+
+    private Result<UnauthorizedException, JWTClaimsSet> validateClaimsSet(JWTClaimsSet claimsSet) {
+        if (claimsSet.getSubject() == null || claimsSet.getSubject().isEmpty()) {
+            LOG.warn("Access Token subject is missing");
+            return Result.failure(new UnauthorizedException());
+        }
+        return Result.success(claimsSet);
     }
 
     private Map<String, Object> getAllowExecuteApiPolicyForSubject(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.accountdata.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSVerifier;
@@ -25,9 +24,11 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.MalformedURLException;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 public class AuthorizeHandler
-        implements RequestHandler<APIGatewayCustomAuthorizerEvent, APIGatewayProxyResponseEvent> {
+        implements RequestHandler<APIGatewayCustomAuthorizerEvent, Map<String, Object>> {
     private static final Logger LOG = LogManager.getLogger(AuthorizeHandler.class);
     private RemoteJwksService jwksService;
 
@@ -49,7 +50,7 @@ public class AuthorizeHandler
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
+    public Map<String, Object> handleRequest(
             APIGatewayCustomAuthorizerEvent apiGatewayCustomAuthorizerEvent, Context context) {
         var token = apiGatewayCustomAuthorizerEvent.getAuthorizationToken();
         try {
@@ -65,7 +66,9 @@ public class AuthorizeHandler
                 throw maybeValidationFailure.getFailure();
             }
 
-            return new APIGatewayProxyResponseEvent().withStatusCode(200);
+            var subject = signedAccessToken.getJWTClaimsSet().getSubject();
+            var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
+            return getAllowExecuteApiPolicyForSubject(subject, methodArn);
         } catch (ParseException | java.text.ParseException e) {
             throw new RuntimeException("TODO");
         }
@@ -112,5 +115,21 @@ public class AuthorizeHandler
         } else {
             return Result.success(null);
         }
+    }
+
+    private Map<String, Object> getAllowExecuteApiPolicyForSubject(
+            String subject, String methodArn) {
+        var executeApiStatement =
+                Map.ofEntries(
+                        Map.entry("Action", "execute-api:Invoke"),
+                        Map.entry("Effect", "Allow"),
+                        Map.entry("Resource", methodArn));
+        return Map.ofEntries(
+                Map.entry("principalId", subject),
+                Map.entry(
+                        "policyDocument",
+                        Map.ofEntries(
+                                Map.entry("Version", "2012-10-17"),
+                                Map.entry("Statement", List.of(executeApiStatement)))));
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/RemoteJwksService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/RemoteJwksService.java
@@ -1,0 +1,56 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.ResourceRetriever;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.Result;
+
+import java.net.URL;
+
+import static java.lang.String.format;
+
+public class RemoteJwksService {
+
+    private static final Logger LOG = LogManager.getLogger(RemoteJwksService.class);
+    private static final ResourceRetriever DEFAULT_RESOURCE_RETRIEVER =
+            new DefaultResourceRetriever(25000, 25000);
+    private final JWKSource<SecurityContext> jwkSource;
+    private final URL url;
+
+    public RemoteJwksService(URL url) {
+        this(
+                JWKSourceBuilder.create(url, DEFAULT_RESOURCE_RETRIEVER)
+                        .retrying(true)
+                        .refreshAheadCache(false)
+                        .cache(true)
+                        .rateLimited(false)
+                        .build(),
+                url);
+    }
+
+    public RemoteJwksService(JWKSource<SecurityContext> jwkSource, URL url) {
+        this.jwkSource = jwkSource;
+        this.url = url;
+    }
+
+    public Result<String, JWK> retrieveJwkFromURLWithKeyId(String keyId) {
+        JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
+
+        LOG.info("Retrieving JWKSet from URL: {}", url);
+        try {
+            var maybeJwk = jwkSource.get(selector, null).stream().findFirst();
+            return maybeJwk.<Result<String, JWK>>map(Result::success)
+                    .orElseGet(() -> Result.failure("No JWK found with matching id"));
+        } catch (KeySourceException e) {
+            return Result.failure(format("Error retrieving jwks key %s", e.getMessage()));
+        }
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
@@ -14,19 +14,22 @@ import java.util.List;
 import java.util.UUID;
 
 public class TokenGeneratorHelper {
+    public static JWTClaimsSet.Builder claimsSetBuilderWithoutSubject(Date expiryDate) {
+        return new JWTClaimsSet.Builder()
+                .claim("scope", List.of("some-scopes"))
+                .issuer("https://example.com")
+                .expirationTime(expiryDate)
+                .issueTime(NowHelper.now())
+                .claim("client_id", "some-client-id")
+                .jwtID(UUID.randomUUID().toString());
+    }
+
+    public static JWTClaimsSet.Builder claimsSetBuilder(String subject, Date expiryDate) {
+        return claimsSetBuilderWithoutSubject(expiryDate).subject(subject);
+    }
 
     public static SignedJWT generateSignedToken(
-            JWSSigner signer, String keyId, Date expiryDate, String subject) {
-
-        JWTClaimsSet.Builder claimsBuilder =
-                new JWTClaimsSet.Builder()
-                        .claim("scope", List.of("some-scopes"))
-                        .issuer("https://example.com")
-                        .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
-                        .claim("client_id", "some-client-id")
-                        .subject(subject)
-                        .jwtID(UUID.randomUUID().toString());
+            JWSSigner signer, String keyId, JWTClaimsSet.Builder claimsBuilder) {
 
         var algorithm = signer instanceof RSASSASigner ? JWSAlgorithm.RS256 : JWSAlgorithm.ES256;
         var jwsHeader = new JWSHeader.Builder(algorithm).keyID(keyId).build();

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
@@ -1,0 +1,42 @@
+package uk.gov.di.authentication.accountdata.helpers;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class TokenGeneratorHelper {
+
+    public static SignedJWT generateSignedToken(JWSSigner signer, String keyId, Date expiryDate) {
+
+        JWTClaimsSet.Builder claimsBuilder =
+                new JWTClaimsSet.Builder()
+                        .claim("scope", List.of("some-scopes"))
+                        .issuer("https://example.com")
+                        .expirationTime(expiryDate)
+                        .issueTime(NowHelper.now())
+                        .claim("client_id", "some-client-id")
+                        .subject("some-subject")
+                        .jwtID(UUID.randomUUID().toString());
+
+        var algorithm = signer instanceof RSASSASigner ? JWSAlgorithm.RS256 : JWSAlgorithm.ES256;
+        var jwsHeader = new JWSHeader.Builder(algorithm).keyID(keyId).build();
+        var signedJWT = new SignedJWT(jwsHeader, claimsBuilder.build());
+
+        try {
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+
+        return signedJWT;
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
@@ -15,7 +15,8 @@ import java.util.UUID;
 
 public class TokenGeneratorHelper {
 
-    public static SignedJWT generateSignedToken(JWSSigner signer, String keyId, Date expiryDate) {
+    public static SignedJWT generateSignedToken(
+            JWSSigner signer, String keyId, Date expiryDate, String subject) {
 
         JWTClaimsSet.Builder claimsBuilder =
                 new JWTClaimsSet.Builder()
@@ -24,7 +25,7 @@ public class TokenGeneratorHelper {
                         .expirationTime(expiryDate)
                         .issueTime(NowHelper.now())
                         .claim("client_id", "some-client-id")
-                        .subject("some-subject")
+                        .subject(subject)
                         .jwtID(UUID.randomUUID().toString());
 
         var algorithm = signer instanceof RSASSASigner ? JWSAlgorithm.RS256 : JWSAlgorithm.ES256;

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -13,6 +13,7 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
-import uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -35,6 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper.claimsSetBuilder;
+import static uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper.claimsSetBuilderWithoutSubject;
+import static uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper.generateSignedToken;
 
 class AuthorizeHandlerTest {
     private static final String KEY_ID = "14342354354353";
@@ -197,12 +200,45 @@ class AuthorizeHandlerTest {
         RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
         JWSSigner signer = new RSASSASigner(rsaKey);
 
-        var signedToken =
-                TokenGeneratorHelper.generateSignedToken(
-                        signer, KEY_ID, expiryDateFiveMinutesFromNow, SUBJECT);
+        var builder = claimsSetBuilder(SUBJECT, expiryDateFiveMinutesFromNow);
+        var signedToken = generateSignedToken(signer, KEY_ID, builder);
         var token = new BearerAccessToken(signedToken.serialize());
 
         event.setAuthorizationToken(token.toAuthorizationHeader());
+
+        RuntimeException exception =
+                assertThrows(
+                        UnauthorizedException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
+    void authorizeHandlerShouldRejectMissingSubjectId() throws JOSEException {
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        var claimsWithoutSubject = claimsSetBuilderWithoutSubject(expiryDateFiveMinutesFromNow);
+        var signedToken = createBearerAccessToken(ecSigningKey, claimsWithoutSubject);
+        event.setAuthorizationToken(signedToken.toAuthorizationHeader());
+
+        RuntimeException exception =
+                assertThrows(
+                        UnauthorizedException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
+    void authorizeHandlerShouldRejectEmptySubjectId() throws JOSEException {
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        var claimsWithEmptySubject = claimsSetBuilder("", expiryDateFiveMinutesFromNow);
+        var signedToken = createBearerAccessToken(ecSigningKey, claimsWithEmptySubject);
+        event.setAuthorizationToken(signedToken.toAuthorizationHeader());
 
         RuntimeException exception =
                 assertThrows(
@@ -228,9 +264,14 @@ class AuthorizeHandlerTest {
 
     private static BearerAccessToken createBearerAccessTokenWithExpiry(
             Date expiryDate, ECKey ecSigningKey) throws JOSEException {
+        var claimsBuilder = claimsSetBuilder(SUBJECT, expiryDate);
+        return createBearerAccessToken(ecSigningKey, claimsBuilder);
+    }
+
+    private static BearerAccessToken createBearerAccessToken(
+            ECKey ecSigningKey, JWTClaimsSet.Builder claimsBuilder) throws JOSEException {
         JWSSigner signer = new ECDSASigner(ecSigningKey);
-        var signedToken =
-                TokenGeneratorHelper.generateSignedToken(signer, KEY_ID, expiryDate, SUBJECT);
+        var signedToken = generateSignedToken(signer, KEY_ID, claimsBuilder);
         return new BearerAccessToken(signedToken.serialize());
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -9,9 +9,17 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper;
+import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.net.MalformedURLException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -19,17 +27,40 @@ import java.util.Date;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 class AuthorizeHandlerTest {
     private static final String KEY_ID = "14342354354353";
     private final Context context = mock(Context.class);
+    private final RemoteJwksService remoteJwksService = mock(RemoteJwksService.class);
+    private static final Date expiryDateFiveMinutesFromNow =
+            Date.from(Instant.now().plus(5, ChronoUnit.MINUTES));
+
+    private static ECKey ecSigningKey;
+
+    @BeforeAll
+    static void setupKeyPair() throws JOSEException {
+        ecSigningKey = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
+    }
+
+    @BeforeEach
+    void setup() {
+        when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
+                .thenReturn(Result.success(ecSigningKey.toPublicJWK()));
+    }
+
+    @AfterEach
+    void resetMocks() {
+        reset(remoteJwksService);
+    }
 
     @Test
     void authorizeHandlerShouldAllowNonExpiredToken() throws JOSEException {
-        var handler = new AuthorizeHandler();
+        var handler = new AuthorizeHandler(remoteJwksService);
 
-        var fiveMinutesFromNow = Instant.now().plus(5, ChronoUnit.MINUTES);
-        var bearerAccessToken = createBearerAccessTokenWithExpiry(Date.from(fiveMinutesFromNow));
+        var bearerAccessToken =
+                createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
         var event = new APIGatewayCustomAuthorizerEvent();
         event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
@@ -41,10 +72,11 @@ class AuthorizeHandlerTest {
 
     @Test
     void authorizeHandlerShouldRejectExpiredToken() throws JOSEException {
-        var handler = new AuthorizeHandler();
+        var handler = new AuthorizeHandler(remoteJwksService);
 
         var yesterdayInstant = Instant.now().minus(1, ChronoUnit.DAYS);
-        var bearerAccessToken = createBearerAccessTokenWithExpiry(Date.from(yesterdayInstant));
+        var bearerAccessToken =
+                createBearerAccessTokenWithExpiry(Date.from(yesterdayInstant), ecSigningKey);
 
         var event = new APIGatewayCustomAuthorizerEvent();
         event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
@@ -57,10 +89,67 @@ class AuthorizeHandlerTest {
         assertEquals("Unauthorized", exception.getMessage());
     }
 
-    private static BearerAccessToken createBearerAccessTokenWithExpiry(Date expiryDate)
-            throws JOSEException {
-        ECKey ecJWK = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
-        JWSSigner signer = new ECDSASigner(ecJWK);
+    @Test
+    void authorizeHandlerShouldRejectTokenWhoseSignatureCannotBeVerified() throws JOSEException {
+        var differentKeyPair = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
+        when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
+                .thenReturn(Result.success(differentKeyPair.toPublicJWK()));
+
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        var bearerAccessToken =
+                createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+
+        var event = new APIGatewayCustomAuthorizerEvent();
+        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
+    void authorizeHandlerShouldRejectTokenWhenJwksRetrievalFails() throws JOSEException {
+        when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
+                .thenReturn(Result.failure("Failed to retrieve jwks key"));
+
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        var bearerAccessToken =
+                createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+
+        var event = new APIGatewayCustomAuthorizerEvent();
+        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
+    void authorizeHandlerFailsToInitialiseWhenAccountDataJwksUrlMalformed()
+            throws MalformedURLException {
+        var configurationService = mock(ConfigurationService.class);
+        when(configurationService.getAccountDataJwksUrl())
+                .thenThrow(new MalformedURLException("uh oh"));
+
+        assertThrows(
+                AuthorizeException.class,
+                () -> new AuthorizeHandler(configurationService),
+                "Expected to throw exception");
+    }
+
+    private static BearerAccessToken createBearerAccessTokenWithExpiry(
+            Date expiryDate, ECKey ecSigningKey) throws JOSEException {
+        JWSSigner signer = new ECDSASigner(ecSigningKey);
         var signedToken = TokenGeneratorHelper.generateSignedToken(signer, KEY_ID, expiryDate);
         return new BearerAccessToken(signedToken.serialize());
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -18,6 +18,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
@@ -70,196 +71,203 @@ class AuthorizeHandlerTest {
         reset(remoteJwksService);
     }
 
-    @Test
-    void authorizeHandlerShouldAllowNonExpiredToken() throws JOSEException {
-        var handler = new AuthorizeHandler(remoteJwksService);
+    @Nested
+    class Success {
+        @Test
+        void authorizeHandlerShouldAllowNonExpiredToken() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        var bearerAccessToken =
-                createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
-        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
-        var result = handler.handleRequest(event, context);
+            var result = handler.handleRequest(event, context);
 
-        var expectedPolicyDocument =
-                """
-                {
-                    "principalId": "%s",
-                    "policyDocument": {
-                        "Version": "2012-10-17",
-                        "Statement": [{
-                            "Action": "execute-api:Invoke",
-                            "Effect": "Allow",
-                            "Resource": "%s"
-                        }]
-                    }
-                }
-                """
-                        .formatted(SUBJECT, METHOD_ARN);
+            var expectedPolicyDocument =
+                    """
+                            {
+                                "principalId": "%s",
+                                "policyDocument": {
+                                    "Version": "2012-10-17",
+                                    "Statement": [{
+                                        "Action": "execute-api:Invoke",
+                                        "Effect": "Allow",
+                                        "Resource": "%s"
+                                    }]
+                                }
+                            }
+                            """
+                            .formatted(SUBJECT, METHOD_ARN);
 
-        assertEquals(
-                JsonParser.parseString(expectedPolicyDocument),
-                JsonParser.parseString(new Gson().toJson(result)));
+            assertEquals(
+                    JsonParser.parseString(expectedPolicyDocument),
+                    JsonParser.parseString(new Gson().toJson(result)));
+        }
     }
 
-    @Test
-    void authorizeHandlerShouldRejectMissingToken() {
-        var handler = new AuthorizeHandler(remoteJwksService);
+    @Nested
+    class Failure {
+        @Test
+        void authorizeHandlerShouldRejectMissingToken() {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        event.setAuthorizationToken("");
+            event.setAuthorizationToken("");
 
-        RuntimeException exception =
-                assertThrows(
-                        RuntimeException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectExpiredToken() throws JOSEException {
-        var handler = new AuthorizeHandler(remoteJwksService);
+        @Test
+        void authorizeHandlerShouldRejectExpiredToken() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        var yesterdayInstant = Instant.now().minus(1, ChronoUnit.DAYS);
-        var bearerAccessToken =
-                createBearerAccessTokenWithExpiry(Date.from(yesterdayInstant), ecSigningKey);
+            var yesterdayInstant = Instant.now().minus(1, ChronoUnit.DAYS);
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(Date.from(yesterdayInstant), ecSigningKey);
 
-        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
-        RuntimeException exception =
-                assertThrows(
-                        RuntimeException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+            RuntimeException exception =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectTokenWhoseSignatureCannotBeVerified() throws JOSEException {
-        var differentKeyPair = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
-        when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
-                .thenReturn(Result.success(differentKeyPair.toPublicJWK()));
+        @Test
+        void authorizeHandlerShouldRejectTokenWhoseSignatureCannotBeVerified()
+                throws JOSEException {
+            var differentKeyPair = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
+            when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
+                    .thenReturn(Result.success(differentKeyPair.toPublicJWK()));
 
-        var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        var bearerAccessToken =
-                createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
-        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
-        RuntimeException exception =
-                assertThrows(
-                        RuntimeException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectTokenWhenJwksRetrievalFails() throws JOSEException {
-        when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
-                .thenReturn(Result.failure("Failed to retrieve jwks key"));
+        @Test
+        void authorizeHandlerShouldRejectTokenWhenJwksRetrievalFails() throws JOSEException {
+            when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
+                    .thenReturn(Result.failure("Failed to retrieve jwks key"));
 
-        var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        var bearerAccessToken =
-                createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
-        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
-        RuntimeException exception =
-                assertThrows(
-                        RuntimeException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectUnparseableToken() {
-        var handler = new AuthorizeHandler(remoteJwksService);
+        @Test
+        void authorizeHandlerShouldRejectUnparseableToken() {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        event.setAuthorizationToken("Bearer not-a-valid-jwt");
+            event.setAuthorizationToken("Bearer not-a-valid-jwt");
 
-        RuntimeException exception =
-                assertThrows(
-                        UnauthorizedException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectAnUnsupportedAlgorithm() throws JOSEException {
-        var handler = new AuthorizeHandler(remoteJwksService);
+        @Test
+        void authorizeHandlerShouldRejectAnUnsupportedAlgorithm() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
-        JWSSigner signer = new RSASSASigner(rsaKey);
+            RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
+            JWSSigner signer = new RSASSASigner(rsaKey);
 
-        var builder = claimsSetBuilder(SUBJECT, expiryDateFiveMinutesFromNow);
-        var signedToken = generateSignedToken(signer, KEY_ID, builder);
-        var token = new BearerAccessToken(signedToken.serialize());
+            var builder = claimsSetBuilder(SUBJECT, expiryDateFiveMinutesFromNow);
+            var signedToken = generateSignedToken(signer, KEY_ID, builder);
+            var token = new BearerAccessToken(signedToken.serialize());
 
-        event.setAuthorizationToken(token.toAuthorizationHeader());
+            event.setAuthorizationToken(token.toAuthorizationHeader());
 
-        RuntimeException exception =
-                assertThrows(
-                        UnauthorizedException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectMissingSubjectId() throws JOSEException {
-        var handler = new AuthorizeHandler(remoteJwksService);
+        @Test
+        void authorizeHandlerShouldRejectMissingSubjectId() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        var claimsWithoutSubject = claimsSetBuilderWithoutSubject(expiryDateFiveMinutesFromNow);
-        var signedToken = createBearerAccessToken(ecSigningKey, claimsWithoutSubject);
-        event.setAuthorizationToken(signedToken.toAuthorizationHeader());
+            var claimsWithoutSubject = claimsSetBuilderWithoutSubject(expiryDateFiveMinutesFromNow);
+            var signedToken = createBearerAccessToken(ecSigningKey, claimsWithoutSubject);
+            event.setAuthorizationToken(signedToken.toAuthorizationHeader());
 
-        RuntimeException exception =
-                assertThrows(
-                        UnauthorizedException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerShouldRejectEmptySubjectId() throws JOSEException {
-        var handler = new AuthorizeHandler(remoteJwksService);
+        @Test
+        void authorizeHandlerShouldRejectEmptySubjectId() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
 
-        var claimsWithEmptySubject = claimsSetBuilder("", expiryDateFiveMinutesFromNow);
-        var signedToken = createBearerAccessToken(ecSigningKey, claimsWithEmptySubject);
-        event.setAuthorizationToken(signedToken.toAuthorizationHeader());
+            var claimsWithEmptySubject = claimsSetBuilder("", expiryDateFiveMinutesFromNow);
+            var signedToken = createBearerAccessToken(ecSigningKey, claimsWithEmptySubject);
+            event.setAuthorizationToken(signedToken.toAuthorizationHeader());
 
-        RuntimeException exception =
-                assertThrows(
-                        UnauthorizedException.class,
-                        () -> handler.handleRequest(event, context),
-                        "Expected to throw exception");
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
 
-        assertEquals("Unauthorized", exception.getMessage());
-    }
+            assertEquals("Unauthorized", exception.getMessage());
+        }
 
-    @Test
-    void authorizeHandlerFailsToInitialiseWhenAccountDataJwksUrlMalformed()
-            throws MalformedURLException {
-        var configurationService = mock(ConfigurationService.class);
-        when(configurationService.getAccountDataJwksUrl())
-                .thenThrow(new MalformedURLException("uh oh"));
+        @Test
+        void authorizeHandlerFailsToInitialiseWhenAccountDataJwksUrlMalformed()
+                throws MalformedURLException {
+            var configurationService = mock(ConfigurationService.class);
+            when(configurationService.getAccountDataJwksUrl())
+                    .thenThrow(new MalformedURLException("uh oh"));
 
-        assertThrows(
-                AuthorizeException.class,
-                () -> new AuthorizeHandler(configurationService),
-                "Expected to throw exception");
+            assertThrows(
+                    AuthorizeException.class,
+                    () -> new AuthorizeHandler(configurationService),
+                    "Expected to throw exception");
+        }
     }
 
     private static BearerAccessToken createBearerAccessTokenWithExpiry(

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -2,6 +2,8 @@ package uk.gov.di.authentication.accountdata.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
@@ -36,8 +38,12 @@ class AuthorizeHandlerTest {
     private final RemoteJwksService remoteJwksService = mock(RemoteJwksService.class);
     private static final Date expiryDateFiveMinutesFromNow =
             Date.from(Instant.now().plus(5, ChronoUnit.MINUTES));
+    private static final String METHOD_ARN =
+            "arn:aws:execute-api:eu-west-2:123456789:abc123/dev/GET/accounts";
+    private static final String SUBJECT = "some-subject";
 
     private static ECKey ecSigningKey;
+    private APIGatewayCustomAuthorizerEvent event;
 
     @BeforeAll
     static void setupKeyPair() throws JOSEException {
@@ -46,6 +52,8 @@ class AuthorizeHandlerTest {
 
     @BeforeEach
     void setup() {
+        event = new APIGatewayCustomAuthorizerEvent();
+        event.setMethodArn(METHOD_ARN);
         when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
                 .thenReturn(Result.success(ecSigningKey.toPublicJWK()));
     }
@@ -62,12 +70,29 @@ class AuthorizeHandlerTest {
         var bearerAccessToken =
                 createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
-        var event = new APIGatewayCustomAuthorizerEvent();
         event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
         var result = handler.handleRequest(event, context);
 
-        assertEquals(200, result.getStatusCode());
+        var expectedPolicyDocument =
+                """
+                {
+                    "principalId": "%s",
+                    "policyDocument": {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                            "Action": "execute-api:Invoke",
+                            "Effect": "Allow",
+                            "Resource": "%s"
+                        }]
+                    }
+                }
+                """
+                        .formatted(SUBJECT, METHOD_ARN);
+
+        assertEquals(
+                JsonParser.parseString(expectedPolicyDocument),
+                JsonParser.parseString(new Gson().toJson(result)));
     }
 
     @Test
@@ -78,7 +103,6 @@ class AuthorizeHandlerTest {
         var bearerAccessToken =
                 createBearerAccessTokenWithExpiry(Date.from(yesterdayInstant), ecSigningKey);
 
-        var event = new APIGatewayCustomAuthorizerEvent();
         event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
         RuntimeException exception =
                 assertThrows(
@@ -100,7 +124,6 @@ class AuthorizeHandlerTest {
         var bearerAccessToken =
                 createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
-        var event = new APIGatewayCustomAuthorizerEvent();
         event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
         RuntimeException exception =
@@ -122,7 +145,6 @@ class AuthorizeHandlerTest {
         var bearerAccessToken =
                 createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
 
-        var event = new APIGatewayCustomAuthorizerEvent();
         event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
         RuntimeException exception =
@@ -150,7 +172,8 @@ class AuthorizeHandlerTest {
     private static BearerAccessToken createBearerAccessTokenWithExpiry(
             Date expiryDate, ECKey ecSigningKey) throws JOSEException {
         JWSSigner signer = new ECDSASigner(ecSigningKey);
-        var signedToken = TokenGeneratorHelper.generateSignedToken(signer, KEY_ID, expiryDate);
+        var signedToken =
+                TokenGeneratorHelper.generateSignedToken(signer, KEY_ID, expiryDate, SUBJECT);
         return new BearerAccessToken(signedToken.serialize());
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
+import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
 import uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -96,6 +97,21 @@ class AuthorizeHandlerTest {
     }
 
     @Test
+    void authorizeHandlerShouldRejectMissingToken() {
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        event.setAuthorizationToken("");
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
     void authorizeHandlerShouldRejectExpiredToken() throws JOSEException {
         var handler = new AuthorizeHandler(remoteJwksService);
 
@@ -150,6 +166,21 @@ class AuthorizeHandlerTest {
         RuntimeException exception =
                 assertThrows(
                         RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
+    void authorizeHandlerShouldRejectUnparseableToken() {
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        event.setAuthorizationToken("Bearer not-a-valid-jwt");
+
+        RuntimeException exception =
+                assertThrows(
+                        UnauthorizedException.class,
                         () -> handler.handleRequest(event, context),
                         "Expected to throw exception");
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -7,9 +7,12 @@ import com.google.gson.JsonParser;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -177,6 +180,29 @@ class AuthorizeHandlerTest {
         var handler = new AuthorizeHandler(remoteJwksService);
 
         event.setAuthorizationToken("Bearer not-a-valid-jwt");
+
+        RuntimeException exception =
+                assertThrows(
+                        UnauthorizedException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    @Test
+    void authorizeHandlerShouldRejectAnUnsupportedAlgorithm() throws JOSEException {
+        var handler = new AuthorizeHandler(remoteJwksService);
+
+        RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
+        JWSSigner signer = new RSASSASigner(rsaKey);
+
+        var signedToken =
+                TokenGeneratorHelper.generateSignedToken(
+                        signer, KEY_ID, expiryDateFiveMinutesFromNow, SUBJECT);
+        var token = new BearerAccessToken(signedToken.serialize());
+
+        event.setAuthorizationToken(token.toAuthorizationHeader());
 
         RuntimeException exception =
                 assertThrows(

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -1,0 +1,67 @@
+package uk.gov.di.authentication.accountdata.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.accountdata.helpers.TokenGeneratorHelper;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class AuthorizeHandlerTest {
+    private static final String KEY_ID = "14342354354353";
+    private final Context context = mock(Context.class);
+
+    @Test
+    void authorizeHandlerShouldAllowNonExpiredToken() throws JOSEException {
+        var handler = new AuthorizeHandler();
+
+        var fiveMinutesFromNow = Instant.now().plus(5, ChronoUnit.MINUTES);
+        var bearerAccessToken = createBearerAccessTokenWithExpiry(Date.from(fiveMinutesFromNow));
+
+        var event = new APIGatewayCustomAuthorizerEvent();
+        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+        var result = handler.handleRequest(event, context);
+
+        assertEquals(200, result.getStatusCode());
+    }
+
+    @Test
+    void authorizeHandlerShouldRejectExpiredToken() throws JOSEException {
+        var handler = new AuthorizeHandler();
+
+        var yesterdayInstant = Instant.now().minus(1, ChronoUnit.DAYS);
+        var bearerAccessToken = createBearerAccessTokenWithExpiry(Date.from(yesterdayInstant));
+
+        var event = new APIGatewayCustomAuthorizerEvent();
+        event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertEquals("Unauthorized", exception.getMessage());
+    }
+
+    private static BearerAccessToken createBearerAccessTokenWithExpiry(Date expiryDate)
+            throws JOSEException {
+        ECKey ecJWK = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
+        JWSSigner signer = new ECDSASigner(ecJWK);
+        var signedToken = TokenGeneratorHelper.generateSignedToken(signer, KEY_ID, expiryDate);
+        return new BearerAccessToken(signedToken.serialize());
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/RemoteJwksServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/RemoteJwksServiceTest.java
@@ -1,0 +1,79 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteJwksServiceTest {
+
+    private static final String KEY_ID = "test-key-id";
+
+    @SuppressWarnings("unchecked")
+    private final JWKSource<SecurityContext> jwkSource = mock(JWKSource.class);
+
+    private final RemoteJwksService service = new RemoteJwksService(jwkSource, dummyUrl());
+
+    @Test
+    void shouldReturnJwkWhenKeyIdMatches() throws Exception {
+        var ecKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+
+        when(jwkSource.get(any(JWKSelector.class), isNull()))
+                .thenReturn(List.of(ecKey.toPublicJWK()));
+
+        var result = service.retrieveJwkFromURLWithKeyId(KEY_ID);
+
+        assertTrue(result.isSuccess());
+        assertEquals(KEY_ID, result.getSuccess().getKeyID());
+    }
+
+    @Test
+    void shouldReturnFailureWhenNoMatchingKeyFound() throws Exception {
+        when(jwkSource.get(any(JWKSelector.class), isNull()))
+                .thenReturn(Collections.<JWK>emptyList());
+
+        var result = service.retrieveJwkFromURLWithKeyId(KEY_ID);
+
+        assertTrue(result.isFailure());
+        assertEquals("No JWK found with matching id", result.getFailure());
+    }
+
+    @Test
+    void shouldReturnFailureWhenKeySourceExceptionThrown() throws Exception {
+        when(jwkSource.get(any(JWKSelector.class), isNull()))
+                .thenThrow(new KeySourceException("connection refused"));
+
+        var result = service.retrieveJwkFromURLWithKeyId(KEY_ID);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getFailure().startsWith("Error retrieving jwks key"));
+    }
+
+    private static URL dummyUrl() {
+        try {
+            return new URL("https://example.com/.well-known/jwks.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -1,0 +1,231 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AuthorizerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub
+        - ${Env}-account-data-authorizer-lambda
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      AutoPublishAlias: active
+      CodeUri: ./account-data-api/build/distributions/account-data-api.zip
+      Handler: uk.gov.di.authentication.accountdata.lambda.AuthorizeHandler::handleRequest
+      Environment:
+        Variables:
+          ENVIRONMENT: !Sub
+            - "${env}"
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          ACCOUNT_DATA_JWKS_URL:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              accountDataJwksUrl,
+            ]
+      LoggingConfig:
+        LogGroup: !Ref AuthorizerFunctionLogGroup
+      Policies:
+        - !Ref LambdaBasicExecutionPolicy
+      SnapStart:
+        ApplyOn: PublishedVersions
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+          - !Ref HttpsEgressSecurityGroup
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
+
+  AuthorizerFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt AuthorizerFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  AuthorizerFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref AuthorizerFunction.Alias
+      Principal: apigateway.amazonaws.com
+
+  AuthorizerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - /aws/lambda/${Env}-account-data-authorizer-lambda
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+      RetentionInDays:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          cloudwatchLogRetentionInDays,
+        ]
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-AuthorizerFunctionLogGroup"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Source
+          Value: govuk-one-login/authentication-api/ci/cloudformation/account-data/function/authorizer.yaml
+
+  AuthorizerFunctionErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub
+        - ${Env}-account-data-authorizer-errors
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      FilterPattern: '{($.level = "ERROR")}'
+      LogGroupName: !Ref AuthorizerFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub
+            - ${Env}-account-data-authorizer-error-count
+            - Env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          MetricNamespace: LambdaErrorsNamespace
+          MetricValue: 1
+
+  AuthorizerFunctionErrorCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Sub "{{resolve:ssm:/deploy/${Environment}/notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-account-data-authorizer-lambda function. ${RunbookLink}"
+        - AlarmThreshold:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              lambdaLogAlarmThreshold,
+              DefaultValue: 5,
+            ]
+          Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          RunbookLink:
+            !FindInMap [
+              LambdaConfiguration,
+              "account-data-authorizer",
+              RunbookLink,
+              DefaultValue: "",
+            ]
+      AlarmName: !Sub
+        - ${Env}-account-data-authorizer-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub
+        - ${Env}-account-data-authorizer-error-count
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      Namespace: LambdaErrorsNamespace
+      Period: 3600
+      Statistic: Sum
+      Threshold:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          lambdaLogAlarmThreshold,
+          DefaultValue: 5,
+        ]
+
+  AuthorizerFunctionErrorRateCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "Lambda error rate of ${ErrorRateThreshold}% has been reached in the ${Env}-account-data-authorizer-lambda. ${RunbookLink}"
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          ErrorRateThreshold:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              lambdaLogAlarmErrorRateThreshold,
+              DefaultValue: 10,
+            ]
+          RunbookLink:
+            !FindInMap [
+              LambdaConfiguration,
+              "account-data-authorizer",
+              RunbookLink,
+              DefaultValue: "",
+            ]
+      AlarmName: !Sub
+        - ${Env}-account-data-authorizer-error-rate-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Metrics:
+        - Id: e1
+          Label: "Error Rate"
+          ReturnData: true
+          Expression: (m2/m1)*100
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub
+                    - ${Env}-account-data-authorizer-lambda
+                    - Env:
+                        !If [
+                          UseSubEnvironment,
+                          !Ref SubEnvironment,
+                          !Ref Environment,
+                        ]
+            Period: 60
+            Stat: Sum
+            Unit: Count
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Errors
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub
+                    - ${Env}-account-data-authorizer-lambda
+                    - Env:
+                        !If [
+                          UseSubEnvironment,
+                          !Ref SubEnvironment,
+                          !Ref Environment,
+                        ]
+            Period: 60
+            Stat: Sum
+            Unit: Count
+      Threshold:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          lambdaLogAlarmErrorRateThreshold,
+          DefaultValue: 10,
+        ]
+
+  AuthorizerFunctionSubscriptionFilter:
+    Condition: IsSplunkEnabled
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref AuthorizerFunctionLogGroup
+
+Outputs:
+  AuthorizerFunctionArn:
+    Value: !GetAtt AuthorizerFunction.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-AccountDataAuthorizerFunctionArn"
+
+  AuthorizerFunctionAliasArn:
+    Value: !Ref AuthorizerFunction.Alias
+    Export:
+      Name: !Sub "${AWS::StackName}-AccountDataAuthorizerFunctionAliasArn"

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -261,6 +261,34 @@ Resources:
           !Ref AWS::NoValue,
         ]
 
+  ApiGatewayAuthorizerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub
+        - ${AWS::StackName}-${Env}-api-gateway-auth-role
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: default
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !Ref AuthorizerFunction.Alias
+      PermissionsBoundary:
+        !If [
+          UsePermissionsBoundary,
+          !Ref PermissionsBoundary,
+          !Ref AWS::NoValue,
+        ]
+
   # ----------------
   # Common Resources
   # ----------------

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -106,12 +106,15 @@ Mappings:
     authdev1:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d41a1b95-0291-4477-93f7-f1428ceef646
+      accountDataJwksUrl: https://5fgwu5kpd2.execute-api.eu-west-2.amazonaws.com/authdev1/.well-known/ad-jwks.json
     authdev2:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
+      accountDataJwksUrl: https://nw0dah7bxk.execute-api.eu-west-2.amazonaws.com/authdev2/.well-known/ad-jwks.json
     authdev3:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
+      accountDataJwksUrl: https://y3s69ubaz5.execute-api.eu-west-2.amazonaws.com/authdev3/.well-known/amc-jwks.json
     dev:
       cloudwatchLogRetentionInDays: 1
       IsSplunkEnabled: "No"
@@ -119,6 +122,7 @@ Mappings:
       UseAlarmActions: "No"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c6a2fb5e-c92b-4129-bc0c-d75b2b72bae8
       dataStoreAccountId: 653994557586
+      accountDataJwksUrl: https://tze402cnbk.execute-api.eu-west-2.amazonaws.com/dev/.well-known/ad-jwks.json
     build:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -126,6 +130,7 @@ Mappings:
       UseAlarmActions: "Yes"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3c2113fe-9f53-4bed-a46f-c53f02f6c117
       dataStoreAccountId: 761723964695
+      accountDataJwksUrl: https://7ecg8e1o73.execute-api.eu-west-2.amazonaws.com/build/.well-known/ad-jwks.json
     staging:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -134,6 +139,7 @@ Mappings:
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/ed6c6a2d-866f-4e2e-9ebd-c499ce9513c6
       dataStoreAccountId: 758531536632
       accountComponentsVpcEndpointId: vpce-0fed7b2d44a0bde33
+      accountDataJwksUrl: https://z02rnzbqw8.execute-api.eu-west-2.amazonaws.com/staging/.well-known/ad-jwks.json
     integration:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -142,6 +148,7 @@ Mappings:
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/743b2818-03fd-4414-bfaf-6aa8a4bb4e45
       dataStoreAccountId: 761723964695
       accountComponentsVpcEndpointId: vpce-00865f4c00dcdbb83
+      accountDataJwksUrl: https://db10ia9pr6.execute-api.eu-west-2.amazonaws.com/integration/.well-known/ad-jwks.json
     production:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -150,6 +157,7 @@ Mappings:
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/b380ea74-d240-4500-b02b-f5c3d414e34e
       dataStoreAccountId: 172348255554
       accountComponentsVpcEndpointId: vpce-08bfce415b33dc8f6
+      accountDataJwksUrl: https://86n9innl95.execute-api.eu-west-2.amazonaws.com/production/.well-known/ad-jwks.json
   LambdaConfiguration:
     passkeys-create:
       RunbookLink: "https://govukverify.atlassian.net/wiki/x/HIHpRQE"

--- a/ci/openAPI/AccountDataApi.yaml
+++ b/ci/openAPI/AccountDataApi.yaml
@@ -245,6 +245,14 @@ components:
       type: "apiKey"
       name: "Authorization"
       in: "header"
+      x-amazon-apigateway-authtype: "custom"
+      x-amazon-apigateway-authorizer:
+        type: "token"
+        authorizerUri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizerFunction.Arn}:active/invocations"
+        authorizerCredentials:
+          Fn::GetAtt: [ApiGatewayAuthorizerRole, Arn]
+        authorizerResultTtlInSeconds: 0
   schemas:
     PasskeyAuthenticatorCreate:
       type: object

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -442,6 +442,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
+    public URL getAccountDataJwksUrl() throws MalformedURLException {
+        return new URL(System.getenv().getOrDefault("ACCOUNT_DATA_JWKS_URL", ""));
+    }
+
     public String getTokenSigningKeyRsaAlias() {
         return System.getenv("TOKEN_SIGNING_KEY_RSA_ALIAS");
     }


### PR DESCRIPTION
**What**

Adds a new lambda for the account data api, which sits in front of all its endpoints as a custom authorizer (see aws documentation [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html)

It ensures that an access token is sent as an authorization header on all requests. It verifies the signature of the access token with the key served by the internal api's jwks endpoint.

If the token cannot be validated for whatever reason, the lambda throws an error and does not return a policy. This is translated by api gateway into a 401 unauthorized response. If the token is valid, the lambda responds with an access policy which will then be attached to the request to the api endpoints.

This is similar to [what we do in the account management api](https://github.com/govuk-one-login/authentication-api/blob/main/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java#L3), although I have simplified the policy generation as we just need to return some json that represents the access policy (see aws docs [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html)).

A subsequent PR will add validation to all the api endpoints that the access policy contains the subject id in the request path - ie the authorizer has granted access to the specific resource being requested.

A general philosophy of this work has been not to add any additional dependency on shared code (either test or implementation) since at some point this api will be split out from this repo. So in some cases, code has been copied across and simplified.

**Related PRs**

Depends on https://github.com/govuk-one-login/authentication-api/pull/8213

[Subsequent PR](https://github.com/govuk-one-login/authentication-api/pull/8214) to add verification of the subject id
