### PR TITLE
ATO-2507: send anomaly alarms to slack

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -277,7 +277,7 @@
         "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java",
         "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 132,
         "is_secret": false
       }
     ],
@@ -365,7 +365,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 399,
         "is_secret": false
       },
       {
@@ -373,7 +373,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 544,
+        "line_number": 558,
         "is_secret": false
       },
       {
@@ -381,7 +381,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 622,
+        "line_number": 638,
         "is_secret": false
       },
       {
@@ -389,7 +389,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 630,
+        "line_number": 646,
         "is_secret": false
       },
       {
@@ -397,7 +397,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 638,
+        "line_number": 654,
         "is_secret": false
       },
       {
@@ -405,7 +405,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 646,
+        "line_number": 662,
         "is_secret": false
       },
       {
@@ -413,7 +413,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 654,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -421,7 +421,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 2825,
+        "line_number": 2840,
         "is_secret": false
       }
     ],
@@ -451,7 +451,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 376,
+        "line_number": 384,
         "is_secret": false
       },
       {
@@ -459,7 +459,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 633,
         "is_secret": false
       },
       {
@@ -467,7 +467,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 709,
+        "line_number": 726,
         "is_secret": false
       },
       {
@@ -475,7 +475,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 717,
+        "line_number": 734,
         "is_secret": false
       },
       {
@@ -483,7 +483,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 725,
+        "line_number": 742,
         "is_secret": false
       },
       {
@@ -491,7 +491,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 733,
+        "line_number": 750,
         "is_secret": false
       },
       {
@@ -499,7 +499,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 741,
+        "line_number": 758,
         "is_secret": false
       },
       {
@@ -507,7 +507,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 2705,
+        "line_number": 2722,
         "is_secret": false
       }
     ],
@@ -881,7 +881,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java",
         "hashed_secret": "3c452d118b5dbfad5feb4c9be02ad0f8dd6a38ac",
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -901,7 +901,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java",
         "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
         "is_verified": false,
-        "line_number": 92,
+        "line_number": 97,
         "is_secret": false
       }
     ],
@@ -911,7 +911,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java",
         "hashed_secret": "e7451a5d89d2e9e5f35668721904c877cfb39d08",
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 50,
         "is_secret": false
       }
     ],
@@ -1247,7 +1247,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "69c1b96f46e66e1100392a01d2437152b949a74d",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -1255,7 +1255,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "9ac2a39cf66fae8a32a979917e2f426c5674a28b",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -1263,7 +1263,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "a303cce93958d7697653352052cc6f999313c4ad",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -1271,7 +1271,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "e8d63aecdc6bc83b9429e94a4ae06eecab59923b",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       }
     ],
@@ -1301,7 +1301,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java",
         "hashed_secret": "251c10082a6308fe3731846101d52f254a84491a",
         "is_verified": false,
-        "line_number": 2142,
+        "line_number": 2141,
         "is_secret": false
       }
     ],
@@ -1547,6 +1547,29 @@
         "is_secret": false
       }
     ],
+    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
+        "hashed_secret": "633b6d73dcfc71676b365534a6b1edff7775f84e",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
+        "hashed_secret": "747ddc98b5f9c1c5155a501872a7f37831bcfdf8",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
+        "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
+        "is_verified": false,
+        "line_number": 89
+      }
+    ],
     "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java": [
       {
         "type": "Base64 High Entropy String",
@@ -1578,50 +1601,6 @@
         "hashed_secret": "dd888a796666370b9523ef44581c34e19372116a",
         "is_verified": false,
         "line_number": 798,
-        "is_secret": false
-      }
-    ],
-    "python-utils/scripts/create_encrypting_key_from_jwks.py": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "python-utils/scripts/create_encrypting_key_from_jwks.py",
-        "hashed_secret": "8ed498ae5227a1732b22eb062e19b81641613f29",
-        "is_verified": false,
-        "line_number": 17,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "python-utils/scripts/create_encrypting_key_from_jwks.py",
-        "hashed_secret": "3732e91c621d2bfb0392f23ccdf62534f9bbf453",
-        "is_verified": false,
-        "line_number": 18,
-        "is_secret": false
-      }
-    ],
-    "python-utils/scripts/create_signing_key_from_jwks.py": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
-        "hashed_secret": "ff1fe68fcd51bee4b399a28fc5f2131bbdac2b91",
-        "is_verified": false,
-        "line_number": 13,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
-        "hashed_secret": "59c70048939981b2c93600f44c21fd7929820cce",
-        "is_verified": false,
-        "line_number": 14,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
-        "hashed_secret": "7311a4913a0cc1042f392865bb031519d00ccf8d",
-        "is_verified": false,
-        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -1907,23 +1886,128 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 150,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "2fadaec2edd927e80cfb2e94a26fed24a1ce0d22",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "6630a415701f2a22d266ef5ff84ce87a71541c38",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "6d638ce73bc18e3d490992a2edbd25aabe2ae88c",
+        "is_verified": false,
+        "line_number": 216
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "f8ff6c162942955ce28332f99a00d66152b26df9",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "0a6660bfb8f15c4996cd4ff06318129c8862c28e",
+        "is_verified": false,
+        "line_number": 218
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "f43c1b313513e120a1c7f1b2e16c4e588a447c7b",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "2599084e2fdd2597f08300eb2094a699200b41e2",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "2a36be9af46cd27c5f1b20aa020887c1fccaa8ae",
+        "is_verified": false,
+        "line_number": 256
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "d2b22571923d78d2ec43c00b0ab37c26cf31dc0a",
+        "is_verified": false,
+        "line_number": 290
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "202abfba0a5645bdd42c4365448acbccd996fa4b",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "d151606c5a71f1a890ed49e96a05aca41d78430f",
+        "is_verified": false,
+        "line_number": 292
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 258,
+        "line_number": 296,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "67357ea9e9105423bfc88d8e24dd80c4ac213a7b",
+        "is_verified": false,
+        "line_number": 326
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "563ca8e169d3eec2259de50e53b964c8c66fbcb3",
+        "is_verified": false,
+        "line_number": 327
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "d5e506d3f6850724c006f45e4dd68b14615d1532",
+        "is_verified": false,
+        "line_number": 328
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 294,
+        "line_number": 341,
         "is_secret": false
       },
       {
@@ -1931,7 +2015,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 302,
+        "line_number": 349,
         "is_secret": false
       },
       {
@@ -1939,7 +2023,7 @@
         "filename": "template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 310,
+        "line_number": 357,
         "is_secret": false
       },
       {
@@ -1947,7 +2031,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 327,
+        "line_number": 374,
         "is_secret": false
       },
       {
@@ -1955,7 +2039,7 @@
         "filename": "template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 335,
+        "line_number": 382,
         "is_secret": false
       },
       {
@@ -1963,7 +2047,7 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 6943,
+        "line_number": 6955,
         "is_secret": false
       },
       {
@@ -1971,10 +2055,10 @@
         "filename": "template.yaml",
         "hashed_secret": "5b2a69401d414f203d94880132858cc997e8c0eb",
         "is_verified": false,
-        "line_number": 7411,
+        "line_number": 7423,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-04-08T14:50:07Z"
+  "generated_at": "2026-04-20T10:29:19Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -8238,7 +8238,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-FetchJwks-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} FetchJwks lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8278,7 +8283,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-OpenIdConfiguration-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} OpenIdConfiguration lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8318,7 +8328,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-trustmark-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8357,7 +8372,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-DocAppCallback-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} DocAppCallback lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8395,7 +8415,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-TokenFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} TokenFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8433,7 +8458,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-LogoutFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} LogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8471,7 +8501,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-AuthenticationCallbackFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthenticationCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8510,7 +8545,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-JwksFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} JwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8549,7 +8589,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-AuthorisationFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthorisationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8588,7 +8633,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-UserInfoFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UserInfoFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8627,7 +8677,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-AuthCodeFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthCodeFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8748,7 +8803,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-IpvCallbackFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8788,7 +8848,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-SpotResponseFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} SpotResponseFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8827,7 +8892,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-StorageTokenJwkFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} StorageTokenJwkFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8865,7 +8935,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-IpvJwksFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8903,7 +8978,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-AuthJwksFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8941,7 +9021,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-GlobalLogoutFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} GlobalLogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - IsNotProduction
+          - !Ref SlackEvents
+          - !Ref OrchProdSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1

--- a/template.yaml
+++ b/template.yaml
@@ -8237,7 +8237,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-FetchJwks-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} FetchJwks lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} FetchJwks lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8282,7 +8282,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-OpenIdConfiguration-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} OpenIdConfiguration lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} OpenIdConfiguration lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8327,7 +8327,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-trustmark-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} trustmark lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8371,7 +8371,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-DocAppCallback-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} DocAppCallback lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} DocAppCallback lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8414,7 +8414,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-TokenFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} TokenFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} TokenFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8457,7 +8457,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-LogoutFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} LogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} LogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8500,7 +8500,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-AuthenticationCallbackFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthenticationCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthenticationCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8544,7 +8544,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-JwksFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} JwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} JwksFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8588,7 +8588,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-AuthorisationFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthorisationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthorisationFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8632,7 +8632,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-UserInfoFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UserInfoFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UserInfoFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8676,7 +8676,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-AuthCodeFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthCodeFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthCodeFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8722,7 +8722,7 @@ Resources:
     Condition: IsNotProduction
     Properties:
       AlarmName: !Sub ${Environment}-UpdateClientConfigFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UpdateClientConfigFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UpdateClientConfigFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
@@ -8763,7 +8763,7 @@ Resources:
     Condition: IsNotProduction
     Properties:
       AlarmName: !Sub ${Environment}-ClientRegistrationFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} ClientRegistrationFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} ClientRegistrationFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: false
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
@@ -8802,7 +8802,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-IpvCallbackFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvCallbackFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8847,7 +8847,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-SpotResponseFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} SpotResponseFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} SpotResponseFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8891,7 +8891,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-StorageTokenJwkFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} StorageTokenJwkFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} StorageTokenJwkFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8934,7 +8934,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-IpvJwksFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} IpvJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -8977,7 +8977,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-AuthJwksFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} AuthJwksFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If
@@ -9020,7 +9020,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${Environment}-GlobalLogoutFunction-error-anomaly-alarm
-      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} GlobalLogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}"
+      AlarmDescription: !Sub "Anomalous Error rate in ${Environment} GlobalLogoutFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
       ActionsEnabled: true
       AlarmActions:
         - !If

--- a/template.yaml
+++ b/template.yaml
@@ -8723,7 +8723,9 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-UpdateClientConfigFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} UpdateClientConfigFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8764,7 +8766,9 @@ Resources:
     Properties:
       AlarmName: !Sub ${Environment}-ClientRegistrationFunction-error-anomaly-alarm
       AlarmDescription: !Sub "Anomalous Error rate in ${Environment} ClientRegistrationFunction lambda.ACCOUNT: di-orchestration-${Environment}. Runbook: https://govukverify.atlassian.net/wiki/x/YYBcggE/"
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1


### PR DESCRIPTION
### Wider context of change
Our anomaly alarms are quite useful, especially as they can help detect errors outside of our normal traffic bands. 


### What’s changed:
- Updates anomaly alarms to enable the alarm actions and send a message to our SNS topic (either the non-prod or prod slack topic) when the alarm enters the ALARM state

### Manual testing

- Deployed to dev
- Used the cloudwatch CLI to put the alarm in ALARM state, saw a message posted to slack

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
