### PR TITLE
BAU: Light pre-commit hooks and script

### DIFF
--- a/.pre-commit-config-light.yaml
+++ b/.pre-commit-config-light.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/govuk-one-login/pre-commit-hooks.git
+    rev: 0.0.1
+    hooks:
+      - id: gradle-spotless-apply
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
           ^(ci|.github|http|openAPI)/.*|\
           docker-compose.*|\
           .pre-commit-config.yaml|\
+          .pre-commit-config-light.yaml|\
           orchestration-canary-alarms.template.yaml|\
           checkov-policies.*|\
           .terraform-docs.yml|\

--- a/scripts/hooks-control.sh
+++ b/scripts/hooks-control.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Pre-commit hook management:"
+echo "  1) Install light hooks (.pre-commit-config-light.yaml only)"
+echo "  2) Install full hooks (.pre-commit-config.yaml)"
+echo "  3) Uninstall hooks"
+read -rp "Choose [1-3]: " choice
+
+case "${choice}" in
+  1) pre-commit install -c .pre-commit-config-light.yaml && echo "Light hooks installed." ;;
+  2) pre-commit install && echo "Full hooks installed." ;;
+  3) pre-commit uninstall && echo "Hooks uninstalled." ;;
+  *) echo "Invalid choice." && exit 1 ;;
+esac


### PR DESCRIPTION


## What

Light pre-commit hooks and script

Contains a light pre-commit config file and a script to control which and whether hooks are configred.

Pre-commit hooks that take ages to run are a disincentive to having any pre-commit hooks at all.  To an extent github actions has replaced the need for pre-commit hooks, apart from detect-secrets where there is actually a benefit to running it before the commit gets uploaded in case it does contain a secret.

A light pre-commit config limited to essential checks removes the friction and provides a better incentive for people to have hooks configred at all.

## How to review

1. Code Review
1. Enable light hooks by running `./scripts/hook-control.sh` and choosing the required option
1. Make a java change that breaks java formatting and stage it.
1. Add a secret to a file (such as another password variable) that will break detect-secrets and stage it.
1. Commit the stages to trigger the hook, see what the effect is.  The first run of the spotless plugin will take a while to install, but after that it's pretty snappy.
1. Discard changes.  Either keep light hooks in place or switch off using the script. 

## Related PRs

#8142 
