### PR TITLE
BAU: pre-commit light detect-secrets only

### DIFF
--- a/.pre-commit-config-light.yaml
+++ b/.pre-commit-config-light.yaml
@@ -1,9 +1,4 @@
 repos:
-  - repo: https://github.com/govuk-one-login/pre-commit-hooks.git
-    rev: 0.0.1
-    hooks:
-      - id: gradle-spotless-apply
-
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:


### PR DESCRIPTION
## What

Pre-commit light detect-secrets only, keep to a bare minimum

## How to review

1. Code Review

## Related PRs

#8211 