### PR TITLE
AUT-5340: Include ADAPI access token in request to account data when retrieving passkeys

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1035,7 +1035,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java",
         "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 76,
         "is_secret": false
       }
     ],
@@ -2060,5 +2060,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T10:29:19Z"
+  "generated_at": "2026-04-20T15:03:36Z"
 }

--- a/ci/cloudformation/auth/function/start-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/start-passkey-assertion.yaml
@@ -40,12 +40,36 @@ Resources:
                   ],
                   accountDataApiId,
                 ]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
+          AUTH_TO_ACCOUNT_DATA_SIGNING_KEY: !Sub
+            - arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${env}-auth-to-account-data-signing-key
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
+          AMC_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              amcClientId,
+            ]
       LoggingConfig:
         LogGroup: !Ref StartPasskeyAssertionFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoAuthSessionStoreReadWriteAccessPolicy
+        - !Ref AuthToAccountDataSigningKeyPolicy
       ProvisionedConcurrencyConfig: !If
         - EnableProvisionedConcurrency
         - ProvisionedConcurrentExecutions:

--- a/ci/cloudformation/auth/function/user-exists.yaml
+++ b/ci/cloudformation/auth/function/user-exists.yaml
@@ -55,6 +55,29 @@ Resources:
                   ],
                   accountDataApiId,
                 ]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
+          AUTH_TO_ACCOUNT_DATA_SIGNING_KEY: !Sub
+            - arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${env}-auth-to-account-data-signing-key
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
+          AMC_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              amcClientId,
+            ]
       LoggingConfig:
         LogGroup: !Ref UserExistsFunctionLogGroup
       Policies:
@@ -66,6 +89,7 @@ Resources:
         - !Ref DynamoClientRegistryReadAccessPolicy
         - !Ref DynamoUserReadWriteAccessPolicy
         - !Ref RedisParametersAccessPolicy
+        - !Ref AuthToAccountDataSigningKeyPolicy
       ProvisionedConcurrencyConfig: !If
         - EnableProvisionedConcurrency
         - ProvisionedConcurrentExecutions:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountDataScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountDataScope.java
@@ -1,7 +1,8 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
 public enum AccountDataScope implements AccessTokenScope {
-    PASSKEY_CREATE("passkey-create");
+    PASSKEY_CREATE("passkey-create"),
+    PASSKEY_RETRIEVE("passkey-retrieve");
 
     private final String value;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyRetrieveError.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyRetrieveError.java
@@ -5,7 +5,8 @@ public enum PasskeyRetrieveError {
     ERROR_PARSING_RESPONSE_FROM_PASSKEY_RETRIEVE(
             "Error parsing response from retrieve passkeys endpoint"),
     IO_EXCEPTION("IO Exception when attempting to retrieve passkeys"),
-    INTERRUPTED_EXCEPTION("Interrupted exception when attempting to retrieve passkeys");
+    INTERRUPTED_EXCEPTION("Interrupted exception when attempting to retrieve passkeys"),
+    ERROR_CREATING_ACCESS_TOKEN("Error creating access token");
 
     private final String value;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -75,9 +75,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                         configurationService,
                         new NowHelper.NowClock(Clock.systemUTC()),
                         new JwtService(new KmsConnectionService(configurationService)),
-                        new AccessTokenConstructorService(
-                                new JwtService(new KmsConnectionService(configurationService)),
-                                configurationService));
+                        new AccessTokenConstructorService(configurationService));
         this.dynamoAmcStateService = new DynamoAmcStateService(configurationService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
@@ -56,9 +56,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
                         configurationService,
                         new NowHelper.NowClock(Clock.systemUTC()),
                         new JwtService(new KmsConnectionService(configurationService)),
-                        new AccessTokenConstructorService(
-                                new JwtService(new KmsConnectionService(configurationService)),
-                                configurationService));
+                        new AccessTokenConstructorService(configurationService));
         this.dynamoAmcStateService = new DynamoAmcStateService(configurationService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -206,7 +206,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         configurationService.isForcedMFAResetAfterMFACheckEnabled()
                                 && requiresMfaResetForInternationalNumber(
                                         authSession, userCredentials, userProfile.get());
-                hasActivePasskey = hasActivePasskey(userProfile.get().getPublicSubjectID());
+                hasActivePasskey =
+                        hasActivePasskey(userProfile.get().getPublicSubjectID(), authSession);
             } else {
                 authSession.setInternalCommonSubjectId(null);
                 auditableEvent = FrontendAuditableEvent.AUTH_CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
@@ -245,17 +246,22 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         }
     }
 
-    private boolean hasActivePasskey(String publicSubjectId) {
+    private boolean hasActivePasskey(String publicSubjectId, AuthSessionItem authSession) {
         if (configurationService.supportPasskeys()) {
             LOG.info("Checking if user has active passkey");
-            var result = passkeysService.hasActivePasskey(publicSubjectId);
-            if (result.isFailure()) {
+
+            var hasActivePasskeyResult =
+                    passkeysService.hasActivePasskey(
+                            publicSubjectId,
+                            authSession.getInternalCommonSubjectId(),
+                            authSession.getSessionId());
+            if (hasActivePasskeyResult.isFailure()) {
                 LOG.warn(
                         "Error retrieving passkey information for user. Error: {}",
-                        result.getFailure());
+                        hasActivePasskeyResult.getFailure());
                 return false;
             }
-            return result.getSuccess();
+            return hasActivePasskeyResult.getSuccess();
         } else return false;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -211,7 +211,7 @@ public class AMCService {
                             .createSignedAccessToken(
                                     internalPairwiseSubject,
                                     config.scope(),
-                                    authSessionItem,
+                                    authSessionItem.getSessionId(),
                                     issueTime,
                                     expiryDate,
                                     config.audience(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorService.java
@@ -6,9 +6,9 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenScope;
-import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.util.Date;
 import java.util.UUID;
@@ -18,16 +18,21 @@ public class AccessTokenConstructorService {
     private final JwtService jwtService;
     private final ConfigurationService configurationService;
 
-    public AccessTokenConstructorService(
-            JwtService jwtService, ConfigurationService configurationService) {
-        this.jwtService = jwtService;
+    public AccessTokenConstructorService(ConfigurationService configurationService) {
+        this.jwtService = new JwtService(new KmsConnectionService(configurationService));
         this.configurationService = configurationService;
+    }
+
+    public AccessTokenConstructorService(
+            ConfigurationService configurationService, JwtService jwtService) {
+        this.configurationService = configurationService;
+        this.jwtService = jwtService;
     }
 
     public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
             String internalPairwiseSubject,
             AccessTokenScope scope,
-            AuthSessionItem authSessionItem,
+            String sessionId,
             Date issueTime,
             Date expiryDate,
             String audience,
@@ -44,7 +49,7 @@ public class AccessTokenConstructorService {
                         .notBeforeTime(issueTime)
                         .subject(internalPairwiseSubject)
                         .claim("client_id", clientId)
-                        .claim("sid", authSessionItem.getSessionId())
+                        .claim("sid", sessionId)
                         .jwtID(UUID.randomUUID().toString())
                         .build();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -1,12 +1,16 @@
 package uk.gov.di.authentication.frontendapi.services.passkeys;
 
 import com.google.gson.JsonParseException;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccountDataScope;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeysRetrieveResponse;
+import uk.gov.di.authentication.frontendapi.services.AccessTokenConstructorService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.HttpClientHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -15,6 +19,8 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
 
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
@@ -22,30 +28,56 @@ public class PasskeysService {
     private final ConfigurationService configurationService;
     HttpClient httpClient;
     private final SerializationService serializationService = SerializationService.getInstance();
+    private final AccessTokenConstructorService accessTokenConstructorService;
     private static final Logger LOG = LogManager.getLogger(PasskeysService.class);
+
+    private final NowHelper.NowClock nowClock = new NowHelper.NowClock(Clock.systemUTC());
+    private static final Long ADAPI_ACCESS_TOKEN_LIFETIME = 5L;
 
     public PasskeysService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+        this.accessTokenConstructorService =
+                new AccessTokenConstructorService(configurationService);
         httpClient = HttpClientHelper.newInstrumentedHttpClient();
     }
 
-    public PasskeysService(ConfigurationService configurationService, HttpClient httpClient) {
+    public PasskeysService(
+            ConfigurationService configurationService,
+            HttpClient httpClient,
+            AccessTokenConstructorService accessTokenConstructorService) {
         this.configurationService = configurationService;
         this.httpClient = httpClient;
+        this.accessTokenConstructorService = accessTokenConstructorService;
     }
 
-    public Result<PasskeyRetrieveError, Boolean> hasActivePasskey(String publicSubjectId) {
-        return retrievePasskeys(publicSubjectId).map(response -> !response.passkeys().isEmpty());
+    public Result<PasskeyRetrieveError, Boolean> hasActivePasskey(
+            String publicSubjectId, String internalCommonSubjectId, String sessionId) {
+        return retrievePasskeys(publicSubjectId, internalCommonSubjectId, sessionId)
+                .map(response -> !response.passkeys().isEmpty());
     }
 
     public Result<PasskeyRetrieveError, PasskeysRetrieveResponse> retrievePasskeys(
-            String publicSubjectId) {
+            String publicSubjectId, String internalCommonSubjectId, String sessionId) {
+
+        var accountDataApiAccessTokenResult =
+                createAccountDataApiAccessToken(internalCommonSubjectId, sessionId);
+        if (accountDataApiAccessTokenResult.isFailure()) {
+            return Result.failure(accountDataApiAccessTokenResult.getFailure());
+        }
+
         var accountDataBaseUri = configurationService.getAccountDataURI();
         var getPasskeysRequestUri =
                 buildURI(
                         accountDataBaseUri,
                         "/accounts/" + publicSubjectId + "/authenticators/passkeys");
-        var request = HttpRequest.newBuilder(getPasskeysRequestUri).build();
+        var request =
+                HttpRequest.newBuilder(getPasskeysRequestUri)
+                        .header(
+                                "Authorization",
+                                accountDataApiAccessTokenResult
+                                        .getSuccess()
+                                        .toAuthorizationHeader())
+                        .build();
         LOG.info("Sending request to account data api retrieve endpoint");
         try {
             var httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -88,5 +120,27 @@ public class PasskeysService {
             return Result.failure(
                     PasskeyRetrieveError.ERROR_PARSING_RESPONSE_FROM_PASSKEY_RETRIEVE);
         }
+    }
+
+    private Result<PasskeyRetrieveError, BearerAccessToken> createAccountDataApiAccessToken(
+            String internalCommonSubjectId, String sessionId) {
+        return accessTokenConstructorService
+                .createSignedAccessToken(
+                        internalCommonSubjectId,
+                        AccountDataScope.PASSKEY_RETRIEVE,
+                        sessionId,
+                        nowClock.now(),
+                        nowClock.nowPlus(ADAPI_ACCESS_TOKEN_LIFETIME, ChronoUnit.MINUTES),
+                        configurationService.getAuthToAccountDataApiAudience(),
+                        configurationService.getAuthIssuerClaim(),
+                        configurationService.getAMCClientId(),
+                        configurationService.getAuthToAccountDataSigningKey())
+                .mapFailure(
+                        failure -> {
+                            LOG.warn(
+                                    "Error creating account data api access token. Error: {}",
+                                    failure);
+                            return PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN;
+                        });
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
@@ -11,7 +11,9 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -26,11 +28,15 @@ public class AccountDataCredentialRepository implements CredentialRepository {
 
     private final PasskeysService passkeysService;
     private final AuthenticationService authenticationService;
+    private final ConfigurationService configurationService;
 
     public AccountDataCredentialRepository(
-            PasskeysService passkeysService, AuthenticationService authenticationService) {
+            PasskeysService passkeysService,
+            AuthenticationService authenticationService,
+            ConfigurationService configurationService) {
         this.passkeysService = passkeysService;
         this.authenticationService = authenticationService;
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -139,12 +145,29 @@ public class AccountDataCredentialRepository implements CredentialRepository {
     private Optional<List<PasskeysRetrieveResponse.PasskeyResponse>>
             retrievePasskeysForPublicSubjectId(String publicSubjectId) {
         return passkeysService
-                .retrievePasskeys(publicSubjectId)
+                .retrievePasskeys(publicSubjectId, getInternalCommonSubjectId(publicSubjectId), "")
                 .fold(
                         failure -> {
                             LOG.warn("Failed to retrieve passkeys: {}", failure);
                             return Optional.empty();
                         },
                         success -> Optional.of(success.passkeys()));
+    }
+
+    private String getInternalCommonSubjectId(String publicSubjectId) {
+        return authenticationService
+                .getOptionalUserProfileFromPublicSubject(publicSubjectId)
+                .map(
+                        userProfile ->
+                                ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                                userProfile,
+                                                configurationService.getInternalSectorUri(),
+                                                authenticationService)
+                                        .getValue())
+                .orElseGet(
+                        () -> {
+                            LOG.warn("Error retrieving internal common subject ID");
+                            return "";
+                        });
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProvider.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProvider.java
@@ -36,7 +36,7 @@ public class RelyingPartyProvider {
 
                     AccountDataCredentialRepository credentialRepository =
                             new AccountDataCredentialRepository(
-                                    passkeysService, authenticationService);
+                                    passkeysService, authenticationService, configurationService);
 
                     return RelyingParty.builder()
                             .identity(rpIdentity)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.google.gson.JsonParser;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -76,6 +77,7 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.ENCODED_DEVICE_DETAILS;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS;
@@ -106,11 +108,14 @@ class CheckUserExistsHandlerTest {
                     .withSessionId(SESSION_ID)
                     .withRequestedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL)
                     .withClientId(CLIENT_ID)
-                    .withRpSectorIdentifierHost(SECTOR_HOST);
+                    .withRpSectorIdentifierHost(SECTOR_HOST)
+                    .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
     private static final Subject SUBJECT = new Subject();
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final ByteBuffer SALT =
             ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
+    private static final BearerAccessToken ADAPI_BEARER_ACCESS_TOKEN =
+            new BearerAccessToken("adapi_bearer");
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
@@ -622,7 +627,8 @@ class CheckUserExistsHandlerTest {
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
-            when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID()))
+            when(passkeysService.hasActivePasskey(
+                            eq(userProfile.getPublicSubjectID()), any(), eq(SESSION_ID)))
                     .thenReturn(Result.success(hasActivePasskey));
 
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
@@ -643,7 +649,9 @@ class CheckUserExistsHandlerTest {
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
-            when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID()))
+
+            when(passkeysService.hasActivePasskey(
+                            eq(userProfile.getPublicSubjectID()), any(), eq(SESSION_ID)))
                     .thenReturn(
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -613,7 +613,7 @@ class AMCServiceTest {
                         invocation -> {
                             String internalPairwiseSubject = invocation.getArgument(0);
                             AccessTokenScope scope = invocation.getArgument(1);
-                            AuthSessionItem session = invocation.getArgument(2);
+                            String sessionId = invocation.getArgument(2);
                             Date issueTime = invocation.getArgument(3);
                             Date expiryDate = invocation.getArgument(4);
                             String audience = invocation.getArgument(5);
@@ -638,7 +638,7 @@ class AMCServiceTest {
                                             .notBeforeTime(issueTime)
                                             .subject(internalPairwiseSubject)
                                             .claim("client_id", clientId)
-                                            .claim("sid", session.getSessionId())
+                                            .claim("sid", sessionId)
                                             .jwtID(UUID.randomUUID().toString())
                                             .build();
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorServiceTest.java
@@ -20,7 +20,6 @@ import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccountDataScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccountManagementScope;
-import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -35,8 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
-import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_PAIRWISE_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 
@@ -56,22 +53,16 @@ class AccessTokenConstructorServiceTest {
     private final JwtService jwtService = mock(JwtService.class);
 
     private AccessTokenConstructorService accessTokenConstructorService;
-    private AuthSessionItem authSessionItem;
     private ECKey signingKey;
 
     @BeforeEach
     void setup() throws Exception {
         accessTokenConstructorService =
-                new AccessTokenConstructorService(jwtService, configurationService);
+                new AccessTokenConstructorService(configurationService, jwtService);
 
         when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
         mockJwtSigning();
         signingKey = new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
-        authSessionItem =
-                new AuthSessionItem()
-                        .withClientId(CLIENT_ID)
-                        .withSessionId(SESSION_ID)
-                        .withEmailAddress(EMAIL);
     }
 
     private static Stream<Arguments> validScopes() {
@@ -91,7 +82,7 @@ class AccessTokenConstructorServiceTest {
                 accessTokenConstructorService.createSignedAccessToken(
                         INTERNAL_PAIRWISE_ID,
                         accessTokenScope,
-                        authSessionItem,
+                        SESSION_ID,
                         NOW,
                         EXPIRY,
                         AUDIENCE,
@@ -128,7 +119,7 @@ class AccessTokenConstructorServiceTest {
                 accessTokenConstructorService.createSignedAccessToken(
                         INTERNAL_PAIRWISE_ID,
                         AccountDataScope.PASSKEY_CREATE,
-                        authSessionItem,
+                        SESSION_ID,
                         NOW,
                         EXPIRY,
                         AUDIENCE,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.frontendapi.services.passkeys;
 
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -8,7 +9,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
+import uk.gov.di.authentication.frontendapi.entity.amc.AccountDataScope;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
+import uk.gov.di.authentication.frontendapi.services.AccessTokenConstructorService;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.io.IOException;
@@ -16,31 +21,57 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 
 class PasskeysServiceTest {
     ConfigurationService configurationService = mock(ConfigurationService.class);
     HttpClient httpClient = mock(HttpClient.class);
     HttpResponse httpResponse = mock(HttpResponse.class);
-    PasskeysService passkeysService = new PasskeysService(configurationService, httpClient);
+    AccessTokenConstructorService accessTokenConstructorService =
+            mock(AccessTokenConstructorService.class);
+
+    PasskeysService passkeysService =
+            new PasskeysService(configurationService, httpClient, accessTokenConstructorService);
 
     private static final String ACCOUNT_DATA_BASE_URI = "https://example.com";
     private static final String EXPECTED_REQUEST_URL =
             "%s/accounts/%s/authenticators/passkeys"
                     .formatted(ACCOUNT_DATA_BASE_URI, PUBLIC_SUBJECT_ID);
+    private static final BearerAccessToken ADAPI_BEARER_ACCESS_TOKEN =
+            new BearerAccessToken("adapi_bearer");
+    private static final String AUTH_ISSUER_CLAIM = "https://signin.account.gov.uk/";
+    private static final String AUTH_TO_ACCOUNT_DATA_AUDIENCE = "https://example.com/ADAPIAudience";
+    private static final String AMC_CLIENT_ID = "amc-client-id";
+    private static final String AUTH_TO_ACCOUNT_DATA_SIGNING_KEY =
+            "auth-to-account-data-signing-key";
 
     @BeforeEach
     void beforeEach() {
         when(configurationService.getAccountDataURI()).thenReturn(ACCOUNT_DATA_BASE_URI);
+        when(configurationService.getAuthToAccountDataApiAudience())
+                .thenReturn(AUTH_TO_ACCOUNT_DATA_AUDIENCE);
+        when(configurationService.getAuthIssuerClaim()).thenReturn(AUTH_ISSUER_CLAIM);
+        when(configurationService.getAMCClientId()).thenReturn(AMC_CLIENT_ID);
+        when(configurationService.getAuthToAccountDataSigningKey())
+                .thenReturn(AUTH_TO_ACCOUNT_DATA_SIGNING_KEY);
+        when(accessTokenConstructorService.createSignedAccessToken(
+                        any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Result.success(ADAPI_BEARER_ACCESS_TOKEN));
     }
 
     @AfterEach
@@ -71,9 +102,32 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID);
+            var result =
+                    passkeysService.hasActivePasskey(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isSuccess());
 
+            var expectedAuthorizationHeader =
+                    Optional.of(ADAPI_BEARER_ACCESS_TOKEN.toAuthorizationHeader());
+            verify(httpClient)
+                    .send(
+                            argThat(
+                                    request ->
+                                            request.headers()
+                                                    .firstValue("Authorization")
+                                                    .equals(expectedAuthorizationHeader)),
+                            any());
+            verify(accessTokenConstructorService)
+                    .createSignedAccessToken(
+                            eq(INTERNAL_COMMON_SUBJECT_ID),
+                            eq(AccountDataScope.PASSKEY_RETRIEVE),
+                            eq(SESSION_ID),
+                            any(),
+                            any(),
+                            eq(AUTH_TO_ACCOUNT_DATA_AUDIENCE),
+                            eq(AUTH_ISSUER_CLAIM),
+                            eq(AMC_CLIENT_ID),
+                            eq(AUTH_TO_ACCOUNT_DATA_SIGNING_KEY));
             var hasActivePasskey = result.getSuccess();
             assertEquals(expectedResult, hasActivePasskey);
         }
@@ -91,7 +145,9 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID);
+            var result =
+                    passkeysService.retrievePasskeys(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isSuccess());
             assertEquals(1, result.getSuccess().passkeys().size());
             assertEquals("123456", result.getSuccess().passkeys().get(0).passkeyId());
@@ -111,7 +167,9 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID);
+            var result =
+                    passkeysService.hasActivePasskey(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -132,7 +190,9 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID);
+            var result =
+                    passkeysService.hasActivePasskey(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -160,7 +220,9 @@ class PasskeysServiceTest {
                             any()))
                     .thenThrow(e);
 
-            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID);
+            var result =
+                    passkeysService.hasActivePasskey(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -177,10 +239,27 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID);
+            var result =
+                    passkeysService.retrievePasskeys(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
             assertEquals(
                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
+        }
+
+        @Test
+        void retrievePasskeysShouldReturnFailureIfErrorCreatingAccessToken() {
+            when(accessTokenConstructorService.createSignedAccessToken(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+            var result =
+                    passkeysService.hasActivePasskey(
+                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+
+            assertTrue(result.isFailure());
+            assertEquals(PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN, result.getFailure());
+            verifyNoInteractions(httpClient);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.frontendapi.services.webauthn;
 import com.yubico.webauthn.CredentialRepository;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
@@ -10,7 +11,9 @@ import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeysRetrieveResp
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -22,6 +25,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
@@ -31,10 +36,20 @@ class AccountDataCredentialRepositoryTest {
 
     private final PasskeysService passkeysService = mock(PasskeysService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AccountDataCredentialRepository repository =
-            new AccountDataCredentialRepository(passkeysService, authenticationService);
+            new AccountDataCredentialRepository(
+                    passkeysService, authenticationService, configurationService);
 
     private static final String PASSKEY_ID_BASE64URL = "dGVzdC1jcmVkZW50aWFsLWlk";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
+
+    @BeforeEach
+    void setUp() {
+        when(authenticationService.getOrGenerateSalt(any())).thenReturn(TEST_SALT);
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
+    }
 
     @Test
     void implementsCredentialRepository() {
@@ -46,7 +61,7 @@ class AccountDataCredentialRepositoryTest {
         @Test
         void returnsCredentialIdsWhenPasskeysExist() {
             setupUserProfile();
-            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
                     .thenReturn(
                             Result.success(
                                     new PasskeysRetrieveResponse(
@@ -65,7 +80,7 @@ class AccountDataCredentialRepositoryTest {
         @Test
         void returnsEmptySetWhenNoPasskeys() {
             setupUserProfile();
-            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
                     .thenReturn(Result.success(new PasskeysRetrieveResponse(List.of())));
 
             var result = repository.getCredentialIdsForUsername(EMAIL);
@@ -86,7 +101,7 @@ class AccountDataCredentialRepositoryTest {
         @Test
         void returnsEmptySetWhenApiCallFails() {
             setupUserProfile();
-            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));
@@ -159,7 +174,7 @@ class AccountDataCredentialRepositoryTest {
 
         @Test
         void returnsRegisteredCredentialWhenFound() {
-            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
                     .thenReturn(
                             Result.success(
                                     new PasskeysRetrieveResponse(
@@ -177,7 +192,7 @@ class AccountDataCredentialRepositoryTest {
 
         @Test
         void returnsEmptyWhenCredentialNotFound() {
-            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
                     .thenReturn(Result.success(new PasskeysRetrieveResponse(List.of())));
             var credentialId = new ByteArray(Base64.getUrlDecoder().decode(PASSKEY_ID_BASE64URL));
 
@@ -188,7 +203,7 @@ class AccountDataCredentialRepositoryTest {
 
         @Test
         void returnsEmptyWhenApiCallFails() {
-            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));
@@ -213,12 +228,15 @@ class AccountDataCredentialRepositoryTest {
     }
 
     private void setupUserProfile() {
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(
-                        Optional.of(
-                                new UserProfile()
-                                        .withEmail(EMAIL)
-                                        .withPublicSubjectID(PUBLIC_SUBJECT_ID)));
+        var userProfile =
+                Optional.of(
+                        new UserProfile()
+                                .withEmail(EMAIL)
+                                .withPublicSubjectID(PUBLIC_SUBJECT_ID)
+                                .withSubjectID("subject"));
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(userProfile);
+        when(authenticationService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
+                .thenReturn(userProfile);
     }
 
     private static PasskeysRetrieveResponse.PasskeyResponse aPasskeyResponse(String passkeyId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -4,12 +4,16 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
@@ -25,6 +29,10 @@ import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.HashMap;
 import java.util.List;
@@ -50,9 +58,16 @@ import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.a
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
+@ExtendWith(SystemStubsExtension.class)
 class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static WireMockServer wireMockServer;
+
+    @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
+
+    @RegisterExtension
+    private static final KmsKeyExtension authToAccountDataSigningKey =
+            new KmsKeyExtension("auth-to-account-data-signing-key", KeyUsageType.SIGN_VERIFY);
 
     private static final ClientID CLIENT_ID = new ClientID("test-client");
     private static final String SECTOR_IDENTIFIER_HOST = "test.com";
@@ -572,6 +587,16 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     class Passkeys {
         String accountDataApiBaseUri;
 
+        @BeforeAll
+        static void setupEnvironment() {
+            environment.set(
+                    "AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "https://example.com/ADAPIAudience");
+            environment.set("AUTH_ISSUER_CLAIM", "https://signin.account.gov.uk/");
+            environment.set("AMC_CLIENT_ID", "amc-client-id");
+            environment.set(
+                    "AUTH_TO_ACCOUNT_DATA_SIGNING_KEY", authToAccountDataSigningKey.getKeyId());
+        }
+
         @BeforeEach
         void setUp() {
             wireMockServer =
@@ -579,6 +604,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             wireMockServer.start();
 
             accountDataApiBaseUri = "http://localhost:" + wireMockServer.port();
+
             txmaAuditQueue.clear();
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -4,14 +4,22 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.authentication.frontendapi.entity.StartPasskeyAssertionRequest;
 import uk.gov.di.authentication.frontendapi.lambda.StartPasskeyAssertionHandler;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Map;
 import java.util.Optional;
@@ -24,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
+@ExtendWith(SystemStubsExtension.class)
 class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String TEST_EMAIL = "user+passkey@digital.cabinet-office.gov.uk";
@@ -33,6 +42,20 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
     private static final String COSE_PUBLIC_KEY_BASE64URL = "cHVibGljLWtleS1jb3Nl";
 
     private WireMockServer wireMockServer;
+
+    @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
+
+    @RegisterExtension
+    private static final KmsKeyExtension authToAccountDataSigningKey =
+            new KmsKeyExtension("auth-to-account-data-signing-key", KeyUsageType.SIGN_VERIFY);
+
+    @BeforeAll
+    static void setupEnvironment() {
+        environment.set("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "https://example.com/ADAPIAudience");
+        environment.set("AUTH_ISSUER_CLAIM", "https://signin.account.gov.uk/");
+        environment.set("AMC_CLIENT_ID", "amc-client-id");
+        environment.set("AUTH_TO_ACCOUNT_DATA_SIGNING_KEY", authToAccountDataSigningKey.getKeyId());
+    }
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## What

When we make a request to the `CheckUserExistsHandler` we are making a request to check if the user has a passkey. As we are adding an authoriser to the ADAPI, we need to send the access token in the request

## How to review

1. Code review
2. Deploy to dev env to test (contingent on authoriser being available)

## Checklist

