### PR TITLE
Aut 5321/subject id validation

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -37,4 +37,24 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
         return handler.handleRequest(request, context);
     }
+
+    protected APIGatewayProxyResponseEvent makeRequest(
+            Optional<String> body,
+            Map<String, String> headers,
+            Map<String, String> queryString,
+            Map<String, String> pathParams,
+            Map<String, Object> authorizerParams) {
+        String requestId = UUID.randomUUID().toString();
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        var requestContext =
+                new APIGatewayProxyRequestEvent.ProxyRequestContext().withRequestId(requestId);
+        requestContext.setAuthorizer(authorizerParams);
+        request.withHeaders(headers)
+                .withQueryStringParameters(queryString)
+                .withPathParameters(pathParams)
+                .withRequestContext(requestContext);
+        body.ifPresent(request::withBody);
+
+        return handler.handleRequest(request, context);
+    }
 }

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -24,24 +24,6 @@ public abstract class ApiGatewayHandlerIntegrationTest {
             Optional<String> body,
             Map<String, String> headers,
             Map<String, String> queryString,
-            Map<String, String> pathParams) {
-        String requestId = UUID.randomUUID().toString();
-        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
-        request.withHeaders(headers)
-                .withQueryStringParameters(queryString)
-                .withPathParameters(pathParams)
-                .withRequestContext(
-                        new APIGatewayProxyRequestEvent.ProxyRequestContext()
-                                .withRequestId(requestId));
-        body.ifPresent(request::withBody);
-
-        return handler.handleRequest(request, context);
-    }
-
-    protected APIGatewayProxyResponseEvent makeRequest(
-            Optional<String> body,
-            Map<String, String> headers,
-            Map<String, String> queryString,
             Map<String, String> pathParams,
             Map<String, Object> authorizerParams) {
         String requestId = UUID.randomUUID().toString();

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
@@ -33,6 +33,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     private final ConfigurationService configurationService = ConfigurationService.getInstance();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =
@@ -70,7 +72,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             Optional.of(requestBody),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID));
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(201));
@@ -109,7 +112,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             Optional.of(requestBodyWithNullCredential),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID));
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(400));
@@ -142,7 +146,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             Optional.of(requestBodyWithDuplicatePasskeyId),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID));
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(409));
@@ -172,7 +177,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             Optional.of(requestBodyWithInvalidAaguid),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID));
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(422));

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysRetrieveHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysRetrieveHandlerIntegrationTest.java
@@ -32,6 +32,8 @@ class PasskeysRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     private final ConfigurationService configurationService = ConfigurationService.getInstance();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =
@@ -73,7 +75,8 @@ class PasskeysRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                             Optional.empty(),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID));
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(200));
@@ -93,7 +96,8 @@ class PasskeysRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                             Optional.empty(),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID));
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(200));
@@ -114,7 +118,8 @@ class PasskeysRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                             Optional.empty(),
                             headers,
                             Collections.emptyMap(),
-                            Map.of("publicSubjectId", ""));
+                            Map.of("publicSubjectId", ""),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertThat(response.getStatusCode(), equalTo(400));

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysUpdateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysUpdateHandlerIntegrationTest.java
@@ -41,6 +41,8 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     private static final int UPDATED_SIGN_COUNT = SIGN_COUNT + 1;
     private static final String UPDATED_LAST_USED_AT =
             Instant.parse(LAST_USED_AT).plus(1, ChronoUnit.MINUTES).toString();
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
 
     @BeforeEach
     void setUp() {
@@ -72,7 +74,8 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                                     "publicSubjectId",
                                     PUBLIC_SUBJECT_ID,
                                     "passkeyId",
-                                    PRIMARY_PASSKEY_ID));
+                                    PRIMARY_PASSKEY_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertEquals(204, response.getStatusCode());
@@ -113,7 +116,8 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                                     "publicSubjectId",
                                     PUBLIC_SUBJECT_ID,
                                     "passkeyId",
-                                    requestPasskeyId));
+                                    requestPasskeyId),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertEquals(404, response.getStatusCode());
@@ -136,7 +140,8 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                                     "publicSubjectId",
                                     PUBLIC_SUBJECT_ID,
                                     "passkeyId",
-                                    PRIMARY_PASSKEY_ID));
+                                    PRIMARY_PASSKEY_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertEquals(400, response.getStatusCode());
@@ -167,7 +172,8 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                                     "publicSubjectId",
                                     PUBLIC_SUBJECT_ID,
                                     "passkeyId",
-                                    PRIMARY_PASSKEY_ID));
+                                    PRIMARY_PASSKEY_ID),
+                            AUTHORIZER_PARAMS);
 
             // Then
             assertEquals(400, response.getStatusCode());

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysCreateFailureReason.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysCreateFailureReason.java
@@ -5,7 +5,8 @@ public enum PasskeysCreateFailureReason {
     PASSKEY_EXISTS("passkey_exists"),
     INVALID_AAGUID("invalid_aaguid"),
     INVALID_REQUEST_BODY("invalid_request_body"),
-    MISSING_SUBJECT_ID("missing_subject_id");
+    MISSING_SUBJECT_ID("missing_subject_id"),
+    UNAUTHORIZED_REQUEST("unauthorized_request");
 
     private final String value;
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysRetrieveFailureReasons.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysRetrieveFailureReasons.java
@@ -3,7 +3,8 @@ package uk.gov.di.authentication.accountdata.entity.passkey.failurereasons;
 public enum PasskeysRetrieveFailureReasons {
     REQUEST_MISSING_PARAMS("request_missing_params"),
     FAILED_TO_GET_PASSKEYS("failed_to_get_passkeys"),
-    FAILED_TO_SERIALIZE_RESPONSE("failed_to_serialize_response");
+    FAILED_TO_SERIALIZE_RESPONSE("failed_to_serialize_response"),
+    UNAUTHORIZED_REQUEST("unauthorized_request");
 
     private final String value;
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysUpdateFailureReason.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysUpdateFailureReason.java
@@ -5,7 +5,8 @@ public enum PasskeysUpdateFailureReason {
     PASSKEY_NOT_FOUND("passkey_not_found"),
     FAILED_TO_UPDATE_PASSKEY("failed_to_update_passkey"),
     MISSING_SUBJECT_ID("missing_subject_id"),
-    MISSING_PASSKEY_ID("missing_passkey_id");
+    MISSING_PASSKEY_ID("missing_passkey_id"),
+    UNAUTHORIZED_REQUEST("unauthorized_request");
 
     private final String value;
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/SubjectIdAuthorizerHelper.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/SubjectIdAuthorizerHelper.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.accountdata.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SubjectIdAuthorizerHelper {
+    private static final Logger LOG = LogManager.getLogger(SubjectIdAuthorizerHelper.class);
+
+    private SubjectIdAuthorizerHelper() {
+        /* This utility class should not be instantiated */
+    }
+
+    private static final String PRINCIPAL_ID_FIELD = "principalId";
+
+    public static boolean isSubjectIdAuthorized(
+            String publicSubjectId,
+            APIGatewayProxyRequestEvent.ProxyRequestContext requestContext) {
+        if (requestContext.getAuthorizer() == null
+                || !requestContext.getAuthorizer().containsKey(PRINCIPAL_ID_FIELD)) {
+            LOG.warn("Authorizer missing from request context or principalId not present");
+            return false;
+        }
+        var principalId = requestContext.getAuthorizer().get(PRINCIPAL_ID_FIELD).toString();
+        var matches = principalId.equals(publicSubjectId);
+        if (!matches) {
+            LOG.warn(
+                    "PrincipalId in authorizer {} does not match publicSubjectId in path {}",
+                    principalId,
+                    publicSubjectId);
+        } else {
+            LOG.info("PrincipalId matches publicSubjectId");
+        }
+        return matches;
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -69,6 +69,7 @@ public class AuthorizeHandler
 
             var subject = validatedClaimsResult.getSuccess().getSubject();
             var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
+            LOG.info("Request validated, returning access policy");
             return getAllowExecuteApiPolicyForSubject(subject, methodArn);
         } catch (ParseException | java.text.ParseException e) {
             LOG.warn("Unable to parse Access Token {}", e.getMessage());

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
@@ -19,7 +19,9 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.INVALID_AAGUID;
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.INVALID_REQUEST_BODY;
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.MISSING_SUBJECT_ID;
+import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.UNAUTHORIZED_REQUEST;
 import static uk.gov.di.authentication.accountdata.helpers.PasskeysHelper.isAaguidValid;
+import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -62,6 +64,7 @@ public class PasskeysCreateHandler
         LOG.info("PasskeysCreateHandler called");
 
         return parseRequest(input)
+                .flatMap(createContext -> validateAuthorizedSubjectId(createContext, input))
                 .flatMap(this::validateRequest)
                 .flatMap(this::createPasskey)
                 .fold(
@@ -71,6 +74,8 @@ public class PasskeysCreateHandler
                                             400, ErrorResponse.INVALID_REQUEST_BODY);
                                     case MISSING_SUBJECT_ID -> generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.MISSING_SUBJECT_ID);
+                                    case UNAUTHORIZED_REQUEST -> generateApiGatewayProxyErrorResponse(
+                                            401, ErrorResponse.UNAUTHORIZED_REQUEST);
                                     case PASSKEY_EXISTS -> generateApiGatewayProxyErrorResponse(
                                             409, ErrorResponse.PASSKEY_ALREADY_EXISTS);
                                     case INVALID_AAGUID -> generateApiGatewayProxyErrorResponse(
@@ -100,6 +105,16 @@ public class PasskeysCreateHandler
         }
 
         return Result.success(new PasskeysCreateContext(publicSubjectId, passkeysCreateRequest));
+    }
+
+    private Result<PasskeysCreateFailureReason, PasskeysCreateContext> validateAuthorizedSubjectId(
+            PasskeysCreateContext context, APIGatewayProxyRequestEvent input) {
+        if (isSubjectIdAuthorized(context.publicSubjectId(), input.getRequestContext())) {
+            return Result.success(context);
+        } else {
+            LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
+            return Result.failure(UNAUTHORIZED_REQUEST);
+        }
     }
 
     private Result<PasskeysCreateFailureReason, PasskeysCreateContext> validateRequest(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -9,6 +9,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.Objects;
+
+import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
@@ -38,6 +41,15 @@ public class PasskeysDeleteHandler
     public APIGatewayProxyResponseEvent passkeysDeleteHandler(
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("PasskeysDeleteHandler called");
+
+        if (Objects.isNull(input.getPathParameters().get("publicSubjectId"))) {
+            return generateApiGatewayProxyResponse(400, "");
+        }
+
+        if (!isSubjectIdAuthorized(
+                input.getPathParameters().get("publicSubjectId"), input.getRequestContext())) {
+            return generateApiGatewayProxyResponse(401, "");
+        }
 
         return generateApiGatewayProxyResponse(204, "");
     }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandler.java
@@ -18,6 +18,8 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
 
+import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons.UNAUTHORIZED_REQUEST;
+import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -59,6 +61,9 @@ public class PasskeysRetrieveHandler
         LOG.info("PasskeysRetrieveHandler called");
 
         return parseRequest(input)
+                .flatMap(
+                        publicSubjectIdFromPath ->
+                                validateAuthorizedSubjectId(publicSubjectIdFromPath, input))
                 .flatMap(passkeysService::retrievePasskeys)
                 .flatMap(this::mapPasskeysListToResponse)
                 .flatMap(this::generateApiResponse)
@@ -67,6 +72,8 @@ public class PasskeysRetrieveHandler
                                 switch (failure) {
                                     case REQUEST_MISSING_PARAMS -> generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.REQUEST_MISSING_PARAMS);
+                                    case UNAUTHORIZED_REQUEST -> generateApiGatewayProxyErrorResponse(
+                                            401, ErrorResponse.UNAUTHORIZED_REQUEST);
                                     case FAILED_TO_GET_PASSKEYS,
                                             FAILED_TO_SERIALIZE_RESPONSE -> generateApiGatewayProxyErrorResponse(
                                             500, ErrorResponse.INTERNAL_SERVER_ERROR);
@@ -83,6 +90,16 @@ public class PasskeysRetrieveHandler
         }
 
         return Result.success(publicSubjectId);
+    }
+
+    private Result<PasskeysRetrieveFailureReasons, String> validateAuthorizedSubjectId(
+            String publicSubjectId, APIGatewayProxyRequestEvent input) {
+        if (isSubjectIdAuthorized(publicSubjectId, input.getRequestContext())) {
+            return Result.success(publicSubjectId);
+        } else {
+            LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
+            return Result.failure(UNAUTHORIZED_REQUEST);
+        }
     }
 
     private Result<PasskeysRetrieveFailureReasons, PasskeysRetrieveResponse>

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandler.java
@@ -19,6 +19,8 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import java.time.DateTimeException;
 import java.time.Instant;
 
+import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason.UNAUTHORIZED_REQUEST;
+import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -65,6 +67,7 @@ public class PasskeysUpdateHandler
         LOG.info("PasskeysUpdateHandler called");
 
         return parseUpdateRequest(input)
+                .flatMap(updateContext -> validateAuthorizedSubjectId(updateContext, input))
                 .flatMap(
                         requestContext ->
                                 passkeysService.updatePasskey(
@@ -108,6 +111,17 @@ public class PasskeysUpdateHandler
                 new PasskeysUpdateContext(publicSubjectId, passkeyId, passkeysUpdateRequest));
     }
 
+    private Result<PasskeysUpdateFailureReason, PasskeysUpdateContext> validateAuthorizedSubjectId(
+            PasskeysUpdateContext passkeysUpdateContext, APIGatewayProxyRequestEvent input) {
+        if (isSubjectIdAuthorized(
+                passkeysUpdateContext.publicSubjectId, input.getRequestContext())) {
+            return Result.success(passkeysUpdateContext);
+        } else {
+            LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
+            return Result.failure(UNAUTHORIZED_REQUEST);
+        }
+    }
+
     private APIGatewayProxyResponseEvent mapFailureReasonToErrorResponse(
             PasskeysUpdateFailureReason failureReason) {
         LOG.warn("Failed to update passkey for reason: {} ", failureReason.getValue());
@@ -122,6 +136,8 @@ public class PasskeysUpdateHandler
                     404, ErrorResponse.PASSKEY_NOT_FOUND);
             case FAILED_TO_UPDATE_PASSKEY -> generateApiGatewayProxyErrorResponse(
                     500, ErrorResponse.INTERNAL_SERVER_ERROR);
+            case UNAUTHORIZED_REQUEST -> generateApiGatewayProxyErrorResponse(
+                    401, ErrorResponse.UNAUTHORIZED_REQUEST);
         };
     }
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/SubjectIdAuthorizerHelperTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/SubjectIdAuthorizerHelperTest.java
@@ -1,0 +1,59 @@
+package uk.gov.di.authentication.accountdata.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class SubjectIdAuthorizerHelperTest {
+
+    @Test
+    void shouldReturnTrueWhenPrincipalIdMatchesPublicSubjectId() {
+        var subjectId = "subject-123";
+        var requestContext = requestContextWithPrincipalId(subjectId);
+
+        var result = SubjectIdAuthorizerHelper.isSubjectIdAuthorized(subjectId, requestContext);
+
+        assertThat(result, equalTo(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenPrincipalIdDoesNotMatchPublicSubjectId() {
+        var requestContext = requestContextWithPrincipalId("subject-123");
+
+        var result =
+                SubjectIdAuthorizerHelper.isSubjectIdAuthorized(
+                        "different-subject", requestContext);
+
+        assertThat(result, equalTo(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenAuthorizerNotSetOnRequest() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+
+        var result = SubjectIdAuthorizerHelper.isSubjectIdAuthorized("subject-123", requestContext);
+
+        assertThat(result, equalTo(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenPrincipalIdNotSetOnAuthorizer() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(Map.of("foo", "bar"));
+
+        var result = SubjectIdAuthorizerHelper.isSubjectIdAuthorized("subject-123", requestContext);
+
+        assertThat(result, equalTo(false));
+    }
+
+    private APIGatewayProxyRequestEvent.ProxyRequestContext requestContextWithPrincipalId(
+            String principalId) {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(Map.of("principalId", principalId));
+        return requestContext;
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
-import uk.gov.di.authentication.accountdata.helpers.CommonTestVariables;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -27,11 +26,10 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.CREDENTIAL;
-import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PASSKEY_TRANSPORTS;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PRIMARY_PASSKEY_ID;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.TEST_AAGUID;
-import static uk.gov.di.authentication.accountdata.helpers.RequestHelper.contextWithSourceIp;
 
 class PasskeysCreateHandlerTest {
 
@@ -39,6 +37,8 @@ class PasskeysCreateHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeysService passkeysService = mock(PasskeysService.class);
     private final Json objectMapper = SerializationService.getInstance();
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
 
     private PasskeysCreateHandler handler;
 
@@ -53,7 +53,7 @@ class PasskeysCreateHandlerTest {
         @Test
         void shouldReturn200ForValidRequest() throws Json.JsonException {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var passkeysCreateRequestBody =
                     buildPasskeysCreateRequestBody(
                             CREDENTIAL,
@@ -65,13 +65,13 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
-            when(passkeysService.createPasskey(any(), eq(CommonTestVariables.PUBLIC_SUBJECT_ID)))
+            when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
                     .thenReturn(Result.success(null));
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(201));
@@ -85,7 +85,7 @@ class PasskeysCreateHandlerTest {
         @Test
         void shouldReturn400WhenReadValueFails() throws Json.JsonException {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var passkeysCreateRequestBody =
                     buildPasskeysCreateRequestBody(
                             CREDENTIAL,
@@ -97,11 +97,11 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(400));
@@ -123,11 +123,11 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(400));
@@ -137,7 +137,7 @@ class PasskeysCreateHandlerTest {
         @Test
         void shouldReturn500WhenFailedToSavePasskey() throws Json.JsonException {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var passkeysCreateRequestBody =
                     buildPasskeysCreateRequestBody(
                             CREDENTIAL,
@@ -149,13 +149,13 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
-            when(passkeysService.createPasskey(any(), eq(CommonTestVariables.PUBLIC_SUBJECT_ID)))
+            when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
                     .thenReturn(Result.failure(PasskeysCreateFailureReason.FAILED_TO_SAVE_PASSKEY));
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(500));
@@ -165,7 +165,7 @@ class PasskeysCreateHandlerTest {
         @Test
         void shouldReturn409WhenPasskeyExists() throws Json.JsonException {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var passkeysCreateRequestBody =
                     buildPasskeysCreateRequestBody(
                             CREDENTIAL,
@@ -177,13 +177,13 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
-            when(passkeysService.createPasskey(any(), eq(CommonTestVariables.PUBLIC_SUBJECT_ID)))
+            when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
                     .thenReturn(Result.failure(PasskeysCreateFailureReason.PASSKEY_EXISTS));
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(409));
@@ -193,7 +193,7 @@ class PasskeysCreateHandlerTest {
         @Test
         void shouldReturn422WhenInvalidAaguid() throws Json.JsonException {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var passkeysCreateRequestBody =
                     buildPasskeysCreateRequestBody(
                             CREDENTIAL,
@@ -205,11 +205,11 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(422));
@@ -219,7 +219,7 @@ class PasskeysCreateHandlerTest {
         @Test
         void shouldReturn422WhenEmptyAaguid() throws Json.JsonException {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var passkeysCreateRequestBody =
                     buildPasskeysCreateRequestBody(
                             CREDENTIAL,
@@ -231,16 +231,46 @@ class PasskeysCreateHandlerTest {
                             false,
                             false,
                             false);
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
             // When
-            var result =
-                    handler.handleRequest(
-                            passkeysCreateRequest(passkeysCreateRequestBody, pathParams), context);
+            var result = handler.handleRequest(request, context);
 
             // Then
             assertThat(result, hasStatus(422));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AAGUID));
         }
+    }
+
+    @Test
+    void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams()
+            throws Json.JsonException {
+        // Given
+        when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
+                .thenReturn(Result.success(null));
+        var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+        var passkeysCreateRequestBody =
+                buildPasskeysCreateRequestBody(
+                        CREDENTIAL,
+                        PRIMARY_PASSKEY_ID,
+                        TEST_AAGUID,
+                        false,
+                        0,
+                        PASSKEY_TRANSPORTS,
+                        false,
+                        false,
+                        false);
+        var authorizerParams = Map.<String, Object>of("principalId", "different-subject-id");
+        var request =
+                passkeysCreateRequest(passkeysCreateRequestBody, pathParams, authorizerParams);
+
+        // When
+        var result = handler.handleRequest(request, context);
+
+        // Then
+        assertThat(result, hasStatus(401));
+        assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
     }
 
     private String buildPasskeysCreateRequestBody(
@@ -269,10 +299,15 @@ class PasskeysCreateHandlerTest {
     }
 
     private APIGatewayProxyRequestEvent passkeysCreateRequest(
-            String requestBody, Map<String, String> pathParams) {
+            String requestBody,
+            Map<String, String> pathParams,
+            Map<String, Object> authorizerParams) {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(authorizerParams);
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters(pathParams)
+                .withRequestContext(requestContext)
                 .withBody(requestBody)
-                .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+                .withRequestContext(requestContext);
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -6,10 +6,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.Map;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.accountdata.helpers.RequestHelper.contextWithSourceIp;
 
 class PasskeysDeleteHandlerTest {
@@ -26,12 +29,37 @@ class PasskeysDeleteHandlerTest {
 
     @Test
     void shouldReturn204ForValidRequest() {
-        var result = handler.handleRequest(passkeysDeleteRequest(), context);
+        var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+        var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+        var result =
+                handler.handleRequest(passkeysDeleteRequest(pathParams, authorizerParams), context);
         assertThat(result, hasStatus(204));
     }
 
-    private APIGatewayProxyRequestEvent passkeysDeleteRequest() {
+    @Test
+    void shouldReturn400WhenPublicSubjectIdNotPresent() {
+        var pathParams = Map.<String, String>of();
+        var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+        var result =
+                handler.handleRequest(passkeysDeleteRequest(pathParams, authorizerParams), context);
+        assertThat(result, hasStatus(400));
+    }
+
+    @Test
+    void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
+        var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+        var authorizerParams = Map.<String, Object>of("principalId", "another-subject-id");
+        var result =
+                handler.handleRequest(passkeysDeleteRequest(pathParams, authorizerParams), context);
+        assertThat(result, hasStatus(401));
+    }
+
+    private APIGatewayProxyRequestEvent passkeysDeleteRequest(
+            Map<String, String> pathParams, Map<String, Object> authorizerParams) {
+        var context = contextWithSourceIp(IP_ADDRESS);
+        context.setAuthorizer(authorizerParams);
         return new APIGatewayProxyRequestEvent()
-                .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+                .withRequestContext(context)
+                .withPathParameters(pathParams);
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandlerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
-import uk.gov.di.authentication.accountdata.helpers.CommonTestVariables;
 import uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -23,6 +22,8 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PRIMARY_PASSKEY_ID;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.accountdata.helpers.RequestHelper.contextWithSourceIp;
 
 class PasskeysRetrieveHandlerTest {
@@ -30,6 +31,8 @@ class PasskeysRetrieveHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeysService passkeysService = mock(PasskeysService.class);
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
 
     private PasskeysRetrieveHandler handler;
 
@@ -44,21 +47,22 @@ class PasskeysRetrieveHandlerTest {
         @Test
         void shouldReturn200ForValidRequest() {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var savedPasskey =
                     PasskeysTestHelper.buildGenericPasskeyForUserWithSubjectId(
-                            CommonTestVariables.PUBLIC_SUBJECT_ID,
-                            CommonTestVariables.PRIMARY_PASSKEY_ID);
+                            PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
             var savedPasskeysForUser = List.of(savedPasskey);
             var expectedRetrievedPasskeys =
                     new PasskeysRetrieveResponse(
                             List.of(PasskeysRetrieveResponse.from(savedPasskey)));
 
-            when(passkeysService.retrievePasskeys(CommonTestVariables.PUBLIC_SUBJECT_ID))
+            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
                     .thenReturn(Result.success(savedPasskeysForUser));
 
             // When
-            var result = handler.handleRequest(passkeysRetrieveRequest(pathParams), context);
+            var result =
+                    handler.handleRequest(
+                            passkeysRetrieveRequest(pathParams, AUTHORIZER_PARAMS), context);
 
             // Then
             assertThat(result, hasStatus(200));
@@ -75,7 +79,9 @@ class PasskeysRetrieveHandlerTest {
             var pathParams = Map.of("publicSubjectId", "");
 
             // When
-            var result = handler.handleRequest(passkeysRetrieveRequest(pathParams), context);
+            var result =
+                    handler.handleRequest(
+                            passkeysRetrieveRequest(pathParams, AUTHORIZER_PARAMS), context);
 
             // Then
             assertThat(result, hasStatus(400));
@@ -83,15 +89,34 @@ class PasskeysRetrieveHandlerTest {
         }
 
         @Test
+        void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
+            // Given
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var authorizerParams =
+                    Map.<String, Object>of("principalId", "a-different-public-subject-id");
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysRetrieveRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(401));
+            assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+        }
+
+        @Test
         void shouldReturn500IfFailedToGetPasskeys() {
             // Given
-            var pathParams = Map.of("publicSubjectId", CommonTestVariables.PUBLIC_SUBJECT_ID);
-            when(passkeysService.retrievePasskeys(CommonTestVariables.PUBLIC_SUBJECT_ID))
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            when(passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID))
                     .thenReturn(
                             Result.failure(PasskeysRetrieveFailureReasons.FAILED_TO_GET_PASSKEYS));
 
             // When
-            var result = handler.handleRequest(passkeysRetrieveRequest(pathParams), context);
+            var result =
+                    handler.handleRequest(
+                            passkeysRetrieveRequest(pathParams, AUTHORIZER_PARAMS), context);
 
             // Then
             assertThat(result, hasStatus(500));
@@ -99,9 +124,12 @@ class PasskeysRetrieveHandlerTest {
         }
     }
 
-    private APIGatewayProxyRequestEvent passkeysRetrieveRequest(Map<String, String> pathParams) {
+    private APIGatewayProxyRequestEvent passkeysRetrieveRequest(
+            Map<String, String> pathParams, Map<String, Object> authorizerParams) {
+        var requestContext = contextWithSourceIp(IP_ADDRESS);
+        requestContext.setAuthorizer(authorizerParams);
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters(pathParams)
-                .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+                .withRequestContext(requestContext);
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
@@ -38,6 +38,8 @@ class PasskeysUpdateHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeysService passkeysService = mock(PasskeysService.class);
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
 
     private PasskeysUpdateHandler handler;
 
@@ -127,7 +129,7 @@ class PasskeysUpdateHandlerTest {
         void shouldReturn400WhenRequestBodyIsInvalid(String invalidRequestBody) {
             // Given
             var request =
-                    baseApiProxyRequest()
+                    baseApiProxyRequest(AUTHORIZER_PARAMS)
                             .withPathParameters(
                                     Map.ofEntries(
                                             Map.entry("publicSubjectId", PUBLIC_SUBJECT_ID),
@@ -150,7 +152,7 @@ class PasskeysUpdateHandlerTest {
             var pathParamsWithoutPublicSubject =
                     Map.ofEntries(Map.entry("passkeyId", PRIMARY_PASSKEY_ID));
             var request =
-                    baseApiProxyRequest()
+                    baseApiProxyRequest(AUTHORIZER_PARAMS)
                             .withPathParameters(pathParamsWithoutPublicSubject)
                             .withBody(requestBody);
 
@@ -163,6 +165,31 @@ class PasskeysUpdateHandlerTest {
         }
 
         @Test
+        void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
+            // Given
+            var authorizerParamsWithDifferentPublicSubjectId =
+                    Map.<String, Object>of("principalId", "a-different-public-subject-id");
+            var request =
+                    baseApiProxyRequest(authorizerParamsWithDifferentPublicSubjectId)
+                            .withPathParameters(
+                                    Map.of(
+                                            "publicSubjectId",
+                                            PUBLIC_SUBJECT_ID,
+                                            "passkeyId",
+                                            PRIMARY_PASSKEY_ID))
+                            .withBody(
+                                    "{\"signCount\":%d, \"lastUsedAt\":\"%s\"}"
+                                            .formatted(SIGN_COUNT, LAST_USED_AT));
+
+            // When
+            var result = handler.handleRequest(request, context);
+
+            // Then
+            assertThat(result, hasStatus(401));
+            assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+        }
+
+        @Test
         void shouldReturn400WhenRequestIsMissingPasskeyId() {
             // Given
             var requestBody =
@@ -170,7 +197,7 @@ class PasskeysUpdateHandlerTest {
             var pathParamsWithoutPublicSubject =
                     Map.ofEntries(Map.entry("publicSubjectId", PUBLIC_SUBJECT_ID));
             var request =
-                    baseApiProxyRequest()
+                    baseApiProxyRequest(AUTHORIZER_PARAMS)
                             .withPathParameters(pathParamsWithoutPublicSubject)
                             .withBody(requestBody);
 
@@ -185,15 +212,16 @@ class PasskeysUpdateHandlerTest {
 
     private APIGatewayProxyRequestEvent passkeysUpdateRequest(
             int signCount, String lastUsed, String publicSubjectId, String passkeyId) {
-        return baseApiProxyRequest()
+        return baseApiProxyRequest(AUTHORIZER_PARAMS)
                 .withPathParameters(
                         Map.of("publicSubjectId", publicSubjectId, "passkeyId", passkeyId))
                 .withBody(
                         "{\"signCount\":%d, \"lastUsedAt\":\"%s\"}".formatted(signCount, lastUsed));
     }
 
-    private APIGatewayProxyRequestEvent baseApiProxyRequest() {
-        return new APIGatewayProxyRequestEvent()
-                .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+    private APIGatewayProxyRequestEvent baseApiProxyRequest(Map<String, Object> authorizerParams) {
+        var context = contextWithSourceIp(IP_ADDRESS);
+        context.setAuthorizer(authorizerParams);
+        return new APIGatewayProxyRequestEvent().withRequestContext(context);
     }
 }

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -18,7 +18,7 @@ Resources:
           ACCOUNT_DATA_JWKS_URL:
             !FindInMap [
               EnvironmentConfiguration,
-              !Ref Environment,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               accountDataJwksUrl,
             ]
       LoggingConfig:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -123,6 +123,7 @@ public enum ErrorResponse {
     INVALID_REQUEST_BODY(4000, "Invalid request body"),
     MISSING_SUBJECT_ID(4001, "Missing subject id"),
     MISSING_PASSKEY_ID(4002, "Missing passkey id"),
+    UNAUTHORIZED_REQUEST(4010, "Unauthorized request"),
     PASSKEY_NOT_FOUND(4040, "Passkey not found"),
     INVALID_CREDENTIAL(4220, "Invalid credential format"),
     INVALID_AAGUID(4221, "Invalid AAGUID format"),


### PR DESCRIPTION
## What

We have a custom authorizer for the account data api which sits in front of all requests to the account data api and attaches an access token to authorized requests based on the token sent in the request. 

This means we now can add validation into each of the account data api handlers that the public subject id in the api path matches the one sent through in the token and attached to the request via the authorizer and api gateway.

This PR achieves that by retrieving the principal id from the request context (which will be populated by api gateway after the request has gone through the authorizer), and checking this against the public subject id in the api request path. If these match, we allow the request, but if not we return a 401 status.

## Related PRs

Depends on https://github.com/govuk-one-login/authentication-api/pull/8209
