### PR TITLE
AUT-5322: Send ADAPI bearer token from proxy

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -53,10 +53,23 @@ public class PasskeysDeleteProxyHandler
         LOG.info("PasskeysDeleteProxyHandler invoked");
 
         var publicSubjectId = input.getPathParameters().getOrDefault("publicSubjectId", "");
+        if (publicSubjectId.isEmpty()) {
+            LOG.warn("No publicSubjectId in path parameters, request will likely fail");
+        }
+
         var passkeyIdentifier = input.getPathParameters().getOrDefault("passkeyIdentifier", "");
+        if (passkeyIdentifier.isEmpty()) {
+            LOG.warn("No passkeyIdentifier in path parameters, request will likely fail");
+        }
+
+        var token = input.getHeaders().getOrDefault("X-ADAPI-AccessToken", "");
+        if (token.isEmpty()) {
+            LOG.warn("No X-ADAPI-AccessToken in headers, request will likely fail");
+        }
 
         try {
-            var response = accountDataApiService.deletePasskey(publicSubjectId, passkeyIdentifier);
+            var response =
+                    accountDataApiService.deletePasskey(publicSubjectId, passkeyIdentifier, token);
             return generateApiGatewayProxyResponse(response.statusCode(), response.body());
         } catch (UnsuccessfulAccountDataApiResponseException e) {
             LOG.warn(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandler.java
@@ -53,9 +53,17 @@ public class PasskeysRetrieveProxyHandler
         LOG.info("PasskeysRetrieveProxyHandler invoked");
 
         var publicSubjectId = input.getPathParameters().getOrDefault("publicSubjectId", "");
+        if (publicSubjectId.isEmpty()) {
+            LOG.warn("No publicSubjectId in path parameters, request will likely fail");
+        }
+
+        var token = input.getHeaders().getOrDefault("X-ADAPI-AccessToken", "");
+        if (token.isEmpty()) {
+            LOG.warn("No X-ADAPI-AccessToken in headers, request will likely fail");
+        }
 
         try {
-            var response = accountDataApiService.retrievePasskeys(publicSubjectId);
+            var response = accountDataApiService.retrievePasskeys(publicSubjectId, token);
             return generateApiGatewayProxyResponse(response.statusCode(), response.body());
         } catch (UnsuccessfulAccountDataApiResponseException e) {
             LOG.warn(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.http.HttpResponse;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,10 +26,13 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-public class PasskeysDeleteProxyHandlerTest {
+class PasskeysDeleteProxyHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AccountDataApiService accountDataApiService = mock(AccountDataApiService.class);
+
+    private static final String ADAPI_TOKEN_HEADER = "X-ADAPI-AccessToken";
+    private static final String TOKEN = "token";
 
     private PasskeysDeleteProxyHandler handler;
 
@@ -47,7 +51,7 @@ public class PasskeysDeleteProxyHandlerTest {
             var mockHttpResponse = mock(HttpResponse.class);
             when(mockHttpResponse.statusCode()).thenReturn(200);
             when(mockHttpResponse.body()).thenReturn("{\"deleted\": true}");
-            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER))
+            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN))
                     .thenReturn(mockHttpResponse);
 
             // Act
@@ -56,7 +60,8 @@ public class PasskeysDeleteProxyHandlerTest {
             // Assert
             assertThat(result, hasStatus(200));
             assertThat(result, hasBody("{\"deleted\": true}"));
-            verify(accountDataApiService).deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER);
+            verify(accountDataApiService)
+                    .deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN);
         }
     }
 
@@ -66,7 +71,7 @@ public class PasskeysDeleteProxyHandlerTest {
         void shouldReturn500IfServiceThrowsException()
                 throws UnsuccessfulAccountDataApiResponseException {
             // Arrange
-            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER))
+            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN))
                     .thenThrow(new UnsuccessfulAccountDataApiResponseException("service error", 0));
 
             // Act
@@ -75,17 +80,21 @@ public class PasskeysDeleteProxyHandlerTest {
             // Assert
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
-            verify(accountDataApiService).deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER);
+            verify(accountDataApiService)
+                    .deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN);
         }
     }
 
     private APIGatewayProxyRequestEvent passkeysDeleteProxyRequest() {
+        var headersWithToken = new HashMap<>(VALID_HEADERS);
+        headersWithToken.put(ADAPI_TOKEN_HEADER, TOKEN);
+
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters(
                         Map.of(
                                 "publicSubjectId", PUBLIC_SUBJECT_ID,
                                 "passkeyIdentifier", PASSKEY_IDENTIFIER))
-                .withHeaders(VALID_HEADERS)
+                .withHeaders(headersWithToken)
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandlerTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.http.HttpResponse;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,12 +26,15 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-public class PasskeysRetrieveProxyHandlerTest {
+class PasskeysRetrieveProxyHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AccountDataApiService accountDataApiService = mock(AccountDataApiService.class);
 
     private PasskeysRetrieveProxyHandler handler;
+
+    private static final String ADAPI_TOKEN_HEADER = "X-ADAPI-AccessToken";
+    private static final String TOKEN = "token";
 
     @BeforeEach
     void setUp() {
@@ -45,7 +49,7 @@ public class PasskeysRetrieveProxyHandlerTest {
             var mockHttpResponse = mock(HttpResponse.class);
             when(mockHttpResponse.statusCode()).thenReturn(200);
             when(mockHttpResponse.body()).thenReturn("{\"passkeys\": []}");
-            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN))
                     .thenReturn(mockHttpResponse);
 
             // Act
@@ -54,7 +58,7 @@ public class PasskeysRetrieveProxyHandlerTest {
             // Assert
             assertThat(result, hasStatus(200));
             assertThat(result, hasBody("{\"passkeys\": []}"));
-            verify(accountDataApiService).retrievePasskeys(PUBLIC_SUBJECT_ID);
+            verify(accountDataApiService).retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN);
         }
     }
 
@@ -64,7 +68,7 @@ public class PasskeysRetrieveProxyHandlerTest {
         void shouldReturn500IfServiceThrowsException()
                 throws UnsuccessfulAccountDataApiResponseException {
             // Arrange
-            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN))
                     .thenThrow(new UnsuccessfulAccountDataApiResponseException("service error", 0));
 
             // Act
@@ -73,14 +77,17 @@ public class PasskeysRetrieveProxyHandlerTest {
             // Assert
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
-            verify(accountDataApiService).retrievePasskeys(PUBLIC_SUBJECT_ID);
+            verify(accountDataApiService).retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN);
         }
     }
 
     private APIGatewayProxyRequestEvent passkeysRetrieveProxyRequest() {
+        var validHeadersWithToken = new HashMap<>(VALID_HEADERS);
+        validHeadersWithToken.put(ADAPI_TOKEN_HEADER, TOKEN);
+
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters((Map.of("publicSubjectId", PUBLIC_SUBJECT_ID)))
-                .withHeaders(VALID_HEADERS)
+                .withHeaders(validHeadersWithToken)
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysDeleteProxyHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysDeleteProxyHandlerIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.accountmanagement.api;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -53,6 +55,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
         var publicSubjectId = "abc";
         var passkeyId = "def";
+        var token = "hij";
 
         accountDataApiWireMockServer.stubFor(
                 delete(
@@ -61,13 +64,14 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys/"
                                                 + passkeyId))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token))
                         .willReturn(aResponse().withStatus(204)));
 
         // Act
         var response =
                 makeRequest(
                         Optional.empty(),
-                        Collections.emptyMap(),
+                        Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
                         Collections.emptyMap(),
@@ -75,6 +79,15 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
         // Assert
         assertThat(response, hasStatus(204));
+        accountDataApiWireMockServer.verify(
+                1,
+                deleteRequestedFor(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token)));
     }
 
     @Test
@@ -84,6 +97,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
         var publicSubjectId = "abc";
         var passkeyId = "def";
+        var token = "hij";
         var adapiResponse =
                 """
                 {
@@ -99,13 +113,14 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys/"
                                                 + passkeyId))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token))
                         .willReturn(aResponse().withStatus(404).withBody(adapiResponse)));
 
         // Act
         var response =
                 makeRequest(
                         Optional.empty(),
-                        Collections.emptyMap(),
+                        Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
                         Collections.emptyMap(),
@@ -114,6 +129,15 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         // Assert
         assertThat(response, hasStatus(404));
         assertThat(response.getBody(), equalTo(adapiResponse));
+        accountDataApiWireMockServer.verify(
+                1,
+                deleteRequestedFor(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token)));
     }
 
     @Test
@@ -123,6 +147,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
         var publicSubjectId = "abc";
         var passkeyId = "def";
+        var token = "hij";
         var adapiResponse =
                 """
                 {
@@ -138,13 +163,14 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys/"
                                                 + passkeyId))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token))
                         .willReturn(aResponse().withStatus(500).withBody(adapiResponse)));
 
         // Act
         var response =
                 makeRequest(
                         Optional.empty(),
-                        Collections.emptyMap(),
+                        Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
                         Collections.emptyMap(),
@@ -153,5 +179,14 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         // Assert
         assertThat(response, hasStatus(500));
         assertThat(response.getBody(), equalTo(adapiResponse));
+        accountDataApiWireMockServer.verify(
+                1,
+                deleteRequestedFor(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token)));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysRetrieveProxyHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysRetrieveProxyHandlerIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.accountmanagement.api;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -26,6 +28,9 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 @ExtendWith(SystemStubsExtension.class)
 class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static WireMockServer accountDataApiWireMockServer;
+
+    private static final String AUTHORIZATION_HEADER_FIELD = "Authorization";
+    private static final String ADAPI_TOKEN_HEADER = "X-ADAPI-AccessToken";
 
     @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
 
@@ -52,6 +57,7 @@ class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerInteg
         handler = new PasskeysRetrieveProxyHandler(TEST_CONFIGURATION_SERVICE);
 
         var publicSubjectId = "abc";
+        var token = "def";
         var adapiResponse =
                 """
                 {
@@ -74,19 +80,29 @@ class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerInteg
 
         accountDataApiWireMockServer.stubFor(
                 get(urlPathMatching("/accounts/" + publicSubjectId + "/authenticators/passkeys"))
+                        .withHeader(AUTHORIZATION_HEADER_FIELD, WireMock.equalTo("Bearer " + token))
                         .willReturn(aResponse().withStatus(200).withBody(adapiResponse)));
 
         // Act
         var response =
                 makeRequest(
                         Optional.empty(),
-                        Collections.emptyMap(),
+                        Map.of(ADAPI_TOKEN_HEADER, token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId));
 
         // Assert
         assertThat(response, hasStatus(200));
         assertThat(response.getBody(), equalTo(adapiResponse));
+        accountDataApiWireMockServer.verify(
+                1,
+                getRequestedFor(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys"))
+                        .withHeader(
+                                AUTHORIZATION_HEADER_FIELD, WireMock.equalTo("Bearer " + token)));
     }
 
     @Test
@@ -95,6 +111,7 @@ class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerInteg
         handler = new PasskeysRetrieveProxyHandler(TEST_CONFIGURATION_SERVICE);
 
         var publicSubjectId = "abc";
+        var token = "def";
         var adapiResponse =
                 """
                 {
@@ -105,18 +122,28 @@ class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerInteg
 
         accountDataApiWireMockServer.stubFor(
                 get(urlPathMatching("/accounts/" + publicSubjectId + "/authenticators/passkeys"))
+                        .withHeader(AUTHORIZATION_HEADER_FIELD, WireMock.equalTo("Bearer " + token))
                         .willReturn(aResponse().withStatus(500).withBody(adapiResponse)));
 
         // Act
         var response =
                 makeRequest(
                         Optional.empty(),
-                        Collections.emptyMap(),
+                        Map.of(ADAPI_TOKEN_HEADER, token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId));
 
         // Assert
         assertThat(response, hasStatus(500));
         assertThat(response.getBody(), equalTo(adapiResponse));
+        accountDataApiWireMockServer.verify(
+                1,
+                getRequestedFor(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys"))
+                        .withHeader(
+                                AUTHORIZATION_HEADER_FIELD, WireMock.equalTo("Bearer " + token)));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
@@ -28,7 +28,7 @@ public class AccountDataApiService {
         this.configurationService = configurationService;
     }
 
-    public HttpResponse<String> retrievePasskeys(String publicSubjectId)
+    public HttpResponse<String> retrievePasskeys(String publicSubjectId, String token)
             throws UnsuccessfulAccountDataApiResponseException {
         var request =
                 HttpRequest.newBuilder(
@@ -37,6 +37,7 @@ public class AccountDataApiService {
                                         "/accounts/"
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys"))
+                        .header("Authorization", "Bearer " + token)
                         .GET()
                         .timeout(
                                 Duration.ofMillis(
@@ -45,7 +46,8 @@ public class AccountDataApiService {
         return sendRequest(request);
     }
 
-    public HttpResponse<String> deletePasskey(String publicSubjectId, String passkeyId)
+    public HttpResponse<String> deletePasskey(
+            String publicSubjectId, String passkeyId, String token)
             throws UnsuccessfulAccountDataApiResponseException {
         var request =
                 HttpRequest.newBuilder(
@@ -55,6 +57,7 @@ public class AccountDataApiService {
                                                 + publicSubjectId
                                                 + "/authenticators/passkeys/"
                                                 + passkeyId))
+                        .header("Authorization", "Bearer " + token)
                         .DELETE()
                         .timeout(
                                 Duration.ofMillis(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
@@ -72,8 +72,7 @@ public class AccountDataApiService {
         try {
             return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (HttpTimeoutException e) {
-            throw timeoutException(
-                    configurationService.getAccountInterventionServiceCallTimeout(), e);
+            throw timeoutException(configurationService.getAccountDataApiCallTimeout(), e);
         } catch (IOException e) {
             throw ioException(e);
         } catch (InterruptedException e) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -53,214 +55,165 @@ class AccountDataApiServiceTest {
 
     @Nested
     class RetrievePasskeys {
-        @Nested
-        class SuccessfulRequest {
-            @Test
-            void shouldBuildCorrectRequestUri()
-                    throws IOException,
-                            InterruptedException,
-                            UnsuccessfulAccountDataApiResponseException {
-                // Arrange
-                var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-                when(httpClient.send(any(), any())).thenReturn(null);
+        @Test
+        void shouldBuildCorrectRequestUri()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+            when(httpClient.send(any(), any())).thenReturn(null);
 
-                // Act
-                service.retrievePasskeys("testPublicSubjectId", TOKEN);
+            // Act
+            service.retrievePasskeys("testPublicSubjectId", TOKEN);
 
-                // Assert
-                verify(httpClient).send(httpRequestCaptor.capture(), any());
-                assertThat(
-                        httpRequestCaptor.getValue().uri(),
-                        equalTo(
-                                URI.create(
-                                        "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys")));
-                assertThat(httpRequestCaptor.getValue().method(), equalTo("GET"));
-                assertThat(
-                        httpRequestCaptor
-                                .getValue()
-                                .headers()
-                                .firstValue("Authorization")
-                                .orElse(""),
-                        equalTo("Bearer " + TOKEN));
-            }
-
-            @Test
-            void shouldReturnVerbatimHttpResponse()
-                    throws IOException,
-                            InterruptedException,
-                            UnsuccessfulAccountDataApiResponseException {
-                // Arrange
-                var mockHttpResponse = mock(HttpResponse.class);
-                when(mockHttpResponse.statusCode()).thenReturn(200);
-                when(mockHttpResponse.body()).thenReturn("{'test': true}");
-                when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
-
-                // Act
-                var resp = service.retrievePasskeys("testPublicSubjectId", TOKEN);
-
-                // Assert
-                assertThat(resp.statusCode(), equalTo(200));
-                assertThat(resp.body(), equalTo("{'test': true}"));
-            }
+            // Assert
+            verify(httpClient).send(httpRequestCaptor.capture(), any());
+            assertThat(
+                    httpRequestCaptor.getValue().uri(),
+                    equalTo(
+                            URI.create(
+                                    "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys")));
+            assertThat(httpRequestCaptor.getValue().method(), equalTo("GET"));
+            assertThat(
+                    httpRequestCaptor.getValue().headers().firstValue("Authorization").orElse(""),
+                    equalTo("Bearer " + TOKEN));
         }
 
-        @Nested
-        class FailedRequest {
-            @Test
-            void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered()
-                    throws IOException, InterruptedException {
-                // Arrange
-                doThrow(new HttpTimeoutException("timed out")).when(httpClient).send(any(), any());
+        @Test
+        void shouldReturnVerbatimHttpResponse()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(mockHttpResponse.statusCode()).thenReturn(200);
+            when(mockHttpResponse.body()).thenReturn("{'test': true}");
+            when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
-                // Act & Assert
-                var exception =
-                        assertThrows(
-                                UnsuccessfulAccountDataApiResponseException.class,
-                                () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
-                assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
-                assertThat(exception.getCause(), instanceOf(HttpTimeoutException.class));
-            }
+            // Act
+            var resp = service.retrievePasskeys("testPublicSubjectId", TOKEN);
 
-            @Test
-            void shouldThrowWrappedExceptionIfIOExceptionEncountered()
-                    throws IOException, InterruptedException {
-                // Arrange
-                doThrow(new IOException("connection failed")).when(httpClient).send(any(), any());
-
-                // Act & Assert
-                var exception =
-                        assertThrows(
-                                UnsuccessfulAccountDataApiResponseException.class,
-                                () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
-                assertThat(exception.getMessage(), containsString("Error when attempting to call"));
-                assertThat(exception.getCause(), instanceOf(IOException.class));
-            }
-
-            @Test
-            void shouldThrowWrappedExceptionIfInterruptedExceptionEncountered()
-                    throws IOException, InterruptedException {
-                // Arrange
-                doThrow(new InterruptedException("interrupted"))
-                        .when(httpClient)
-                        .send(any(), any());
-
-                // Act & Assert
-                var exception =
-                        assertThrows(
-                                UnsuccessfulAccountDataApiResponseException.class,
-                                () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
-                assertThat(exception.getMessage(), containsString("Interrupted exception"));
-                assertThat(exception.getCause(), instanceOf(InterruptedException.class));
-            }
+            // Assert
+            assertThat(resp.statusCode(), equalTo(200));
+            assertThat(resp.body(), equalTo("{'test': true}"));
         }
     }
 
     @Nested
     class DeletePasskey {
-        @Nested
-        class SuccessfulRequest {
-            @Test
-            void shouldBuildCorrectRequestUri()
-                    throws IOException,
-                            InterruptedException,
-                            UnsuccessfulAccountDataApiResponseException {
-                // Arrange
-                var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-                when(httpClient.send(any(), any())).thenReturn(null);
+        @Test
+        void shouldBuildCorrectRequestUri()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+            when(httpClient.send(any(), any())).thenReturn(null);
 
-                // Act
-                service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
+            // Act
+            service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
 
-                // Assert
-                verify(httpClient).send(httpRequestCaptor.capture(), any());
-                assertThat(
-                        httpRequestCaptor.getValue().uri(),
-                        equalTo(
-                                URI.create(
-                                        "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys/testPasskeyId")));
-                assertThat(httpRequestCaptor.getValue().method(), equalTo("DELETE"));
-                assertThat(
-                        httpRequestCaptor
-                                .getValue()
-                                .headers()
-                                .firstValue("Authorization")
-                                .orElse(""),
-                        equalTo("Bearer " + TOKEN));
-            }
-
-            @Test
-            void shouldReturnVerbatimHttpResponse()
-                    throws IOException,
-                            InterruptedException,
-                            UnsuccessfulAccountDataApiResponseException {
-                // Arrange
-                var mockHttpResponse = mock(HttpResponse.class);
-                when(mockHttpResponse.statusCode()).thenReturn(200);
-                when(mockHttpResponse.body()).thenReturn("{'deleted': true}");
-                when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
-
-                // Act
-                var resp = service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
-
-                // Assert
-                assertThat(resp.statusCode(), equalTo(200));
-                assertThat(resp.body(), equalTo("{'deleted': true}"));
-            }
+            // Assert
+            verify(httpClient).send(httpRequestCaptor.capture(), any());
+            assertThat(
+                    httpRequestCaptor.getValue().uri(),
+                    equalTo(
+                            URI.create(
+                                    "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys/testPasskeyId")));
+            assertThat(httpRequestCaptor.getValue().method(), equalTo("DELETE"));
+            assertThat(
+                    httpRequestCaptor.getValue().headers().firstValue("Authorization").orElse(""),
+                    equalTo("Bearer " + TOKEN));
         }
 
-        @Nested
-        class FailedRequest {
-            @Test
-            void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered()
-                    throws IOException, InterruptedException {
-                // Arrange
-                doThrow(new HttpTimeoutException("timed out")).when(httpClient).send(any(), any());
+        @Test
+        void shouldReturnVerbatimHttpResponse()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(mockHttpResponse.statusCode()).thenReturn(200);
+            when(mockHttpResponse.body()).thenReturn("{'deleted': true}");
+            when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
-                // Act & Assert
-                var exception =
-                        assertThrows(
-                                UnsuccessfulAccountDataApiResponseException.class,
-                                () ->
-                                        service.deletePasskey(
-                                                "testPublicSubjectId", "testPasskeyId", TOKEN));
-                assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
-                assertThat(exception.getCause(), instanceOf(HttpTimeoutException.class));
-            }
+            // Act
+            var resp = service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
 
-            @Test
-            void shouldThrowWrappedExceptionIfIOExceptionEncountered()
-                    throws IOException, InterruptedException {
-                // Arrange
-                doThrow(new IOException("connection failed")).when(httpClient).send(any(), any());
+            // Assert
+            assertThat(resp.statusCode(), equalTo(200));
+            assertThat(resp.body(), equalTo("{'deleted': true}"));
+        }
+    }
 
-                // Act & Assert
-                var exception =
-                        assertThrows(
-                                UnsuccessfulAccountDataApiResponseException.class,
-                                () ->
-                                        service.deletePasskey(
-                                                "testPublicSubjectId", "testPasskeyId", TOKEN));
-                assertThat(exception.getMessage(), containsString("Error when attempting to call"));
-                assertThat(exception.getCause(), instanceOf(IOException.class));
-            }
+    @Nested
+    class FailedRequest {
+        @ParameterizedTest
+        @EnumSource(PasskeysMethod.class)
+        void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered(PasskeysMethod method)
+                throws IOException, InterruptedException {
+            // Arrange
+            doThrow(new HttpTimeoutException("timed out")).when(httpClient).send(any(), any());
 
-            @Test
-            void shouldThrowWrappedExceptionIfInterruptedExceptionEncountered()
-                    throws IOException, InterruptedException {
-                // Arrange
-                doThrow(new InterruptedException("interrupted"))
-                        .when(httpClient)
-                        .send(any(), any());
+            // Act
+            var exception =
+                    assertThrows(
+                            UnsuccessfulAccountDataApiResponseException.class,
+                            () -> method.call(service));
 
-                // Act & Assert
-                var exception =
-                        assertThrows(
-                                UnsuccessfulAccountDataApiResponseException.class,
-                                () ->
-                                        service.deletePasskey(
-                                                "testPublicSubjectId", "testPasskeyId", TOKEN));
-                assertThat(exception.getMessage(), containsString("Interrupted exception"));
-                assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+            // Assert
+            assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
+            assertThat(exception.getCause(), instanceOf(HttpTimeoutException.class));
+        }
+
+        @ParameterizedTest
+        @EnumSource(PasskeysMethod.class)
+        void shouldThrowWrappedExceptionIfIOExceptionEncountered(PasskeysMethod method)
+                throws IOException, InterruptedException {
+            // Arrange
+            doThrow(new IOException("connection failed")).when(httpClient).send(any(), any());
+
+            // Act
+            var exception =
+                    assertThrows(
+                            UnsuccessfulAccountDataApiResponseException.class,
+                            () -> method.call(service));
+
+            // Assert
+            assertThat(exception.getMessage(), containsString("Error when attempting to call"));
+            assertThat(exception.getCause(), instanceOf(IOException.class));
+        }
+
+        @ParameterizedTest
+        @EnumSource(PasskeysMethod.class)
+        void shouldThrowWrappedExceptionIfInterruptedExceptionEncountered(PasskeysMethod method)
+                throws IOException, InterruptedException {
+            // Arrange
+            doThrow(new InterruptedException("interrupted")).when(httpClient).send(any(), any());
+
+            // Act
+            var exception =
+                    assertThrows(
+                            UnsuccessfulAccountDataApiResponseException.class,
+                            () -> method.call(service));
+
+            // Assert
+            assertThat(exception.getMessage(), containsString("Interrupted exception"));
+            assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+        }
+    }
+
+    enum PasskeysMethod {
+        RETRIEVE_PASSKEYS,
+        DELETE_PASSKEY;
+
+        void call(AccountDataApiService service)
+                throws UnsuccessfulAccountDataApiResponseException {
+            switch (this) {
+                case RETRIEVE_PASSKEYS -> service.retrievePasskeys("testPublicSubjectId", TOKEN);
+                case DELETE_PASSKEY -> service.deletePasskey(
+                        "testPublicSubjectId", "testPasskeyId", TOKEN);
             }
         }
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -35,13 +35,14 @@ class AccountDataApiServiceTest {
     private AccountDataApiService service;
 
     private static final String TOKEN = "token";
+    private static final long TIMEOUT = 1000L;
 
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         service = new AccountDataApiService(httpClient, configurationService);
         when(configurationService.getAccountDataURI()).thenReturn("https://example.com");
-        when(configurationService.getAccountDataApiCallTimeout()).thenReturn(1000L);
+        when(configurationService.getAccountDataApiCallTimeout()).thenReturn(TIMEOUT);
     }
 
     @AfterEach
@@ -117,7 +118,7 @@ class AccountDataApiServiceTest {
                         assertThrows(
                                 UnsuccessfulAccountDataApiResponseException.class,
                                 () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
-                assertThat(exception.getMessage(), containsString("Timeout"));
+                assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
                 assertThat(
                         exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
             }
@@ -226,7 +227,7 @@ class AccountDataApiServiceTest {
                                 () ->
                                         service.deletePasskey(
                                                 "testPublicSubjectId", "testPasskeyId", TOKEN));
-                assertThat(exception.getMessage(), containsString("Timeout"));
+                assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
                 assertThat(
                         exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
             }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -109,9 +110,7 @@ class AccountDataApiServiceTest {
             void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered()
                     throws IOException, InterruptedException {
                 // Arrange
-                doThrow(new java.net.http.HttpTimeoutException("timed out"))
-                        .when(httpClient)
-                        .send(any(), any());
+                doThrow(new HttpTimeoutException("timed out")).when(httpClient).send(any(), any());
 
                 // Act & Assert
                 var exception =
@@ -119,8 +118,7 @@ class AccountDataApiServiceTest {
                                 UnsuccessfulAccountDataApiResponseException.class,
                                 () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
                 assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
-                assertThat(
-                        exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
+                assertThat(exception.getCause(), instanceOf(HttpTimeoutException.class));
             }
 
             @Test
@@ -216,9 +214,7 @@ class AccountDataApiServiceTest {
             void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered()
                     throws IOException, InterruptedException {
                 // Arrange
-                doThrow(new java.net.http.HttpTimeoutException("timed out"))
-                        .when(httpClient)
-                        .send(any(), any());
+                doThrow(new HttpTimeoutException("timed out")).when(httpClient).send(any(), any());
 
                 // Act & Assert
                 var exception =
@@ -228,8 +224,7 @@ class AccountDataApiServiceTest {
                                         service.deletePasskey(
                                                 "testPublicSubjectId", "testPasskeyId", TOKEN));
                 assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
-                assertThat(
-                        exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
+                assertThat(exception.getCause(), instanceOf(HttpTimeoutException.class));
             }
 
             @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -34,6 +34,8 @@ class AccountDataApiServiceTest {
 
     private AccountDataApiService service;
 
+    private static final String TOKEN = "token";
+
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
@@ -61,7 +63,7 @@ class AccountDataApiServiceTest {
                 when(httpClient.send(any(), any())).thenReturn(null);
 
                 // Act
-                service.retrievePasskeys("testPublicSubjectId");
+                service.retrievePasskeys("testPublicSubjectId", TOKEN);
 
                 // Assert
                 verify(httpClient).send(httpRequestCaptor.capture(), any());
@@ -71,6 +73,13 @@ class AccountDataApiServiceTest {
                                 URI.create(
                                         "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys")));
                 assertThat(httpRequestCaptor.getValue().method(), equalTo("GET"));
+                assertThat(
+                        httpRequestCaptor
+                                .getValue()
+                                .headers()
+                                .firstValue("Authorization")
+                                .orElse(""),
+                        equalTo("Bearer " + TOKEN));
             }
 
             @Test
@@ -85,7 +94,7 @@ class AccountDataApiServiceTest {
                 when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
                 // Act
-                var resp = service.retrievePasskeys("testPublicSubjectId");
+                var resp = service.retrievePasskeys("testPublicSubjectId", TOKEN);
 
                 // Assert
                 assertThat(resp.statusCode(), equalTo(200));
@@ -107,7 +116,7 @@ class AccountDataApiServiceTest {
                 var exception =
                         assertThrows(
                                 UnsuccessfulAccountDataApiResponseException.class,
-                                () -> service.retrievePasskeys("testPublicSubjectId"));
+                                () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
                 assertThat(exception.getMessage(), containsString("Timeout"));
                 assertThat(
                         exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
@@ -123,7 +132,7 @@ class AccountDataApiServiceTest {
                 var exception =
                         assertThrows(
                                 UnsuccessfulAccountDataApiResponseException.class,
-                                () -> service.retrievePasskeys("testPublicSubjectId"));
+                                () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
                 assertThat(exception.getMessage(), containsString("Error when attempting to call"));
                 assertThat(exception.getCause(), instanceOf(IOException.class));
             }
@@ -140,7 +149,7 @@ class AccountDataApiServiceTest {
                 var exception =
                         assertThrows(
                                 UnsuccessfulAccountDataApiResponseException.class,
-                                () -> service.retrievePasskeys("testPublicSubjectId"));
+                                () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
                 assertThat(exception.getMessage(), containsString("Interrupted exception"));
                 assertThat(exception.getCause(), instanceOf(InterruptedException.class));
             }
@@ -161,7 +170,7 @@ class AccountDataApiServiceTest {
                 when(httpClient.send(any(), any())).thenReturn(null);
 
                 // Act
-                service.deletePasskey("testPublicSubjectId", "testPasskeyId");
+                service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
 
                 // Assert
                 verify(httpClient).send(httpRequestCaptor.capture(), any());
@@ -171,6 +180,13 @@ class AccountDataApiServiceTest {
                                 URI.create(
                                         "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys/testPasskeyId")));
                 assertThat(httpRequestCaptor.getValue().method(), equalTo("DELETE"));
+                assertThat(
+                        httpRequestCaptor
+                                .getValue()
+                                .headers()
+                                .firstValue("Authorization")
+                                .orElse(""),
+                        equalTo("Bearer " + TOKEN));
             }
 
             @Test
@@ -185,7 +201,7 @@ class AccountDataApiServiceTest {
                 when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
 
                 // Act
-                var resp = service.deletePasskey("testPublicSubjectId", "testPasskeyId");
+                var resp = service.deletePasskey("testPublicSubjectId", "testPasskeyId", TOKEN);
 
                 // Assert
                 assertThat(resp.statusCode(), equalTo(200));
@@ -209,7 +225,7 @@ class AccountDataApiServiceTest {
                                 UnsuccessfulAccountDataApiResponseException.class,
                                 () ->
                                         service.deletePasskey(
-                                                "testPublicSubjectId", "testPasskeyId"));
+                                                "testPublicSubjectId", "testPasskeyId", TOKEN));
                 assertThat(exception.getMessage(), containsString("Timeout"));
                 assertThat(
                         exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
@@ -227,7 +243,7 @@ class AccountDataApiServiceTest {
                                 UnsuccessfulAccountDataApiResponseException.class,
                                 () ->
                                         service.deletePasskey(
-                                                "testPublicSubjectId", "testPasskeyId"));
+                                                "testPublicSubjectId", "testPasskeyId", TOKEN));
                 assertThat(exception.getMessage(), containsString("Error when attempting to call"));
                 assertThat(exception.getCause(), instanceOf(IOException.class));
             }
@@ -246,7 +262,7 @@ class AccountDataApiServiceTest {
                                 UnsuccessfulAccountDataApiResponseException.class,
                                 () ->
                                         service.deletePasskey(
-                                                "testPublicSubjectId", "testPasskeyId"));
+                                                "testPublicSubjectId", "testPasskeyId", TOKEN));
                 assertThat(exception.getMessage(), containsString("Interrupted exception"));
                 assertThat(exception.getCause(), instanceOf(InterruptedException.class));
             }


### PR DESCRIPTION
## What

- `PasskeysRetrieveProxyHandler` and `PasskeysDeleteProxyHandler` receives `X-ADAPI-AccessToken` header with token, extracting the value.
- The proxy handler then passes this value on to ADAPI in bearer authentication `Authorization: Bearer <token>` format

## How to review

1. Code Review
2. Test in dev alongside built authorizer

