### PR TITLE
AUT-4808: Log a warning if a priority identifier is not included on a verify phone number request

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -412,6 +412,8 @@ public class SendOtpNotificationHandler
         if (notificationType == NotificationType.VERIFY_PHONE_NUMBER) {
             PriorityIdentifier priorityIdentifier;
             if (Objects.isNull(sendNotificationRequest.priorityIdentifier())) {
+                LOG.warn(
+                        "Priority identifier not sent in request, this behaviour will soon be disallowed");
                 priorityIdentifier = PriorityIdentifier.DEFAULT;
             } else {
                 priorityIdentifier = sendNotificationRequest.priorityIdentifier();


### PR DESCRIPTION
We want to start requiring the priority identifier as a field on the post request to the send notification handler in the account management api.

Before we reject these requests entirely, log a warning if the field is not present on the request, so we can verify that all calls are working first.
