### PR TITLE
BAU: Refactor and fix mfa method management audit events

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -108,42 +108,12 @@ public class AuditHelper {
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest,
             ConfigurationService configurationService,
-            DynamoService dynamoService,
-            Logger logger) {
-        try {
-            var initialMetadataPairs =
-                    new AuditService.MetadataPair[] {
-                        pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.getValue())
-                    };
-
-            var context =
-                    new AuditContext(
-                            input.getRequestContext()
-                                    .getAuthorizer()
-                                    .getOrDefault(ATTRIBUTE_CLIENT_ID, AuditService.UNKNOWN)
-                                    .toString(),
-                            ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                            RequestHeaderHelper.getHeaderValueOrElse(
-                                    input.getHeaders(), SESSION_ID_HEADER, ""),
-                            ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                            userProfile,
-                                            configurationService.getInternalSectorUri(),
-                                            dynamoService)
-                                    .getValue(),
-                            userProfile.getEmail(),
-                            IpAddressHelper.extractIpAddress(input),
-                            null,
-                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            getTxmaAuditEncoded(input.getHeaders()),
-                            List.of(initialMetadataPairs));
-
-            context = enrichAuditContextForMfaMethod(auditEvent, context, mfaMethodCreateRequest);
-
-            return Result.success(context);
-        } catch (Exception e) {
-            logger.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
+            DynamoService dynamoService) {
+        return buildAuditContext(configurationService, dynamoService, input, userProfile)
+                .map(
+                        baseContext ->
+                                enrichAuditContextForMfaMethod(
+                                        auditEvent, baseContext, mfaMethodCreateRequest));
     }
 
     public static Result<ErrorResponse, AuditContext> buildAuditContextForMfaMethod(
@@ -151,46 +121,21 @@ public class AuditHelper {
             UserProfile userProfile,
             MFAMethod mfaMethod,
             ConfigurationService configurationService,
-            DynamoService dynamoService,
-            Logger logger) {
-        try {
-            var phoneNumber =
-                    mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.name())
-                            ? mfaMethod.getDestination()
-                            : AuditService.UNKNOWN;
-
-            var metadataPairs =
-                    new AuditService.MetadataPair[] {
-                        pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.getValue()),
-                        pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType())
-                    };
-
-            var context =
-                    new AuditContext(
-                            input.getRequestContext()
-                                    .getAuthorizer()
-                                    .getOrDefault(ATTRIBUTE_CLIENT_ID, AuditService.UNKNOWN)
-                                    .toString(),
-                            ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                            RequestHeaderHelper.getHeaderValueOrElse(
-                                    input.getHeaders(), SESSION_ID_HEADER, ""),
-                            ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                            userProfile,
-                                            configurationService.getInternalSectorUri(),
-                                            dynamoService)
-                                    .getValue(),
-                            userProfile.getEmail(),
-                            IpAddressHelper.extractIpAddress(input),
-                            phoneNumber,
-                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            getTxmaAuditEncoded(input.getHeaders()),
-                            List.of(metadataPairs));
-
-            return Result.success(context);
-        } catch (Exception e) {
-            logger.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
+            DynamoService dynamoService) {
+        return buildAuditContext(configurationService, dynamoService, input, userProfile)
+                .map(
+                        baseContext -> {
+                            var phoneNumber =
+                                    mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.name())
+                                            ? mfaMethod.getDestination()
+                                            : AuditService.UNKNOWN;
+                            return baseContext
+                                    .withPhoneNumber(phoneNumber)
+                                    .withMetadataItem(
+                                            pair(
+                                                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                                    mfaMethod.getMfaMethodType()));
+                        });
     }
 
     private static AuditContext enrichAuditContextForMfaMethod(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -63,18 +63,13 @@ public class AuditHelper {
         }
     }
 
-    public static Result<ErrorResponse, AuditContext> buildAuditContext(
+    public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
             ConfigurationService configurationService,
             DynamoService dynamoService,
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile) {
         try {
-            var metadataPairs =
-                    new AuditService.MetadataPair[] {
-                        pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.getValue())
-                    };
-
-            var context =
+            return Result.success(
                     new AuditContext(
                             input.getRequestContext()
                                     .getAuthorizer()
@@ -93,9 +88,10 @@ public class AuditHelper {
                             null,
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                             getTxmaAuditEncoded(input.getHeaders()),
-                            List.of(metadataPairs));
-
-            return Result.success(context);
+                            List.of(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                                            ACCOUNT_MANAGEMENT.getValue()))));
         } catch (Exception e) {
             LOG.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
@@ -109,7 +105,8 @@ public class AuditHelper {
             MfaMethodCreateRequest mfaMethodCreateRequest,
             ConfigurationService configurationService,
             DynamoService dynamoService) {
-        return buildAuditContext(configurationService, dynamoService, input, userProfile)
+        return accountManagementAuditContext(
+                        configurationService, dynamoService, input, userProfile)
                 .map(
                         baseContext ->
                                 enrichAuditContextForMfaMethod(
@@ -122,7 +119,8 @@ public class AuditHelper {
             MFAMethod mfaMethod,
             ConfigurationService configurationService,
             DynamoService dynamoService) {
-        return buildAuditContext(configurationService, dynamoService, input, userProfile)
+        return accountManagementAuditContext(
+                        configurationService, dynamoService, input, userProfile)
                 .map(
                         baseContext -> {
                             var phoneNumber =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -98,21 +98,6 @@ public class AuditHelper {
         }
     }
 
-    public static Result<ErrorResponse, AuditContext> buildAuditContextForMfa(
-            AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
-            UserProfile userProfile,
-            MfaMethodCreateRequest mfaMethodCreateRequest,
-            ConfigurationService configurationService,
-            DynamoService dynamoService) {
-        return accountManagementAuditContext(
-                        configurationService, dynamoService, input, userProfile)
-                .map(
-                        baseContext ->
-                                enrichAuditContextForMfaMethod(
-                                        auditEvent, baseContext, mfaMethodCreateRequest));
-    }
-
     public static Result<ErrorResponse, AuditContext> buildAuditContextForMfaMethod(
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile,
@@ -136,7 +121,7 @@ public class AuditHelper {
                         });
     }
 
-    private static AuditContext enrichAuditContextForMfaMethod(
+    public static AuditContext enrichAuditContextForMfaMethod(
             AccountManagementAuditableEvent auditEvent,
             AuditContext context,
             MfaMethodCreateRequest mfaMethodCreateRequest) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -88,29 +87,6 @@ public class AuditHelper {
             LOG.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
         }
-    }
-
-    public static Result<ErrorResponse, AuditContext> buildAuditContextForMfaMethod(
-            APIGatewayProxyRequestEvent input,
-            UserProfile userProfile,
-            MFAMethod mfaMethod,
-            ConfigurationService configurationService,
-            DynamoService dynamoService) {
-        return accountManagementAuditContext(
-                        configurationService, dynamoService, input, userProfile)
-                .map(
-                        baseContext -> {
-                            var phoneNumber =
-                                    mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.name())
-                                            ? mfaMethod.getDestination()
-                                            : AuditService.UNKNOWN;
-                            return baseContext
-                                    .withPhoneNumber(phoneNumber)
-                                    .withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                                    mfaMethod.getMfaMethodType()));
-                        });
     }
 
     public static Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -11,13 +11,10 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
-import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
-import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -29,18 +26,13 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
-import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class AuditHelper {
@@ -119,64 +111,6 @@ public class AuditHelper {
                                                     AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
                                                     mfaMethod.getMfaMethodType()));
                         });
-    }
-
-    public static AuditContext enrichAuditContextForMfaMethod(
-            AccountManagementAuditableEvent auditEvent,
-            AuditContext context,
-            MfaMethodCreateRequest mfaMethodCreateRequest) {
-
-        if (mfaMethodCreateRequest != null) {
-            context =
-                    context.withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                            mfaMethodCreateRequest
-                                                    .mfaMethod()
-                                                    .method()
-                                                    .mfaMethodType()
-                                                    .toString()))
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                            PriorityIdentifier.BACKUP.name().toLowerCase()));
-
-            if (mfaMethodCreateRequest.mfaMethod().method()
-                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
-                context =
-                        context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                        PhoneNumberHelper.getCountry(
-                                                requestSmsMfaDetail.phoneNumber())));
-
-                if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)
-                        && requestSmsMfaDetail.otp() != null) {
-                    context =
-                            context.withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                    requestSmsMfaDetail.otp()))
-                                    .withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                    MFA_SMS.name()));
-                }
-            }
-
-            if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)) {
-                context =
-                        context.withMetadataItem(
-                                        pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                                ACCOUNT_MANAGEMENT.name()));
-            }
-        }
-
-        return context;
     }
 
     public static Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -6,10 +6,8 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -18,7 +16,6 @@ import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 
 import java.util.List;
 import java.util.Map;
@@ -26,8 +23,6 @@ import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
@@ -87,52 +82,6 @@ public class AuditHelper {
             LOG.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
         }
-    }
-
-    public static Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(
-            UserProfile userProfile,
-            AuditContext auditContext,
-            MFAMethodsService mfaMethodsService,
-            Logger logger) {
-
-        var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
-
-        if (maybeMfaMethods.isFailure()) {
-            logger.error("No MFA methods found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        var mfaMethods = maybeMfaMethods.getSuccess();
-
-        var defaultMfaMethod =
-                mfaMethods.stream()
-                        .filter(
-                                method ->
-                                        method.getPriority()
-                                                .equalsIgnoreCase(
-                                                        PriorityIdentifier.DEFAULT.name()))
-                        .findFirst();
-
-        if (defaultMfaMethod.isEmpty()) {
-            logger.error("No default MFA method found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        if (defaultMfaMethod.get().getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            auditContext = auditContext.withPhoneNumber(defaultMfaMethod.get().getDestination());
-        }
-
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                defaultMfaMethod.get().getMfaMethodType()));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
-        return Result.success(auditContext);
     }
 
     public static Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -449,16 +449,6 @@ public class MFAMethodsCreateHandler
                 var context = context1;
 
                 if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
-                    context =
-                            context.withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                            mfaMethodCreateRequest
-                                                    .mfaMethod()
-                                                    .method()
-                                                    .mfaMethodType()
-                                                    .toString()));
-
                     if (mfaMethodCreateRequest.mfaMethod().method()
                             instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
                         context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -532,54 +532,51 @@ public class MFAMethodsCreateHandler
             AuditContext context,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
 
-        if (mfaMethodCreateRequest != null) {
+        context =
+                context.withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                        mfaMethodCreateRequest
+                                                .mfaMethod()
+                                                .method()
+                                                .mfaMethodType()
+                                                .toString()))
+                        .withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                        PriorityIdentifier.BACKUP.name().toLowerCase()));
+
+        if (mfaMethodCreateRequest.mfaMethod().method()
+                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+            context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
             context =
                     context.withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                            mfaMethodCreateRequest
-                                                    .mfaMethod()
-                                                    .method()
-                                                    .mfaMethodType()
-                                                    .toString()))
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                            PriorityIdentifier.BACKUP.name().toLowerCase()));
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                                    PhoneNumberHelper.getCountry(
+                                            requestSmsMfaDetail.phoneNumber())));
 
-            if (mfaMethodCreateRequest.mfaMethod().method()
-                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+            if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)
+                    && requestSmsMfaDetail.otp() != null) {
                 context =
                         context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                        PhoneNumberHelper.getCountry(
-                                                requestSmsMfaDetail.phoneNumber())));
-
-                if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)
-                        && requestSmsMfaDetail.otp() != null) {
-                    context =
-                            context.withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                    requestSmsMfaDetail.otp()))
-                                    .withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                    MFA_SMS.name()));
-                }
-            }
-
-            if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)) {
-                context =
-                        context.withMetadataItem(
-                                        pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
+                                                requestSmsMfaDetail.otp()))
                                 .withMetadataItem(
                                         pair(
-                                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                                ACCOUNT_MANAGEMENT.name()));
+                                                AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
+                                                MFA_SMS.name()));
             }
+        }
+
+        if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)) {
+            context =
+                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
+                            .withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                                            ACCOUNT_MANAGEMENT.name()));
         }
 
         return context;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -401,9 +401,57 @@ public class MFAMethodsCreateHandler
                                         updateAuditContextForFailedMFACreation(
                                                 method, baseAuditContext));
             } else {
-                var context =
-                        enrichAuditContextForMfaMethod(
-                                auditEvent, baseAuditContext, mfaMethodCreateRequest);
+                AuditContext context1 = baseAuditContext;
+
+                context1 =
+                        context1.withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                                mfaMethodCreateRequest
+                                                        .mfaMethod()
+                                                        .method()
+                                                        .mfaMethodType()
+                                                        .toString()))
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                                PriorityIdentifier.BACKUP.name().toLowerCase()));
+
+                if (mfaMethodCreateRequest.mfaMethod().method()
+                        instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
+                    context1 = context1.withPhoneNumber(requestSmsMfaDetail1.phoneNumber());
+                    context1 =
+                            context1.withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                                            PhoneNumberHelper.getCountry(
+                                                    requestSmsMfaDetail1.phoneNumber())));
+
+                    if (auditEvent.equals(AUTH_CODE_VERIFIED)
+                            && requestSmsMfaDetail1.otp() != null) {
+                        context1 =
+                                context1.withMetadataItem(
+                                                pair(
+                                                        AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
+                                                        requestSmsMfaDetail1.otp()))
+                                        .withMetadataItem(
+                                                pair(
+                                                        AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
+                                                        MFA_SMS.name()));
+                    }
+                }
+
+                if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
+                    context1 =
+                            context1.withMetadataItem(
+                                            pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
+                                    .withMetadataItem(
+                                            pair(
+                                                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                                                    ACCOUNT_MANAGEMENT.name()));
+                }
+
+                var context = context1;
 
                 if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
                     context =
@@ -525,61 +573,6 @@ public class MFAMethodsCreateHandler
                 .withPhoneNumber(phoneNumber)
                 .withMetadataItem(mfaTypeExtension)
                 .withMetadataItem(priorityExtension);
-    }
-
-    private static AuditContext enrichAuditContextForMfaMethod(
-            AccountManagementAuditableEvent auditEvent,
-            AuditContext context,
-            MfaMethodCreateRequest mfaMethodCreateRequest) {
-
-        context =
-                context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                        mfaMethodCreateRequest
-                                                .mfaMethod()
-                                                .method()
-                                                .mfaMethodType()
-                                                .toString()))
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        PriorityIdentifier.BACKUP.name().toLowerCase()));
-
-        if (mfaMethodCreateRequest.mfaMethod().method()
-                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
-            context =
-                    context.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                    PhoneNumberHelper.getCountry(
-                                            requestSmsMfaDetail.phoneNumber())));
-
-            if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)
-                    && requestSmsMfaDetail.otp() != null) {
-                context =
-                        context.withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                requestSmsMfaDetail.otp()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                MFA_SMS.name()));
-            }
-        }
-
-        if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)) {
-            context =
-                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                            ACCOUNT_MANAGEMENT.name()));
-        }
-
-        return context;
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -389,36 +389,18 @@ public class MFAMethodsCreateHandler
 
     private Result<ErrorResponse, AuditContext> buildAuditContext(
             AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest,
-            MFAMethod mfaMethod) {
+            MFAMethod mfaMethod,
+            AuditContext baseAuditContext) {
         try {
             if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
-                var baseContextResult =
-                        accountManagementAuditContext(
-                                configurationService, dynamoService, input, userProfile);
-                if (baseContextResult.isFailure()) {
-                    return baseContextResult;
-                }
                 return updateAuditContextForFailedMFACreation(
-                        userProfile, baseContextResult.getSuccess(), mfaMethodsService);
+                        userProfile, baseAuditContext, mfaMethodsService);
             } else {
-                var baseContextResult =
-                        accountManagementAuditContext(
-                                        configurationService, dynamoService, input, userProfile)
-                                .map(
-                                        baseContext ->
-                                                enrichAuditContextForMfaMethod(
-                                                        auditEvent,
-                                                        baseContext,
-                                                        mfaMethodCreateRequest));
-
-                if (baseContextResult.isFailure()) {
-                    return baseContextResult;
-                }
-
-                var context = baseContextResult.getSuccess();
+                var context =
+                        enrichAuditContextForMfaMethod(
+                                auditEvent, baseAuditContext, mfaMethodCreateRequest);
 
                 if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
                     context =
@@ -469,8 +451,16 @@ public class MFAMethodsCreateHandler
             MfaMethodCreateRequest mfaMethodCreateRequest,
             MFAMethod mfaMethod) {
         var maybeAuditContext =
-                buildAuditContext(
-                        auditEvent, input, userProfile, mfaMethodCreateRequest, mfaMethod);
+                accountManagementAuditContext(
+                                configurationService, dynamoService, input, userProfile)
+                        .flatMap(
+                                baseContext ->
+                                        buildAuditContext(
+                                                auditEvent,
+                                                userProfile,
+                                                mfaMethodCreateRequest,
+                                                mfaMethod,
+                                                baseContext));
         if (maybeAuditContext.isFailure()) {
             LOG.error(
                     "Error when building audit context for {} audit event with error code {}. No event raised",

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.util.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -39,6 +40,7 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 
@@ -135,7 +137,7 @@ public class MFAMethodsCreateHandler
     }
 
     private Result<APIGatewayProxyResponseEvent, UserProfile>
-            getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
+    getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
         if (!configurationService.isMfaMethodManagementApiEnabled()) {
             LOG.error(
                     "Request to create MFA method in {} environment but feature is switched off.",
@@ -392,49 +394,32 @@ public class MFAMethodsCreateHandler
                                                 method, baseAuditContext));
             } else {
                 AuditContext context = baseAuditContext;
+                var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
+                var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
+                context = context
+                        .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType))
+                        .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
 
-                context =
-                        context.withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                                mfaMethodCreateRequest
-                                                        .mfaMethod()
-                                                        .method()
-                                                        .mfaMethodType()
-                                                        .toString()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.BACKUP.name().toLowerCase()));
-
-                if (mfaMethodCreateRequest.mfaMethod().method()
-                        instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
-                    context = context.withPhoneNumber(requestSmsMfaDetail1.phoneNumber());
-                    context =
-                            context.withMetadataItem(
+                if (mfaMethodCreateRequest.mfaMethod().method() instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
+                    context = context
+                            .withPhoneNumber(requestSmsMfaDetail1.phoneNumber())
+                            .withMetadataItem(
                                     pair(
                                             AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                            PhoneNumberHelper.getCountry(
-                                                    requestSmsMfaDetail1.phoneNumber())));
+                                            PhoneNumberHelper.getCountry(requestSmsMfaDetail1.phoneNumber())));
 
-                    if (auditEvent.equals(AUTH_CODE_VERIFIED)
-                            && requestSmsMfaDetail1.otp() != null) {
-                        context =
-                                context.withMetadataItem(
-                                                pair(
-                                                        AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                        requestSmsMfaDetail1.otp()))
-                                        .withMetadataItem(
-                                                pair(
-                                                        AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                        MFA_SMS.name()));
+                    if (auditEvent.equals(AUTH_CODE_VERIFIED) && requestSmsMfaDetail1.otp() != null) {
+                        var mfaCodeEnteredPair =
+                                pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, requestSmsMfaDetail1.otp());
+                        var notificationTypePair = pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
+                        context = context
+                                .withMetadataItem(mfaCodeEnteredPair)
+                                .withMetadataItem(notificationTypePair);
                     }
                 }
 
                 if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                    context =
-                            context.withMetadataItem(
-                                    pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
+                    context = context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
                 }
 
                 return Result.success(context);
@@ -452,7 +437,7 @@ public class MFAMethodsCreateHandler
             MfaMethodCreateRequest mfaMethodCreateRequest) {
         var maybeAuditContext =
                 accountManagementAuditContext(
-                                configurationService, dynamoService, input, userProfile)
+                        configurationService, dynamoService, input, userProfile)
                         .flatMap(
                                 baseContext ->
                                         buildAuditContext(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -50,7 +50,6 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
@@ -444,11 +443,7 @@ public class MFAMethodsCreateHandler
                 if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
                     context1 =
                             context1.withMetadataItem(
-                                            pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                                    .withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                                    ACCOUNT_MANAGEMENT.name()));
+                                    pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
                 }
 
                 var context = context1;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -439,13 +439,6 @@ public class MFAMethodsCreateHandler
 
                 var context = context1;
 
-                if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
-                    if (mfaMethodCreateRequest.mfaMethod().method()
-                            instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                        context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
-                    }
-                }
-
                 return Result.success(context);
             }
         } catch (Exception e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
+import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -48,14 +49,20 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.DEFAULT_MFA_ALREADY_EXISTS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_OTP;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.REQUEST_MISSING_PARAMS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
+import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -402,7 +409,7 @@ public class MFAMethodsCreateHandler
                                         configurationService, dynamoService, input, userProfile)
                                 .map(
                                         baseContext ->
-                                                AuditHelper.enrichAuditContextForMfaMethod(
+                                                enrichAuditContextForMfaMethod(
                                                         auditEvent,
                                                         baseContext,
                                                         mfaMethodCreateRequest));
@@ -482,6 +489,64 @@ public class MFAMethodsCreateHandler
 
         LOG.info("Successfully submitted audit event: {}", auditEvent.name());
         return Result.success(null);
+    }
+
+    private static AuditContext enrichAuditContextForMfaMethod(
+            AccountManagementAuditableEvent auditEvent,
+            AuditContext context,
+            MfaMethodCreateRequest mfaMethodCreateRequest) {
+
+        if (mfaMethodCreateRequest != null) {
+            context =
+                    context.withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                            mfaMethodCreateRequest
+                                                    .mfaMethod()
+                                                    .method()
+                                                    .mfaMethodType()
+                                                    .toString()))
+                            .withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                            PriorityIdentifier.BACKUP.name().toLowerCase()));
+
+            if (mfaMethodCreateRequest.mfaMethod().method()
+                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+                context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+                context =
+                        context.withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                                        PhoneNumberHelper.getCountry(
+                                                requestSmsMfaDetail.phoneNumber())));
+
+                if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)
+                        && requestSmsMfaDetail.otp() != null) {
+                    context =
+                            context.withMetadataItem(
+                                            pair(
+                                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
+                                                    requestSmsMfaDetail.otp()))
+                                    .withMetadataItem(
+                                            pair(
+                                                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
+                                                    MFA_SMS.name()));
+                }
+            }
+
+            if (auditEvent.equals(AccountManagementAuditableEvent.AUTH_CODE_VERIFIED)) {
+                context =
+                        context.withMetadataItem(
+                                        pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                                                ACCOUNT_MANAGEMENT.name()));
+            }
+        }
+
+        return context;
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.jose.util.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -40,7 +39,6 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
 
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 
@@ -137,7 +135,7 @@ public class MFAMethodsCreateHandler
     }
 
     private Result<APIGatewayProxyResponseEvent, UserProfile>
-    getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
+            getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
         if (!configurationService.isMfaMethodManagementApiEnabled()) {
             LOG.error(
                     "Request to create MFA method in {} environment but feature is switched off.",
@@ -385,48 +383,50 @@ public class MFAMethodsCreateHandler
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest,
             AuditContext baseAuditContext) {
-        try {
-            if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
-                return getDefaultMethod(userProfile)
-                        .map(
-                                method ->
-                                        updateAuditContextForFailedMFACreation(
-                                                method, baseAuditContext));
-            } else {
-                AuditContext context = baseAuditContext;
-                var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
-                var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
-                context = context
-                        .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType))
-                        .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
+        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
+            return getDefaultMethod(userProfile)
+                    .map(
+                            method ->
+                                    updateAuditContextForFailedMFACreation(
+                                            method, baseAuditContext));
+        } else {
+            AuditContext context = baseAuditContext;
+            var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
+            var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
+            context =
+                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType))
+                            .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
 
-                if (mfaMethodCreateRequest.mfaMethod().method() instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
-                    context = context
-                            .withPhoneNumber(requestSmsMfaDetail1.phoneNumber())
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                            PhoneNumberHelper.getCountry(requestSmsMfaDetail1.phoneNumber())));
+            if (mfaMethodCreateRequest.mfaMethod().method()
+                    instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
+                context =
+                        context.withPhoneNumber(requestSmsMfaDetail1.phoneNumber())
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                                                PhoneNumberHelper.getCountry(
+                                                        requestSmsMfaDetail1.phoneNumber())));
 
-                    if (auditEvent.equals(AUTH_CODE_VERIFIED) && requestSmsMfaDetail1.otp() != null) {
-                        var mfaCodeEnteredPair =
-                                pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, requestSmsMfaDetail1.otp());
-                        var notificationTypePair = pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
-                        context = context
-                                .withMetadataItem(mfaCodeEnteredPair)
-                                .withMetadataItem(notificationTypePair);
-                    }
+                if (auditEvent.equals(AUTH_CODE_VERIFIED) && requestSmsMfaDetail1.otp() != null) {
+                    var mfaCodeEnteredPair =
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
+                                    requestSmsMfaDetail1.otp());
+                    var notificationTypePair =
+                            pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
+                    context =
+                            context.withMetadataItem(mfaCodeEnteredPair)
+                                    .withMetadataItem(notificationTypePair);
                 }
-
-                if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                    context = context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
-                }
-
-                return Result.success(context);
             }
-        } catch (Exception e) {
-            LOG.error("Error building audit context", e);
-            return Result.failure(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);
+
+            if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
+                context =
+                        context.withMetadataItem(
+                                pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
+            }
+
+            return Result.success(context);
         }
     }
 
@@ -437,7 +437,7 @@ public class MFAMethodsCreateHandler
             MfaMethodCreateRequest mfaMethodCreateRequest) {
         var maybeAuditContext =
                 accountManagementAuditContext(
-                        configurationService, dynamoService, input, userProfile)
+                                configurationService, dynamoService, input, userProfile)
                         .flatMap(
                                 baseContext ->
                                         buildAuditContext(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -388,7 +388,7 @@ public class MFAMethodsCreateHandler
         try {
             if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
                 var baseContextResult =
-                        AuditHelper.buildAuditContext(
+                        AuditHelper.accountManagementAuditContext(
                                 configurationService, dynamoService, input, userProfile);
                 if (baseContextResult.isFailure()) {
                     return baseContextResult;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -391,10 +391,10 @@ public class MFAMethodsCreateHandler
                                         updateAuditContextForFailedMFACreation(
                                                 method, baseAuditContext));
             } else {
-                AuditContext context1 = baseAuditContext;
+                AuditContext context = baseAuditContext;
 
-                context1 =
-                        context1.withMetadataItem(
+                context =
+                        context.withMetadataItem(
                                         pair(
                                                 AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
                                                 mfaMethodCreateRequest
@@ -409,9 +409,9 @@ public class MFAMethodsCreateHandler
 
                 if (mfaMethodCreateRequest.mfaMethod().method()
                         instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
-                    context1 = context1.withPhoneNumber(requestSmsMfaDetail1.phoneNumber());
-                    context1 =
-                            context1.withMetadataItem(
+                    context = context.withPhoneNumber(requestSmsMfaDetail1.phoneNumber());
+                    context =
+                            context.withMetadataItem(
                                     pair(
                                             AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
                                             PhoneNumberHelper.getCountry(
@@ -419,8 +419,8 @@ public class MFAMethodsCreateHandler
 
                     if (auditEvent.equals(AUTH_CODE_VERIFIED)
                             && requestSmsMfaDetail1.otp() != null) {
-                        context1 =
-                                context1.withMetadataItem(
+                        context =
+                                context.withMetadataItem(
                                                 pair(
                                                         AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
                                                         requestSmsMfaDetail1.otp()))
@@ -432,12 +432,10 @@ public class MFAMethodsCreateHandler
                 }
 
                 if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                    context1 =
-                            context1.withMetadataItem(
+                    context =
+                            context.withMetadataItem(
                                     pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
                 }
-
-                var context = context1;
 
                 return Result.success(context);
             }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -46,6 +46,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
@@ -388,7 +389,7 @@ public class MFAMethodsCreateHandler
         try {
             if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
                 var baseContextResult =
-                        AuditHelper.accountManagementAuditContext(
+                        accountManagementAuditContext(
                                 configurationService, dynamoService, input, userProfile);
                 if (baseContextResult.isFailure()) {
                     return baseContextResult;
@@ -397,13 +398,14 @@ public class MFAMethodsCreateHandler
                         userProfile, baseContextResult.getSuccess(), mfaMethodsService, LOG);
             } else {
                 var baseContextResult =
-                        AuditHelper.buildAuditContextForMfa(
-                                auditEvent,
-                                input,
-                                userProfile,
-                                mfaMethodCreateRequest,
-                                configurationService,
-                                dynamoService);
+                        accountManagementAuditContext(
+                                        configurationService, dynamoService, input, userProfile)
+                                .map(
+                                        baseContext ->
+                                                AuditHelper.enrichAuditContextForMfaMethod(
+                                                        auditEvent,
+                                                        baseContext,
+                                                        mfaMethodCreateRequest));
 
                 if (baseContextResult.isFailure()) {
                     return baseContextResult;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -304,11 +304,7 @@ public class MFAMethodsCreateHandler
 
         var addCompletedResult =
                 sendAuditEvent(
-                        AUTH_MFA_METHOD_ADD_COMPLETED,
-                        input,
-                        userProfile,
-                        mfaMethodCreateRequest,
-                        backupMfaMethod);
+                        AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
 
         if (addCompletedResult.isFailure()) {
             LOG.error(addCompletedResult.getFailure());
@@ -323,11 +319,7 @@ public class MFAMethodsCreateHandler
         if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
             var updatePhoneNumberResult =
                     sendAuditEvent(
-                            AUTH_UPDATE_PHONE_NUMBER,
-                            input,
-                            userProfile,
-                            mfaMethodCreateRequest,
-                            backupMfaMethod);
+                            AUTH_UPDATE_PHONE_NUMBER, input, userProfile, mfaMethodCreateRequest);
 
             if (updatePhoneNumberResult.isFailure()) {
                 LOG.error(updatePhoneNumberResult.getFailure());
@@ -390,7 +382,6 @@ public class MFAMethodsCreateHandler
             AccountManagementAuditableEvent auditEvent,
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest,
-            MFAMethod mfaMethod,
             AuditContext baseAuditContext) {
         try {
             if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
@@ -455,15 +446,6 @@ public class MFAMethodsCreateHandler
                     }
                 }
 
-                if (auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER) && mfaMethod != null) {
-                    // Always set mfa-method to DEFAULT for AUTH_UPDATE_PHONE_NUMBER events
-                    context =
-                            context.withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                            PriorityIdentifier.DEFAULT.name().toLowerCase()));
-                }
-
                 return Result.success(context);
             }
         } catch (Exception e) {
@@ -477,15 +459,6 @@ public class MFAMethodsCreateHandler
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
-        return sendAuditEvent(auditEvent, input, userProfile, mfaMethodCreateRequest, null);
-    }
-
-    private Result<ErrorResponse, Void> sendAuditEvent(
-            AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
-            UserProfile userProfile,
-            MfaMethodCreateRequest mfaMethodCreateRequest,
-            MFAMethod mfaMethod) {
         var maybeAuditContext =
                 accountManagementAuditContext(
                                 configurationService, dynamoService, input, userProfile)
@@ -495,7 +468,6 @@ public class MFAMethodsCreateHandler
                                                 auditEvent,
                                                 userProfile,
                                                 mfaMethodCreateRequest,
-                                                mfaMethod,
                                                 baseContext));
         if (maybeAuditContext.isFailure()) {
             LOG.error(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -398,26 +398,8 @@ public class MFAMethodsCreateHandler
                             .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
 
             if (mfaMethodCreateRequest.mfaMethod().method()
-                    instanceof RequestSmsMfaDetail requestSmsMfaDetail1) {
-                context =
-                        context.withPhoneNumber(requestSmsMfaDetail1.phoneNumber())
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                                PhoneNumberHelper.getCountry(
-                                                        requestSmsMfaDetail1.phoneNumber())));
-
-                if (auditEvent.equals(AUTH_CODE_VERIFIED) && requestSmsMfaDetail1.otp() != null) {
-                    var mfaCodeEnteredPair =
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                    requestSmsMfaDetail1.otp());
-                    var notificationTypePair =
-                            pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
-                    context =
-                            context.withMetadataItem(mfaCodeEnteredPair)
-                                    .withMetadataItem(notificationTypePair);
-                }
+                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+                context = enrichWithSmsDetails(context, auditEvent, requestSmsMfaDetail);
             }
 
             if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
@@ -428,6 +410,28 @@ public class MFAMethodsCreateHandler
 
             return Result.success(context);
         }
+    }
+
+    private AuditContext enrichWithSmsDetails(
+            AuditContext context,
+            AccountManagementAuditableEvent auditEvent,
+            RequestSmsMfaDetail smsDetail) {
+        var updatedContext =
+                context.withPhoneNumber(smsDetail.phoneNumber())
+                        .withMetadataItem(
+                                pair(
+                                        AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                                        PhoneNumberHelper.getCountry(smsDetail.phoneNumber())));
+
+        if (auditEvent.equals(AUTH_CODE_VERIFIED) && smsDetail.otp() != null) {
+            return updatedContext
+                    .withMetadataItem(
+                            pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, smsDetail.otp()))
+                    .withMetadataItem(
+                            pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name()));
+        }
+
+        return updatedContext;
     }
 
     private Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -395,8 +395,11 @@ public class MFAMethodsCreateHandler
             AuditContext baseAuditContext) {
         try {
             if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
-                return updateAuditContextForFailedMFACreation(
-                        userProfile, baseAuditContext, mfaMethodsService);
+                return getDefaultMethod(userProfile)
+                        .map(
+                                method ->
+                                        updateAuditContextForFailedMFACreation(
+                                                method, baseAuditContext));
             } else {
                 var context =
                         enrichAuditContextForMfaMethod(
@@ -481,11 +484,7 @@ public class MFAMethodsCreateHandler
         return Result.success(null);
     }
 
-    private static Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(
-            UserProfile userProfile,
-            AuditContext auditContext,
-            MFAMethodsService mfaMethodsService) {
-
+    private Result<ErrorResponse, MFAMethod> getDefaultMethod(UserProfile userProfile) {
         var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
 
         if (maybeMfaMethods.isFailure()) {
@@ -507,23 +506,25 @@ public class MFAMethodsCreateHandler
         if (defaultMfaMethod.isEmpty()) {
             LOG.error("No default MFA method found for user");
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
+        } else return Result.success(defaultMfaMethod.get());
+    }
 
-        if (defaultMfaMethod.get().getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            auditContext = auditContext.withPhoneNumber(defaultMfaMethod.get().getDestination());
-        }
-
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                defaultMfaMethod.get().getMfaMethodType()));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
-        return Result.success(auditContext);
+    private static AuditContext updateAuditContextForFailedMFACreation(
+            MFAMethod defaultMethod, AuditContext auditContext) {
+        var phoneNumber =
+                defaultMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())
+                        ? defaultMethod.getDestination()
+                        : null;
+        var mfaTypeExtension =
+                pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, defaultMethod.getMfaMethodType());
+        var priorityExtension =
+                pair(
+                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                        PriorityIdentifier.DEFAULT.name().toLowerCase());
+        return auditContext
+                .withPhoneNumber(phoneNumber)
+                .withMetadataItem(mfaTypeExtension)
+                .withMetadataItem(priorityExtension);
     }
 
     private static AuditContext enrichAuditContextForMfaMethod(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -403,8 +403,7 @@ public class MFAMethodsCreateHandler
                                 userProfile,
                                 mfaMethodCreateRequest,
                                 configurationService,
-                                dynamoService,
-                                LOG);
+                                dynamoService);
 
                 if (baseContextResult.isFailure()) {
                     return baseContextResult;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -401,8 +401,8 @@ public class MFAMethodsCreateHandler
                 if (baseContextResult.isFailure()) {
                     return baseContextResult;
                 }
-                return AuditHelper.updateAuditContextForFailedMFACreation(
-                        userProfile, baseContextResult.getSuccess(), mfaMethodsService, LOG);
+                return updateAuditContextForFailedMFACreation(
+                        userProfile, baseContextResult.getSuccess(), mfaMethodsService);
             } else {
                 var baseContextResult =
                         accountManagementAuditContext(
@@ -489,6 +489,51 @@ public class MFAMethodsCreateHandler
 
         LOG.info("Successfully submitted audit event: {}", auditEvent.name());
         return Result.success(null);
+    }
+
+    private static Result<ErrorResponse, AuditContext> updateAuditContextForFailedMFACreation(
+            UserProfile userProfile,
+            AuditContext auditContext,
+            MFAMethodsService mfaMethodsService) {
+
+        var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
+
+        if (maybeMfaMethods.isFailure()) {
+            LOG.error("No MFA methods found for user");
+            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+        }
+
+        var mfaMethods = maybeMfaMethods.getSuccess();
+
+        var defaultMfaMethod =
+                mfaMethods.stream()
+                        .filter(
+                                method ->
+                                        method.getPriority()
+                                                .equalsIgnoreCase(
+                                                        PriorityIdentifier.DEFAULT.name()))
+                        .findFirst();
+
+        if (defaultMfaMethod.isEmpty()) {
+            LOG.error("No default MFA method found for user");
+            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
+        }
+
+        if (defaultMfaMethod.get().getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
+            auditContext = auditContext.withPhoneNumber(defaultMfaMethod.get().getDestination());
+        }
+
+        auditContext =
+                auditContext.withMetadataItem(
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                defaultMfaMethod.get().getMfaMethodType()));
+        auditContext =
+                auditContext.withMetadataItem(
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
+        return Result.success(auditContext);
     }
 
     private static AuditContext enrichAuditContextForMfaMethod(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.audit.AuditContext;
@@ -17,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -30,6 +30,8 @@ import java.util.Map;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_DELETE_COMPLETED;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
@@ -38,6 +40,7 @@ import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLangua
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachTraceId;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class MFAMethodsDeleteHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -191,7 +194,17 @@ public class MFAMethodsDeleteHandler
 
     private Result<ErrorResponse, AuditContext> buildAuditContext(
             APIGatewayProxyRequestEvent input, UserProfile userProfile, MFAMethod mfaMethod) {
-        return AuditHelper.buildAuditContextForMfaMethod(
-                input, userProfile, mfaMethod, configurationService, dynamoService);
+        var phoneNumber =
+                mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.name())
+                        ? mfaMethod.getDestination()
+                        : AuditService.UNKNOWN;
+        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
+        return accountManagementAuditContext(
+                        configurationService, dynamoService, input, userProfile)
+                .map(
+                        baseContext ->
+                                baseContext
+                                        .withPhoneNumber(phoneNumber)
+                                        .withMetadataItem(mfaTypePair));
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -192,6 +192,6 @@ public class MFAMethodsDeleteHandler
     private Result<ErrorResponse, AuditContext> buildAuditContext(
             APIGatewayProxyRequestEvent input, UserProfile userProfile, MFAMethod mfaMethod) {
         return AuditHelper.buildAuditContextForMfaMethod(
-                input, userProfile, mfaMethod, configurationService, dynamoService, LOG);
+                input, userProfile, mfaMethod, configurationService, dynamoService);
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -601,7 +601,7 @@ public class MFAMethodsPutHandler
         }
 
         var maybeAuditContext =
-                AuditHelper.buildAuditContext(
+                AuditHelper.accountManagementAuditContext(
                         configurationService, dynamoService, input, putRequest.userProfile);
 
         if (maybeAuditContext.isFailure()) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
@@ -98,7 +98,7 @@ class AuditHelperTest {
             when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
 
             Result<ErrorResponse, AuditContext> result =
-                    AuditHelper.buildAuditContext(
+                    AuditHelper.accountManagementAuditContext(
                             configurationService, dynamoService, input, userProfile);
 
             assertTrue(result.isSuccess());
@@ -120,7 +120,7 @@ class AuditHelperTest {
             input = new APIGatewayProxyRequestEvent();
 
             Result<ErrorResponse, AuditContext> result =
-                    AuditHelper.buildAuditContext(
+                    AuditHelper.accountManagementAuditContext(
                             configurationService, dynamoService, input, userProfile);
 
             assertTrue(result.isFailure());

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -316,11 +316,7 @@ class MFAMethodsCreateHandlerTest {
                             .withPhoneNumber(TEST_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
-            // TODO: AUDIT_EVENT_EXTENSIONS_MFA_METHOD added twice and conflicts with the already
-            // added mfa method, can
-            //  be updated when production code fixed
+                            .withMetadataItem(pair("phone_number_country_code", "44"));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -290,10 +290,7 @@ class MFAMethodsCreateHandlerTest {
                             .withMetadataItem(pair("phone_number_country_code", "44"))
                             .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                             .withMetadataItem(pair("notification-type", MFA_SMS.name()))
-                            .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
-            // TODO: journey type  is being added twice in the code (is in base audit context too),
-            //  when this fixed can remove this
+                            .withMetadataItem(pair("account-recovery", "false"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -404,8 +401,7 @@ class MFAMethodsCreateHandlerTest {
                             .withPhoneNumber(null)
                             .withMetadataItem(pair("mfa-type", AUTH_APP.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+                            .withMetadataItem(pair("account-recovery", "false"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -488,8 +484,7 @@ class MFAMethodsCreateHandlerTest {
                             .withMetadataItem(pair("phone_number_country_code", "44"))
                             .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                             .withMetadataItem(pair("notification-type", MFA_SMS.name()))
-                            .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+                            .withMetadataItem(pair("account-recovery", "false"));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -303,9 +303,7 @@ class MFAMethodsCreateHandlerTest {
                             .withPhoneNumber(TEST_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"))
-                            .withMetadataItem(pair("mfa-type", SMS.name()));
-            // TODO: mfa type also being added twice in the code, when this fixed can remove this
+                            .withMetadataItem(pair("phone_number_country_code", "44"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -413,9 +411,7 @@ class MFAMethodsCreateHandlerTest {
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(null)
                             .withMetadataItem(pair("mfa-type", AUTH_APP.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.name()));
-            // TODO another duplicate here
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -549,6 +549,7 @@ class MFAMethodsCreateHandlerTest {
         void shouldReturn400WhenInternationalNumberAndFeatureFlagDisabled() {
             when(configurationService.isAccountManagementInternationalSmsEnabled())
                     .thenReturn(false);
+            when(mfaMethodsService.getMfaMethods(TEST_EMAIL)).thenReturn(Result.success(List.of()));
 
             var event =
                     generateApiGatewayEvent(


### PR DESCRIPTION
Following on from [the PR which improved the test assertions for account management](https://github.com/govuk-one-login/authentication-api/pull/8223), which gives us a safer base to refactor the production code from since we're now asserting on full audit events, this PR:

* Significantly refactors the code to create audit events both in the shared code and in the mfa methods create handler specifically. Previously the code went through a fairly convoluted chain of helper methods that made it very difficult to work out how audit events were being constructed.
* Fixes some minor issues of duplication of metadata pairs
* Fixes one ticketed issue (4808) where the wrong data is being sent in the audit event. This was easier to do as part of the refactor as it was easier to see in the refactored state what was going wrong (it was being added twice but with contradictory values).

The general refactoring philosophy here was to inline all the helper methods one by one to see the total state of the logic, and then refactor from there.

Hopefully the end state is a much easier to understand construction of audit events.

Still to come: a similar refactoring for the mfa methods put handler.

It's possible that at that point we'd identify some common helper methods to put back into the audit helper, but for now I've kept all the create specific logic in the handler.