### PR TITLE
AUT-5369: Format phone numbers to E.164 in audit events

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -193,7 +193,7 @@ public class AuditHelper {
         }
     }
 
-    private static AuditContext enrichAuditContextForMfaMethod(
+    static AuditContext enrichAuditContextForMfaMethod(
             AccountManagementAuditableEvent auditEvent,
             AuditContext context,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
@@ -215,7 +215,10 @@ public class AuditHelper {
 
             if (mfaMethodCreateRequest.mfaMethod().method()
                     instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                context = context.withPhoneNumber(requestSmsMfaDetail.phoneNumber());
+                context =
+                        context.withPhoneNumber(
+                                PhoneNumberHelper.formatPhoneNumber(
+                                        requestSmsMfaDetail.phoneNumber()));
                 context =
                         context.withMetadataItem(
                                 pair(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
@@ -4,11 +4,16 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.domain.RequestHeaders;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
+import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -27,6 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.TXMA_ENCODED_HEADER_NAME;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -128,6 +140,165 @@ class AuditHelperTest {
             assertThat(
                     logging.events(),
                     hasItem(withMessageContaining("Error building audit context")));
+        }
+    }
+
+    @Nested
+    class EnrichAuditContextForMfaMethodTests {
+
+        private final AuditContext baseContext = AuditContext.emptyAuditContext();
+
+        @Test
+        void shouldReturnUnmodifiedContextWhenRequestIsNull() {
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED,
+                            baseContext,
+                            null);
+
+            assertEquals(baseContext, result);
+        }
+
+        @Test
+        void shouldAddMfaTypeAndMethodForAuthAppRequest() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestAuthAppMfaDetail("some-credential"));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED,
+                            baseContext,
+                            request);
+
+            assertEquals(
+                    "AUTH_APP",
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_MFA_TYPE).get().value());
+            assertEquals(
+                    "backup",
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_MFA_METHOD).get().value());
+            assertTrue(
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE)
+                            .isEmpty());
+        }
+
+        @Test
+        void shouldAddPhoneNumberAndCountryCodeForSmsRequest() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestSmsMfaDetail("+447700900000", "123456"));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED,
+                            baseContext,
+                            request);
+
+            assertEquals("+447700900000", result.phoneNumber());
+            assertTrue(
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE)
+                            .isPresent());
+        }
+
+        @Test
+        void shouldAddOtpAndNotificationTypeForSmsCodeVerified() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestSmsMfaDetail("+447700900000", "123456"));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_CODE_VERIFIED,
+                            baseContext,
+                            request);
+
+            assertEquals(
+                    "123456",
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED)
+                            .get()
+                            .value());
+            assertEquals(
+                    "MFA_SMS",
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE)
+                            .get()
+                            .value());
+        }
+
+        @Test
+        void shouldNotAddOtpFieldsWhenOtpIsNull() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestSmsMfaDetail("+447700900000", null));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_CODE_VERIFIED,
+                            baseContext,
+                            request);
+
+            assertTrue(
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED).isEmpty());
+        }
+
+        @Test
+        void shouldAddAccountRecoveryAndJourneyTypeForCodeVerified() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestAuthAppMfaDetail("some-credential"));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_CODE_VERIFIED,
+                            baseContext,
+                            request);
+
+            assertEquals(
+                    "false",
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY)
+                            .get()
+                            .value());
+            assertEquals(
+                    "ACCOUNT_MANAGEMENT",
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE).get().value());
+        }
+
+        @Test
+        void shouldFormatPhoneNumberToE164ForAuditContext() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestSmsMfaDetail("07700900000", "123456"));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED,
+                            baseContext,
+                            request);
+
+            assertEquals("+447700900000", result.phoneNumber());
+        }
+
+        @Test
+        void shouldNotAddAccountRecoveryFieldsForNonCodeVerifiedEvent() {
+            var request =
+                    MfaMethodCreateRequest.from(
+                            PriorityIdentifier.BACKUP,
+                            new RequestAuthAppMfaDetail("some-credential"));
+
+            var result =
+                    AuditHelper.enrichAuditContextForMfaMethod(
+                            AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED,
+                            baseContext,
+                            request);
+
+            assertTrue(
+                    result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY).isEmpty());
+            assertTrue(result.getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE).isEmpty());
         }
     }
 }


### PR DESCRIPTION

## What

Format phone numbers to E.164 in audit events

When a backup number is added the number is audited in local UK format rather than E.164. (It is always saved correctly in the database in E.164)

- add set of tests calling 'enrichAuditContextForMfaMethod'
- add test to prove number format conversion 'shouldFormatPhoneNumberToE164ForAuditContext'

## How to review

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Add a backup and review that phone numbers are all recorded in E.164 (test in staging to reproduce the issue)

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

