### PR TITLE
Bau/improve test assertions

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -719,7 +719,10 @@ public class MFAMethodsPutHandler
                                 .withMetadataItem(
                                         pair(
                                                 AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                                requestedMethod.method().mfaMethodType()));
+                                                requestedMethod
+                                                        .method()
+                                                        .mfaMethodType()
+                                                        .toString()));
             }
 
             return Result.success(context);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/CommonTestVariables.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/CommonTestVariables.java
@@ -9,6 +9,7 @@ public class CommonTestVariables {
     public static final String PERSISTENT_ID = "some-persistent-session-id";
     public static final String SESSION_ID = "some-session-id";
     public static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
+    public static final String IP_ADDRESS = "192.0.2.0/24";
     public static final Map<String, String> VALID_HEADERS =
             Map.of(
                     PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
@@ -26,7 +25,6 @@ import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
-import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
@@ -57,7 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -70,21 +67,19 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.PERSISTENT_ID;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.TXMA_ENCODED_HEADER_VALUE;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.containsMetadataPair;
-import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
+import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
+import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
@@ -107,7 +102,6 @@ class MFAMethodsCreateHandlerTest {
     private static final String TEST_CLIENT_ID = "some-client-id";
     private static final String TEST_NON_CLIENT_SESSION_ID = "some-non-client-session-id";
     private static final String TEST_PUBLIC_SUBJECT = new Subject().getValue();
-    private static final String TEST_IP_ADDRESS = "123.123.123.123";
     private static final ConfigurationService configurationService =
             mock(ConfigurationService.class);
     private static final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -129,6 +123,17 @@ class MFAMethodsCreateHandlerTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_PUBLIC_SUBJECT, "test.account.gov.uk", TEST_SALT);
     private final Json objectMapper = SerializationService.getInstance();
+    private static final AuditContext BASE_AUDIT_CONTEXT =
+            AuditContext.emptyAuditContext()
+                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withEmail(TEST_EMAIL)
+                    .withClientSessionId(SESSION_ID)
+                    .withSessionId(TEST_NON_CLIENT_SESSION_ID)
+                    .withSubjectId(TEST_INTERNAL_SUBJECT)
+                    .withIpAddress(IP_ADDRESS)
+                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withPersistentSessionId(PERSISTENT_ID)
+                    .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
 
     private MFAMethodsCreateHandler handler;
 
@@ -171,7 +176,7 @@ class MFAMethodsCreateHandlerTest {
         authorizerParams.put("principalId", principal);
         authorizerParams.put("clientId", TEST_CLIENT_ID);
         proxyRequestContext.setAuthorizer(authorizerParams);
-        proxyRequestContext.setIdentity(identityWithSourceIp(TEST_IP_ADDRESS));
+        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
 
         Map<String, String> headers = new HashMap<>(VALID_HEADERS);
         headers.put(SESSION_ID_HEADER, TEST_NON_CLIENT_SESSION_ID);
@@ -277,82 +282,56 @@ class MFAMethodsCreateHandlerTest {
                     JsonParser.parseString(expectedResponse).getAsJsonObject().toString();
             assertEquals(expectedResponseParsedToString, result.getBody());
 
-            InOrder inOrder = inOrder(auditService);
+            var expectedAuthCodeVerifiedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.name()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"))
+                            .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
+                            .withMetadataItem(pair("notification-type", MFA_SMS.name()))
+                            .withMetadataItem(pair("account-recovery", "false"))
+                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+            // TODO: journey type  is being added twice in the code (is in base audit context too),
+            //  when this fixed can remove this
 
-            ArgumentCaptor<AuditContext> auditContextCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
-
-            inOrder.verify(auditService)
+            verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_CODE_VERIFIED),
-                            auditContextCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
+                            AUTH_CODE_VERIFIED,
+                            expectedAuthCodeVerifiedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
 
-            AuditContext capturedCodeVerifiedContext = auditContextCaptor.getValue();
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                    ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.SMS.name());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    PriorityIdentifier.BACKUP.name().toLowerCase());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
-            containsMetadataPair(
-                    capturedCodeVerifiedContext, AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, TEST_OTP);
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                    MFA_SMS.name());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                    "44");
+            var expectedAuthMfaMethodAddCompleteContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.name()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"))
+                            .withMetadataItem(pair("mfa-type", SMS.name()));
+            // TODO: mfa type also being added twice in the code, when this fixed can remove this
 
-            ArgumentCaptor<AuditContext> addCompletedCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
-            inOrder.verify(auditService)
+            verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_COMPLETED),
-                            addCompletedCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
+                            AUTH_MFA_METHOD_ADD_COMPLETED,
+                            expectedAuthMfaMethodAddCompleteContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
 
-            AuditContext capturedAddCompletedContext = addCompletedCaptor.getValue();
-            containsMetadataPair(
-                    capturedAddCompletedContext,
-                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                    ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedAddCompletedContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.SMS.name());
-            containsMetadataPair(
-                    capturedAddCompletedContext,
-                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                    "44");
+            var expectedUpdatedPhoneNumberContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.name()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+            // TODO: AUDIT_EVENT_EXTENSIONS_MFA_METHOD added twice and conflicts with the already
+            // added mfa method, can
+            //  be updated when production code fixed
 
-            ArgumentCaptor<AuditContext> updatePhoneCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
-            inOrder.verify(auditService)
+            verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_UPDATE_PHONE_NUMBER),
-                            updatePhoneCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            AuditContext capturedUpdatePhoneContext = updatePhoneCaptor.getValue();
-            containsMetadataPair(
-                    capturedUpdatePhoneContext,
-                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                    ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedUpdatePhoneContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    backupMfa.getPriority().toLowerCase());
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            expectedUpdatedPhoneNumberContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -420,50 +399,33 @@ class MFAMethodsCreateHandlerTest {
             verify(auditService, never())
                     .submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any(), any());
 
-            InOrder inOrder = inOrder(auditService);
+            var expectedAuthCodeVerifiedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.name()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("account-recovery", "false"))
+                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
 
-            ArgumentCaptor<AuditContext> auditContextCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
-
-            inOrder.verify(auditService)
-                    .submitAuditEvent(
-                            eq(AUTH_CODE_VERIFIED),
-                            auditContextCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            AuditContext capturedCodeVerifiedContext = auditContextCaptor.getValue();
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                    ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.name());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    PriorityIdentifier.BACKUP.name().toLowerCase());
-            containsMetadataPair(
-                    capturedCodeVerifiedContext, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
-
-            ArgumentCaptor<AuditContext> addCompletedCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_COMPLETED),
-                            addCompletedCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
+                            AUTH_CODE_VERIFIED,
+                            expectedAuthCodeVerifiedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
 
-            AuditContext capturedAddCompletedContext = addCompletedCaptor.getValue();
-            containsMetadataPair(
-                    capturedAddCompletedContext,
-                    AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                    ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedAddCompletedContext,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.name());
+            var expectedAddCompletedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.name()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.name()));
+            // TODO another duplicate here
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_MFA_METHOD_ADD_COMPLETED,
+                            expectedAddCompletedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -518,28 +480,22 @@ class MFAMethodsCreateHandlerTest {
 
             handler.handleRequest(event, context);
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            var expectedAuthCodeVerifiedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.name()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"))
+                            .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
+                            .withMetadataItem(pair("notification-type", MFA_SMS.name()))
+                            .withMetadataItem(pair("account-recovery", "false"))
+                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_CODE_VERIFIED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
-
-            containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, TEST_OTP);
-            containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    PriorityIdentifier.BACKUP.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    DEFAULT_SMS_METHOD.getMfaMethodType());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
+                            AUTH_CODE_VERIFIED,
+                            expectedAuthCodeVerifiedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
     }
 
@@ -719,24 +675,17 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.MFA_METHOD_COUNT_LIMIT_REACHED));
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            var expectedMfaMethodAddFailedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_FAILED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
-
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    DEFAULT.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.toString());
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedMfaMethodAddFailedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -764,26 +713,19 @@ class MFAMethodsCreateHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_NUMBER));
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_FAILED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
 
             // Query: should this instead be reflecting the method that has failed to add? Ie sms
+            var expectedMfaMethodAddFailedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
 
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    DEFAULT.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.toString());
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedMfaMethodAddFailedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -809,22 +751,17 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_NUMBER));
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            var expectedMfaMethodAddFailedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_FAILED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            AuditContext capturedObject = captor.getValue();
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    PriorityIdentifier.DEFAULT.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.name());
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedMfaMethodAddFailedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
 
             // Verify that getMfaMethods was called but addBackupMfa was not
             verify(mfaMethodsService).getMfaMethods(TEST_EMAIL);
@@ -853,18 +790,19 @@ class MFAMethodsCreateHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_OTP));
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+
+            var expectedInvalidCodeSentAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"));
 
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_INVALID_CODE_SENT),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+                            AUTH_INVALID_CODE_SENT,
+                            expectedInvalidCodeSentAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
 
             verifyNoInteractions(sqsClient);
         }
@@ -893,24 +831,17 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.SMS_MFA_WITH_NUMBER_EXISTS));
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            var expectedMfaMethodAddFailedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_FAILED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
-
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    DEFAULT.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.toString());
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedMfaMethodAddFailedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -936,24 +867,17 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.AUTH_APP_EXISTS));
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+            var expectedMfaMethodAddFailedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_FAILED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
-
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    DEFAULT.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                    MFAMethodType.AUTH_APP.toString());
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedMfaMethodAddFailedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -986,29 +910,18 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR));
             verifyNoInteractions(sqsClient);
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+
+            var expectedMfaMethodAddFailedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.toString()))
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_CODE_VERIFIED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_ADD_FAILED),
-                            captor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-            AuditContext capturedObject = captor.getValue();
-
-            containsMetadataPair(
-                    capturedObject,
-                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                    DEFAULT.name().toLowerCase());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(
-                    capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.toString());
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedMfaMethodAddFailedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.google.gson.JsonParser;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -203,9 +204,16 @@ class MFAMethodsCreateHandlerTest {
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(userProfile));
-        reset(mfaMethodsService);
         when(mfaMethodsService.migrateMfaCredentialsForUser(any()))
                 .thenReturn(Result.success(false));
+    }
+
+    @AfterEach
+    void resetMocks() {
+        reset(configurationService);
+        reset(dynamoService);
+        reset(mfaMethodsService);
+        reset(codeStorageService);
     }
 
     @Nested
@@ -764,7 +772,7 @@ class MFAMethodsCreateHandlerTest {
                             eq(AUDIT_EVENT_COMPONENT_ID_HOME));
             AuditContext capturedObject = captor.getValue();
 
-            //Query: should this instead be reflecting the method that has failed to add? Ie sms
+            // Query: should this instead be reflecting the method that has failed to add? Ie sms
 
             containsMetadataPair(
                     capturedObject,
@@ -870,6 +878,7 @@ class MFAMethodsCreateHandlerTest {
                             TEST_INTERNAL_SUBJECT);
             when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                     .thenReturn(Optional.of(userProfile));
+            when(codeStorageService.isValidOtpCode(any(), any(), any())).thenReturn(true);
             when(mfaMethodsService.addBackupMfa(any(), any()))
                     .thenReturn(Result.failure(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS));
             var defaultMfa =

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -764,6 +764,8 @@ class MFAMethodsCreateHandlerTest {
                             eq(AUDIT_EVENT_COMPONENT_ID_HOME));
             AuditContext capturedObject = captor.getValue();
 
+            //Query: should this instead be reflecting the method that has failed to add? Ie sms
+
             containsMetadataPair(
                     capturedObject,
                     AUDIT_EVENT_EXTENSIONS_MFA_METHOD,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
@@ -37,20 +36,21 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_DELETE_COMPLETED;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.PERSISTENT_ID;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.TXMA_ENCODED_HEADER_VALUE;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -131,40 +131,23 @@ class MFAMethodsDeleteHandlerTest {
                                             NotificationType.BACKUP_METHOD_REMOVED,
                                             LocaleHelper.SupportedLanguage.EN)));
 
-            ArgumentCaptor<AuditContext> auditContextCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
+            var expectedAuditContext =
+                    AuditContext.emptyAuditContext()
+                            .withPhoneNumber(SMS_MFA_METHOD.getDestination())
+                            .withEmail(TEST_EMAIL)
+                            .withClientSessionId(SESSION_ID)
+                            .withSubjectId(TEST_INTERNAL_SUBJECT)
+                            .withIpAddress(IP_ADDRESS)
+                            .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                            .withPersistentSessionId(PERSISTENT_ID)
+                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()))
+                            .withMetadataItem(pair("mfa-type", SMS.getValue(), false));
 
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_DELETE_COMPLETED),
-                            auditContextCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            AuditContext capturedContext = auditContextCaptor.getValue();
-
-            assertEquals(SMS_MFA_METHOD.getDestination(), capturedContext.phoneNumber());
-
-            assertTrue(
-                    capturedContext
-                            .getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_MFA_TYPE)
-                            .isPresent());
-            assertEquals(
-                    SMS.name(),
-                    capturedContext
-                            .getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_MFA_TYPE)
-                            .get()
-                            .value());
-
-            assertTrue(
-                    capturedContext
-                            .getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE)
-                            .isPresent());
-            assertEquals(
-                    ACCOUNT_MANAGEMENT.name(),
-                    capturedContext
-                            .getMetadataItemByKey(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE)
-                            .get()
-                            .value());
+                            AUTH_MFA_METHOD_DELETE_COMPLETED,
+                            expectedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test
@@ -314,7 +297,7 @@ class MFAMethodsDeleteHandlerTest {
         authorizerParams.put("principalId", principal);
         authorizerParams.put("clientId", TEST_CLIENT);
         proxyRequestContext.setAuthorizer(authorizerParams);
-        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
+        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
 
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
@@ -67,16 +66,15 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.CHANGED_DEFAULT_MFA;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.PERSISTENT_ID;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.TXMA_ENCODED_HEADER_VALUE;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
+import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.containsMetadataPair;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
@@ -115,6 +113,16 @@ class MFAMethodsPutHandlerTest {
     private static final String MFA_IDENTIFIER = "some-mfa-identifier";
     public static final String TEST_OTP = "123456";
     public static final String INCORRECT_OTP = "111111";
+    private static final AuditContext BASE_AUDIT_CONTEXT =
+            AuditContext.emptyAuditContext()
+                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withEmail(EMAIL)
+                    .withClientSessionId(SESSION_ID)
+                    .withSubjectId(TEST_INTERNAL_SUBJECT)
+                    .withIpAddress(IP_ADDRESS)
+                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withPersistentSessionId(PERSISTENT_ID)
+                    .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
 
     private MFAMethodsPutHandler handler;
 
@@ -430,20 +438,16 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        var expectedAuditContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(UK_MOBILE_NUMBER)
+                        .withMetadataItem(pair("mfa-type", defaultMfaMethod.getMfaMethodType()));
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_MFA_METHOD_SWITCH_COMPLETED),
-                        captor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-        AuditContext capturedObject = captor.getValue();
-
-        containsMetadataPair(
-                capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-        containsMetadataPair(
-                capturedObject,
-                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                defaultMfaMethod.getMfaMethodType());
+                        AUTH_MFA_METHOD_SWITCH_COMPLETED,
+                        expectedAuditContext,
+                        AUDIT_EVENT_COMPONENT_ID_HOME);
     }
 
     private static Stream<MFAMethodUpdateIdentifier> phoneNumberUpdateTypeIdentifiers() {
@@ -496,20 +500,17 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        var expectedAuditContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(UK_MOBILE_NUMBER)
+                        .withMetadataItem(
+                                pair("mfa-method", defaultMfaMethod.getPriority().toLowerCase()));
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_UPDATE_PHONE_NUMBER),
-                        captor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-        AuditContext capturedObject = captor.getValue();
-
-        containsMetadataPair(
-                capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-        containsMetadataPair(
-                capturedObject,
-                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                defaultMfaMethod.getPriority().toLowerCase());
+                        AUTH_UPDATE_PHONE_NUMBER,
+                        expectedAuditContext,
+                        AUDIT_EVENT_COMPONENT_ID_HOME);
     }
 
     @Test
@@ -560,23 +561,17 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        ArgumentCaptor<AuditContext> switchCompletedCaptor =
-                ArgumentCaptor.forClass(AuditContext.class);
+        var expectedAuditContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(UK_MOBILE_NUMBER)
+                        .withMetadataItem(pair("mfa-type", defaultMfaMethod.getMfaMethodType()));
+        // Query: This event contains the number switched from, not the new number.
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_MFA_METHOD_SWITCH_COMPLETED),
-                        switchCompletedCaptor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-        AuditContext switchCompletedContext = switchCompletedCaptor.getValue();
-
-        containsMetadataPair(
-                switchCompletedContext,
-                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                ACCOUNT_MANAGEMENT.name());
-        containsMetadataPair(
-                switchCompletedContext,
-                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                defaultMfaMethod.getMfaMethodType());
+                        AUTH_MFA_METHOD_SWITCH_COMPLETED,
+                        expectedAuditContext,
+                        AUDIT_EVENT_COMPONENT_ID_HOME);
 
         verify(auditService, never()).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any(), any());
     }
@@ -658,27 +653,23 @@ class MFAMethodsPutHandlerTest {
 
         handler.handleRequest(eventWithUpdateRequest, context);
 
-        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        var expectedAuditContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(UK_MOBILE_NUMBER)
+                        .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()))
+                        .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
+                        .withMetadataItem(pair("notification-type", "MFA_SMS"))
+                        .withMetadataItem(pair("account-recovery", "false"))
+                        .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()))
+                        .withMetadataItem(
+                                pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
+                        .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
+        // journey type repeated here (also in base context)- to fix
+        // mfa type also repeated - to fix
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_CODE_VERIFIED),
-                        captor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-        AuditContext capturedObject = captor.getValue();
-
-        containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, TEST_OTP);
-        containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
-        containsMetadataPair(
-                capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-        containsMetadataPair(
-                capturedObject,
-                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                DEFAULT_SMS_METHOD.getPriority().toLowerCase());
-        containsMetadataPair(
-                capturedObject,
-                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                DEFAULT_SMS_METHOD.getMfaMethodType());
-        containsMetadataPair(capturedObject, AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS");
+                        AUTH_CODE_VERIFIED, expectedAuditContext, AUDIT_EVENT_COMPONENT_ID_HOME);
     }
 
     @Test
@@ -926,24 +917,17 @@ class MFAMethodsPutHandlerTest {
 
         handler.handleRequest(eventWithUpdateRequest, context);
 
-        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        var expectedAuditContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(UK_MOBILE_NUMBER)
+                        .withMetadataItem(pair("mfa-type", BACKUP_SMS_METHOD.getMfaMethodType()))
+                        .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_MFA_METHOD_SWITCH_FAILED),
-                        captor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-        AuditContext capturedObject = captor.getValue();
-
-        containsMetadataPair(
-                capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-        containsMetadataPair(
-                capturedObject,
-                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                BACKUP_SMS_METHOD.getMfaMethodType());
-        containsMetadataPair(
-                capturedObject,
-                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                PriorityIdentifier.BACKUP.name().toLowerCase());
+                        AUTH_MFA_METHOD_SWITCH_FAILED,
+                        expectedAuditContext,
+                        AUDIT_EVENT_COMPONENT_ID_HOME);
     }
 
     @Test
@@ -1222,13 +1206,13 @@ class MFAMethodsPutHandlerTest {
     void shouldReturn200WhenValidRequestWithNullMethodForSwitching() {
         var requestBody =
                 """
-        {
-          "mfaMethod": {
-            "priorityIdentifier": "DEFAULT",
-            "method": null
-          }
-        }
-        """;
+                        {
+                          "mfaMethod": {
+                            "priorityIdentifier": "DEFAULT",
+                            "method": null
+                          }
+                        }
+                        """;
         var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT).withBody(requestBody);
 
         when(authenticationService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
@@ -1354,17 +1338,17 @@ class MFAMethodsPutHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.INVALID_OTP));
 
-        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        var expectedAuditContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(phoneNumber)
+                        .withMetadataItem(pair("mfa-type", "SMS"))
+                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_INVALID_CODE_SENT),
-                        captor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-        AuditContext capturedObject = captor.getValue();
-        containsMetadataPair(
-                capturedObject, AUDIT_EVENT_EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
-        containsMetadataPair(
-                capturedObject, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+                        AUTH_INVALID_CODE_SENT,
+                        expectedAuditContext,
+                        AUDIT_EVENT_COMPONENT_ID_HOME);
 
         verify(sqsClient, never()).send(any());
     }
@@ -1401,18 +1385,19 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
+        var expectedContext =
+                BASE_AUDIT_CONTEXT
+                        .withPhoneNumber(null)
+                        .withMetadataItem(pair("mfa-type", "AUTH_APP"))
+                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()))
+                        .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+        // Journey type duplicated here - in base context
+
         verify(auditService)
                 .submitAuditEvent(
-                        eq(AUTH_UPDATE_PROFILE_AUTH_APP),
-                        captor.capture(),
-                        eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-        AuditContext capturedContext = captor.getValue();
-        containsMetadataPair(capturedContext, AUDIT_EVENT_EXTENSIONS_MFA_TYPE, "AUTH_APP");
-        containsMetadataPair(capturedContext, AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default");
-        containsMetadataPair(
-                capturedContext, AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, "ACCOUNT_MANAGEMENT");
+                        AUTH_UPDATE_PROFILE_AUTH_APP,
+                        expectedContext,
+                        AUDIT_EVENT_COMPONENT_ID_HOME);
     }
 
     private static APIGatewayProxyRequestEvent generateApiGatewayEvent(String principal) {
@@ -1422,7 +1407,7 @@ class MFAMethodsPutHandlerTest {
         authorizerParams.put("principalId", principal);
         authorizerParams.put("clientId", TEST_CLIENT);
         proxyRequestContext.setAuthorizer(authorizerParams);
-        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
+        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
 
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters(
@@ -1436,33 +1421,33 @@ class MFAMethodsPutHandlerTest {
     private String updateSmsRequest(String phoneNumber, String otp) {
         return format(
                 """
-        {
-          "mfaMethod": {
-            "priorityIdentifier": "DEFAULT",
-            "method": {
-                "mfaMethodType": "SMS",
-                "phoneNumber": "%s",
-                "otp": "%s"
-            }
-          }
-        }
-        """,
+                        {
+                          "mfaMethod": {
+                            "priorityIdentifier": "DEFAULT",
+                            "method": {
+                                "mfaMethodType": "SMS",
+                                "phoneNumber": "%s",
+                                "otp": "%s"
+                            }
+                          }
+                        }
+                        """,
                 phoneNumber, otp);
     }
 
     private String updateAuthAppRequest(String credential) {
         return format(
                 """
-        {
-          "mfaMethod": {
-            "priorityIdentifier": "DEFAULT",
-            "method": {
-                "mfaMethodType": "AUTH_APP",
-                "credential": "%s"
-            }
-          }
-        }
-        """,
+                        {
+                          "mfaMethod": {
+                            "priorityIdentifier": "DEFAULT",
+                            "method": {
+                                "mfaMethodType": "AUTH_APP",
+                                "credential": "%s"
+                            }
+                          }
+                        }
+                        """,
                 credential);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -160,6 +160,7 @@ public class AuditAssertionsHelper {
                         .get("device_information"));
     }
 
+    // Deprecate this when no longer used
     public static void containsMetadataPair(
             AuditContext capturedObject, String field, String value) {
         capturedObject

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -1,9 +1,7 @@
 package uk.gov.di.authentication.sharedtest.helper;
 
 import com.google.gson.JsonElement;
-import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 
 import java.time.Duration;
@@ -15,10 +13,8 @@ import java.util.Objects;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
 
 public class AuditAssertionsHelper {
@@ -158,19 +154,6 @@ public class AuditAssertionsHelper {
                         .get("restricted")
                         .getAsJsonObject()
                         .get("device_information"));
-    }
-
-    // Deprecate this when no longer used
-    public static void containsMetadataPair(
-            AuditContext capturedObject, String field, String value) {
-        capturedObject
-                .getMetadataItemByKey(field)
-                .ifPresentOrElse(
-                        actualMetadataPairForMfaMethod ->
-                                assertEquals(
-                                        AuditService.MetadataPair.pair(field, value),
-                                        actualMetadataPairForMfaMethod),
-                        () -> fail("Missing metadata key: " + field));
     }
 
     public static void assertAuditEventExpectations(


### PR DESCRIPTION
## What

Switches all tests for audit events in the account management api to assert on the full event.

This is stage one in a refactor for how we construct audit events in the account management api, which is convoluted and has some minor issues - as demonstrated here in the TODOs.

We were previously asserting on partial bits of the audit event, which hid a few issues:

1. We were adding duplicates of the same data (not an issue since the downstream event would just contain one of these, but a symptom of overly convoluted construction
2. In some cases, we are adding contradictory data - ie two bits of metadata with the same key but different values, which leads to one of these being discarded in the actual submitted audit event, which is a problem.

This PR does not fix these issues, but makes them clear in tests, and will serve a base from which to refactor the production code safely.

The TODOs are left in deliberately, and will be fixed in a subsequent PR, so the sonar issues highlighting this can be ignored.


## How to review

1. Code review