### PR TITLE
ATO-2517: Enable new signing keys in prod (again)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -277,7 +277,7 @@
         "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java",
         "hashed_secret": "e8c594c3bc504a7f57bfff4db7dea9491c97d893",
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 132,
         "is_secret": false
       }
     ],
@@ -365,7 +365,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 399,
         "is_secret": false
       },
       {
@@ -373,7 +373,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 544,
+        "line_number": 558,
         "is_secret": false
       },
       {
@@ -381,7 +381,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 622,
+        "line_number": 638,
         "is_secret": false
       },
       {
@@ -389,7 +389,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 630,
+        "line_number": 646,
         "is_secret": false
       },
       {
@@ -397,7 +397,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 638,
+        "line_number": 654,
         "is_secret": false
       },
       {
@@ -405,7 +405,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 646,
+        "line_number": 662,
         "is_secret": false
       },
       {
@@ -413,7 +413,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 654,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -421,7 +421,7 @@
         "filename": "ci/cloudformation/account-management/parent.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 2825,
+        "line_number": 2840,
         "is_secret": false
       }
     ],
@@ -451,7 +451,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 376,
+        "line_number": 384,
         "is_secret": false
       },
       {
@@ -459,7 +459,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 633,
         "is_secret": false
       },
       {
@@ -467,7 +467,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 709,
+        "line_number": 726,
         "is_secret": false
       },
       {
@@ -475,7 +475,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 717,
+        "line_number": 734,
         "is_secret": false
       },
       {
@@ -483,7 +483,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 725,
+        "line_number": 742,
         "is_secret": false
       },
       {
@@ -491,7 +491,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 733,
+        "line_number": 750,
         "is_secret": false
       },
       {
@@ -499,7 +499,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 741,
+        "line_number": 758,
         "is_secret": false
       },
       {
@@ -507,7 +507,7 @@
         "filename": "ci/cloudformation/auth/parent.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 2705,
+        "line_number": 2722,
         "is_secret": false
       }
     ],
@@ -881,7 +881,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java",
         "hashed_secret": "3c452d118b5dbfad5feb4c9be02ad0f8dd6a38ac",
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -901,7 +901,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java",
         "hashed_secret": "b30b3723adc678cf5a5a649d0d12782697c96a48",
         "is_verified": false,
-        "line_number": 92,
+        "line_number": 97,
         "is_secret": false
       }
     ],
@@ -911,7 +911,7 @@
         "filename": "frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java",
         "hashed_secret": "e7451a5d89d2e9e5f35668721904c877cfb39d08",
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 50,
         "is_secret": false
       }
     ],
@@ -1247,7 +1247,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "69c1b96f46e66e1100392a01d2437152b949a74d",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -1255,7 +1255,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "9ac2a39cf66fae8a32a979917e2f426c5674a28b",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -1263,7 +1263,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "a303cce93958d7697653352052cc6f999313c4ad",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -1271,7 +1271,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java",
         "hashed_secret": "e8d63aecdc6bc83b9429e94a4ae06eecab59923b",
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 412,
         "is_secret": false
       }
     ],
@@ -1301,7 +1301,7 @@
         "filename": "integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java",
         "hashed_secret": "251c10082a6308fe3731846101d52f254a84491a",
         "is_verified": false,
-        "line_number": 2142,
+        "line_number": 2141,
         "is_secret": false
       }
     ],
@@ -1547,6 +1547,29 @@
         "is_secret": false
       }
     ],
+    "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
+        "hashed_secret": "633b6d73dcfc71676b365534a6b1edff7775f84e",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
+        "hashed_secret": "747ddc98b5f9c1c5155a501872a7f37831bcfdf8",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java",
+        "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
+        "is_verified": false,
+        "line_number": 89
+      }
+    ],
     "orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java": [
       {
         "type": "Base64 High Entropy String",
@@ -1578,50 +1601,6 @@
         "hashed_secret": "dd888a796666370b9523ef44581c34e19372116a",
         "is_verified": false,
         "line_number": 798,
-        "is_secret": false
-      }
-    ],
-    "python-utils/scripts/create_encrypting_key_from_jwks.py": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "python-utils/scripts/create_encrypting_key_from_jwks.py",
-        "hashed_secret": "8ed498ae5227a1732b22eb062e19b81641613f29",
-        "is_verified": false,
-        "line_number": 17,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "python-utils/scripts/create_encrypting_key_from_jwks.py",
-        "hashed_secret": "3732e91c621d2bfb0392f23ccdf62534f9bbf453",
-        "is_verified": false,
-        "line_number": 18,
-        "is_secret": false
-      }
-    ],
-    "python-utils/scripts/create_signing_key_from_jwks.py": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
-        "hashed_secret": "ff1fe68fcd51bee4b399a28fc5f2131bbdac2b91",
-        "is_verified": false,
-        "line_number": 13,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
-        "hashed_secret": "59c70048939981b2c93600f44c21fd7929820cce",
-        "is_verified": false,
-        "line_number": 14,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "python-utils/scripts/create_signing_key_from_jwks.py",
-        "hashed_secret": "7311a4913a0cc1042f392865bb031519d00ccf8d",
-        "is_verified": false,
-        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -1907,23 +1886,128 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 151,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "2fadaec2edd927e80cfb2e94a26fed24a1ce0d22",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "6630a415701f2a22d266ef5ff84ce87a71541c38",
+        "is_verified": false,
+        "line_number": 183
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "6d638ce73bc18e3d490992a2edbd25aabe2ae88c",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "f8ff6c162942955ce28332f99a00d66152b26df9",
+        "is_verified": false,
+        "line_number": 218
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "0a6660bfb8f15c4996cd4ff06318129c8862c28e",
+        "is_verified": false,
+        "line_number": 219
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "f43c1b313513e120a1c7f1b2e16c4e588a447c7b",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "2599084e2fdd2597f08300eb2094a699200b41e2",
+        "is_verified": false,
+        "line_number": 256
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "2a36be9af46cd27c5f1b20aa020887c1fccaa8ae",
+        "is_verified": false,
+        "line_number": 257
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "d2b22571923d78d2ec43c00b0ab37c26cf31dc0a",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "202abfba0a5645bdd42c4365448acbccd996fa4b",
+        "is_verified": false,
+        "line_number": 292
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "d151606c5a71f1a890ed49e96a05aca41d78430f",
+        "is_verified": false,
+        "line_number": 293
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 258,
+        "line_number": 297,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "67357ea9e9105423bfc88d8e24dd80c4ac213a7b",
+        "is_verified": false,
+        "line_number": 327
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "563ca8e169d3eec2259de50e53b964c8c66fbcb3",
+        "is_verified": false,
+        "line_number": 328
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "template.yaml",
+        "hashed_secret": "d5e506d3f6850724c006f45e4dd68b14615d1532",
+        "is_verified": false,
+        "line_number": 329
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 294,
+        "line_number": 342,
         "is_secret": false
       },
       {
@@ -1931,7 +2015,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 302,
+        "line_number": 350,
         "is_secret": false
       },
       {
@@ -1939,7 +2023,7 @@
         "filename": "template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 310,
+        "line_number": 358,
         "is_secret": false
       },
       {
@@ -1947,7 +2031,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 327,
+        "line_number": 375,
         "is_secret": false
       },
       {
@@ -1955,7 +2039,7 @@
         "filename": "template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 335,
+        "line_number": 383,
         "is_secret": false
       },
       {
@@ -1963,7 +2047,7 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 6943,
+        "line_number": 6956,
         "is_secret": false
       },
       {
@@ -1971,10 +2055,10 @@
         "filename": "template.yaml",
         "hashed_secret": "5b2a69401d414f203d94880132858cc997e8c0eb",
         "is_verified": false,
-        "line_number": 7411,
+        "line_number": 7424,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-04-20T15:03:36Z"
+  "generated_at": "2026-04-23T08:42:41Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -136,6 +136,7 @@ Conditions:
         !Equals [build, !Ref Environment],
         !Equals [staging, !Ref Environment],
         !Equals [integration, !Ref Environment],
+        !Equals [production, !Ref Environment],
       ],
     ]
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]


### PR DESCRIPTION
### Wider context of change

We would like to rotate our RP facing signing keys. This does that. We will revert this later today.

### What’s changed:
- Enables the feature flag to use our new signing keys 
### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
