### PR TITLE
BAU: Attempt to fix some flakey tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -217,7 +217,7 @@
         "filename": "account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/BulkRemoveAccountHandlerIntegrationTest.java",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 39,
         "is_secret": false
       }
     ],
@@ -1610,7 +1610,7 @@
         "filename": "shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java",
         "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 52,
         "is_secret": false
       }
     ],

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -177,11 +177,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         public AccountInterventionsTestConfigurationService(
                 AccountInterventionsStubExtension accountInterventionsStubExtension) {
-            super(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super(notificationsQueue, tokenSigner, configurationParameters);
             this.accountInterventionsStubExtension = accountInterventionsStubExtension;
         }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -176,10 +176,7 @@ class AuthoriseAccessTokenIntegrationTest
     void shouldValidateTokenSignedWithTestKey() throws JOSEException {
         var configServiceWithTestToken =
                 new IntegrationTestConfigurationService(
-                        notificationsQueue,
-                        tokenSigner,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters) {
+                        notificationsQueue, tokenSigner, configurationParameters) {
                     @Override
                     public String getTestTokenSigningKeyAlias() {
                         return testTokenSigner.getKeyAlias();

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/BulkRemoveAccountHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/BulkRemoveAccountHandlerIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.accountmanagement.api;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.BulkUserDeleteRequest;
@@ -10,7 +11,9 @@ import uk.gov.di.accountmanagement.entity.BulkUserDeleteResponse;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.accountmanagement.lambda.BulkRemoveAccountHandler;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 
@@ -34,6 +37,24 @@ class BulkRemoveAccountHandlerIntegrationTest
     private static final String EMAIL_4 = "user4@example.com";
     private static final String EMAIL_5 = "user5@example.com";
     private static final String PASSWORD = "password123";
+
+    @RegisterExtension
+    protected static final SnsTopicExtension snsTopicExtension =
+            new SnsTopicExtension("test-topic");
+
+    protected static final ConfigurationService BULK_DELETION_TXMA_ENABLED_CONFIGUARION_SERVICE =
+            new IntegrationTestConfigurationService(
+                    notificationsQueue, tokenSigner, configurationParameters) {
+                @Override
+                public String getTxmaAuditQueueUrl() {
+                    return txmaAuditQueue.getQueueUrl();
+                }
+
+                @Override
+                public String getLegacyAccountDeletionTopicArn() {
+                    return snsTopicExtension.getTopicArn();
+                }
+            };
 
     @BeforeEach
     void setup() {

--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -42,11 +42,7 @@ class NotifyCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     private static final IntegrationTestConfigurationService CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters,
-                    new SystemService()) {
+                    notificationsQueue, tokenSigner, configurationParameters, new SystemService()) {
                 @Override
                 public boolean isBulkUserEmailEnabled() {
                     return true;

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -148,11 +148,7 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
 
         public AccountInterventionsTestConfigurationService(
                 AccountInterventionsStubExtension accountInterventionsStubExtension) {
-            super(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super(notificationsQueue, tokenSigner, configurationParameters);
             this.accountInterventionsStubExtension = accountInterventionsStubExtension;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
@@ -91,11 +91,7 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
             extends IntegrationTestConfigurationService {
 
         public AccountRecoveryTestConfigurationService() {
-            super(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super(notificationsQueue, tokenSigner, configurationParameters);
         }
 
         @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -62,10 +62,7 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
     void setup() throws Json.JsonException {
         var configurationService =
                 new IntegrationTestConfigurationService(
-                        notificationsQueue,
-                        tokenSigner,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters) {
+                        notificationsQueue, tokenSigner, configurationParameters) {
 
                     @Override
                     public String getTxmaAuditQueueUrl() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -98,7 +98,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void setup() throws JOSEException {
         var configurationService =
                 new AuthenticationTokenHandlerIntegrationTest.TestConfigurationService(
-                        notificationsQueue, tokenSigner, docAppPrivateKeyJwtSigner);
+                        notificationsQueue, tokenSigner);
 
         handler = new TokenHandler(configurationService);
 
@@ -132,7 +132,6 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                 new AuthenticationTokenHandlerIntegrationTest.TestConfigurationService(
                         notificationsQueue,
                         tokenSigner,
-                        docAppPrivateKeyJwtSigner,
                         signWithOrchStubKey ? Optional.of(STUB_PUBLIC_KEY) : Optional.empty());
         handler = new TokenHandler(configurationService);
 
@@ -181,10 +180,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         authJwksExtension.init(new JWKSet());
         var configurationService =
                 new AuthenticationTokenHandlerIntegrationTest.TestConfigurationService(
-                        notificationsQueue,
-                        tokenSigner,
-                        docAppPrivateKeyJwtSigner,
-                        Optional.of(STUB_PUBLIC_KEY));
+                        notificationsQueue, tokenSigner, Optional.of(STUB_PUBLIC_KEY));
         handler = new TokenHandler(configurationService);
 
         Map<String, List<String>> baseParams =
@@ -304,26 +300,15 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         private final Optional<String> orchStubPublicSigningKeyOpt;
 
         public TestConfigurationService(
-                SqsQueueExtension notificationQueue,
-                TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension docAppPrivateKeyJwtSigner) {
-            this(
-                    notificationQueue,
-                    tokenSigningKey,
-                    docAppPrivateKeyJwtSigner,
-                    Optional.of(STUB_PUBLIC_KEY));
+                SqsQueueExtension notificationQueue, TokenSigningExtension tokenSigningKey) {
+            this(notificationQueue, tokenSigningKey, Optional.of(STUB_PUBLIC_KEY));
         }
 
         public TestConfigurationService(
                 SqsQueueExtension notificationQueue,
                 TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension docAppPrivateKeyJwtSigner,
                 Optional<String> orchStubPublicSigningKeyOpt) {
-            super(
-                    notificationQueue,
-                    tokenSigningKey,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super(notificationQueue, tokenSigningKey, configurationParameters);
             this.orchStubPublicSigningKeyOpt = orchStubPublicSigningKeyOpt;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -85,10 +85,7 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
 
     private static final IntegrationTestConfigurationService CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+                    notificationsQueue, tokenSigner, configurationParameters) {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -293,10 +293,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();
@@ -334,10 +331,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();
@@ -375,10 +369,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();
@@ -417,10 +408,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();
@@ -460,10 +448,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();
@@ -503,10 +488,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();
@@ -545,10 +527,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             handler =
                     new CheckUserExistsHandler(
                             new IntegrationTestConfigurationService(
-                                    notificationsQueue,
-                                    tokenSigner,
-                                    docAppPrivateKeyJwtSigner,
-                                    configurationParameters) {
+                                    notificationsQueue, tokenSigner, configurationParameters) {
                                 @Override
                                 public String getTxmaAuditQueueUrl() {
                                     return txmaAuditQueue.getQueueUrl();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -430,10 +430,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     class InternationalSmsSendLimitTests {
         private static final ConfigurationService TXMA_WITH_INT_SMS_LIMIT_CONFIG =
                 new IntegrationTestConfigurationService(
-                        notificationsQueue,
-                        tokenSigner,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters) {
+                        notificationsQueue, tokenSigner, configurationParameters) {
                     @Override
                     public String getTxmaAuditQueueUrl() {
                         return txmaAuditQueue.getQueueUrl();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -422,11 +422,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
             extends IntegrationTestConfigurationService {
 
         public ResetPasswordTestConfigurationService() {
-            super(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super(notificationsQueue, tokenSigner, configurationParameters);
         }
 
         @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -54,10 +54,7 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final ConfigurationService CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+                    notificationsQueue, tokenSigner, configurationParameters) {
                 @Override
                 public String getTxmaAuditQueueUrl() {
                     return txmaAuditQueue.getQueueUrl();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -587,11 +587,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
 
         public TestConfigurationService() {
-            super(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super(notificationsQueue, tokenSigner, configurationParameters);
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -587,10 +587,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     private ConfigurationService forcedMfaResetEnabledConfigurationService() {
         return new IntegrationTestConfigurationService(
-                notificationsQueue,
-                tokenSigner,
-                docAppPrivateKeyJwtSigner,
-                configurationParameters) {
+                notificationsQueue, tokenSigner, configurationParameters) {
             @Override
             public String getTxmaAuditQueueUrl() {
                 return txmaAuditQueue.getQueueUrl();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -1231,10 +1231,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private ConfigurationService forcedMfaResetEnabledConfigurationService() {
         return new IntegrationTestConfigurationService(
-                notificationsQueue,
-                tokenSigner,
-                docAppPrivateKeyJwtSigner,
-                configurationParameters) {
+                notificationsQueue, tokenSigner, configurationParameters) {
             @Override
             public String getTxmaAuditQueueUrl() {
                 return txmaAuditQueue.getQueueUrl();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -57,7 +57,6 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
                 new IntegrationTestConfigurationService(
                         notificationsQueue,
                         tokenSigner,
-                        docAppPrivateKeyJwtSigner,
                         configurationParameters,
                         new SystemService()) {
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
@@ -124,10 +124,7 @@ public class BulkUserEmailSenderScheduledEventHandlerIntegrationTest
             String sendMode, String senderType, int batchSize) {
         SecureRandom secureRandom = new SecureRandom();
         return new IntegrationTestConfigurationService(
-                notificationsQueue,
-                tokenSigner,
-                docAppPrivateKeyJwtSigner,
-                configurationParameters) {
+                notificationsQueue, tokenSigner, configurationParameters) {
 
             @Override
             public String getTxmaAuditQueueUrl() {

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/SpotResponseIntegrationTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.queuehandlers;
+package uk.gov.di.orchestration.ipv.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.sharedtest.extensions.CommonPasswordsExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
-import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
@@ -270,20 +269,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 }
             };
 
-    protected static final ConfigurationService BULK_DELETION_TXMA_ENABLED_CONFIGUARION_SERVICE =
-            new IntegrationTestConfigurationService(
-                    notificationsQueue, tokenSigner, configurationParameters) {
-                @Override
-                public String getTxmaAuditQueueUrl() {
-                    return txmaAuditQueue.getQueueUrl();
-                }
-
-                @Override
-                public String getLegacyAccountDeletionTopicArn() {
-                    return snsTopicExtension.getTopicArn();
-                }
-            };
-
     protected RequestHandler<Q, S> handler;
     protected final Json objectMapper = SerializationService.getInstance();
     protected final Context context = mock(Context.class);
@@ -305,10 +290,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
     @RegisterExtension
     protected static final CommonPasswordsExtension commonPasswords =
             new CommonPasswordsExtension();
-
-    @RegisterExtension
-    protected static final SnsTopicExtension snsTopicExtension =
-            new SnsTopicExtension("test-topic");
 
     protected Map<String, String> constructHeaders(Optional<HttpCookie> cookie) {
         final Map<String, String> headers = new HashMap<>();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -291,12 +291,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final CommonPasswordsExtension commonPasswords =
             new CommonPasswordsExtension();
 
-    protected Map<String, String> constructHeaders(Optional<HttpCookie> cookie) {
-        final Map<String, String> headers = new HashMap<>();
-        cookie.ifPresent(c -> headers.put("Cookie", c.toString()));
-        return headers;
-    }
-
     protected Map<String, String> constructFrontendHeaders(String sessionId) {
         return constructFrontendHeaders(sessionId, Optional.empty(), Optional.empty());
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SystemService;
 import uk.gov.di.authentication.sharedtest.extensions.AccountModifiersStoreExtension;
-import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 import uk.gov.di.authentication.sharedtest.extensions.CommonPasswordsExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
@@ -86,19 +85,8 @@ public abstract class HandlerIntegrationTest<Q, S> {
             new SqsQueueExtension("pending-email-check-queue");
 
     @RegisterExtension
-    protected static final SqsQueueExtension spotQueue = new SqsQueueExtension("spot-queue");
-
-    @RegisterExtension
-    protected static final SqsQueueExtension spotRequestQueue =
-            new SqsQueueExtension("spot-request-queue");
-
-    @RegisterExtension
     protected static final SqsQueueExtension txmaAuditQueue =
             new SqsQueueExtension("txma-audit-queue");
-
-    @RegisterExtension
-    protected static final AuditSnsTopicExtension auditTopic =
-            new AuditSnsTopicExtension("local-events");
 
     @RegisterExtension
     protected static final KmsKeyExtension auditSigningKey =
@@ -114,10 +102,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
     @RegisterExtension
     protected static final TokenSigningExtension ipvPrivateKeyJwtSigner =
             new TokenSigningExtension("ipv-token-auth-key");
-
-    @RegisterExtension
-    protected static final TokenSigningExtension docAppPrivateKeyJwtSigner =
-            new TokenSigningExtension("doc-app-token-auth-key");
 
     @RegisterExtension
     protected static final TokenSigningExtension orchestrationPrivateKeyJwtSigner =
@@ -153,17 +137,11 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     protected static final IntegrationTestConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+                    notificationsQueue, tokenSigner, configurationParameters);
 
     protected static final ConfigurationService TXMA_ENABLED_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+                    notificationsQueue, tokenSigner, configurationParameters) {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {
@@ -174,10 +152,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static ConfigurationService supportPasskeysAndTxmaEnabledConfigurationService(
             String accountDataBaseUri) {
         return new IntegrationTestConfigurationService(
-                notificationsQueue,
-                tokenSigner,
-                docAppPrivateKeyJwtSigner,
-                configurationParameters) {
+                notificationsQueue, tokenSigner, configurationParameters) {
 
             @Override
             public String getTxmaAuditQueueUrl() {
@@ -199,10 +174,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService
             REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(
-                            notificationsQueue,
-                            tokenSigner,
-                            docAppPrivateKeyJwtSigner,
-                            configurationParameters) {
+                            notificationsQueue, tokenSigner, configurationParameters) {
                         @Override
                         public String getTxmaAuditQueueUrl() {
                             return txmaAuditQueue.getQueueUrl();
@@ -221,10 +193,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     protected static final ConfigurationService EMAIL_CHECK_AND_TXMA_ENABLED_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+                    notificationsQueue, tokenSigner, configurationParameters) {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {
@@ -235,10 +204,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService
             ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(
-                            notificationsQueue,
-                            tokenSigner,
-                            docAppPrivateKeyJwtSigner,
-                            configurationParameters) {
+                            notificationsQueue, tokenSigner, configurationParameters) {
                         @Override
                         public String getTxmaAuditQueueUrl() {
                             return txmaAuditQueue.getQueueUrl();
@@ -253,10 +219,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService
             ACCOUNT_MANAGEMENT_INT_SMS_DISABLED_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(
-                            notificationsQueue,
-                            tokenSigner,
-                            docAppPrivateKeyJwtSigner,
-                            configurationParameters) {
+                            notificationsQueue, tokenSigner, configurationParameters) {
                         @Override
                         public String getTxmaAuditQueueUrl() {
                             return txmaAuditQueue.getQueueUrl();
@@ -276,10 +239,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ConfigurationService
             INTERNAL_API_INT_SMS_DISABLED_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(
-                            notificationsQueue,
-                            tokenSigner,
-                            docAppPrivateKeyJwtSigner,
-                            configurationParameters) {
+                            notificationsQueue, tokenSigner, configurationParameters) {
                         @Override
                         public String getTxmaAuditQueueUrl() {
                             return txmaAuditQueue.getQueueUrl();
@@ -298,10 +258,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     protected static final ConfigurationService INT_SMS_SENDING_DISABLED_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+                    notificationsQueue, tokenSigner, configurationParameters) {
                 @Override
                 public String getTxmaAuditQueueUrl() {
                     return txmaAuditQueue.getQueueUrl();
@@ -315,10 +272,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     protected static final ConfigurationService BULK_DELETION_TXMA_ENABLED_CONFIGUARION_SERVICE =
             new IntegrationTestConfigurationService(
-                    notificationsQueue,
-                    tokenSigner,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+                    notificationsQueue, tokenSigner, configurationParameters) {
                 @Override
                 public String getTxmaAuditQueueUrl() {
                     return txmaAuditQueue.getQueueUrl();
@@ -399,29 +353,24 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
         private final SqsQueueExtension notificationQueue;
         private final TokenSigningExtension tokenSigningKey;
-        private final TokenSigningExtension docAppPrivateKeyJwtSigner;
 
         public IntegrationTestConfigurationService(
                 SqsQueueExtension notificationQueue,
                 TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension docAppPrivateKeyJwtSigner,
                 ParameterStoreExtension parameterStoreExtension) {
             super(parameterStoreExtension.getClient());
             this.notificationQueue = notificationQueue;
             this.tokenSigningKey = tokenSigningKey;
-            this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
         }
 
         public IntegrationTestConfigurationService(
                 SqsQueueExtension notificationQueue,
                 TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension docAppPrivateKeyJwtSigner,
                 ParameterStoreExtension parameterStoreExtension,
                 SystemService systemService) {
             super(parameterStoreExtension.getClient());
             this.notificationQueue = notificationQueue;
             this.tokenSigningKey = tokenSigningKey;
-            this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
             super.systemService = systemService;
         }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
@@ -1,8 +1,0 @@
-package uk.gov.di.authentication.sharedtest.extensions;
-
-public class AuditSnsTopicExtension extends SnsTopicExtension {
-
-    public AuditSnsTopicExtension(String topicNameSuffix) {
-        super(topicNameSuffix);
-    }
-}


### PR DESCRIPTION
In auth, we have some tests that are frequently flakey in CI. These fail on a before hook to create an sns queue, but in auth these are no longer used except in one handler, so we should stop creating these queues unecessarily for every integration test.

See, for example, a screenshot from a test report from a failed integration test in CI:
<img width="1105" height="241" alt="Screenshot 2026-04-23 at 14 43 14" src="https://github.com/user-attachments/assets/59b8c78c-ceeb-4f4d-aa71-3482d51cb0ea" />

Hopefully this will fix some of the flakiness. It should definitely avoid creating a lot of unnecessary resources for integration tests and works as a general tidy.
