### PR TITLE
ATO-2517: Revert key rotation in prod

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1886,7 +1886,7 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 150,
         "is_secret": false
       },
       {
@@ -1894,91 +1894,91 @@
         "filename": "template.yaml",
         "hashed_secret": "77f0f02bfda441ee33dc37d4f98e3840df68822e",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 180
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "2fadaec2edd927e80cfb2e94a26fed24a1ce0d22",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 181
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "6630a415701f2a22d266ef5ff84ce87a71541c38",
         "is_verified": false,
-        "line_number": 183
+        "line_number": 182
       },
       {
         "type": "Hex High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "6d638ce73bc18e3d490992a2edbd25aabe2ae88c",
         "is_verified": false,
-        "line_number": 217
+        "line_number": 216
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "f8ff6c162942955ce28332f99a00d66152b26df9",
         "is_verified": false,
-        "line_number": 218
+        "line_number": 217
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "0a6660bfb8f15c4996cd4ff06318129c8862c28e",
         "is_verified": false,
-        "line_number": 219
+        "line_number": 218
       },
       {
         "type": "Hex High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "f43c1b313513e120a1c7f1b2e16c4e588a447c7b",
         "is_verified": false,
-        "line_number": 255
+        "line_number": 254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "2599084e2fdd2597f08300eb2094a699200b41e2",
         "is_verified": false,
-        "line_number": 256
+        "line_number": 255
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "2a36be9af46cd27c5f1b20aa020887c1fccaa8ae",
         "is_verified": false,
-        "line_number": 257
+        "line_number": 256
       },
       {
         "type": "Hex High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "d2b22571923d78d2ec43c00b0ab37c26cf31dc0a",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 290
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "202abfba0a5645bdd42c4365448acbccd996fa4b",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 291
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "d151606c5a71f1a890ed49e96a05aca41d78430f",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 292
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 296,
         "is_secret": false
       },
       {
@@ -1986,28 +1986,28 @@
         "filename": "template.yaml",
         "hashed_secret": "67357ea9e9105423bfc88d8e24dd80c4ac213a7b",
         "is_verified": false,
-        "line_number": 327
+        "line_number": 326
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "563ca8e169d3eec2259de50e53b964c8c66fbcb3",
         "is_verified": false,
-        "line_number": 328
+        "line_number": 327
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "template.yaml",
         "hashed_secret": "d5e506d3f6850724c006f45e4dd68b14615d1532",
         "is_verified": false,
-        "line_number": 329
+        "line_number": 328
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 342,
+        "line_number": 341,
         "is_secret": false
       },
       {
@@ -2015,7 +2015,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 350,
+        "line_number": 349,
         "is_secret": false
       },
       {
@@ -2023,7 +2023,7 @@
         "filename": "template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 358,
+        "line_number": 357,
         "is_secret": false
       },
       {
@@ -2031,7 +2031,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 375,
+        "line_number": 374,
         "is_secret": false
       },
       {
@@ -2039,7 +2039,7 @@
         "filename": "template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 383,
+        "line_number": 382,
         "is_secret": false
       },
       {
@@ -2047,7 +2047,7 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 6956,
+        "line_number": 6955,
         "is_secret": false
       },
       {
@@ -2055,10 +2055,10 @@
         "filename": "template.yaml",
         "hashed_secret": "5b2a69401d414f203d94880132858cc997e8c0eb",
         "is_verified": false,
-        "line_number": 7424,
+        "line_number": 7423,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-04-23T08:42:41Z"
+  "generated_at": "2026-04-23T14:04:11Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -136,7 +136,6 @@ Conditions:
         !Equals [build, !Ref Environment],
         !Equals [staging, !Ref Environment],
         !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
       ],
     ]
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]


### PR DESCRIPTION
### Wider context of change

We are exiting our testing phase, so we can revert this for now


### What’s changed

- Reverts the feature flag to enable the key rotation in prod

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
