### PR TITLE
AUT-4808: Require priority identifier on verify phone requests

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -20,7 +20,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.PendingEmailCheckRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -155,14 +154,20 @@ public class SendOtpNotificationHandler
 
     private Result<APIGatewayProxyResponseEvent, SendNotificationRequest> checkRequestFormat(
             APIGatewayProxyRequestEvent input) {
+        var requestMissingParamsResponse =
+                generateApiGatewayProxyErrorResponse(400, REQUEST_MISSING_PARAMS);
         try {
             var sendNotificationRequest =
                     objectMapper.readValue(input.getBody(), SendNotificationRequest.class);
+            if (sendNotificationRequest.notificationType() == NotificationType.VERIFY_PHONE_NUMBER
+                    && Objects.isNull(sendNotificationRequest.priorityIdentifier())) {
+                LOG.error("Verify phone number notification is missing priority identifier");
+                return Result.failure(requestMissingParamsResponse);
+            }
             return Result.success(sendNotificationRequest);
         } catch (JsonException e) {
             LOG.error("Error parsing sendNotificationRequest", e);
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(400, REQUEST_MISSING_PARAMS));
+            return Result.failure(requestMissingParamsResponse);
         }
     }
 
@@ -410,14 +415,7 @@ public class SendOtpNotificationHandler
                 pair("test-user", isTestUserRequest));
 
         if (notificationType == NotificationType.VERIFY_PHONE_NUMBER) {
-            PriorityIdentifier priorityIdentifier;
-            if (Objects.isNull(sendNotificationRequest.priorityIdentifier())) {
-                LOG.warn(
-                        "Priority identifier not sent in request, this behaviour will soon be disallowed");
-                priorityIdentifier = PriorityIdentifier.DEFAULT;
-            } else {
-                priorityIdentifier = sendNotificationRequest.priorityIdentifier();
-            }
+            var priorityIdentifier = sendNotificationRequest.priorityIdentifier();
             auditService.submitAuditEvent(
                     AccountManagementAuditableEvent.AUTH_PHONE_CODE_SENT,
                     auditContext,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -311,10 +311,6 @@ class SendOtpNotificationHandlerTest {
     }
 
     private static Stream<Arguments> validPhoneRequests() {
-        var eventWithoutPriorityIdentifier =
-                format(
-                        "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\"  }",
-                        TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER);
         var verifyPhoneNumberForDefaultMethod =
                 format(
                         "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"%s\"  }",
@@ -324,7 +320,6 @@ class SendOtpNotificationHandlerTest {
                         "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"%s\"  }",
                         TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER, "BACKUP");
         return Stream.of(
-                Arguments.of(eventWithoutPriorityIdentifier, "default"),
                 Arguments.of(verifyPhoneNumberForDefaultMethod, "default"),
                 Arguments.of(verifyPhoneNumberForBackupMethod, "backup"));
     }
@@ -398,7 +393,7 @@ class SendOtpNotificationHandlerTest {
         var event = createEmptyEvent();
         event.setBody(
                 format(
-                        "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\" }",
                         TEST_TEST_USER_EMAIL_ADDRESS,
                         VERIFY_PHONE_NUMBER,
                         INTERNATIONAL_MOBILE_NUMBER));
@@ -457,7 +452,7 @@ class SendOtpNotificationHandlerTest {
             var event = createEmptyEvent();
             event.setBody(
                     format(
-                            "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
+                            "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                             TEST_EMAIL_ADDRESS, VERIFY_EMAIL));
 
             var result = handler.handleRequest(event, context);
@@ -477,6 +472,23 @@ class SendOtpNotificationHandlerTest {
             @Test
             void shouldReturn400IfRequestIsMissingEmail() {
                 var event = createEmptyEvent();
+
+                var result = handler.handleRequest(event, context);
+
+                assertEquals(400, result.getStatusCode());
+                assertThat(result, hasJsonBody(ErrorResponse.REQUEST_MISSING_PARAMS));
+
+                verifyNoInteractions(auditService);
+            }
+
+            @Test
+            void shouldReturn400AndNotPutMessageOnQueueForPhoneRequestWithoutPriorityIdentifier() {
+                var eventWithoutPriorityIdentifier =
+                        format(
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\"}",
+                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER);
+
+                var event = createEmptyEvent().withBody(eventWithoutPriorityIdentifier);
 
                 var result = handler.handleRequest(event, context);
 
@@ -510,7 +522,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, "12345"));
 
                 var result = handler.handleRequest(event, context);
@@ -530,7 +542,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
 
                 var result = handler.handleRequest(event, context);
@@ -549,7 +561,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
 
                 var result = handler.handleRequest(event, context);
@@ -567,7 +579,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, "not-a phone number"));
 
                 var result = handler.handleRequest(event, context);
@@ -627,7 +639,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
 
                 var result = handler.handleRequest(event, context);
@@ -646,7 +658,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
 
                 var result = handler.handleRequest(event, context);
@@ -664,7 +676,7 @@ class SendOtpNotificationHandlerTest {
                 var event = createEmptyEvent();
                 event.setBody(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\"  }",
                                 TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, "not a phone-num"));
 
                 var result = handler.handleRequest(event, context);
@@ -731,7 +743,7 @@ class SendOtpNotificationHandlerTest {
             var event = createEmptyEvent();
             event.setBody(
                     format(
-                            "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\"  }",
+                            "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"priorityIdentifier\": \"DEFAULT\" }",
                             TEST_TEST_USER_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
 
             var result = handler.handleRequest(event, context);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -164,7 +164,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         {
                             "email": "%s",
                             "notificationType": "VERIFY_PHONE_NUMBER",
-                            "phoneNumber": "%s"
+                            "phoneNumber": "%s",
+                            "priorityIdentifier": "DEFAULT"
                         }
                         """
                     .formatted(email, phoneNumber);


### PR DESCRIPTION
Requests to account management's otp handler with a type of verify phone request require a priority identifier, otherwise we do not have the necessary information to submit the relevant audit event. The calling code has now been updated and we've had no instances of the warning log since, so we can now update the code to require this field and fail validation if not present

