### PR TITLE
AUT-5387: Log sns message id when publishing a message (after a manual delete)

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -34,6 +34,7 @@ dependencies {
             project(":shared-test"),
             libs.bundles.awsLambda,
             libs.awsSqs,
+            libs.awsSns,
             libs.awsS3,
             libs.bundles.awsDynamoDb
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AwsSnsClient.java
@@ -1,5 +1,7 @@
 package uk.gov.di.accountmanagement.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -9,6 +11,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest;
 import java.net.URI;
 
 public class AwsSnsClient {
+    private static final Logger LOG = LogManager.getLogger(AwsSnsClient.class);
     private final SnsClient snsClient;
     private final String topicArn;
 
@@ -29,8 +32,14 @@ public class AwsSnsClient {
         this.topicArn = topicArn;
     }
 
+    AwsSnsClient(SnsClient snsClient, String topicArn) {
+        this.snsClient = snsClient;
+        this.topicArn = topicArn;
+    }
+
     public void publish(String message) throws SdkClientException {
         var publishRequest = PublishRequest.builder().message(message).topicArn(topicArn).build();
-        snsClient.publish(publishRequest);
+        var response = snsClient.publish(publishRequest);
+        LOG.info("Message published to SNS with messageId: {}", response.messageId());
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AwsSnsClientTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AwsSnsClientTest.java
@@ -1,0 +1,60 @@
+package uk.gov.di.accountmanagement.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+class AwsSnsClientTest {
+
+    private static final String TOPIC_ARN = "arn:aws:sns:eu-west-2:123456789012:test-topic";
+    private static final String MESSAGE = "test-message";
+    private static final String MESSAGE_ID = "test-message-id-12345";
+
+    private final SnsClient snsClient = mock(SnsClient.class);
+    private final AwsSnsClient awsSnsClient = new AwsSnsClient(snsClient, TOPIC_ARN);
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging = new CaptureLoggingExtension(AwsSnsClient.class);
+
+    @Test
+    void shouldPublishMessageToSns() {
+        var expectedRequest = PublishRequest.builder().message(MESSAGE).topicArn(TOPIC_ARN).build();
+        when(snsClient.publish(expectedRequest))
+                .thenReturn(PublishResponse.builder().messageId(MESSAGE_ID).build());
+
+        awsSnsClient.publish(MESSAGE);
+
+        verify(snsClient).publish(expectedRequest);
+    }
+
+    @Test
+    void shouldLogMessageIdWhenPublishSucceeds() {
+        var expectedRequest = PublishRequest.builder().message(MESSAGE).topicArn(TOPIC_ARN).build();
+        when(snsClient.publish(expectedRequest))
+                .thenReturn(PublishResponse.builder().messageId(MESSAGE_ID).build());
+
+        awsSnsClient.publish(MESSAGE);
+
+        assertThat(logging.events(), hasItem(withMessageContaining(MESSAGE_ID)));
+    }
+
+    @Test
+    void shouldThrowSdkClientExceptionWhenPublishFails() {
+        var expectedRequest = PublishRequest.builder().message(MESSAGE).topicArn(TOPIC_ARN).build();
+        when(snsClient.publish(expectedRequest)).thenThrow(SdkClientException.create("error"));
+
+        assertThrows(SdkClientException.class, () -> awsSnsClient.publish(MESSAGE));
+    }
+}


### PR DESCRIPTION

## What

Log sns message id when publishing a message (after a manual delete)

Want to be able to trace across services with Home to prove that messages are being delivered for manual deletes

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)


