### PR TITLE
Bau/am audit refactor for put

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -23,10 +23,13 @@ import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
+import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class AuditHelper {
@@ -97,5 +100,12 @@ public class AuditHelper {
         }
 
         return Result.success(null);
+    }
+
+    public static AuditContext addMetadataForSmsAuthCodeVerified(
+            AuditContext baseAuditContext, String otpEntered) {
+        return baseAuditContext
+                .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, otpEntered))
+                .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name()));
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -14,8 +14,8 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.List;
 import java.util.Map;
@@ -51,7 +51,7 @@ public class AuditHelper {
 
     public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
             ConfigurationService configurationService,
-            DynamoService dynamoService,
+            AuthenticationService authenticationService,
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile) {
         try {
@@ -67,7 +67,7 @@ public class AuditHelper {
                             ClientSubjectHelper.getSubjectWithSectorIdentifier(
                                             userProfile,
                                             configurationService.getInternalSectorUri(),
-                                            dynamoService)
+                                            authenticationService)
                                     .getValue(),
                             userProfile.getEmail(),
                             IpAddressHelper.extractIpAddress(input),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -48,12 +48,11 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.addMetadataForSmsAuthCodeVerified;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.DEFAULT_MFA_ALREADY_EXISTS;
@@ -61,7 +60,6 @@ import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_OTP;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.REQUEST_MISSING_PARAMS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
-import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -424,11 +422,7 @@ public class MFAMethodsCreateHandler
                                         PhoneNumberHelper.getCountry(smsDetail.phoneNumber())));
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED) && smsDetail.otp() != null) {
-            return updatedContext
-                    .withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, smsDetail.otp()))
-                    .withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name()));
+            return addMetadataForSmsAuthCodeVerified(updatedContext, smsDetail.otp());
         }
 
         return updatedContext;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -421,7 +421,7 @@ public class MFAMethodsCreateHandler
                                         AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
                                         PhoneNumberHelper.getCountry(smsDetail.phoneNumber())));
 
-        if (auditEvent.equals(AUTH_CODE_VERIFIED) && smsDetail.otp() != null) {
+        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
             return addMetadataForSmsAuthCodeVerified(updatedContext, smsDetail.otp());
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -625,69 +625,58 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        try {
-            var phoneNumber =
-                    mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
-                            ? mfaMethod.getDestination()
-                            : AuditService.UNKNOWN;
+        var phoneNumber =
+                mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
+                        ? mfaMethod.getDestination()
+                        : AuditService.UNKNOWN;
 
-            var auditContextResult =
-                    accountManagementAuditContext(
-                            configurationService,
-                            authenticationService,
-                            input,
-                            putRequest.userProfile);
-            if (auditContextResult.isFailure()) {
-                return Result.failure(auditContextResult.getFailure());
-            }
-            var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
-
-            if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-                context =
-                        context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                        mfaMethod.getMfaMethodType()));
-            }
-
-            if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
-                    || auditEvent.equals(AUTH_INVALID_CODE_SENT)
-                    || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-                context =
-                        context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        mfaMethod.getPriority().toLowerCase()));
-            }
-
-            if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
-                if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
-                        && requestSmsMfaDetail.otp() != null) {
-                    context =
-                            context.withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                    requestSmsMfaDetail.otp()))
-                                    .withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                    MFA_SMS.name()));
-                }
-                var priorityPair =
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                requestedMethod.priorityIdentifier().name().toLowerCase());
-                context =
-                        context.withMetadataItem(
-                                        pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                                .withMetadataItem(priorityPair);
-            }
-
-            return Result.success(context);
-        } catch (Exception e) {
-            LOG.error("Error building audit context", e);
-            return Result.failure(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);
+        var auditContextResult =
+                accountManagementAuditContext(
+                        configurationService, authenticationService, input, putRequest.userProfile);
+        if (auditContextResult.isFailure()) {
+            return Result.failure(auditContextResult.getFailure());
         }
+        var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
+
+        if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+            context =
+                    context.withMetadataItem(
+                            pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType()));
+        }
+
+        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
+                || auditEvent.equals(AUTH_INVALID_CODE_SENT)
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+            context =
+                    context.withMetadataItem(
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                    mfaMethod.getPriority().toLowerCase()));
+        }
+
+        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
+            MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
+            if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
+                    && requestSmsMfaDetail.otp() != null) {
+                context =
+                        context.withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
+                                                requestSmsMfaDetail.otp()))
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
+                                                MFA_SMS.name()));
+            }
+            var priorityPair =
+                    pair(
+                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                            requestedMethod.priorityIdentifier().name().toLowerCase());
+            context =
+                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
+                            .withMetadataItem(priorityPair);
+        }
+
+        return Result.success(context);
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -17,7 +17,6 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -27,11 +26,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodUpdateIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodUpdateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
-import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
-import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -54,15 +49,14 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
-import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -600,7 +594,7 @@ public class MFAMethodsPutHandler
         }
 
         var maybeAuditContext =
-                AuditHelper.accountManagementAuditContext(
+                accountManagementAuditContext(
                         configurationService, dynamoService, input, putRequest.userProfile);
 
         if (maybeAuditContext.isFailure()) {
@@ -637,33 +631,16 @@ public class MFAMethodsPutHandler
                             ? mfaMethod.getDestination()
                             : AuditService.UNKNOWN;
 
-            var initialMetadataPairs =
-                    new AuditService.MetadataPair[] {
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                JourneyType.ACCOUNT_MANAGEMENT.getValue()),
-                    };
-
-            var context =
-                    new AuditContext(
-                            input.getRequestContext()
-                                    .getAuthorizer()
-                                    .getOrDefault(ATTRIBUTE_CLIENT_ID, AuditService.UNKNOWN)
-                                    .toString(),
-                            ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                            RequestHeaderHelper.getHeaderValueOrElse(
-                                    input.getHeaders(), SESSION_ID_HEADER, ""),
-                            ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                            putRequest.userProfile,
-                                            configurationService.getInternalSectorUri(),
-                                            authenticationService)
-                                    .getValue(),
-                            putRequest.userProfile.getEmail(),
-                            IpAddressHelper.extractIpAddress(input),
-                            phoneNumber,
-                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
-                            List.of(initialMetadataPairs));
+            var auditContextResult =
+                    accountManagementAuditContext(
+                            configurationService,
+                            authenticationService,
+                            input,
+                            putRequest.userProfile);
+            if (auditContextResult.isFailure()) {
+                return Result.failure(auditContextResult.getFailure());
+            }
+            var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
 
             if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
                 context =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -628,19 +628,16 @@ public class MFAMethodsPutHandler
         var context = baseContext.withPhoneNumber(phoneNumber);
 
         if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-            context =
-                    context.withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType()));
+            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
+            context = context.withMetadataItem(mfaTypePair);
         }
 
         if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
                 || auditEvent.equals(AUTH_INVALID_CODE_SENT)
-                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-            context =
-                    context.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    mfaMethod.getPriority().toLowerCase()));
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
+                || auditEvent.equals(AUTH_CODE_VERIFIED)) {
+            var priority = mfaMethod.getPriority().toLowerCase();
+            context = context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority));
         }
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
@@ -649,13 +646,9 @@ public class MFAMethodsPutHandler
                     && requestSmsMfaDetail.otp() != null) {
                 context = addMetadataForSmsAuthCodeVerified(context, requestSmsMfaDetail.otp());
             }
-            var priorityPair =
-                    pair(
-                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                            requestedMethod.priorityIdentifier().name().toLowerCase());
             context =
-                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                            .withMetadataItem(priorityPair);
+                    context.withMetadataItem(
+                            pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
         }
 
         return context;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -572,16 +572,14 @@ public class MFAMethodsPutHandler
                     generateApiGatewayProxyErrorResponse(500, auditContextResult.getFailure()));
         }
 
-        var result =
-                AuditHelper.sendAuditEvent(
-                        auditEvent, auditContextResult.getSuccess(), auditService, LOG);
-
-        if (result.isFailure()) {
-            return Result.failure(generateApiGatewayProxyErrorResponse(500, result.getFailure()));
-        }
-
-        LOG.info("Successfully submitted audit event: {}", auditEvent.name());
-        return Result.success(null);
+        return AuditHelper.sendAuditEvent(
+                        auditEvent, auditContextResult.getSuccess(), auditService, LOG)
+                .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
+                .map(
+                        success -> {
+                            LOG.info("Successfully submitted audit event: {}", auditEvent.name());
+                            return success;
+                        });
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> emitAuditEventForAuthAppUpdate(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -50,14 +50,12 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.addMetadataForSmsAuthCodeVerified;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
-import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -550,10 +548,7 @@ public class MFAMethodsPutHandler
                         .orElseThrow();
 
         return sendAuditEvent(
-                        AUTH_MFA_METHOD_SWITCH_COMPLETED,
-                        input,
-                        putRequest,
-                        postUpdateDefaultMfaMethod);
+                AUTH_MFA_METHOD_SWITCH_COMPLETED, input, putRequest, postUpdateDefaultMfaMethod);
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> sendAuditEvent(
@@ -651,15 +646,7 @@ public class MFAMethodsPutHandler
             MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
             if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
                     && requestSmsMfaDetail.otp() != null) {
-                context =
-                        context.withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                requestSmsMfaDetail.otp()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                MFA_SMS.name()));
+                context = addMetadataForSmsAuthCodeVerified(context, requestSmsMfaDetail.otp());
             }
             var priorityPair =
                     pair(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -609,21 +609,17 @@ public class MFAMethodsPutHandler
                     generateApiGatewayProxyErrorResponse(401, maybeAuditContext.getFailure()));
         }
 
+        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.getValue());
+        var mfaMethodPair =
+                pair(
+                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                        PriorityIdentifier.DEFAULT.name().toLowerCase());
+
         var auditContext =
                 maybeAuditContext
                         .getSuccess()
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                        MFAMethodType.AUTH_APP.getValue()))
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        PriorityIdentifier.DEFAULT.name().toLowerCase()))
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                        JourneyType.ACCOUNT_MANAGEMENT.getValue()));
+                        .withMetadataItem(mfaTypePair)
+                        .withMetadataItem(mfaMethodPair);
 
         auditService.submitAuditEvent(
                 AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -63,7 +63,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
-import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -701,10 +700,6 @@ public class MFAMethodsPutHandler
                 context =
                         context.withMetadataItem(
                                         pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                                ACCOUNT_MANAGEMENT.name()))
                                 .withMetadataItem(
                                         pair(
                                                 AUDIT_EVENT_EXTENSIONS_MFA_METHOD,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -674,23 +674,14 @@ public class MFAMethodsPutHandler
                                                     AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
                                                     MFA_SMS.name()));
                 }
+                var priorityPair =
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                requestedMethod.priorityIdentifier().name().toLowerCase());
                 context =
                         context.withMetadataItem(
                                         pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                requestedMethod
-                                                        .priorityIdentifier()
-                                                        .name()
-                                                        .toLowerCase()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                                requestedMethod
-                                                        .method()
-                                                        .mfaMethodType()
-                                                        .toString()));
+                                .withMetadataItem(priorityPair);
             }
 
             return Result.success(context);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -556,16 +556,25 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        var maybeAuditContext = buildAuditContext(auditEvent, input, putRequest, mfaMethod);
+        var auditContextResult =
+                accountManagementAuditContext(
+                                configurationService,
+                                authenticationService,
+                                input,
+                                putRequest.userProfile)
+                        .map(
+                                context ->
+                                        enrichAuditContextForEvent(
+                                                auditEvent, putRequest, mfaMethod, context));
 
-        if (maybeAuditContext.isFailure()) {
+        if (auditContextResult.isFailure()) {
             return Result.failure(
-                    generateApiGatewayProxyErrorResponse(500, maybeAuditContext.getFailure()));
+                    generateApiGatewayProxyErrorResponse(500, auditContextResult.getFailure()));
         }
 
         var result =
                 AuditHelper.sendAuditEvent(
-                        auditEvent, maybeAuditContext.getSuccess(), auditService, LOG);
+                        auditEvent, auditContextResult.getSuccess(), auditService, LOG);
 
         if (result.isFailure()) {
             return Result.failure(generateApiGatewayProxyErrorResponse(500, result.getFailure()));
@@ -608,23 +617,17 @@ public class MFAMethodsPutHandler
         return Result.success(null);
     }
 
-    private Result<ErrorResponse, AuditContext> buildAuditContext(
+    private AuditContext enrichAuditContextForEvent(
             AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
-            MFAMethod mfaMethod) {
+            MFAMethod mfaMethod,
+            AuditContext baseContext) {
         var phoneNumber =
                 mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
                         ? mfaMethod.getDestination()
                         : AuditService.UNKNOWN;
 
-        var auditContextResult =
-                accountManagementAuditContext(
-                        configurationService, authenticationService, input, putRequest.userProfile);
-        if (auditContextResult.isFailure()) {
-            return Result.failure(auditContextResult.getFailure());
-        }
-        var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
+        var context = baseContext.withPhoneNumber(phoneNumber);
 
         if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
             context =
@@ -657,6 +660,6 @@ public class MFAMethodsPutHandler
                             .withMetadataItem(priorityPair);
         }
 
-        return Result.success(context);
+        return context;
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -549,18 +549,11 @@ public class MFAMethodsPutHandler
                         .findFirst()
                         .orElseThrow();
 
-        var maybeCompletedAuditEvent =
-                sendAuditEvent(
+        return sendAuditEvent(
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
                         input,
                         putRequest,
                         postUpdateDefaultMfaMethod);
-
-        if (maybeCompletedAuditEvent.isFailure()) {
-            return maybeCompletedAuditEvent;
-        }
-
-        return Result.success(null);
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -642,8 +642,7 @@ public class MFAMethodsPutHandler
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
             MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
-            if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
-                    && requestSmsMfaDetail.otp() != null) {
+            if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
                 context = addMetadataForSmsAuthCodeVerified(context, requestSmsMfaDetail.otp());
             }
             context =

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -702,7 +702,6 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_NUMBER));
 
-            // Query: should this instead be reflecting the method that has failed to add? Ie sms
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(null)

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -656,11 +656,11 @@ class MFAMethodsPutHandlerTest {
                 BASE_AUDIT_CONTEXT
                         .withPhoneNumber(UK_MOBILE_NUMBER)
                         .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()))
+                        .withMetadataItem(
+                                pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
                         .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                         .withMetadataItem(pair("notification-type", "MFA_SMS"))
-                        .withMetadataItem(pair("account-recovery", "false"))
-                        .withMetadataItem(
-                                pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()));
+                        .withMetadataItem(pair("account-recovery", "false"));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -1389,9 +1389,7 @@ class MFAMethodsPutHandlerTest {
                 BASE_AUDIT_CONTEXT
                         .withPhoneNumber(null)
                         .withMetadataItem(pair("mfa-type", "AUTH_APP"))
-                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()))
-                        .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
-        // Journey type duplicated here - in base context
+                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -565,7 +565,6 @@ class MFAMethodsPutHandlerTest {
                 BASE_AUDIT_CONTEXT
                         .withPhoneNumber(UK_MOBILE_NUMBER)
                         .withMetadataItem(pair("mfa-type", defaultMfaMethod.getMfaMethodType()));
-        // Query: This event contains the number switched from, not the new number.
 
         verify(auditService)
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -660,12 +660,10 @@ class MFAMethodsPutHandlerTest {
                         .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                         .withMetadataItem(pair("notification-type", "MFA_SMS"))
                         .withMetadataItem(pair("account-recovery", "false"))
-                        .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()))
                         .withMetadataItem(
                                 pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
                         .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
-        // journey type repeated here (also in base context)- to fix
-        // mfa type also repeated - to fix
+        // mfa type repeated - to fix
 
         verify(auditService)
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -661,9 +661,7 @@ class MFAMethodsPutHandlerTest {
                         .withMetadataItem(pair("notification-type", "MFA_SMS"))
                         .withMetadataItem(pair("account-recovery", "false"))
                         .withMetadataItem(
-                                pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
-                        .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
-        // mfa type repeated - to fix
+                                pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()));
 
         verify(auditService)
                 .submitAuditEvent(


### PR DESCRIPTION
Refactors for the creation of audit events for the put endpoint, similar to recent refactors for the create mfa endpoint.

Some duplicated metadata items have been removed - these would not have been causing any issues, but did result from some confusing code.

Removes some comments where I've had some clarifying conversations in the background.

## How to review

1. Look at the overall diff to get a sense of the general shape of the refactor (does it look better to you?)
2. Review commit by commit

## Future improvements

I'd like to remove the metadata pairs from the audit context entirely, as they can be passed in separately when submitting an audit event. The audit context is supposed to be a common bit of context shared between all audit events emitted by a handler, containing basic information about a user / request. It is not supposed to contain data specific to a certain audit event, and this confusion is currently making the code harder to read.

The tests for the put handler could also do with a bit of tidying up.