### PR TITLE
ATO-2527: UPRN fix

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
@@ -16,8 +16,6 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -223,16 +221,17 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getPhoneNumberVerified(), equalTo(true));
         assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
 
-        var addressClaim = (JSONArray) userInfoResponse.getClaim(ValidClaims.ADDRESS.getValue());
-        var passportClaim = (JSONArray) userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue());
+        var addressClaim = userInfoResponse.getJSONArrayClaim(ValidClaims.ADDRESS.getValue());
+        var passportClaim = userInfoResponse.getJSONArrayClaim(ValidClaims.PASSPORT.getValue());
         var drivingPermitClaim =
-                (JSONArray) userInfoResponse.getClaim(ValidClaims.DRIVING_PERMIT.getValue());
+                userInfoResponse.getJSONArrayClaim(ValidClaims.DRIVING_PERMIT.getValue());
         var returnCodeClaim =
-                (JSONArray) userInfoResponse.getClaim(ValidClaims.RETURN_CODE.getValue());
-        assertThat(((JSONObject) addressClaim.get(0)).size(), equalTo(7));
-        assertThat(((JSONObject) passportClaim.get(0)).size(), equalTo(2));
-        assertThat(((JSONObject) drivingPermitClaim.get(0)).size(), equalTo(6));
-        assertThat(((JSONObject) returnCodeClaim.get(0)).size(), equalTo(1));
+                userInfoResponse.getJSONArrayClaim(ValidClaims.RETURN_CODE.getValue());
+
+        assertThat(addressClaim.toJSONString(), equalTo(ADDRESS_CLAIM));
+        assertThat(passportClaim.toJSONString(), equalTo(PASSPORT_CLAIM));
+        assertThat(drivingPermitClaim.toJSONString(), equalTo(DRIVING_PERMIT));
+        assertThat(returnCodeClaim.toJSONString(), equalTo(RETURN_CODE));
 
         assertThat(
                 userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
@@ -16,6 +16,8 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -221,17 +223,16 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getPhoneNumberVerified(), equalTo(true));
         assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
 
-        var addressClaim = userInfoResponse.getJSONArrayClaim(ValidClaims.ADDRESS.getValue());
-        var passportClaim = userInfoResponse.getJSONArrayClaim(ValidClaims.PASSPORT.getValue());
+        var addressClaim = (JSONArray) userInfoResponse.getClaim(ValidClaims.ADDRESS.getValue());
+        var passportClaim = (JSONArray) userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue());
         var drivingPermitClaim =
-                userInfoResponse.getJSONArrayClaim(ValidClaims.DRIVING_PERMIT.getValue());
+                (JSONArray) userInfoResponse.getClaim(ValidClaims.DRIVING_PERMIT.getValue());
         var returnCodeClaim =
-                userInfoResponse.getJSONArrayClaim(ValidClaims.RETURN_CODE.getValue());
-
-        assertThat(addressClaim.toJSONString(), equalTo(ADDRESS_CLAIM));
-        assertThat(passportClaim.toJSONString(), equalTo(PASSPORT_CLAIM));
-        assertThat(drivingPermitClaim.toJSONString(), equalTo(DRIVING_PERMIT));
-        assertThat(returnCodeClaim.toJSONString(), equalTo(RETURN_CODE));
+                (JSONArray) userInfoResponse.getClaim(ValidClaims.RETURN_CODE.getValue());
+        assertThat(((JSONObject) addressClaim.get(0)).size(), equalTo(8));
+        assertThat(((JSONObject) passportClaim.get(0)).size(), equalTo(2));
+        assertThat(((JSONObject) drivingPermitClaim.get(0)).size(), equalTo(6));
+        assertThat(((JSONObject) returnCodeClaim.get(0)).size(), equalTo(1));
 
         assertThat(
                 userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -1,13 +1,11 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.google.gson.internal.LinkedTreeMap;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -255,15 +253,16 @@ class UserInfoServiceTest {
             assertThat(
                     userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
                     equalTo(coreIdentityJWT));
-            var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
-            var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
+            var addressClaim = userInfo.getJSONArrayClaim(ValidClaims.ADDRESS.getValue());
+            var passportClaim = userInfo.getJSONArrayClaim(ValidClaims.PASSPORT.getValue());
             var drivingPermitClaim =
-                    (JSONArray) userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue());
-            var returnCodeClaim = (JSONArray) userInfo.getClaim(ValidClaims.RETURN_CODE.getValue());
-            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
-            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
-            assertThat(((LinkedTreeMap) drivingPermitClaim.get(0)).size(), equalTo(6));
-            assertThat(((LinkedTreeMap) returnCodeClaim.get(0)).size(), equalTo(1));
+                    userInfo.getJSONArrayClaim(ValidClaims.DRIVING_PERMIT.getValue());
+            var returnCodeClaim = userInfo.getJSONArrayClaim(ValidClaims.RETURN_CODE.getValue());
+
+            assertThat(addressClaim.toJSONString(), equalTo(ADDRESS_CLAIM));
+            assertThat(passportClaim.toJSONString(), equalTo(PASSPORT_CLAIM));
+            assertThat(drivingPermitClaim.toJSONString(), equalTo(DRIVING_PERMIT));
+            assertThat(returnCodeClaim.toJSONString(), equalTo(RETURN_CODE));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/IdentityTestData.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/IdentityTestData.java
@@ -4,7 +4,7 @@ public final class IdentityTestData {
     private IdentityTestData() {}
 
     public static final String ADDRESS_CLAIM =
-            "[{\"buildingNumber\":\"10\",\"streetName\":\"DowningStreet\",\"dependentAddressLocality\":\"Westminster\",\"addressLocality\":\"London\",\"postalCode\":\"SW1A2AA\",\"addressCountry\":\"GB\",\"validFrom\":\"2019-07-24\"}]";
+            "[{\"uprn\":10022812929,\"buildingNumber\":\"10\",\"streetName\":\"DowningStreet\",\"dependentAddressLocality\":\"Westminster\",\"addressLocality\":\"London\",\"postalCode\":\"SW1A2AA\",\"addressCountry\":\"GB\",\"validFrom\":\"2019-07-24\"}]";
 
     public static final String PASSPORT_CLAIM =
             "[{\"documentNumber\":\"12345678\",\"expiryDate\":\"2022-02-01\"}]";

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SerializationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SerializationService.java
@@ -4,6 +4,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.ToNumberPolicy;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
@@ -35,6 +36,7 @@ public class SerializationService implements Json {
         gson =
                 new GsonBuilder()
                         .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                         .serializeNulls()
                         .excludeFieldsWithoutExposeAnnotation()
                         .registerTypeAdapter(State.class, new StateAdapter())


### PR DESCRIPTION
### Wider context of change

We are currently serialising UPRNs incorrectly in the UserInfo response - they should be preserved in the format they are returned from IPV, but due to the need to deserialise + serialise (for compatibility with Nimbusds) we end up mangling the format as it goes via Double.

E.g.: `10022812929` => `1.0022812929E10`

N.B. Although UPRN is often formatted with leading zeroes (i.e. as a string), this is not in the spec: https://github.com/co-cddo/open-standards/issues/68#issuecomment-491245902

### What’s changed

Update the GSON strategy to use `LONG_TO_DOUBLE`, so it tries to use a long first (which doesn't lose any precision).

An ideal fix might eliminate this round-trip serialisation entire, but that's hard to achieve with our use of the Nimbusds library.

### Manual testing

Run locally and passed the userinfo claim back from the IPV stub.
