### PR TITLE
ATO-2414: deploy hosted zone dev

### DIFF
--- a/ci/stack-orchestration/configuration/dev/hosted-zone/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/hosted-zone/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "DeploySubEnvDomains",
+    "ParameterValue": "No"
+  }
+]

--- a/ci/stack-orchestration/deploy-dev.sh
+++ b/ci/stack-orchestration/deploy-dev.sh
@@ -17,6 +17,7 @@ PROVISION_VPC_STACK=false
 PROVISION_PIPELINE_STACK=false
 PROVISION_TXMA_STACK=false
 PROVISION_CLOUDWATCH_ALARM_STACK=false
+PROVISION_HOSTED_ZONE=false
 
 ENVIRONMENT=dev
 
@@ -59,6 +60,7 @@ function usage() {
     -c, --cloudwatch-alarm                 Provisions the cloudwatch alarm stack: A stack for deploying an alarm which
                                            monitors the lambda code storage and sends an alert when a threshold is reached.
                                            See confluence page: https://govukverify.atlassian.net/wiki/x/AwCc3Q
+    -h, --hosted-zone                      Provisions the hosted zone stack for the OIDC domain.
 USAGE
 }
 
@@ -103,6 +105,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -c | --cloudwatch-alarm)
       PROVISION_CLOUDWATCH_ALARM_STACK=true
+      ;;
+    -h | --hosted-zone)
+      PROVISION_HOSTED_ZONE=true
       ;;
     *)
       usage
@@ -179,6 +184,20 @@ function provision_pipeline_stack() {
   echo "Provisioned secure pipeline stack"
 }
 
+function provision_hosted_zone_stack() {
+  export AWS_REGION="eu-west-2"
+
+  echo "Provisioning hosted zone stack"
+  TEMPLATE_FILE="$(pwd)/manual-stacks/domains/template.yaml"
+  if [ ! -f "${TEMPLATE_FILE}" ]; then
+    echo "Could not find the hosted zone stack template at path: ${TEMPLATE_FILE}"
+    exit 1
+  fi
+
+  ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
+  echo "Provisioned hosted zone stack"
+}
+
 # --------------------
 # Run provision commands
 # --------------------
@@ -198,3 +217,5 @@ function provision_pipeline_stack() {
 [ "${PROVISION_TXMA_STACK}" == "true" ] && provision_txma_stack
 #This stack currently has a dependency on the main application stack for the SNS topic
 [ "${PROVISION_CLOUDWATCH_ALARM_STACK}" == "true" ] && provision_cloudwatch_alarm_stack
+
+[ "${PROVISION_HOSTED_ZONE}" == "true" ] && provision_hosted_zone_stack

--- a/ci/stack-orchestration/local-provisioner.sh
+++ b/ci/stack-orchestration/local-provisioner.sh
@@ -236,7 +236,7 @@ function main {
       execute_change_set "${STACK_NAME}" "${CHANGE_SET_NAME}"
     fi
   else
-    create_stack "${STACK_NAME}" "${template_path}" "${PARAMETERS_FILE}" "${TAGS_FILE}" # Creates a new stack
+    create_stack "${STACK_NAME}" "${TEMPLATE_PATH}" "${PARAMETERS_FILE}" "${TAGS_FILE}" # Creates a new stack
   fi
   get_stack_outputs "${STACK_NAME}" # Print the stack outputs
 }

--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -87,7 +87,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Description: !Sub
-        - "SSM parameter to stored the hosted ID for the oidc${EndpointSuffix}.${DomainSuffix} hosted zone"
+        - "SSM parameter to stored the hosted zone ID for the oidc${EndpointSuffix}.${DomainSuffix} hosted zone"
         - DomainSuffix:
             !FindInMap [
               EnvironmentConfiguration,
@@ -158,7 +158,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Description: !Sub
-        - "SSM parameter to stored the ARN of the ACM certificate for the oidc${EndpointSuffix}.${DomainSuffix} domain"
+        - "SSM parameter to store the ARN of the ACM certificate for the oidc${EndpointSuffix}.${DomainSuffix} domain"
         - DomainSuffix:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -253,9 +253,11 @@ Outputs:
 
   OidcHostedZoneNameServers:
     Description: "Name servers for the OIDC domain"
-    Value: !GetAtt
-      - OidcHostedZone
-      - NameServers
+    Value: !Join
+      - ","
+      - !GetAtt
+        - OidcHostedZone
+        - NameServers
     Export:
       Name: !Sub "${AWS::StackName}-OidcHostedZoneNameServers"
 
@@ -290,26 +292,32 @@ Outputs:
   OrchDev1HostedZoneNameServers:
     Condition: DeployDevSubDomains
     Description: "Name servers for the orchdev1 domain"
-    Value: !GetAtt
-      - Orchdev1HostedZone
-      - NameServers
+    Value: !Join
+      - ","
+      - !GetAtt
+        - Orchdev1HostedZone
+        - NameServers
     Export:
       Name: !Sub "${AWS::StackName}-orchdev1-HostedZoneNameServers"
 
   OrchDev2HostedZoneNameServers:
     Condition: DeployDevSubDomains
     Description: "Name servers for the orchdev2 domain"
-    Value: !GetAtt
-      - Orchdev2HostedZone
-      - NameServers
+    Value: !Join
+      - ","
+      - !GetAtt
+        - Orchdev2HostedZone
+        - NameServers
     Export:
       Name: !Sub "${AWS::StackName}-orchdev2-HostedZoneNameServers"
 
   OrchDev3HostedZoneNameServers:
     Condition: DeployDevSubDomains
     Description: "Name servers for the orchdev3 domain"
-    Value: !GetAtt
-      - Orchdev3HostedZone
-      - NameServers
+    Value: !Join
+      - ","
+      - !GetAtt
+        - Orchdev3HostedZone
+        - NameServers
     Export:
       Name: !Sub "${AWS::StackName}-orchdev3-HostedZoneNameServers"

--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -81,29 +81,6 @@ Resources:
               domainSuffix,
             ]
 
-  # Manually Create the NS records sets here as we want to adjust the
-  # TTL to 60 seconds from the default created by the public hosted zone
-  # See here: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-migrating.html#:~:text=The%20typical%20TTL,something%20goes%20wrong.
-  OidcNSRecordSet:
-    Type: AWS::Route53::RecordSet
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      Name: !Sub
-        - oidc${EndpointSuffix}.${DomainSuffix}
-        - DomainSuffix:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              domainSuffix,
-            ]
-      Type: NS
-      HostedZoneId: !Ref OidcHostedZone
-      ResourceRecords: !GetAtt
-        - OidcHostedZone
-        - NameServers
-      TTL: "60"
-
   OidcHostedZoneIdSSMParam:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain

--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -51,7 +51,7 @@ Conditions:
       !Equals [!Ref Environment, dev],
       !Equals [!Ref DeploySubEnvDomains, "Yes"],
     ]
-  DeployCertificate: !And [!Equals [!Ref DeployCertificate, "Yes"]]
+  DeployCertificate: !Equals [!Ref DeployCertificate, "Yes"]
 
 Mappings:
   EnvironmentConfiguration:
@@ -175,6 +175,7 @@ Resources:
         - !Ref AWS::NoValue
 
   OidcCertificateArnSSMParam:
+    Condition: DeployCertificate
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::SSM::Parameter
@@ -283,6 +284,7 @@ Outputs:
 
   CertificateArn:
     Description: "The ARN of the ACM certificate"
+    Condition: DeployCertificate
     Value: !Ref OidcHostedZoneRootCertificate
     Export:
       Name: !Sub "${AWS::StackName}-certificateArn"

--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -104,6 +104,23 @@ Resources:
         - NameServers
       TTL: "60"
 
+  OidcHostedZoneIdSSMParam:
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: !Sub
+        - "SSM parameter to stored the hosted ID for the oidc${EndpointSuffix}.${DomainSuffix} hosted zone"
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+      Name: !Sub "/deploy/hosted-zone/oidc${EndpointSuffix}/hosted-zone-id"
+      Type: String
+      Value: !Ref OidcHostedZone
+
   OidcHostedZoneRootCertificate:
     Condition: DeployCertificate
     DeletionPolicy: Retain
@@ -156,6 +173,23 @@ Resources:
                   domainSuffix,
                 ]
         - !Ref AWS::NoValue
+
+  OidcCertificateArnSSMParam:
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: !Sub
+        - "SSM parameter to stored the ARN of the ACM certificate for the oidc${EndpointSuffix}.${DomainSuffix} domain"
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+      Name: !Sub "/deploy/hosted-zone/oidc${EndpointSuffix}/certificate-Arn"
+      Type: String
+      Value: !Ref OidcHostedZoneRootCertificate
 
   Orchdev1HostedZone:
     Condition: DeployDevSubDomains


### PR DESCRIPTION
### Wider context of change:

- We'd like to deploy our hosted zone stack to the dev account. 

### What’s changed:
- Updates our deploy dev script to deploy the hosted zone 
- Adds the requisite parameters file for dev
- Adds some SSM params to make cross CF stack referencing easier
- Fixes some stuff I got wrong initially 

### Manual testing:
- I've deployed the hosted zone and cert to dev
- Go check they're there
- I've also updated the [domains repo](https://github.com/govuk-one-login/domains/pull/175) with the new name servers
- run `dig +short NS oidc.dev.account.gov.uk` and validate the name servers match the output of the `hosted-zone` stack

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
