### PR TITLE
BAU: Send publicSubjectId in ADAPI access tokens

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -251,10 +251,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             LOG.info("Checking if user has active passkey");
 
             var hasActivePasskeyResult =
-                    passkeysService.hasActivePasskey(
-                            publicSubjectId,
-                            authSession.getInternalCommonSubjectId(),
-                            authSession.getSessionId());
+                    passkeysService.hasActivePasskey(publicSubjectId, authSession.getSessionId());
             if (hasActivePasskeyResult.isFailure()) {
                 LOG.warn(
                         "Error retrieving passkey information for user. Error: {}",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -65,7 +65,7 @@ public class AMCService {
             String internalPairwiseSubject,
             AMCScope amcScope,
             AuthSessionItem authSessionItem,
-            String publicSubject,
+            String publicSubjectId,
             String amcRedirectUri,
             List<AccessTokenConfig> accessTokenConfigs,
             RSAPublicKey publicEncryptionKey,
@@ -74,10 +74,10 @@ public class AMCService {
 
         return createTransportJWTAndAmcCookie(
                         internalPairwiseSubject,
+                        publicSubjectId,
                         amcScope,
                         amcRedirectUri,
                         authSessionItem,
-                        publicSubject,
                         accessTokenConfigs,
                         publicEncryptionKey,
                         state)
@@ -134,10 +134,10 @@ public class AMCService {
 
     private Result<AMCFailureReason, EncryptedJWTAndAmcCookie> createTransportJWTAndAmcCookie(
             String internalPairwiseSubject,
+            String publicSubjectId,
             AMCScope amcScope,
             String amcRedirectUri,
             AuthSessionItem authSessionItem,
-            String publicSubject,
             List<AccessTokenConfig> accessTokenConfigs,
             RSAPublicKey publicEncryptionKey,
             State state) {
@@ -146,8 +146,8 @@ public class AMCService {
 
         return createAccessTokenClaimsMap(
                         accessTokenConfigs,
-                        internalPairwiseSubject,
-                        authSessionItem,
+                        publicSubjectId,
+                        authSessionItem.getSessionId(),
                         issueTime,
                         expiryDate)
                 .flatMap(
@@ -171,7 +171,7 @@ public class AMCService {
                                             .expirationTime(expiryDate)
                                             .subject(internalPairwiseSubject)
                                             .claim("email", authSessionItem.getEmailAddress())
-                                            .claim("public_sub", publicSubject);
+                                            .claim("public_sub", publicSubjectId);
 
                             accessTokenMap.forEach(
                                     (claimName, accessToken) ->
@@ -199,8 +199,8 @@ public class AMCService {
 
     private Result<AMCFailureReason, Map<String, BearerAccessToken>> createAccessTokenClaimsMap(
             List<AccessTokenConfig> configs,
-            String internalPairwiseSubject,
-            AuthSessionItem authSessionItem,
+            String publicSubjectId,
+            String sessionId,
             Date issueTime,
             Date expiryDate) {
         var accessTokens = new HashMap<String, BearerAccessToken>();
@@ -209,9 +209,9 @@ public class AMCService {
             var result =
                     accessTokenConstructorService
                             .createSignedAccessToken(
-                                    internalPairwiseSubject,
+                                    publicSubjectId,
                                     config.scope(),
-                                    authSessionItem.getSessionId(),
+                                    sessionId,
                                     issueTime,
                                     expiryDate,
                                     config.audience(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorService.java
@@ -30,7 +30,7 @@ public class AccessTokenConstructorService {
     }
 
     public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
-            String internalPairwiseSubject,
+            String publicSubjectId,
             AccessTokenScope scope,
             String sessionId,
             Date issueTime,
@@ -47,7 +47,7 @@ public class AccessTokenConstructorService {
                         .expirationTime(expiryDate)
                         .issueTime(issueTime)
                         .notBeforeTime(issueTime)
-                        .subject(internalPairwiseSubject)
+                        .subject(publicSubjectId)
                         .claim("client_id", clientId)
                         .claim("sid", sessionId)
                         .jwtID(UUID.randomUUID().toString())

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -51,16 +51,16 @@ public class PasskeysService {
     }
 
     public Result<PasskeyRetrieveError, Boolean> hasActivePasskey(
-            String publicSubjectId, String internalCommonSubjectId, String sessionId) {
-        return retrievePasskeys(publicSubjectId, internalCommonSubjectId, sessionId)
+            String publicSubjectId, String sessionId) {
+        return retrievePasskeys(publicSubjectId, sessionId)
                 .map(response -> !response.passkeys().isEmpty());
     }
 
     public Result<PasskeyRetrieveError, PasskeysRetrieveResponse> retrievePasskeys(
-            String publicSubjectId, String internalCommonSubjectId, String sessionId) {
+            String publicSubjectId, String sessionId) {
 
         var accountDataApiAccessTokenResult =
-                createAccountDataApiAccessToken(internalCommonSubjectId, sessionId);
+                createAccountDataApiAccessToken(publicSubjectId, sessionId);
         if (accountDataApiAccessTokenResult.isFailure()) {
             return Result.failure(accountDataApiAccessTokenResult.getFailure());
         }
@@ -123,10 +123,10 @@ public class PasskeysService {
     }
 
     private Result<PasskeyRetrieveError, BearerAccessToken> createAccountDataApiAccessToken(
-            String internalCommonSubjectId, String sessionId) {
+            String publicSubjectId, String sessionId) {
         return accessTokenConstructorService
                 .createSignedAccessToken(
-                        internalCommonSubjectId,
+                        publicSubjectId,
                         AccountDataScope.PASSKEY_RETRIEVE,
                         sessionId,
                         nowClock.now(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
@@ -11,9 +11,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -28,15 +26,11 @@ public class AccountDataCredentialRepository implements CredentialRepository {
 
     private final PasskeysService passkeysService;
     private final AuthenticationService authenticationService;
-    private final ConfigurationService configurationService;
 
     public AccountDataCredentialRepository(
-            PasskeysService passkeysService,
-            AuthenticationService authenticationService,
-            ConfigurationService configurationService) {
+            PasskeysService passkeysService, AuthenticationService authenticationService) {
         this.passkeysService = passkeysService;
         this.authenticationService = authenticationService;
-        this.configurationService = configurationService;
     }
 
     @Override
@@ -145,29 +139,12 @@ public class AccountDataCredentialRepository implements CredentialRepository {
     private Optional<List<PasskeysRetrieveResponse.PasskeyResponse>>
             retrievePasskeysForPublicSubjectId(String publicSubjectId) {
         return passkeysService
-                .retrievePasskeys(publicSubjectId, getInternalCommonSubjectId(publicSubjectId), "")
+                .retrievePasskeys(publicSubjectId, "")
                 .fold(
                         failure -> {
                             LOG.warn("Failed to retrieve passkeys: {}", failure);
                             return Optional.empty();
                         },
                         success -> Optional.of(success.passkeys()));
-    }
-
-    private String getInternalCommonSubjectId(String publicSubjectId) {
-        return authenticationService
-                .getOptionalUserProfileFromPublicSubject(publicSubjectId)
-                .map(
-                        userProfile ->
-                                ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                                userProfile,
-                                                configurationService.getInternalSectorUri(),
-                                                authenticationService)
-                                        .getValue())
-                .orElseGet(
-                        () -> {
-                            LOG.warn("Error retrieving internal common subject ID");
-                            return "";
-                        });
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProvider.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProvider.java
@@ -36,7 +36,7 @@ public class RelyingPartyProvider {
 
                     AccountDataCredentialRepository credentialRepository =
                             new AccountDataCredentialRepository(
-                                    passkeysService, authenticationService, configurationService);
+                                    passkeysService, authenticationService);
 
                     return RelyingParty.builder()
                             .identity(rpIdentity)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -627,8 +627,7 @@ class CheckUserExistsHandlerTest {
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
-            when(passkeysService.hasActivePasskey(
-                            eq(userProfile.getPublicSubjectID()), any(), eq(SESSION_ID)))
+            when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID))
                     .thenReturn(Result.success(hasActivePasskey));
 
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
@@ -650,8 +649,7 @@ class CheckUserExistsHandlerTest {
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
 
-            when(passkeysService.hasActivePasskey(
-                            eq(userProfile.getPublicSubjectID()), any(), eq(SESSION_ID)))
+            when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID))
                     .thenReturn(
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -410,7 +410,7 @@ class AMCServiceTest {
             assertAll(
                     "Access Token Claims",
                     () -> assertEquals(AUTH_ISSUER_CLAIM, accessTokenClaims.getIssuer()),
-                    () -> assertEquals(INTERNAL_PAIRWISE_ID, accessTokenClaims.getSubject()),
+                    () -> assertEquals(PUBLIC_SUBJECT, accessTokenClaims.getSubject()),
                     () -> assertEquals(List.of(expectedAudience), accessTokenClaims.getAudience()),
                     () ->
                             assertEquals(
@@ -611,7 +611,7 @@ class AMCServiceTest {
                         any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenAnswer(
                         invocation -> {
-                            String internalPairwiseSubject = invocation.getArgument(0);
+                            String publicSubjectId = invocation.getArgument(0);
                             AccessTokenScope scope = invocation.getArgument(1);
                             String sessionId = invocation.getArgument(2);
                             Date issueTime = invocation.getArgument(3);
@@ -636,7 +636,7 @@ class AMCServiceTest {
                                             .expirationTime(expiryDate)
                                             .issueTime(issueTime)
                                             .notBeforeTime(issueTime)
-                                            .subject(internalPairwiseSubject)
+                                            .subject(publicSubjectId)
                                             .claim("client_id", clientId)
                                             .claim("sid", sessionId)
                                             .jwtID(UUID.randomUUID().toString())

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AccessTokenConstructorServiceTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_PAIRWISE_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 
 class AccessTokenConstructorServiceTest {
@@ -80,7 +80,7 @@ class AccessTokenConstructorServiceTest {
         // Act
         var result =
                 accessTokenConstructorService.createSignedAccessToken(
-                        INTERNAL_PAIRWISE_ID,
+                        PUBLIC_SUBJECT_ID,
                         accessTokenScope,
                         SESSION_ID,
                         NOW,
@@ -100,7 +100,7 @@ class AccessTokenConstructorServiceTest {
         assertEquals(expectedScope, claims.getClaim("scope"));
         assertEquals(ISSUER, claims.getIssuer());
         assertEquals(AUDIENCE, claims.getAudience().get(0));
-        assertEquals(INTERNAL_PAIRWISE_ID, claims.getSubject());
+        assertEquals(PUBLIC_SUBJECT_ID, claims.getSubject());
         assertEquals(AMC_CLIENT_ID, claims.getClaim("client_id"));
         assertEquals(SESSION_ID, claims.getClaim("sid"));
         assertEquals(NOW, claims.getIssueTime());
@@ -117,7 +117,7 @@ class AccessTokenConstructorServiceTest {
         // Act
         var result =
                 accessTokenConstructorService.createSignedAccessToken(
-                        INTERNAL_PAIRWISE_ID,
+                        PUBLIC_SUBJECT_ID,
                         AccountDataScope.PASSKEY_CREATE,
                         SESSION_ID,
                         NOW,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 
@@ -102,9 +101,7 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result =
-                    passkeysService.hasActivePasskey(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isSuccess());
 
             var expectedAuthorizationHeader =
@@ -119,7 +116,7 @@ class PasskeysServiceTest {
                             any());
             verify(accessTokenConstructorService)
                     .createSignedAccessToken(
-                            eq(INTERNAL_COMMON_SUBJECT_ID),
+                            eq(PUBLIC_SUBJECT_ID),
                             eq(AccountDataScope.PASSKEY_RETRIEVE),
                             eq(SESSION_ID),
                             any(),
@@ -145,9 +142,7 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result =
-                    passkeysService.retrievePasskeys(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isSuccess());
             assertEquals(1, result.getSuccess().passkeys().size());
             assertEquals("123456", result.getSuccess().passkeys().get(0).passkeyId());
@@ -167,9 +162,7 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result =
-                    passkeysService.hasActivePasskey(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -190,9 +183,7 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result =
-                    passkeysService.hasActivePasskey(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -220,9 +211,7 @@ class PasskeysServiceTest {
                             any()))
                     .thenThrow(e);
 
-            var result =
-                    passkeysService.hasActivePasskey(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -239,9 +228,7 @@ class PasskeysServiceTest {
                             any()))
                     .thenReturn(httpResponse);
 
-            var result =
-                    passkeysService.retrievePasskeys(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
             assertEquals(
                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
@@ -253,9 +240,7 @@ class PasskeysServiceTest {
                             any(), any(), any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
 
-            var result =
-                    passkeysService.hasActivePasskey(
-                            PUBLIC_SUBJECT_ID, INTERNAL_COMMON_SUBJECT_ID, SESSION_ID);
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
 
             assertTrue(result.isFailure());
             assertEquals(PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN, result.getFailure());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.frontendapi.services.webauthn;
 import com.yubico.webauthn.CredentialRepository;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
@@ -11,9 +10,7 @@ import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeysRetrieveResp
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -36,20 +33,10 @@ class AccountDataCredentialRepositoryTest {
 
     private final PasskeysService passkeysService = mock(PasskeysService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AccountDataCredentialRepository repository =
-            new AccountDataCredentialRepository(
-                    passkeysService, authenticationService, configurationService);
+            new AccountDataCredentialRepository(passkeysService, authenticationService);
 
     private static final String PASSKEY_ID_BASE64URL = "dGVzdC1jcmVkZW50aWFsLWlk";
-    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
-    private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
-
-    @BeforeEach
-    void setUp() {
-        when(authenticationService.getOrGenerateSalt(any())).thenReturn(TEST_SALT);
-        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
-    }
 
     @Test
     void implementsCredentialRepository() {
@@ -61,7 +48,7 @@ class AccountDataCredentialRepositoryTest {
         @Test
         void returnsCredentialIdsWhenPasskeysExist() {
             setupUserProfile();
-            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any()))
                     .thenReturn(
                             Result.success(
                                     new PasskeysRetrieveResponse(
@@ -80,7 +67,7 @@ class AccountDataCredentialRepositoryTest {
         @Test
         void returnsEmptySetWhenNoPasskeys() {
             setupUserProfile();
-            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any()))
                     .thenReturn(Result.success(new PasskeysRetrieveResponse(List.of())));
 
             var result = repository.getCredentialIdsForUsername(EMAIL);
@@ -101,7 +88,7 @@ class AccountDataCredentialRepositoryTest {
         @Test
         void returnsEmptySetWhenApiCallFails() {
             setupUserProfile();
-            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any()))
                     .thenReturn(
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));
@@ -174,7 +161,7 @@ class AccountDataCredentialRepositoryTest {
 
         @Test
         void returnsRegisteredCredentialWhenFound() {
-            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any()))
                     .thenReturn(
                             Result.success(
                                     new PasskeysRetrieveResponse(
@@ -192,7 +179,7 @@ class AccountDataCredentialRepositoryTest {
 
         @Test
         void returnsEmptyWhenCredentialNotFound() {
-            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any()))
                     .thenReturn(Result.success(new PasskeysRetrieveResponse(List.of())));
             var credentialId = new ByteArray(Base64.getUrlDecoder().decode(PASSKEY_ID_BASE64URL));
 
@@ -203,7 +190,7 @@ class AccountDataCredentialRepositoryTest {
 
         @Test
         void returnsEmptyWhenApiCallFails() {
-            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any(), any()))
+            when(passkeysService.retrievePasskeys(eq(PUBLIC_SUBJECT_ID), any()))
                     .thenReturn(
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));
@@ -235,8 +222,6 @@ class AccountDataCredentialRepositoryTest {
                                 .withPublicSubjectID(PUBLIC_SUBJECT_ID)
                                 .withSubjectID("subject"));
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(userProfile);
-        when(authenticationService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
-                .thenReturn(userProfile);
     }
 
     private static PasskeysRetrieveResponse.PasskeyResponse aPasskeyResponse(String passkeyId) {


### PR DESCRIPTION
## What

We were sending the internalPairwiseSubjectId as the subject on the ADAPI access token. After building the authoriser we realised this was incorrect so have changed that subject to the be the publicSubjectId

## How to review

1. Code review
