### PR TITLE
ATO-2519: add account_data_api_access_token as a valid claim

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaims.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaims.java
@@ -17,7 +17,8 @@ public enum AuthUserInfoClaims {
     VERIFIED_MFA_METHOD_TYPE("verified_mfa_method_type"),
     NEW_ACCOUNT("new_account"),
     UPLIFT_REQUIRED("uplift_required"),
-    ACHIEVED_CREDENTIAL_STRENGTH("achieved_credential_strength");
+    ACHIEVED_CREDENTIAL_STRENGTH("achieved_credential_strength"),
+    ACCOUNT_DATA_API_ACCESS_TOKEN("account_data_api_access_token");
 
     private final String value;
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaimsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/AuthUserInfoClaimsTest.java
@@ -27,7 +27,8 @@ class AuthUserInfoClaimsTest {
                 "verified_mfa_method_type",
                 "email",
                 "new_account",
-                "achieved_credential_strength");
+                "achieved_credential_strength",
+                "account_data_api_access_token");
     }
 
     static Stream<String> unsupportedClaims() {
@@ -36,7 +37,7 @@ class AuthUserInfoClaimsTest {
 
     @Test
     void shouldReturnCorrectNumberOfClaimsSupported() {
-        assertThat(AuthUserInfoClaims.getAllValidClaims().size(), equalTo(13));
+        assertThat(AuthUserInfoClaims.getAllValidClaims().size(), equalTo(14));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Wider context of change

As part of auth's passkeys work, Home and Authentication are building a new component - the Account Management Component, which means Home will need to be able to authenticate to create a passkey.

### What’s changed

Adds `account_data_api_access_token` as a valid AuthUserInfoClaim

### Manual testing

N/A

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**