### PR TITLE
Bau/refactor put audit events

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -14,8 +14,8 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.List;
 import java.util.Map;
@@ -51,7 +51,7 @@ public class AuditHelper {
 
     public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
             ConfigurationService configurationService,
-            DynamoService dynamoService,
+            AuthenticationService authenticationService,
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile) {
         try {
@@ -67,7 +67,7 @@ public class AuditHelper {
                             ClientSubjectHelper.getSubjectWithSectorIdentifier(
                                             userProfile,
                                             configurationService.getInternalSectorUri(),
-                                            dynamoService)
+                                            authenticationService)
                                     .getValue(),
                             userProfile.getEmail(),
                             IpAddressHelper.extractIpAddress(input),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -568,23 +568,18 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        var maybeAuditContext = buildAuditContext(auditEvent, input, putRequest, mfaMethod);
-
-        if (maybeAuditContext.isFailure()) {
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(500, maybeAuditContext.getFailure()));
-        }
-
-        var result =
-                AuditHelper.sendAuditEvent(
-                        auditEvent, maybeAuditContext.getSuccess(), auditService, LOG);
-
-        if (result.isFailure()) {
-            return Result.failure(generateApiGatewayProxyErrorResponse(500, result.getFailure()));
-        }
-
-        LOG.info("Successfully submitted audit event: {}", auditEvent.name());
-        return Result.success(null);
+        return buildAuditContext(auditEvent, input, putRequest, mfaMethod)
+                .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
+                .flatMap(
+                        context ->
+                                AuditHelper.sendAuditEvent(auditEvent, context, auditService, LOG)
+                                        .mapFailure(
+                                                f -> generateApiGatewayProxyErrorResponse(500, f)))
+                .map(
+                        success -> {
+                            LOG.info("Successfully submitted audit event: {}", auditEvent.name());
+                            return success;
+                        });
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> emitAuditEventForAuthAppUpdate(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -17,7 +17,6 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -53,7 +52,6 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
@@ -614,11 +612,7 @@ public class MFAMethodsPutHandler
                         .withMetadataItem(
                                 pair(
                                         AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        PriorityIdentifier.DEFAULT.name().toLowerCase()))
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                        JourneyType.ACCOUNT_MANAGEMENT.getValue()));
+                                        PriorityIdentifier.DEFAULT.name().toLowerCase()));
 
         auditService.submitAuditEvent(
                 AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -618,17 +618,17 @@ public class MFAMethodsPutHandler
     private AuditContext buildAuditContext(
             AccountManagementAuditableEvent auditEvent,
             ValidPutRequest putRequest,
-            MFAMethod mfaMethod,
+            MFAMethod retrievedMfaMethod,
             AuditContext baseContext) {
         var phoneNumber =
-                mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
-                        ? mfaMethod.getDestination()
+                retrievedMfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
+                        ? retrievedMfaMethod.getDestination()
                         : AuditService.UNKNOWN;
         var context = baseContext.withPhoneNumber(phoneNumber);
 
         if (!(auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
                 || auditEvent.equals(AUTH_CODE_VERIFIED))) {
-            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
+            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, retrievedMfaMethod.getMfaMethodType());
             context = context.withMetadataItem(mfaTypePair);
         }
 
@@ -636,7 +636,7 @@ public class MFAMethodsPutHandler
                 || auditEvent.equals(AUTH_INVALID_CODE_SENT)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
             var priorityPair =
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaMethod.getPriority().toLowerCase());
+                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, retrievedMfaMethod.getPriority().toLowerCase());
             context = context.withMetadataItem(priorityPair);
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -59,7 +59,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
-import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -678,10 +677,6 @@ public class MFAMethodsPutHandler
             }
             context =
                     context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                            ACCOUNT_MANAGEMENT.name()))
                             .withMetadataItem(
                                     pair(
                                             AUDIT_EVENT_EXTENSIONS_MFA_METHOD,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -628,7 +628,8 @@ public class MFAMethodsPutHandler
 
         if (!(auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
                 || auditEvent.equals(AUTH_CODE_VERIFIED))) {
-            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, retrievedMfaMethod.getMfaMethodType());
+            var mfaTypePair =
+                    pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, retrievedMfaMethod.getMfaMethodType());
             context = context.withMetadataItem(mfaTypePair);
         }
 
@@ -636,7 +637,9 @@ public class MFAMethodsPutHandler
                 || auditEvent.equals(AUTH_INVALID_CODE_SENT)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
             var priorityPair =
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, retrievedMfaMethod.getPriority().toLowerCase());
+                    pair(
+                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                            retrievedMfaMethod.getPriority().toLowerCase());
             context = context.withMetadataItem(priorityPair);
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -568,8 +568,10 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        return buildAuditContext(auditEvent, input, putRequest, mfaMethod)
+        return accountManagementAuditContext(
+                        configurationService, authenticationService, input, putRequest.userProfile)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
+                .map(context -> buildAuditContext(auditEvent, putRequest, mfaMethod, context))
                 .flatMap(
                         context ->
                                 AuditHelper.sendAuditEvent(auditEvent, context, auditService, LOG)
@@ -613,24 +615,16 @@ public class MFAMethodsPutHandler
         return Result.success(null);
     }
 
-    private Result<ErrorResponse, AuditContext> buildAuditContext(
+    private AuditContext buildAuditContext(
             AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
-            MFAMethod mfaMethod) {
-        var auditContextResult =
-                accountManagementAuditContext(
-                        configurationService, authenticationService, input, putRequest.userProfile);
-
-        if (auditContextResult.isFailure()) {
-            return auditContextResult;
-        }
-
+            MFAMethod mfaMethod,
+            AuditContext baseContext) {
         var phoneNumber =
                 mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
                         ? mfaMethod.getDestination()
                         : AuditService.UNKNOWN;
-        var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
+        var context = baseContext.withPhoneNumber(phoneNumber);
 
         if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
             var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
@@ -667,6 +661,6 @@ public class MFAMethodsPutHandler
                             .withMetadataItem(mfaTypePair);
         }
 
-        return Result.success(context);
+        return context;
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -600,8 +600,8 @@ public class MFAMethodsPutHandler
         }
 
         var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.getValue());
-        // TODO: check whether this should always be default
-        var priorityPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
+        var priority = putRequest.request.mfaMethod().priorityIdentifier().toString().toLowerCase();
+        var priorityPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority);
 
         var auditContext =
                 maybeAuditContext

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -27,11 +27,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodUpdateIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodUpdateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetail;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
-import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
-import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -54,6 +50,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -62,7 +59,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
-import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
@@ -601,7 +597,7 @@ public class MFAMethodsPutHandler
         }
 
         var maybeAuditContext =
-                AuditHelper.accountManagementAuditContext(
+                accountManagementAuditContext(
                         configurationService, dynamoService, input, putRequest.userProfile);
 
         if (maybeAuditContext.isFailure()) {
@@ -636,99 +632,69 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        try {
-            var phoneNumber =
-                    mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
-                            ? mfaMethod.getDestination()
-                            : AuditService.UNKNOWN;
+        var auditContextResult =
+                accountManagementAuditContext(
+                        configurationService, authenticationService, input, putRequest.userProfile);
 
-            var initialMetadataPairs =
-                    new AuditService.MetadataPair[] {
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                JourneyType.ACCOUNT_MANAGEMENT.getValue()),
-                    };
-
-            var context =
-                    new AuditContext(
-                            input.getRequestContext()
-                                    .getAuthorizer()
-                                    .getOrDefault(ATTRIBUTE_CLIENT_ID, AuditService.UNKNOWN)
-                                    .toString(),
-                            ClientSessionIdHelper.extractSessionIdFromHeaders(input.getHeaders()),
-                            RequestHeaderHelper.getHeaderValueOrElse(
-                                    input.getHeaders(), SESSION_ID_HEADER, ""),
-                            ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                            putRequest.userProfile,
-                                            configurationService.getInternalSectorUri(),
-                                            authenticationService)
-                                    .getValue(),
-                            putRequest.userProfile.getEmail(),
-                            IpAddressHelper.extractIpAddress(input),
-                            phoneNumber,
-                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
-                            List.of(initialMetadataPairs));
-
-            if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-                context =
-                        context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                        mfaMethod.getMfaMethodType()));
-            }
-
-            if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
-                    || auditEvent.equals(AUTH_INVALID_CODE_SENT)
-                    || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-                context =
-                        context.withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        mfaMethod.getPriority().toLowerCase()));
-            }
-
-            if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
-                if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
-                        && requestSmsMfaDetail.otp() != null) {
-                    context =
-                            context.withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                    requestSmsMfaDetail.otp()))
-                                    .withMetadataItem(
-                                            pair(
-                                                    AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                    MFA_SMS.name()));
-                }
-                context =
-                        context.withMetadataItem(
-                                        pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                                ACCOUNT_MANAGEMENT.name()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                requestedMethod
-                                                        .priorityIdentifier()
-                                                        .name()
-                                                        .toLowerCase()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                                requestedMethod
-                                                        .method()
-                                                        .mfaMethodType()
-                                                        .toString()));
-            }
-
-            return Result.success(context);
-        } catch (Exception e) {
-            LOG.error("Error building audit context", e);
-            return Result.failure(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);
+        if (auditContextResult.isFailure()) {
+            return auditContextResult;
         }
+
+        var phoneNumber =
+                mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
+                        ? mfaMethod.getDestination()
+                        : AuditService.UNKNOWN;
+        var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
+
+        if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+            context =
+                    context.withMetadataItem(
+                            pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType()));
+        }
+
+        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
+                || auditEvent.equals(AUTH_INVALID_CODE_SENT)
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+            context =
+                    context.withMetadataItem(
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                    mfaMethod.getPriority().toLowerCase()));
+        }
+
+        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
+            MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
+            if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
+                    && requestSmsMfaDetail.otp() != null) {
+                context =
+                        context.withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
+                                                requestSmsMfaDetail.otp()))
+                                .withMetadataItem(
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
+                                                MFA_SMS.name()));
+            }
+            context =
+                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
+                            .withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
+                                            ACCOUNT_MANAGEMENT.name()))
+                            .withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                            requestedMethod
+                                                    .priorityIdentifier()
+                                                    .name()
+                                                    .toLowerCase()))
+                            .withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                                            requestedMethod.method().mfaMethodType().toString()));
+        }
+
+        return Result.success(context);
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -626,7 +626,8 @@ public class MFAMethodsPutHandler
                         : AuditService.UNKNOWN;
         var context = baseContext.withPhoneNumber(phoneNumber);
 
-        if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+        if (!(auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
+                || auditEvent.equals(AUTH_CODE_VERIFIED))) {
             var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
             context = context.withMetadataItem(mfaTypePair);
         }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -602,17 +602,15 @@ public class MFAMethodsPutHandler
                     generateApiGatewayProxyErrorResponse(401, maybeAuditContext.getFailure()));
         }
 
+        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.getValue());
+        // TODO: check whether this should always be default
+        var priorityPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
+
         var auditContext =
                 maybeAuditContext
                         .getSuccess()
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                        MFAMethodType.AUTH_APP.getValue()))
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                        PriorityIdentifier.DEFAULT.name().toLowerCase()));
+                        .withMetadataItem(mfaTypePair)
+                        .withMetadataItem(priorityPair);
 
         auditService.submitAuditEvent(
                 AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);
@@ -640,48 +638,38 @@ public class MFAMethodsPutHandler
         var context = auditContextResult.getSuccess().withPhoneNumber(phoneNumber);
 
         if (!auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-            context =
-                    context.withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType()));
+            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
+            context = context.withMetadataItem(mfaTypePair);
         }
 
         if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
                 || auditEvent.equals(AUTH_INVALID_CODE_SENT)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-            context =
-                    context.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    mfaMethod.getPriority().toLowerCase()));
+            var priorityPair =
+                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaMethod.getPriority().toLowerCase());
+            context = context.withMetadataItem(priorityPair);
         }
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
             MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
             if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
                     && requestSmsMfaDetail.otp() != null) {
+                var codeEnteredPair =
+                        pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, requestSmsMfaDetail.otp());
+                var notificationTypePair =
+                        pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
                 context =
-                        context.withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED,
-                                                requestSmsMfaDetail.otp()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE,
-                                                MFA_SMS.name()));
+                        context.withMetadataItem(codeEnteredPair)
+                                .withMetadataItem(notificationTypePair);
             }
+            var priority = requestedMethod.priorityIdentifier().name().toLowerCase();
+            var mfaType = requestedMethod.method().mfaMethodType().toString();
+            var priorityPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority);
+            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType);
             context =
                     context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                            requestedMethod
-                                                    .priorityIdentifier()
-                                                    .name()
-                                                    .toLowerCase()))
-                            .withMetadataItem(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                                            requestedMethod.method().mfaMethodType().toString()));
+                            .withMetadataItem(priorityPair)
+                            .withMetadataItem(mfaTypePair);
         }
 
         return Result.success(context);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -702,7 +702,6 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_NUMBER));
 
-            // Query: should this instead be reflecting the method that has failed to add? Ie sms
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(null)

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -635,14 +635,12 @@ class MFAMethodsPutHandlerTest {
         var expectedAuditContext =
                 BASE_AUDIT_CONTEXT
                         .withPhoneNumber(UK_MOBILE_NUMBER)
-                        .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()))
                         .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                         .withMetadataItem(pair("notification-type", "MFA_SMS"))
                         .withMetadataItem(pair("account-recovery", "false"))
                         .withMetadataItem(
                                 pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
                         .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
-        // mfa type also repeated - to fix
 
         verify(auditService)
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -639,11 +639,9 @@ class MFAMethodsPutHandlerTest {
                         .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                         .withMetadataItem(pair("notification-type", "MFA_SMS"))
                         .withMetadataItem(pair("account-recovery", "false"))
-                        .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()))
                         .withMetadataItem(
                                 pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
                         .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
-        // journey type repeated here (also in base context)- to fix
         // mfa type also repeated - to fix
 
         verify(auditService)

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -1321,9 +1321,7 @@ class MFAMethodsPutHandlerTest {
                 BASE_AUDIT_CONTEXT
                         .withPhoneNumber(null)
                         .withMetadataItem(pair("mfa-type", "AUTH_APP"))
-                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()))
-                        .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
-        // Journey type duplicated here - in base context
+                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
 
         verify(auditService)
                 .submitAuditEvent(


### PR DESCRIPTION
Refactors audit event creation in the put handler to:

* Reduce noise and improve readability
* Reuse an existing helper method
* Remove some duplicate adding of metadata pair

At some point I'd like to radically simplify things by removing metadata pairs from the audit context (which shouldn't contain any event-specific data) but this left to a later point.
