### PR TITLE
ATO-2520: request account_data_api_access_token claim in AuthenticationAuthorizationService

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
@@ -339,6 +339,7 @@ public class AuthenticationAuthorizationService {
         if (amScopePresent) {
             LOG.info("am scope is present. Adding the public_subject_id claim");
             claimsSet.add(AuthUserInfoClaims.PUBLIC_SUBJECT_ID);
+            claimsSet.add(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN);
         } else if (PUBLIC.toString().equalsIgnoreCase(clientRegistry.getSubjectType())) {
             LOG.info("client has PUBLIC subjectType. Adding the public_subject_id claim");
             claimsSet.add(AuthUserInfoClaims.PUBLIC_SUBJECT_ID);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
@@ -68,6 +68,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -84,6 +85,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.oidc.entity.AuthErrorCodes.SFAD_ERROR;
 import static uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX;
 import static uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService.GOOGLE_ANALYTICS_QUERY_PARAMETER_KEY;
+import static uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN;
 import static uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH;
 import static uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims.EMAIL;
 import static uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims.EMAIL_VERIFIED;
@@ -207,6 +209,7 @@ class AuthenticationAuthorizationServiceTest {
                             .readValue(claimsSet.getClaim("claim").toString(), Map.class);
             var actualUserInfoClaims = (Map<String, String>) actualUserinfo.get("userinfo");
             assertRequiredUserInfoClaimsAreSet(actualUserInfoClaims);
+            assertFalse(actualUserInfoClaims.containsKey(ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test
@@ -242,6 +245,7 @@ class AuthenticationAuthorizationServiceTest {
             assertRequiredUserInfoClaimsAreSet(actualUserInfoClaims);
             assertTrue(actualUserInfoClaims.containsKey(PHONE_NUMBER.getValue()));
             assertTrue(actualUserInfoClaims.containsKey(SALT.getValue()));
+            assertFalse(actualUserInfoClaims.containsKey(ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test
@@ -292,6 +296,7 @@ class AuthenticationAuthorizationServiceTest {
                             .readValue(claimsSet.getClaim("claim").toString(), Map.class);
             var actualUserInfoClaims = (Map<String, String>) actualUserinfo.get("userinfo");
             assertRequiredUserInfoClaimsAreSet(actualUserInfoClaims);
+            assertFalse(actualUserInfoClaims.containsKey(ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test
@@ -469,7 +474,8 @@ class AuthenticationAuthorizationServiceTest {
         }
 
         @Test
-        void shouldAddPublicSubjectIdClaimIfAuthRequestHasAmScope() throws Exception {
+        void shouldAddPublicSubjectIdClaimAndAccountDataApiAccessTokenClaimIfAuthRequestHasAmScope()
+                throws Exception {
             var authRequest =
                     authRequestBuilder(AUTH_ONLY_VTR).scope(Scope.parse("openid am")).build();
             authService.generateAuthRedirectRequest(
@@ -491,6 +497,7 @@ class AuthenticationAuthorizationServiceTest {
                             .readValue(claimsSet.getClaim("claim").toString(), Map.class);
             var actualUserInfoClaims = (Map<String, String>) actualUserinfo.get("userinfo");
             assertTrue(actualUserInfoClaims.containsKey(PUBLIC_SUBJECT_ID.getValue()));
+            assertTrue(actualUserInfoClaims.containsKey(ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test


### PR DESCRIPTION
### Wider context of change

As part of auth's passkeys work, Home and Authentication are building a new component - the Account Management Component, which means Home will need to be able to authenticate to create a passkey.

### What’s changed

If AM scope exists, the `account_data_api_access_token` claim is added.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8245