### PR TITLE
ATO-2521: return account_data_api_access_token if AM scope present in UserInfoService

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -124,6 +124,10 @@ public class UserInfoService {
             userInfo.setClaim(
                     AuthUserInfoClaims.PUBLIC_SUBJECT_ID.getValue(),
                     tmpUserInfo.getClaim(AuthUserInfoClaims.PUBLIC_SUBJECT_ID.getValue()));
+            userInfo.setClaim(
+                    AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue(),
+                    tmpUserInfo.getClaim(
+                            AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
         if (accessTokenInfo.scopes().contains(CustomScopeValue.WALLET_SUBJECT_ID.getValue())) {
             var walletSubjectID = calculateWalletSubjectID(accessTokenInfo);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
@@ -38,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -136,6 +138,7 @@ class UserInfoServiceTest {
         assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
+        assertNull(userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
     }
 
     @Test
@@ -177,6 +180,7 @@ class UserInfoServiceTest {
         assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        assertNull(userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
     }
 
     @Nested
@@ -207,6 +211,8 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+            assertNull(
+                    userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test
@@ -263,6 +269,8 @@ class UserInfoServiceTest {
             assertThat(passportClaim.toJSONString(), equalTo(PASSPORT_CLAIM));
             assertThat(drivingPermitClaim.toJSONString(), equalTo(DRIVING_PERMIT));
             assertThat(returnCodeClaim.toJSONString(), equalTo(RETURN_CODE));
+            assertNull(
+                    userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
@@ -298,6 +306,8 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+            assertNull(
+                    userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test
@@ -327,6 +337,8 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+            assertNull(
+                    userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
         }
 
         @Test
@@ -367,8 +379,57 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
+            assertNull(
+                    userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+        }
+
+        @Test
+        void shouldJustPopulateAccountDataApiAccessTokenClaimWhenOnlyAmScopeIsPresent()
+                throws AccessTokenException, ClientNotFoundException, ParseException {
+            givenThereIsUserInfo();
+            when(configurationService.isIdentityEnabled()).thenReturn(false);
+            var scopes =
+                    List.of(
+                            OIDCScopeValue.OPENID.getValue(),
+                            CustomScopeValue.ACCOUNT_MANAGEMENT.getValue());
+
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(),
+                            JOURNEY_ID,
+                            SUBJECT.getValue(),
+                            scopes,
+                            null,
+                            CLIENT_ID);
+
+            UserInfo testUserInfo = new UserInfo(INTERNAL_SUBJECT);
+            testUserInfo.setEmailAddress(EMAIL);
+            testUserInfo.setEmailVerified(true);
+            testUserInfo.setPhoneNumber(PHONE_NUMBER);
+            testUserInfo.setPhoneNumberVerified(true);
+            testUserInfo.setClaim(
+                    AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue(), "test-token");
+
+            when(userInfoStorageService.getAuthenticationUserInfo(
+                            INTERNAL_PAIRWISE_SUBJECT.getValue(), JOURNEY_ID))
+                    .thenReturn(Optional.of(testUserInfo));
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertEquals(
+                    "test-token",
+                    userInfo.getClaim(AuthUserInfoClaims.ACCOUNT_DATA_API_ACCESS_TOKEN.getValue()));
+            assertNull(userInfo.getPhoneNumber());
+            assertNull(userInfo.getPhoneNumberVerified());
+            assertNull(userInfo.getEmailAddress());
+            assertNull(userInfo.getEmailVerified());
+            assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.RETURN_CODE.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
         }
     }
 


### PR DESCRIPTION
### Wider context of change

As part of auth's passkeys work, Home and Authentication are building a new component - the Account Management Component, which means Home will need to be able to authenticate to create a passkey.

### What’s changed

Return `account_data_api_access_token` if AM scope is present in UserInfoService

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8247
