### PR TITLE
ATO 2482 use a new session-ended page

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -336,7 +336,7 @@ public class DocAppCallbackHandler
                     authFrontend.errorURI(), e);
         } catch (NoSessionException e) {
             return RedirectService.redirectToFrontendErrorPageForNoSession(
-                    authFrontend.errorURI(), e);
+                    authFrontend.sessionEndedURI(), e);
         } catch (ParseException e) {
             return RedirectService.redirectToFrontendErrorPageWithErrorLog(
                     authFrontend.errorURI(),

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -98,6 +98,8 @@ class DocAppCallbackHandlerTest {
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
 
     private static final URI EXPECTED_ERROR_REDIRECT_URI = URI.create("https://example.com/error");
+    private static final URI EXPECTED_SESSION_ENDED_REDIRECT_URI =
+            URI.create("https://example.com/session-ended");
 
     private static final URI DOC_APP_CRI_V2_URI = URI.create("https://base-url.com/userinfo/v2");
     private static final URI CRI_URI = URI.create("http://cri/");
@@ -165,6 +167,7 @@ class DocAppCallbackHandlerTest {
                         docAppCriApi,
                         orchSessionService);
         when(authFrontend.errorURI()).thenReturn(EXPECTED_ERROR_REDIRECT_URI);
+        when(authFrontend.sessionEndedURI()).thenReturn(EXPECTED_SESSION_ENDED_REDIRECT_URI);
         when(docAppCriApi.criDataURI()).thenReturn(DOC_APP_CRI_V2_URI);
         when(configService.getDocAppBackendURI()).thenReturn(CRI_URI);
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
@@ -506,7 +509,7 @@ class DocAppCallbackHandlerTest {
 
     @Test
     void
-            shouldRedirectToFrontendErrorPageWhenNoSessionCookieButCallToNoSessionOrchestrationServiceThrowsException()
+            shouldRedirectToSessionEndedPageWhenNoSessionCookieButCallToNoSessionOrchestrationServiceThrowsException()
                     throws NoSessionException {
         usingValidClientSession();
 
@@ -529,7 +532,7 @@ class DocAppCallbackHandlerTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get("Location"),
-                equalTo(EXPECTED_ERROR_REDIRECT_URI.toString()));
+                equalTo(EXPECTED_SESSION_ENDED_REDIRECT_URI.toString()));
         assertThat(
                 redirectLogging.events(),
                 hasItem(

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthenticationCallbackHandlerIntegrationTest.java
@@ -111,8 +111,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     public static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID);
     public static final State RP_STATE = new State();
     public static final State ORCH_TO_AUTH_STATE = new State();
-    private static final String ERROR_ENDPOINT = "error";
     private static final String BLOCKED_ENDPOINT = "unavailable-permanent";
+    private static final String SESSION_ENDED_ENDPOINT = "session-ended";
     private static final String SUSPENDED_ENDPOINT = "unavailable-temporary";
 
     @RegisterExtension
@@ -325,11 +325,12 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     }
 
     @Test
-    void shouldRedirectToFrontendErrorPageWhenNoSessionCookieAndNoQueryParams() {
+    void shouldRedirectToSessionEndedPageWhenNoSessionCookieAndNoQueryParams() {
         var response = makeRequest(Optional.empty(), emptyMap(), emptyMap());
 
         var expectedURI =
-                buildURI(configurationService.getAuthFrontendBaseURL(), ERROR_ENDPOINT).toString();
+                buildURI(configurationService.getAuthFrontendBaseURL(), SESSION_ENDED_ENDPOINT)
+                        .toString();
         assertThat(response, hasStatus(302));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(expectedURI));
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -595,7 +595,7 @@ public class AuthenticationCallbackHandler
                     new Error("Cannot retrieve auth request params from client session id"));
         } catch (NoSessionException | SessionNotFoundException e) {
             return RedirectService.redirectToFrontendErrorPageForNoSession(
-                    authFrontend.errorURI(), e);
+                    authFrontend.sessionEndedURI(), e);
         }
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -172,6 +172,8 @@ class AuthenticationCallbackHandlerTest {
     private static final String TEST_FRONTEND_BASE_URI = "http://example.com";
     private static final String TEST_FRONTEND_LOGIN_URI = "http://example.com/login";
     private static final String TEST_FRONTEND_ERROR_URI = "http://example.com/error";
+    private static final String TEST_FRONTEND_SESSION_ENDED_URI =
+            "http://example.com/session-ended";
     private static final String TEST_AUTH_BACKEND_BASE_URL = "https://test.auth.backend.url";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String PERSISTENT_SESSION_ID =
@@ -221,6 +223,8 @@ class AuthenticationCallbackHandlerTest {
         when(configurationService.getEnvironment()).thenReturn("test-env");
         when(authFrontend.errorURI()).thenReturn(URI.create(TEST_FRONTEND_ERROR_URI));
         when(authFrontend.baseURI()).thenReturn(URI.create(TEST_FRONTEND_BASE_URI));
+        when(authFrontend.sessionEndedURI())
+                .thenReturn(URI.create(TEST_FRONTEND_SESSION_ENDED_URI));
         when(authFrontend.authorizeURI(any(), any()))
                 .thenReturn(URI.create(TEST_FRONTEND_LOGIN_URI));
         when(configurationService.getAuthenticationBackendURI())
@@ -453,7 +457,7 @@ class AuthenticationCallbackHandlerTest {
 
     @Test
     void
-            shouldRedirectToFrontendErrorPageWhenNoSessionCookieButCallToNoSessionOrchestrationServiceThrowsException()
+            shouldRedirectToFrontendSessionEndedPageWhenNoSessionCookieButCallToNoSessionOrchestrationServiceThrowsException()
                     throws NoSessionException {
         var event = new APIGatewayProxyRequestEvent();
 
@@ -470,7 +474,7 @@ class AuthenticationCallbackHandlerTest {
         var response = handler.handleRequest(event, CONTEXT);
 
         assertThat(response, hasStatus(302));
-        assertThat(response.getHeaders().get("Location"), equalTo(TEST_FRONTEND_ERROR_URI));
+        assertThat(response.getHeaders().get("Location"), equalTo(TEST_FRONTEND_SESSION_ENDED_URI));
 
         verifyNoInteractions(tokenService, auditService, userInfoStorageService, metrics);
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/AuthFrontend.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/AuthFrontend.java
@@ -71,4 +71,8 @@ public class AuthFrontend implements CommonFrontend {
     public URI errorIpvCallbackURI() {
         return buildURI(frontendBaseUri, "ipv-callback-session-expiry-error");
     }
+
+    public URI sessionEndedUri() {
+        return buildURI(frontendBaseUri, "session-ended");
+    }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/AuthFrontend.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/AuthFrontend.java
@@ -72,7 +72,7 @@ public class AuthFrontend implements CommonFrontend {
         return buildURI(frontendBaseUri, "ipv-callback-session-expiry-error");
     }
 
-    public URI sessionEndedUri() {
+    public URI sessionEndedURI() {
         return buildURI(frontendBaseUri, "session-ended");
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/CommonFrontend.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/api/CommonFrontend.java
@@ -11,4 +11,6 @@ public interface CommonFrontend {
     URI errorURI();
 
     URI errorIpvCallbackURI();
+
+    URI sessionEndedURI();
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/api/AuthFrontendTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/api/AuthFrontendTest.java
@@ -139,4 +139,11 @@ class AuthFrontendTest {
         var actualUri = authFrontend.errorIpvCallbackURI();
         assertThat(actualUri, equalTo(expectedUri));
     }
+
+    @Test
+    void sessionEndedURIReturnsCorrectUri() {
+        var expectedUri = URI.create("https://auth.frontend/session-ended");
+        var actualUri = authFrontend.sessionEndedUri();
+        assertThat(actualUri, equalTo(expectedUri));
+    }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/api/AuthFrontendTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/api/AuthFrontendTest.java
@@ -143,7 +143,7 @@ class AuthFrontendTest {
     @Test
     void sessionEndedURIReturnsCorrectUri() {
         var expectedUri = URI.create("https://auth.frontend/session-ended");
-        var actualUri = authFrontend.sessionEndedUri();
+        var actualUri = authFrontend.sessionEndedURI();
         assertThat(actualUri, equalTo(expectedUri));
     }
 }


### PR DESCRIPTION
### Wider context of change

Auth want to have better metrics around error, and session-related errors are an obstacle to that.  They built a new session-ended page for use to use with redirects.  This PR brings that page into use by orchestration-managed lambda handlers.

### What’s changed

Redirects for session-related errors now point to a different frontend page.



### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.


