### PR TITLE
AUT-5369: Normalise phone numbers to E.164 in audit events

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -417,7 +417,8 @@ public class MFAMethodsCreateHandler
             AccountManagementAuditableEvent auditEvent,
             RequestSmsMfaDetail smsDetail) {
         var updatedContext =
-                context.withPhoneNumber(smsDetail.phoneNumber())
+                context.withPhoneNumber(
+                                PhoneNumberHelper.formatPhoneNumber(smsDetail.phoneNumber()))
                         .withMetadataItem(
                                 pair(
                                         AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -95,6 +95,7 @@ class MFAMethodsCreateHandlerTest {
 
     private final Context context = mock(Context.class);
     private static final String TEST_PHONE_NUMBER = "07123123123";
+    private static final String TEST_E164_PHONE_NUMBER = "+447123123123";
     private static final String TEST_EMAIL = "test@test.com";
     private static final String TEST_SMS_MFA_ID = "35c7940d-be5f-4b31-95b7-0eedc42929b9";
     private static final String TEST_AUTH_APP_ID = "f2ec40f3-9e63-496c-a0a5-a3bdafee868b";
@@ -284,7 +285,7 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedAuthCodeVerifiedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("phone_number_country_code", "44"))
@@ -300,7 +301,7 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedAuthMfaMethodAddCompleteContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("phone_number_country_code", "44"));
@@ -313,7 +314,7 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedUpdatedPhoneNumberContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("phone_number_country_code", "44"));
@@ -470,7 +471,7 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedAuthCodeVerifiedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("phone_number_country_code", "44"))
@@ -780,7 +781,7 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedInvalidCodeSentAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_PHONE_NUMBER)
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.toString()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("phone_number_country_code", "44"));

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -52,6 +52,7 @@ import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSI
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
+import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.USER_PHONE;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
@@ -207,7 +208,12 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             addCompletedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             addCompletedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
             addCompletedAttributes.put(EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "44");
+            addCompletedAttributes.put(USER_PHONE, TEST_PHONE_NUMBER_TWO_WITH_COUNTRY_CODE);
             eventExpectations.put(AUTH_MFA_METHOD_ADD_COMPLETED.name(), addCompletedAttributes);
+
+            Map<String, String> updatePhoneAttributes = new HashMap<>();
+            updatePhoneAttributes.put(USER_PHONE, TEST_PHONE_NUMBER_TWO_WITH_COUNTRY_CODE);
+            eventExpectations.put(AUTH_UPDATE_PHONE_NUMBER.name(), updatePhoneAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
         }
@@ -299,10 +305,15 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             Map<String, String> addCompletedAttributes = new HashMap<>();
             addCompletedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             addCompletedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
+            addCompletedAttributes.put(USER_PHONE, phoneNumberWithCountryCode);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
             eventExpectations.put(AUTH_CODE_VERIFIED.name(), codeVerifiedAttributes);
             eventExpectations.put(AUTH_MFA_METHOD_ADD_COMPLETED.name(), addCompletedAttributes);
+
+            Map<String, String> updatePhoneAttributes = new HashMap<>();
+            updatePhoneAttributes.put(USER_PHONE, phoneNumberWithCountryCode);
+            eventExpectations.put(AUTH_UPDATE_PHONE_NUMBER.name(), updatePhoneAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
         }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/testsupport/AuditTestConstants.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/testsupport/AuditTestConstants.java
@@ -7,4 +7,5 @@ public interface AuditTestConstants {
     String EXTENSIONS_MFA_METHOD = "extensions.mfa-method";
     String EXTENSIONS_MFA_TYPE = "extensions.mfa-type";
     String EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE = "extensions.phone_number_country_code";
+    String USER_PHONE = "user.phone";
 }


### PR DESCRIPTION
## What

- Format phone numbers to E.164 in audit events
- MFAMethodsCreateHandlerIntegrationTest to check for normalisation in the audit events

When a backup number is added the number is audited in local UK format rather than E.164. (It is always saved correctly in the database in E.164)

The issue was reported by as the hash of the number appeared to change in audit events

Events impacted:

- AUTH_MFA_METHOD_ADD_COMPLETED
- AUTH_UPDATE_PHONE_NUMBER

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

