### PR TITLE
Bau/assert on full audit event

### DIFF
--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -42,16 +41,17 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED;
+import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.PERSISTENT_ID;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.TXMA_ENCODED_HEADER_VALUE;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason.ALREADY_MIGRATED;
 import static uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason.NO_CREDENTIALS_FOUND_FOR_USER;
 import static uk.gov.di.authentication.shared.services.mfa.MfaMigrationFailureReason.UNEXPECTED_ERROR_RETRIEVING_METHODS;
@@ -70,6 +70,16 @@ class MfaMethodsMigrationServiceTest {
     private static final String TEST_PUBLIC_SUBJECT = new Subject().getValue();
     private static final String TEST_CLIENT = "test-client";
     private static final String MFA_IDENTIFIER = "some-mfa-identifier";
+    private static final AuditContext BASE_AUDIT_CONTEXT =
+            AuditContext.emptyAuditContext()
+                    .withEmail(EMAIL)
+                    .withClientId(TEST_CLIENT)
+                    .withIpAddress(IP_ADDRESS)
+                    .withPersistentSessionId(PERSISTENT_ID)
+                    .withSessionId(SESSION_ID)
+                    .withSubjectId(TEST_PUBLIC_SUBJECT)
+                    .withClientSessionId(TEST_CLIENT)
+                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE));
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -227,30 +237,27 @@ class MfaMethodsMigrationServiceTest {
             service.migrateMfaCredentialsForUserIfRequired(userProfile, logger, input, mfaDetail);
 
             // Then
-            ArgumentCaptor<AuditContext> auditContextCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
+            var expectedAuditContext =
+                    BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber());
+
+            if (expectedMfaMethodType.equals(MFAMethodType.SMS)) {
+                expectedAuditContext =
+                        expectedAuditContext.withMetadataItem(
+                                pair("phone_number_country_code", "44"));
+            }
+
+            expectedAuditContext =
+                    expectedAuditContext
+                            .withMetadataItem(pair("had-partial", true))
+                            .withMetadataItem(pair("mfa-type", expectedMfaMethodType))
+                            .withMetadataItem(pair("journey-type", JourneyType.ACCOUNT_MANAGEMENT))
+                            .withMetadataItem(pair("migration-succeeded", true));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_MIGRATION_ATTEMPTED),
-                            auditContextCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            AuditContext capturedContext = auditContextCaptor.getValue();
-
-            containsMetadataPair(
-                    capturedContext, "journey-type", JourneyType.ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(capturedContext, "mfa-type", expectedMfaMethodType.getValue());
-            containsMetadataPair(capturedContext, "migration-succeeded", "true");
-            if (expectedMfaMethodType.equals(MFAMethodType.SMS)) {
-                containsMetadataPair(capturedContext, "phone_number_country_code", "44");
-            }
-            assertEquals(EMAIL, capturedContext.email());
-            assertEquals(TEST_CLIENT, capturedContext.clientSessionId());
-            assertEquals("123.123.123.123", capturedContext.ipAddress());
-            assertEquals(PERSISTENT_ID, capturedContext.persistentSessionId());
-            assertEquals(userProfile.getPhoneNumber(), capturedContext.phoneNumber());
-            assertEquals(SESSION_ID, capturedContext.sessionId());
-            assertEquals(TEST_PUBLIC_SUBJECT, capturedContext.subjectId());
+                            AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
+                            expectedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @ParameterizedTest
@@ -267,30 +274,27 @@ class MfaMethodsMigrationServiceTest {
             service.migrateMfaCredentialsForUserIfRequired(userProfile, logger, input, mfaDetail);
 
             // Then
-            ArgumentCaptor<AuditContext> auditContextCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
+            var expectedAuditContext =
+                    BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber());
+
+            if (expectedMfaMethodType.equals(MFAMethodType.SMS)) {
+                expectedAuditContext =
+                        expectedAuditContext.withMetadataItem(
+                                pair("phone_number_country_code", "44"));
+            }
+
+            expectedAuditContext =
+                    expectedAuditContext
+                            .withMetadataItem(pair("had-partial", false))
+                            .withMetadataItem(pair("mfa-type", expectedMfaMethodType))
+                            .withMetadataItem(pair("journey-type", JourneyType.ACCOUNT_MANAGEMENT))
+                            .withMetadataItem(pair("migration-succeeded", false));
+
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_MFA_METHOD_MIGRATION_ATTEMPTED),
-                            auditContextCaptor.capture(),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
-
-            AuditContext capturedContext = auditContextCaptor.getValue();
-
-            containsMetadataPair(
-                    capturedContext, "journey-type", JourneyType.ACCOUNT_MANAGEMENT.name());
-            containsMetadataPair(capturedContext, "mfa-type", expectedMfaMethodType.getValue());
-            containsMetadataPair(capturedContext, "migration-succeeded", "false");
-            if (expectedMfaMethodType.equals(MFAMethodType.SMS)) {
-                containsMetadataPair(capturedContext, "phone_number_country_code", "44");
-            }
-            assertEquals(EMAIL, capturedContext.email());
-            assertEquals(TEST_CLIENT, capturedContext.clientSessionId());
-            assertEquals("123.123.123.123", capturedContext.ipAddress());
-            assertEquals(PERSISTENT_ID, capturedContext.persistentSessionId());
-            assertEquals(userProfile.getPhoneNumber(), capturedContext.phoneNumber());
-            assertEquals(SESSION_ID, capturedContext.sessionId());
-            assertEquals(TEST_PUBLIC_SUBJECT, capturedContext.subjectId());
+                            AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
+                            expectedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
     }
 
@@ -300,7 +304,7 @@ class MfaMethodsMigrationServiceTest {
         Map<String, Object> authorizerParams = new HashMap<>();
         authorizerParams.put("clientId", TEST_CLIENT);
         proxyRequestContext.setAuthorizer(authorizerParams);
-        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
+        proxyRequestContext.setIdentity(identityWithSourceIp(IP_ADDRESS));
         Map<String, String> headers =
                 Map.of(
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
@@ -319,15 +323,5 @@ class MfaMethodsMigrationServiceTest {
                                 Map.entry("mfaIdentifier", MFA_IDENTIFIER)))
                 .withHeaders(headers)
                 .withRequestContext(proxyRequestContext);
-    }
-
-    private void containsMetadataPair(AuditContext capturedObject, String field, String value) {
-        capturedObject
-                .getMetadataItemByKey(field)
-                .ifPresent(
-                        actualMetadataPairForMfaMethod -> {
-                            assertEquals(field, actualMetadataPairForMfaMethod.key());
-                            assertEquals(value, actualMetadataPairForMfaMethod.value().toString());
-                        });
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -98,6 +97,7 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMA
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
@@ -705,32 +705,17 @@ class SendNotificationHandlerTest {
                             "{ \"email\": \"%s\", \"phoneNumber\": \"%s\", \"notificationType\": \"%s\",  \"journeyType\": \"%s\" }",
                             EMAIL, UK_MOBILE_NUMBER, notificationType, REGISTRATION);
             var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-            var expectedMetadataPairForMfaMethod =
-                    new AuditService.MetadataPair("mfa-method", "default", false);
-            var expectedMetadataPairForJourneyType =
-                    new AuditService.MetadataPair("journey-type", REGISTRATION, false);
 
             handler.handleRequest(event, context);
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
-            verify(auditService).submitAuditEvent(eq(AUTH_PHONE_CODE_SENT), captor.capture());
-            AuditContext capturedObject = captor.getValue();
-
-            assertEquals(UK_MOBILE_NUMBER, capturedObject.phoneNumber());
-            capturedObject
-                    .getMetadataItemByKey("mfa-method")
-                    .ifPresent(
-                            actualMetadataPairForMfaMethod ->
-                                    assertEquals(
-                                            expectedMetadataPairForMfaMethod,
-                                            actualMetadataPairForMfaMethod));
-            capturedObject
-                    .getMetadataItemByKey("journey-type")
-                    .ifPresent(
-                            actualMetadataPairForJourneyType ->
-                                    assertEquals(
-                                            expectedMetadataPairForJourneyType,
-                                            actualMetadataPairForJourneyType));
+            var priorityPair = pair("mfa-method", "default");
+            var journeyTypePair = pair("journey-type", REGISTRATION);
+            var expectedAuditContext =
+                    auditContext
+                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
+                            .withMetadataItem(priorityPair)
+                            .withMetadataItem(journeyTypePair);
+            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
         }
 
         @Test
@@ -748,32 +733,17 @@ class SendNotificationHandlerTest {
                             "{ \"email\": \"%s\", \"phoneNumber\": \"%s\", \"notificationType\": \"%s\",  \"journeyType\": \"%s\" }",
                             EMAIL, UK_MOBILE_NUMBER, VERIFY_PHONE_NUMBER, REGISTRATION);
             var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-            var expectedMetadataPairForMfaMethod =
-                    new AuditService.MetadataPair("mfa-method", "default", false);
-            var expectedMetadataPairForJourneyType =
-                    new AuditService.MetadataPair("journey-type", REGISTRATION, false);
 
             handler.handleRequest(event, context);
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
-            verify(auditService).submitAuditEvent(eq(AUTH_PHONE_CODE_SENT), captor.capture());
-            AuditContext capturedObject = captor.getValue();
-
-            assertEquals(UK_MOBILE_NUMBER, capturedObject.phoneNumber());
-            capturedObject
-                    .getMetadataItemByKey("mfa-method")
-                    .ifPresent(
-                            actualMetadataPairForMfaMethod ->
-                                    assertEquals(
-                                            expectedMetadataPairForMfaMethod,
-                                            actualMetadataPairForMfaMethod));
-            capturedObject
-                    .getMetadataItemByKey("journey-type")
-                    .ifPresent(
-                            actualMetadataPairForJourneyType ->
-                                    assertEquals(
-                                            expectedMetadataPairForJourneyType,
-                                            actualMetadataPairForJourneyType));
+            var priorityPair = pair("mfa-method", "default");
+            var journeyTypePair = pair("journey-type", REGISTRATION);
+            var expectedAuditContext =
+                    auditContext
+                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
+                            .withMetadataItem(priorityPair)
+                            .withMetadataItem(journeyTypePair);
+            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
         }
 
         @Test
@@ -787,28 +757,14 @@ class SendNotificationHandlerTest {
 
             handler.handleRequest(event, context);
 
-            ArgumentCaptor<AuditContext> auditContextCaptor =
-                    ArgumentCaptor.forClass(AuditContext.class);
-            verify(auditService)
-                    .submitAuditEvent(eq(AUTH_PHONE_CODE_SENT), auditContextCaptor.capture());
-
-            AuditContext capturedContext = auditContextCaptor.getValue();
-            assertTrue(capturedContext.getMetadataItemByKey("mfa-method").isPresent());
-            assertTrue(capturedContext.getMetadataItemByKey("journey-type").isPresent());
-            assertEquals(
-                    "default", capturedContext.getMetadataItemByKey("mfa-method").get().value());
-            assertEquals(
-                    REGISTRATION,
-                    capturedContext.getMetadataItemByKey("journey-type").get().value());
-            assertEquals(UK_MOBILE_NUMBER, capturedContext.phoneNumber());
-            assertEquals(CLIENT_ID, capturedContext.clientId());
-            assertEquals(CLIENT_SESSION_ID, capturedContext.clientSessionId());
-            assertEquals(SESSION_ID, capturedContext.sessionId());
-            assertEquals(INTERNAL_COMMON_SUBJECT_ID, capturedContext.subjectId());
-            assertEquals(EMAIL, capturedContext.email());
-            assertEquals(IP_ADDRESS, capturedContext.ipAddress());
-            assertEquals(DI_PERSISTENT_SESSION_ID, capturedContext.persistentSessionId());
-            assertEquals(Optional.of(ENCODED_DEVICE_DETAILS), capturedContext.txmaAuditEncoded());
+            var priorityPair = pair("mfa-method", "default");
+            var journeyTypePair = pair("journey-type", REGISTRATION);
+            var expectedAuditContext =
+                    auditContext
+                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
+                            .withMetadataItem(priorityPair)
+                            .withMetadataItem(journeyTypePair);
+            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
         }
 
         @Test
@@ -862,16 +818,16 @@ class SendNotificationHandlerTest {
                                                             CLIENT_SESSION_ID)),
                                             "unique_notification_reference")));
 
-            ArgumentCaptor<AuditContext> captor = ArgumentCaptor.forClass(AuditContext.class);
-            verify(auditService).submitAuditEvent(eq(AUTH_PHONE_CODE_SENT), captor.capture());
-            AuditContext capturedContext = captor.getValue();
-
-            assertEquals(newPhoneNumber, capturedContext.phoneNumber());
             // Business rule: new phone numbers should be reported as the default mfa method in
             // audit events
-            capturedContext
-                    .getMetadataItemByKey("mfa-method")
-                    .ifPresent(metadata -> assertEquals("default", metadata.value()));
+            var priorityPair = pair("mfa-method", "default");
+            var journeyTypePair = pair("journey-type", REGISTRATION);
+            var expectedAuditContext =
+                    auditContext
+                            .withPhoneNumber(newPhoneNumber)
+                            .withMetadataItem(priorityPair)
+                            .withMetadataItem(journeyTypePair);
+            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
         }
     }
 


### PR DESCRIPTION
## What

A test refactor - Stop using argument captors to assert on individual fields in the submitted audit event's context, instead assert on the entire audit context.

This is done for:
* readability / simplicity
* to ensure that we don't mask issues where we add conflicting metadata (multiple pairs with the same key but different values) to the audit context (which does not show up in tests where we just assert on individual items)
* to provide a solid foundation for refactoring

I'm planning a subsequent change to stop allowing metadata items to be set on the audit context (at the moment it can be sent through for the audit event in multiple ways), so this is a preparatory step to ensure we have a good base of tests to make this change from.
