### PR TITLE
AUT-5360: Enable strongly consistent reads in the authentication auth code handler

### DIFF
--- a/ci/cloudformation/auth/function/amc-authorize.yaml
+++ b/ci/cloudformation/auth/function/amc-authorize.yaml
@@ -97,11 +97,11 @@ Resources:
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
           SESSION_EXPIRY: "3600"
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref AMCAuthorizeFunctionLogGroup

--- a/ci/cloudformation/auth/function/amc-callback.yaml
+++ b/ci/cloudformation/auth/function/amc-callback.yaml
@@ -19,11 +19,11 @@ Resources:
                   !Ref Environment,
                   dataStoreAccountId,
                 ]
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           AMC_TOKEN_URI:
             !FindInMap [

--- a/ci/cloudformation/auth/function/check-email-fraud-block.yaml
+++ b/ci/cloudformation/auth/function/check-email-fraud-block.yaml
@@ -40,11 +40,11 @@ Resources:
             ]
           REDIS_KEY: "session"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref CheckEmailFraudBlockFunctionLogGroup

--- a/ci/cloudformation/auth/function/check-reauth-user.yaml
+++ b/ci/cloudformation/auth/function/check-reauth-user.yaml
@@ -53,11 +53,11 @@ Resources:
               supportReauthSignoutEnabled,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref CheckReAuthUserFunctionLogGroup

--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -62,11 +62,11 @@ Resources:
               termsConditionsVersion,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           INTERNATIONAL_SMS_SENDING_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
@@ -99,11 +99,11 @@ Resources:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           REDIS_KEY: "session"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref MfaResetAuthorizeFunctionLogGroup

--- a/ci/cloudformation/auth/function/mfa.yaml
+++ b/ci/cloudformation/auth/function/mfa.yaml
@@ -65,11 +65,11 @@ Resources:
               testClientsEnabled,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           INTERNATIONAL_SMS_SENDING_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/function/orch-auth-code.yaml
+++ b/ci/cloudformation/auth/function/orch-auth-code.yaml
@@ -40,6 +40,12 @@ Resources:
               !Ref Environment,
               enhancedAuthCodeProtectionEnabled,
             ]
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              authSessionUseStronglyConsistentReads,
+            ]
       LoggingConfig:
         LogGroup: !Ref OrchAuthCodeFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/function/reset-password-request.yaml
+++ b/ci/cloudformation/auth/function/reset-password-request.yaml
@@ -60,11 +60,11 @@ Resources:
           REDIS_KEY: "session"
           RESET_PASSWORD_ROUTE: "reset-password?code="
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref ResetPasswordRequestFunctionLogGroup

--- a/ci/cloudformation/auth/function/reset-password.yaml
+++ b/ci/cloudformation/auth/function/reset-password.yaml
@@ -47,11 +47,11 @@ Resources:
               termsConditionsVersion,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           INTERNATIONAL_SMS_SENDING_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/function/reverification-result.yaml
+++ b/ci/cloudformation/auth/function/reverification-result.yaml
@@ -62,11 +62,11 @@ Resources:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           REDIS_KEY: "session"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref ReverificationResultFunctionLogGroup

--- a/ci/cloudformation/auth/function/send-notification.yaml
+++ b/ci/cloudformation/auth/function/send-notification.yaml
@@ -81,11 +81,11 @@ Resources:
               testClientsEnabled,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           INTERNATIONAL_SMS_SENDING_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/function/signup.yaml
+++ b/ci/cloudformation/auth/function/signup.yaml
@@ -34,11 +34,11 @@ Resources:
               termsConditionsVersion,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref SignUpFunctionLogGroup

--- a/ci/cloudformation/auth/function/start.yaml
+++ b/ci/cloudformation/auth/function/start.yaml
@@ -51,11 +51,11 @@ Resources:
           REDIS_KEY: "session"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
           AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref StartFunctionLogGroup

--- a/ci/cloudformation/auth/function/update-profile.yaml
+++ b/ci/cloudformation/auth/function/update-profile.yaml
@@ -35,11 +35,11 @@ Resources:
               termsConditionsVersion,
             ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
       LoggingConfig:
         LogGroup: !Ref UpdateProfileFunctionLogGroup

--- a/ci/cloudformation/auth/function/verify-code.yaml
+++ b/ci/cloudformation/auth/function/verify-code.yaml
@@ -89,11 +89,11 @@ Resources:
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           FORCED_MFA_RESET_AFTER_MFA_CHECK_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/function/verify-mfa-code.yaml
+++ b/ci/cloudformation/auth/function/verify-mfa-code.yaml
@@ -95,11 +95,11 @@ Resources:
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          USE_STRONGLY_CONSISTENT_READS:
+          AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              useStronglyConsistentReads,
+              authSessionUseStronglyConsistentReads,
             ]
           FORCED_MFA_RESET_AFTER_MFA_CHECK_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -240,7 +240,7 @@ Mappings:
       supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
-      useStronglyConsistentReads: true
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 590183679200
       OrchAccountID: 816047645251
@@ -293,7 +293,7 @@ Mappings:
       supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
-      useStronglyConsistentReads: true
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 590183679200
       OrchAccountID: 816047645251
@@ -346,7 +346,7 @@ Mappings:
       supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
-      useStronglyConsistentReads: true
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 590183679200
       OrchAccountID: 816047645251
@@ -413,7 +413,7 @@ Mappings:
       supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
-      useStronglyConsistentReads: true
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 590183679200
       OrchAccountID: 816047645251
@@ -476,7 +476,7 @@ Mappings:
       supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
-      useStronglyConsistentReads: true
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 851725166715
       OrchAccountID: 767397776536
@@ -545,7 +545,7 @@ Mappings:
       supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
-      useStronglyConsistentReads: true
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 891377189576
       OrchAccountID: 590183975515
@@ -614,7 +614,7 @@ Mappings:
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2f7fd1cc-c0e1-40f5-a747-2ed29e02427d
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
       internationalNumberSendCountTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3fd823db-5980-4853-bd9b-ed674ea8719e
-      useStronglyConsistentReads: false
+      authSessionUseStronglyConsistentReads: false
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 211125427676
       OrchAccountID: 058264132019
@@ -683,7 +683,7 @@ Mappings:
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/7f36e093-d4c1-4b18-8cf3-0c11a59e6d67
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
       internationalNumberSendCountTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/6269785d-3811-487d-af5a-a732d318c6ca
-      useStronglyConsistentReads: false
+      authSessionUseStronglyConsistentReads: false
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 637423504848
       OrchAccountID: 533266965190

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -614,7 +614,7 @@ Mappings:
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2f7fd1cc-c0e1-40f5-a747-2ed29e02427d
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
       internationalNumberSendCountTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3fd823db-5980-4853-bd9b-ed674ea8719e
-      authSessionUseStronglyConsistentReads: false
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 211125427676
       OrchAccountID: 058264132019
@@ -683,7 +683,7 @@ Mappings:
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/7f36e093-d4c1-4b18-8cf3-0c11a59e6d67
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
       internationalNumberSendCountTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/6269785d-3811-487d-af5a-a732d318c6ca
-      authSessionUseStronglyConsistentReads: false
+      authSessionUseStronglyConsistentReads: true
       forcedMFAResetAfterMFACheckEnabled: true
       AuthExpAccountId: 637423504848
       OrchAccountID: 533266965190

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthSessionService.java
@@ -31,7 +31,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         super(AuthSessionItem.class, "auth-session", configurationService);
         this.timeToLive = configurationService.getSessionExpiry();
         this.configurationService = configurationService;
-        this.useConsistentReads = configurationService.isUsingStronglyConsistentReads();
+        this.useConsistentReads = configurationService.isAuthSessionUsingStronglyConsistentReads();
         LOG.info("Is using strongly consistent reads: {}", useConsistentReads);
     }
 
@@ -42,7 +42,7 @@ public class AuthSessionService extends BaseDynamoService<AuthSessionItem> {
         super(dynamoDbTable, dynamoDbClient);
         this.timeToLive = configurationService.getSessionExpiry();
         this.configurationService = configurationService;
-        this.useConsistentReads = configurationService.isUsingStronglyConsistentReads();
+        this.useConsistentReads = configurationService.isAuthSessionUsingStronglyConsistentReads();
         LOG.info("Is using strongly consistent reads: {}", useConsistentReads);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -841,9 +841,9 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
-    public boolean isUsingStronglyConsistentReads() {
+    public boolean isAuthSessionUsingStronglyConsistentReads() {
         return System.getenv()
-                .getOrDefault("USE_STRONGLY_CONSISTENT_READS", FEATURE_SWITCH_OFF)
+                .getOrDefault("AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS", FEATURE_SWITCH_OFF)
                 .equals(FEATURE_SWITCH_ON);
     }
 


### PR DESCRIPTION
## What

- Rename useStronglyConsistentReads to authSessionUseStronglyConsistentReads as it is only used in the AuthSessionService for the AuthSession table
- Expose this value to the AuthenticationAuthCodeHandler so we get authSessionUseStronglyConsistentReads in the AuthSession table
- Set this value to true in integration and production

## How to review

1. Code review

## Checklist


