### PR TITLE
AUT-5324: AMC changes for integration

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -251,7 +251,7 @@ Mappings:
       amcSfadRedirectUri: https://signin.authdev1.dev.account.gov.uk/sfad-callback
       amcTokenUri: https://amcstub.signin.authdev1.dev.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.authdev1.dev.account.gov.uk/journeyoutcome
-      amcClientId: auth_amc
+      amcClientId: auth
       accountDataApiId: rjlo8fsb55
       EvcsApiVpcEndpointId: ""
       enhancedAuthCodeProtectionEnabled: true
@@ -304,7 +304,7 @@ Mappings:
       amcSfadRedirectUri: https://signin.authdev2.dev.account.gov.uk/sfad-callback
       amcTokenUri: https://amcstub.signin.authdev2.dev.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.authdev2.dev.account.gov.uk/journeyoutcome
-      amcClientId: auth_amc
+      amcClientId: auth
       accountDataApiId: ez2ro7vca7
       EvcsApiVpcEndpointId: ""
       enhancedAuthCodeProtectionEnabled: true
@@ -361,7 +361,7 @@ Mappings:
       amcSfadRedirectUri: https://signin.authdev3.dev.account.gov.uk/sfad-callback
       amcTokenUri: https://amcstub.signin.authdev3.dev.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.authdev3.dev.account.gov.uk/journeyoutcome
-      amcClientId: auth_amc
+      amcClientId: auth
       accountDataApiId: 5ctgxqnq37
       EvcsApiVpcEndpointId: ""
       enhancedAuthCodeProtectionEnabled: true
@@ -423,7 +423,7 @@ Mappings:
       amcAuthorizeUri: https://amcstub.signin.dev.account.gov.uk/authorize
       amcTokenUri: https://amcstub.signin.dev.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.dev.account.gov.uk/journeyoutcome
-      amcClientId: auth_amc
+      amcClientId: auth
       accountDataApiId: 0aqzty84lj
       amcSfadRedirectUri: https://signin.dev.account.gov.uk/sfad-callback
       enhancedAuthCodeProtectionEnabled: true
@@ -491,7 +491,7 @@ Mappings:
       amcSfadRedirectUri: https://signin.build.account.gov.uk/sfad-callback
       amcTokenUri: https://amcstub.signin.build.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.build.account.gov.uk/journeyoutcome
-      amcClientId: auth_amc
+      amcClientId: auth
       accountDataApiId: ac3znt5m23
       enhancedAuthCodeProtectionEnabled: false
       supportPasskeys: false

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -6,6 +6,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
@@ -90,6 +91,9 @@ public class AMCService {
                                                             configurationService.getAMCClientId()))
                                             .endpointURI(configurationService.getAMCAuthorizeURI())
                                             .requestObject(encryptedJWTAndAmcCookie.encryptedJWT)
+                                            .scope(new Scope(amcScope.getValue()))
+                                            .redirectionURI(URI.create(amcRedirectUri))
+                                            .state(state)
                                             .build();
                             String authorizationUrl = authRequest.toURI().toString();
                             LOG.info("AMC authorization URL created");
@@ -154,7 +158,7 @@ public class AMCService {
                         accessTokenMap -> {
                             var claimsBuilder =
                                     new JWTClaimsSet.Builder()
-                                            .issuer(configurationService.getAuthIssuerClaim())
+                                            .issuer(configurationService.getAMCClientId())
                                             .claim(
                                                     "client_id",
                                                     configurationService.getAMCClientId())

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -224,7 +224,11 @@ class AMCServiceTest {
             String authorizationUrl = result.getSuccess().url();
             assertTrue(authorizationUrl.startsWith(AMC_AUTHORIZE_URI));
 
-            SignedJWT compositeJWT = extractSignedJwtFromAuthUrl(authorizationUrl);
+            AuthorizationRequest parsedAuthRequest =
+                    AuthorizationRequest.parse(URI.create(authorizationUrl));
+            assertPresenceOfQueryParams(parsedAuthRequest);
+
+            SignedJWT compositeJWT = extractSignedJwtFromAuthRequest(parsedAuthRequest);
 
             String amcCookie = result.getSuccess().amcCookie();
             assertEquals(HashHelper.hashSha256String(compositeJWT.serialize()), amcCookie);
@@ -375,7 +379,7 @@ class AMCServiceTest {
         private void assertCompositeJWTClaims(JWTClaimsSet compositeClaims) {
             assertAll(
                     "Composite JWT Claims",
-                    () -> assertEquals(AUTH_ISSUER_CLAIM, compositeClaims.getIssuer()),
+                    () -> assertEquals(AMC_CLIENT_ID, compositeClaims.getIssuer()),
                     () ->
                             assertEquals(
                                     List.of(AUTH_TO_AMC_PUBLIC_AUDIENCE),
@@ -431,11 +435,18 @@ class AMCServiceTest {
                     () -> assertDoesNotThrow(() -> UUID.fromString(accessTokenClaims.getJWTID())));
         }
 
-        private SignedJWT extractSignedJwtFromAuthUrl(String authorizationUrl) throws Exception {
-            AuthorizationRequest authRequest = AuthorizationRequest.parse(authorizationUrl);
+        private SignedJWT extractSignedJwtFromAuthRequest(AuthorizationRequest authRequest)
+                throws Exception {
             EncryptedJWT encryptedJWT = (EncryptedJWT) authRequest.getRequestObject();
             encryptedJWT.decrypt(new RSADecrypter(TEST_PRIVATE_ENCRYPTION_KEY));
             return encryptedJWT.getPayload().toSignedJWT();
+        }
+
+        private void assertPresenceOfQueryParams(AuthorizationRequest parsedAuthRequest) {
+            assertEquals(
+                    AMCScope.ACCOUNT_DELETE.getValue(), parsedAuthRequest.getScope().toString());
+            assertEquals(URI.create(REDIRECT_URI), parsedAuthRequest.getRedirectionURI());
+            assertEquals(STATE.getValue(), parsedAuthRequest.getState().getValue());
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
@@ -172,6 +172,9 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
         assertTrue(redirectUrl.contains("response_type=code"));
         assertTrue(redirectUrl.contains("client_id=test-amc-client"));
         assertTrue(redirectUrl.contains("request="));
+        assertTrue(redirectUrl.contains("scope="));
+        assertTrue(redirectUrl.contains("redirect_uri="));
+        assertTrue(redirectUrl.contains("state="));
 
         String requestParam =
                 Arrays.stream(new URI(redirectUrl).getQuery().split("&"))


### PR DESCRIPTION
## What

- Add scope, redirect_uri, state as query params on authorize URL
- Set transport JWT iss to AMC client ID
- Update amcClientId from auth_amc to auth

## How to review

1. Code Review
2. Run against stub changes in dev

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
