### PR TITLE
ATO-2517: Rotate production ID token signing keys

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -136,6 +136,7 @@ Conditions:
         !Equals [build, !Ref Environment],
         !Equals [staging, !Ref Environment],
         !Equals [integration, !Ref Environment],
+        !Equals [production, !Ref Environment],
       ],
     ]
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]


### PR DESCRIPTION
**DO NOT MERGE UNTIL 10:20**

This flag enabled signing with the new keys

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
