### PR TITLE
ATO-2416: Deploy cloudfront to dev

### DIFF
--- a/.github/workflows/call_terraform_validate.yml
+++ b/.github/workflows/call_terraform_validate.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: "1.14.9"
 
       - name: Terraform Validate
         working-directory: ci/terraform/${{ matrix.module }}

--- a/ci/stack-orchestration/configuration/dev/cloudfront-monitoring-alarm/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/cloudfront-monitoring-alarm/parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "CloudFrontAdditionaldMetricsEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmSNSTopicARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:816047645251:dev-CloudFrontCacheHitSlackAlerts"
+  },
+  {
+    "ParameterKey": "CloudfrontDistribution",
+    "ParameterValue": "E185IA0TYZXSVO"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmDescription",
+    "ParameterValue": "Cache Hit detected for dev OIDC Cloudfront. Runbook: https://govukverify.atlassian.net/wiki/x/AYC0gwE"
+  }
+]

--- a/ci/stack-orchestration/configuration/dev/cloudfront-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/cloudfront-notifications/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "DeploySlackNotificationTopic",
+    "ParameterValue": "Yes"
+  }
+]

--- a/ci/stack-orchestration/configuration/dev/cloudfront-tls-certificate/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/cloudfront-tls-certificate/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "HostedZoneID",
+    "ParameterValue": "Z056572238AB2L8H3WIDI"
+  },
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "oidc.dev.account.gov.uk"
+  }
+]

--- a/ci/stack-orchestration/configuration/dev/dev-oidc-cloudfront/parameters.json
+++ b/ci/stack-orchestration/configuration/dev/dev-oidc-cloudfront/parameters.json
@@ -1,0 +1,34 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc.dev.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:816047645251:certificate/ca28c86c-44f0-4ca6-9886-86c265eef06b"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  }
+]

--- a/ci/stack-orchestration/configuration/dev/dev-oidc-cloudfront/tags.json
+++ b/ci/stack-orchestration/configuration/dev/dev-oidc-cloudfront/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "FMSGlobalCustomPolicy",
+    "Value": "true"
+  },
+  {
+    "Key": "FMSGlobalCustomPolicyName",
+    "Value": "cloudfrontoidc"
+  }
+]

--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+set -euo pipefail
+
+#Ensure we are in the same dir as the script
+cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
+
+CLOUDFRONT_DISTRIBUTION_STACK_VERSION="v2.3.9"
+CERTIFICATE_STACK_VERSION="v1.1.4"
+CLOUDFRONT_MONITORING_STACK_VERSION="v2.1.0"
+
+PROVISION_CLOUDFRONT_TLS_CERT=false
+PROVISION_CLOUDFRONT=false
+PROVISION_CLOUDFRONT_MONITORING=false
+PROVISION_CLOUDFRONT_NOTIFICATION_STACK=false
+
+PROVISION_COMMAND="../../../devplatform-deploy/stack-orchestration-tool/provisioner.sh"
+
+export AWS_PAGER=""
+export SKIP_AWS_AUTHENTICATION="${SKIP_AWS_AUTHENTICATION:-true}"
+export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-false}"
+
+if [ ! -f ${PROVISION_COMMAND} ]; then
+  echo "Provisioner script not found. Please clone dev-platform deploy repo next to this one."
+  exit 1
+fi
+
+function usage {
+  cat << USAGE
+  Script to deploy the OIDC CloudFront distribution and manage the migration from the auth account cloudfront to the orchestration account.
+
+  Usage:
+    $0 [-e|--environment <env name>] [-c|--certificate] [-d|--distribution] [-m|--monitoring]
+
+  Options:
+    -e, --environment        The environment you wish to deploy to i.e dev, build, staging, integration, or production
+    -c, --certificate        Creates certificate in us-east-1 region for CloudFront Distribution.
+    -d, --distribution       Creates the CloudFront distribution
+    -m, --monitoring         Deploys CloudFront Extended Monitoring stack in us-east-1
+    -n, --notification        Deploys a stack which allows us to forward our Cloudfront alarms to Slack in our non-prod envs, or PagerDuty in
+                             the production environment. This requires us to setup some manual secrets for the relevant webhooks/slack channel IDs.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    -e | --environment)
+      ENVIRONMENT="${2}"
+
+      PERMITTED_ENVIRONMENTS="dev build staging integration production"
+      if ! [[ ${PERMITTED_ENVIRONMENTS} =~ ( |^)${ENVIRONMENT}( |$) ]]; then
+        echo "Environment provided: ${ENVIRONMENT} is not one of ${PERMITTED_ENVIRONMENTS}"
+        exit 1
+      fi
+
+      echo "Selected environment: ${ENVIRONMENT}"
+      shift
+      ;;
+    -c | --certificate)
+      PROVISION_CLOUDFRONT_TLS_CERT=true
+      ;;
+    -d | --distribution)
+      PROVISION_CLOUDFRONT=true
+      ;;
+    -m | --monitoring)
+      PROVISION_CLOUDFRONT_MONITORING=true
+      ;;
+    -n | --notification)
+      PROVISION_CLOUDFRONT_NOTIFICATION_STACK=true
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+TAGS_FILE="$(pwd)/configuration/${ENVIRONMENT}/tags.json"
+export TAGS_FILE
+
+function provision_cloudfront_distribution() {
+  export AWS_REGION="eu-west-2"
+  echo "Provisioning cloudfront stack"
+
+  STACK_TAGS_FILE="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-oidc-cloudfront/tags.json"
+  # shellcheck disable=SC2155
+  local params_file="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-oidc-cloudfront/parameters.json"
+
+  if [ -f "${STACK_TAGS_FILE}" ]; then
+    tmp_tags_file="$(mktemp)"
+    jq -s 'add | group_by(.Key) | map(last)' "${TAGS_FILE}" "${STACK_TAGS_FILE}" > "${tmp_tags_file}"
+  fi
+  TAGS_FILE="${tmp_tags_file}" PARAMETERS_FILE="${params_file}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "${ENVIRONMENT}-oidc-cloudfront" "cloudfront-distribution" "${CLOUDFRONT_DISTRIBUTION_STACK_VERSION}"
+
+  echo "Provisioned cloudfront stack"
+}
+
+function provision_cloudfront_monitoring() {
+
+  echo "Provisioning cloudfront monitoring stack"
+  AWS_REGION="us-east-1" PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/cloudfront-monitoring-alarm/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "${ENVIRONMENT}-oidc-cloudfront-monitoring" "cloudfront-monitoring-alarm" "${CLOUDFRONT_MONITORING_STACK_VERSION}"
+
+  echo "Provisioned cloudwatch alarm stack"
+}
+
+function provision_cloudfront_certificate() {
+
+  echo "Provisioning cloudfront certificate stack"
+  AWS_REGION="us-east-1" PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/cloudfront-tls-certificate/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "cloudfront-tls-certificate" "certificate" "${CERTIFICATE_STACK_VERSION}"
+
+  echo "Provisioned cloudfront certificate stack"
+}
+
+function provision_cloudfront_notification() {
+  echo "Provisioning cloudfront notification stack"
+
+  # shellcheck disable=SC2155
+  local parameters=$(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "configuration/${ENVIRONMENT}/cloudfront-notifications/parameters.json")
+
+  # shellcheck disable=SC2155
+  local tags=$(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "configuration/${ENVIRONMENT}/tags.json")
+
+  # shellcheck disable=SC2155
+  local template_dir="$(pwd)/manual-stacks/cloudfront-notifications/template.yaml"
+
+  if [ ! -f "${template_dir}" ]; then
+    echo "Could not find the manual cloudfront notification template stack at path: ${template_dir}"
+    exit 1
+  fi
+
+  # We need to potentially build the lambda
+  pushd "$(pwd)/manual-stacks/cloudfront-notifications"
+
+  sam build
+  sam deploy \
+    --stack-name "cloudfront-notification" \
+    --resolve-s3 true \
+    --s3-prefix "cloudfront-notification" \
+    --region "us-east-1" \
+    --capabilities "CAPABILITY_IAM" \
+    --confirm-changeset \
+    --no-fail-on-empty-changeset \
+    --parameter-overrides ${parameters} \
+    --tags ${tags}
+
+  popd
+
+  echo "Provisioned cloudfront notification stack"
+
+}
+
+# deploy certs first as these are a dependency of the cloudfront stack
+[ "${PROVISION_CLOUDFRONT_TLS_CERT}" == "true" ] && provision_cloudfront_certificate
+
+# deploy CF distribution
+[ "${PROVISION_CLOUDFRONT}" == "true" ] && provision_cloudfront_distribution
+
+#Deploy notification stack as it is needed by the monitoring stack.
+
+[ "${PROVISION_CLOUDFRONT_NOTIFICATION_STACK}" == "true" ] && provision_cloudfront_notification
+
+# deploy monitoring as it needs the CF distribution to exist
+[ "${PROVISION_CLOUDFRONT_MONITORING}" == "true" ] && provision_cloudfront_monitoring
+
+#Reset stuff
+export AWS_REGION="eu-west-2"

--- a/ci/stack-orchestration/manual-stacks/cloudfront-notifications/README.md
+++ b/ci/stack-orchestration/manual-stacks/cloudfront-notifications/README.md
@@ -1,0 +1,11 @@
+## Cloudfront Notification Stack
+
+This stack contains an SNS topic with either a PagerDuty integration in production or Lambda -> Slack integration in non
+production environments.
+
+This stack requires some manual secrets to be setup as part of the initial setup process. These are contained within the
+template and should be setup as part of deploying this stack.
+
+On initial deployment, the parameters to deploy the PagerDuty/Slack integration should be set to "No". This will deploy
+the relevant secrets to support the integration. Once you've deployed this and set up the required secrets, you can enable
+the Slack/PagerDuty integration parameters.

--- a/ci/stack-orchestration/manual-stacks/cloudfront-notifications/index.js
+++ b/ci/stack-orchestration/manual-stacks/cloudfront-notifications/index.js
@@ -1,0 +1,107 @@
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+
+const secretsManagerClient = new SecretsManagerClient();
+
+const getSecretWithId = async (secretArn) => {
+  const getSecretCommand = new GetSecretValueCommand({
+    SecretId: secretArn,
+  });
+  return (await secretsManagerClient.send(getSecretCommand)).SecretString;
+};
+
+const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
+  var descriptionAndAccount = snsMessage.AlarmDescription.split("ACCOUNT:");
+  var runbook = null;
+  var account = snsMessage.AWSAccountId;
+  if (descriptionAndAccount.length > 1) {
+    const runbookSplit = descriptionAndAccount[1].split("Runbook: ");
+    if (runbookSplit.length > 1) {
+      runbook = runbookSplit[1];
+    }
+    account = runbookSplit[0];
+  }
+  var description = descriptionAndAccount[0];
+  var fields = [
+    {
+      title: "Status",
+      value: snsMessage.NewStateValue,
+      short: false,
+    },
+    {
+      title: "Account",
+      value: account.trim(),
+      short: false,
+    },
+  ];
+  if (runbook != null) {
+    fields.push({
+      title: "Runbook",
+      value: runbook.trim(),
+      short: false,
+    });
+  }
+  return {
+    attachments: [
+      {
+        fallback: description.trim(),
+        color: colorCode,
+        title: snsMessage.AlarmName,
+        text: description.trim(),
+        fields: fields,
+        footer: snsMessageFooter,
+      },
+    ],
+  };
+};
+const sendAlertToSlack = async function (messageRequestBody) {
+  const slackHookUrl = await getSecretWithId(
+    process.env.SLACK_WEBHOOK_SECRET_ARN,
+  );
+  const messageRequest = {
+    method: "post",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(messageRequestBody),
+  };
+  try {
+    const response = await fetch(slackHookUrl, messageRequest);
+    const message = await response.text();
+
+    if (response.status !== 200) {
+      console.error(
+        "Slack webhook responded with non-200 status code: " + response.status,
+      );
+    }
+
+    console.log(message);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const handler = async function (event, _ignored) {
+  console.log("Alert lambda triggered");
+  let colorCode = "#C70039";
+  let snsMessageFooter = "GOV.UK Sign In alert";
+
+  let snsMessage = JSON.parse(event.Records[0].Sns.Message);
+  if (snsMessage.NewStateValue === "OK") {
+    colorCode = "#36a64f";
+  }
+  const messageRequestBody = formatMessage(
+    snsMessage,
+    colorCode,
+    snsMessageFooter,
+  );
+
+  messageRequestBody.channel = await getSecretWithId(
+    process.env.SLACK_CHANNEL_ID_SECRET_ARN,
+  );
+
+  console.log("Sending alert to slack");
+  await sendAlertToSlack(messageRequestBody);
+};

--- a/ci/stack-orchestration/manual-stacks/cloudfront-notifications/package.json
+++ b/ci/stack-orchestration/manual-stacks/cloudfront-notifications/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cloudfront-notifications-lambda",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/ci/stack-orchestration/manual-stacks/cloudfront-notifications/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/cloudfront-notifications/template.yaml
@@ -1,0 +1,189 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform:
+  - AWS::Serverless-2016-10-31
+
+Rules:
+  MustBeDeployedInUSEast1:
+    Assertions:
+      - Assert: !Equals [!Ref AWS::Region, "us-east-1"]
+        AssertDescription: "Template must be deployed in us-east-1"
+
+Parameters:
+  Environment:
+    Type: String
+    Description: The name of the environment to deploy to
+    AllowedValues:
+      - dev
+      - build
+      - staging
+      - integration
+      - production
+  DeployPagerDutySnsTopic:
+    Type: String
+    Description: |
+      Should deploy the PagerDuty SNS topic. Should only be set to yes once the secrets have been setup.
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Default: "No"
+  DeploySlackNotificationTopic:
+    Type: String
+    Description: |
+      Should deploy the Slack Notification SNS topic. Should only be set to yes once the secrets have been setup.
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Default: "No"
+
+Conditions:
+  DeployPagerDutyIntegration:
+    !And [
+      !Equals [!Ref Environment, production],
+      !Equals [!Ref DeployPagerDutySnsTopic, "Yes"],
+    ]
+  DeployPagerDutySecrets: !Equals [!Ref Environment, production]
+  DeploySlackIntegration:
+    !And [
+      !Equals [!Ref DeploySlackNotificationTopic, "Yes"],
+      !Or [
+        !Equals [dev, !Ref Environment],
+        !Equals [build, !Ref Environment],
+        !Equals [staging, !Ref Environment],
+        !Equals [integration, !Ref Environment],
+      ],
+    ]
+  DeploySlackSecrets:
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
+    ]
+
+Resources:
+  #region Production PagerDuty resources
+
+  PagerDutyUrlSecret:
+    # This needs to be manually populated
+    Condition: DeployPagerDutySecrets
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: pager_duty_url
+
+  CloudFrontCacheHitPagerDutySnsTopic:
+    Condition: DeployPagerDutyIntegration
+    Type: AWS::SNS::Topic
+    Properties:
+      # No customer managed key as it is this is only used for alerting
+      DisplayName: !Sub ${Environment}-CloudFrontCacheHitP1Alerts
+      TopicName: !Sub ${Environment}-CloudFrontCacheHitP1Alerts
+
+  CloudFrontCacheHitPagerDutyTopicPolicy:
+    Condition: DeployPagerDutyIntegration
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref CloudFrontCacheHitPagerDutySnsTopic
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sns:Publish
+            Effect: Allow
+            Resource: !Ref CloudFrontCacheHitPagerDutySnsTopic
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+            Condition:
+              StringEquals:
+                AWS:SourceAccount: !Ref AWS::AccountId
+
+  PagerDutySNSSubscription:
+    Condition: DeployPagerDutyIntegration
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub
+        - "{{resolve:secretsmanager:${SecretArn}:SecretString:integrationURL}}"
+        - SecretArn: !Ref PagerDutyUrlSecret
+      Protocol: https
+      RawMessageDelivery: true
+      TopicArn: !Ref CloudFrontCacheHitPagerDutySnsTopic
+  #endregion
+
+  #region non-prod Slack events resources
+
+  SlackWebHookUrlSecret:
+    # This needs to be manually populated
+    Condition: DeploySlackSecrets
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: slack_webhook_url
+
+  SlackChannelIdSecret:
+    # This needs to be manually populated
+    Condition: DeploySlackSecrets
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: slack_channel_id
+
+  CloudFrontCacheHitSlackNotificationsTopic:
+    Condition: DeploySlackIntegration
+    Type: AWS::SNS::Topic
+    Properties:
+      # No customer managed key as it is this is only used for alerting
+      DisplayName: !Sub ${Environment}-CloudFrontCacheHitSlackAlerts
+      TopicName: !Sub ${Environment}-CloudFrontCacheHitSlackAlerts
+
+  CloudFrontCacheHitSlackNotificationsTopicPolicy:
+    Condition: DeploySlackIntegration
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref CloudFrontCacheHitSlackNotificationsTopic
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sns:Publish
+            Effect: Allow
+            Resource: !Ref CloudFrontCacheHitSlackNotificationsTopic
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+            Condition:
+              StringEquals:
+                AWS:SourceAccount: !Ref AWS::AccountId
+
+  CloudFrontCacheHitSlackNotificationsLambdaFunction:
+    Condition: DeploySlackIntegration
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${Environment}-CloudFrontSlackNotifications
+      CodeUri: .
+      Handler: index.handler
+      ReservedConcurrentExecutions: 1
+      Runtime: nodejs22.x
+      Environment:
+        Variables:
+          SLACK_WEBHOOK_SECRET_ARN: !Ref SlackWebHookUrlSecret
+          SLACK_CHANNEL_ID_SECRET_ARN: !Ref SlackChannelIdSecret
+      Policies:
+        - Statement:
+            - Sid: AllowGetSlackSecrets
+              Effect: "Allow"
+              Action:
+                - "secretsmanager:GetSecretValue"
+              Resource:
+                - !Ref SlackWebHookUrlSecret
+                - !Ref SlackChannelIdSecret
+      Tags:
+        CheckovRulesToSkip: CKV_AWS_116.CKV_AWS_117.CKV_AWS_173
+      Events:
+        SNS:
+          Type: SNS
+          Properties:
+            Topic: !Ref CloudFrontCacheHitSlackNotificationsTopic
+    Metadata:
+      BuildProperties:
+        External:
+          - "@aws-sdk/*" # AWS SDK v3 dependencies are already included in the lambda runtime
+        UseNpmCi: true
+#endregion

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -250,6 +250,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
 }
 
 resource "aws_api_gateway_base_path_mapping" "api" {
+  count       = var.deploy_oidc_api_gateway_domain ? 1 : 0
   api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
   domain_name = local.oidc_api_fqdn

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -109,3 +109,4 @@ performance_tuning = {
 
 use_strongly_consistent_reads  = true
 support_reauth_signout_enabled = true
+deploy_oidc_api_gateway_domain = false

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -78,6 +78,7 @@ resource "aws_acm_certificate_validation" "oidc_api" {
 }
 
 resource "aws_api_gateway_domain_name" "oidc_api" {
+  count                    = var.deploy_oidc_api_gateway_domain ? 1 : 0
   regional_certificate_arn = aws_acm_certificate_validation.oidc_api.certificate_arn
   domain_name              = local.oidc_api_fqdn
 
@@ -99,14 +100,15 @@ data "aws_cloudfront_distribution" "oidc_cloudfront_distribution" {
 }
 
 resource "aws_route53_record" "oidc_api" {
+  count   = var.deploy_oidc_api_gateway_domain ? 1 : 0
   name    = local.oidc_api_fqdn
   type    = "A"
   zone_id = aws_route53_zone.oidc_api_zone.zone_id
 
   alias {
     evaluate_target_health = true
-    name                   = var.oidc_cloudfront_enabled ? data.aws_cloudfront_distribution.oidc_cloudfront_distribution[0].domain_name : aws_api_gateway_domain_name.oidc_api.regional_domain_name
-    zone_id                = var.oidc_cloudfront_enabled ? data.aws_cloudfront_distribution.oidc_cloudfront_distribution[0].hosted_zone_id : aws_api_gateway_domain_name.oidc_api.regional_zone_id
+    name                   = var.oidc_cloudfront_enabled ? data.aws_cloudfront_distribution.oidc_cloudfront_distribution[0].domain_name : aws_api_gateway_domain_name.oidc_api[0].regional_domain_name
+    zone_id                = var.oidc_cloudfront_enabled ? data.aws_cloudfront_distribution.oidc_cloudfront_distribution[0].hosted_zone_id : aws_api_gateway_domain_name.oidc_api[0].regional_zone_id
   }
 }
 
@@ -115,15 +117,15 @@ output "oidc_api_name_servers" {
 }
 
 resource "aws_route53_record" "oidc_origin_api" {
-  count   = var.oidc_cloudfront_enabled ? 1 : 0
+  count   = var.oidc_cloudfront_enabled && var.deploy_oidc_api_gateway_domain ? 1 : 0
   name    = local.oidc_origin_api_fqdn
   type    = "A"
   zone_id = aws_route53_zone.oidc_api_zone.zone_id
 
   alias {
     evaluate_target_health = true
-    name                   = aws_api_gateway_domain_name.oidc_api.regional_domain_name
-    zone_id                = aws_api_gateway_domain_name.oidc_api.regional_zone_id
+    name                   = aws_api_gateway_domain_name.oidc_api[0].regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.oidc_api[0].regional_zone_id
   }
 }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -735,3 +735,9 @@ variable "ipv_jwks_call_enabled" {
   type    = bool
   default = false
 }
+
+
+variable "deploy_oidc_api_gateway_domain" {
+  type    = bool
+  default = true
+}

--- a/template.yaml
+++ b/template.yaml
@@ -140,6 +140,7 @@ Conditions:
       ],
     ]
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]
+  UseCloudfront: !Equals [dev, !Ref Environment]
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseStoredOldIdTokenPublicKeys:
@@ -183,6 +184,7 @@ Mappings:
         "y": "nd02oQv8Uz9mjy3-EUG6nzuzdhW4TwYh6RA94n8RAJc",
         "alg": "ES256"
         }]'
+      oidcDomainName: "oidc.dev.account.gov.uk"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -5991,6 +5993,7 @@ Resources:
       Tags:
         Name: orchestration-oidc-api
         CheckovRulesToSkip: CKV_AWS_120
+        FMSRegionalPolicy: "false"
 
   OidcApiAccessLogGroup:
     Condition: ProvisionNewApiGateway
@@ -6013,6 +6016,70 @@ Resources:
       StageKeys:
         - RestApiId: !Ref OrchestrationOidcApi
           StageName: !Sub "${Environment}"
+
+  OrchestrationOidcApiWafAssociation:
+    Type: "AWS::WAFv2::WebACLAssociation"
+    Condition: UseCloudfront
+    Properties:
+      WebACLArn:
+        Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-CloakingOriginWebACLArn"
+      ResourceArn: !Sub "arn:aws:apigateway:${AWS::Region}::/restapis/${OrchestrationOidcApi}/stages/${Environment}"
+    DependsOn:
+      - OrchestrationOidcApiStage # Needs to wait for the stage created by the AWS::Serverless::Api
+
+  OrchestrationOidcApiCustomDomain:
+    Type: AWS::ApiGatewayV2::DomainName
+    Condition: UseCloudfront
+    Properties:
+      DomainName:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
+      DomainNameConfigurations:
+        - CertificateArn: "{{resolve:ssm:/deploy/hosted-zone/oidc/certificate-Arn}}"
+          SecurityPolicy: TLS_1_2
+
+  OrchestrationOidcApiBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Condition: UseCloudfront
+    Properties:
+      DomainName:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
+      RestApiId: !Ref OrchestrationOidcApi
+      Stage: !Sub "${Environment}"
+    DependsOn:
+      - OrchestrationOidcApiStage # Needs to wait for the stage created by the AWS::Serverless::Api
+
+  OrchestrationOidcOriginRecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: UseCloudfront
+    Properties:
+      Name: !Sub
+        - "origin.${oidcDomain}"
+        - oidcDomain:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              oidcDomainName,
+            ]
+      Type: A
+      HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc/hosted-zone-id}}"
+      AliasTarget:
+        DNSName: !GetAtt OrchestrationOidcApiCustomDomain.RegionalDomainName
+        HostedZoneId: !GetAtt OrchestrationOidcApiCustomDomain.RegionalHostedZoneId
+        EvaluateTargetHealth: false
+
+  OrchestrationOidcCloudFrontRecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: UseCloudfront
+    Properties:
+      Name:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
+      Type: A
+      HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc/hosted-zone-id}}"
+      AliasTarget:
+        DNSName:
+          Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
+        HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
+        EvaluateTargetHealth: false
 
   #endregion
 


### PR DESCRIPTION
### Wider context of change:

We would like to have our Cloudfront and API gateway in our own account. As part of this there are some stacks we need to deploy, including the Cloudfront Distribution, as well as some other stacks for monitoring, alerting etc.

### What’s changed: 
- Adds a script to manage the deployment of our Cloudfront related resources. This deploys dev platforms stacks:
   - Cloudfront distribution: Deploys the dev-platform cloudfront distribution
   - Monitoring: Deploys the dev-platform cloudfront monitoring stack to monitor for 5XX and Cache Hits in us-east-1
   - Certificate: Deploys a TLS cert in [us-east-1 for use with cloudfront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html#https-requirements-certificate-issuer)
   - Notifications: A custom stack with an SNS topic either linked to a Lambda (and then slack) or directly linked to PagerDuty in non-prod and prod environments respectively. Again deployed in us-east-1 due to the monitoring alarm being deployed there
- Adds a feature flag to control the deployment of the API GW custom domain resources (this is needed due to the fact that we cannot have the same API GW custom domains clashing within the same region)
- Actually link the two up by setting up the custom domain, base path mapping and DNS A records to link all the things together

### Manual testing
- Happy to talk through reviewing this one but:
- All stacks are currently deployed to dev, so hitting `oidc.dev.account.gov.uk` at any valid path (like `/trustmark` or `/.well-known/jwks.json`) should return a valid response and you should be able to trace the request through the metrics for our CF and API GW
- I would recommend reading RFC 0072, and ensuring the setup here matches what is described [here](https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/4153541152/RFC+0072+AWS+CloudFront+in+GOV.UK+One+Login#Domain-names-and-TLS-certificates)
- Also needed deploying the terraform to auth's dev to make the relevant changes there

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
