### PR TITLE
AUT-5324: Send kid in JAR header

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -39,7 +39,6 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.MalformedURLException;
-import java.security.interfaces.RSAPublicKey;
 import java.time.Clock;
 import java.util.List;
 
@@ -131,16 +130,24 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
         Result<AMCFailureReason, AMCAuthorizationUrlAndCookie> result =
                 getAMCPublicEncryptionKey()
                         .flatMap(
-                                publicEncryptionKey ->
-                                        amcService.buildAuthorizationResult(
+                                rsaKey -> {
+                                    try {
+                                        return amcService.buildAuthorizationResult(
                                                 authSessionItem.getInternalCommonSubjectId(),
                                                 transportJwtConfig.scope(),
                                                 authSessionItem,
                                                 userProfile.getPublicSubjectID(),
                                                 transportJwtConfig.redirectUri(),
                                                 accessTokenConfigsForJourneyType,
-                                                publicEncryptionKey,
-                                                state));
+                                                rsaKey.toRSAPublicKey(),
+                                                rsaKey.getKeyID(),
+                                                state);
+                                    } catch (JOSEException e) {
+                                        LOG.error("Could not parse JWK", e);
+                                        return Result.failure(
+                                                AMCFailureReason.JWKS_RETRIEVAL_ERROR);
+                                    }
+                                });
 
         return result.fold(
                 AMCFailureHttpMapper::toApiGatewayProxyErrorResponse,
@@ -155,7 +162,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                 });
     }
 
-    private Result<AMCFailureReason, RSAPublicKey> getAMCPublicEncryptionKey() {
+    private Result<AMCFailureReason, RSAKey> getAMCPublicEncryptionKey() {
         LOG.info("Retrieving RSA encryption JWK from AMC JWKS endpoint for auth -> AMC encryption");
         try {
             return Result.success(
@@ -170,13 +177,9 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                             .orElseThrow(
                                     () ->
                                             new KeySourceException(
-                                                    "No RSA key found on the JWKS endpoint"))
-                            .toRSAPublicKey());
+                                                    "No RSA key found on the JWKS endpoint")));
         } catch (KeySourceException e) {
             LOG.error("Could not retrieve JWKS", e);
-            return Result.failure(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
-        } catch (JOSEException e) {
-            LOG.error("Could not parse JWK", e);
             return Result.failure(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -70,6 +70,7 @@ public class AMCService {
             String amcRedirectUri,
             List<AccessTokenConfig> accessTokenConfigs,
             RSAPublicKey publicEncryptionKey,
+            String encryptionKeyId,
             State state) {
         LOG.info("Building AMC authorization URL");
 
@@ -81,6 +82,7 @@ public class AMCService {
                         authSessionItem,
                         accessTokenConfigs,
                         publicEncryptionKey,
+                        encryptionKeyId,
                         state)
                 .map(
                         encryptedJWTAndAmcCookie -> {
@@ -144,6 +146,7 @@ public class AMCService {
             AuthSessionItem authSessionItem,
             List<AccessTokenConfig> accessTokenConfigs,
             RSAPublicKey publicEncryptionKey,
+            String encryptionKeyId,
             State state) {
         Date issueTime = nowClock.now();
         Date expiryDate = nowClock.nowPlus(CLIENT_ASSERTION_LIFETIME, ChronoUnit.MINUTES);
@@ -192,7 +195,7 @@ public class AMCService {
                         signedJWT -> {
                             var hashedCookie = HashHelper.hashSha256String(signedJWT.serialize());
                             return jwtService
-                                    .encryptJWT(signedJWT, publicEncryptionKey)
+                                    .encryptJWT(signedJWT, publicEncryptionKey, encryptionKeyId)
                                     .map(
                                             encryptedJWT ->
                                                     new EncryptedJWTAndAmcCookie(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/JwtService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/JwtService.java
@@ -103,15 +103,20 @@ public class JwtService {
 
     public Result<JwtFailureReason, EncryptedJWT> encryptJWT(
             SignedJWT signedJWT, RSAPublicKey publicEncryptionKey) {
+        return encryptJWT(signedJWT, publicEncryptionKey, null);
+    }
+
+    public Result<JwtFailureReason, EncryptedJWT> encryptJWT(
+            SignedJWT signedJWT, RSAPublicKey publicEncryptionKey, String keyId) {
         try {
             LOG.info("Encrypting SignedJWT");
-            JWEObject jweObject =
-                    new JWEObject(
-                            new JWEHeader.Builder(
-                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
-                                    .contentType("JWT")
-                                    .build(),
-                            new Payload(signedJWT));
+            var headerBuilder =
+                    new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                            .contentType("JWT");
+            if (keyId != null) {
+                headerBuilder.keyID(keyId);
+            }
+            JWEObject jweObject = new JWEObject(headerBuilder.build(), new Payload(signedJWT));
             jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
             LOG.info("SignedJWT has been successfully encrypted");
             return Result.success(EncryptedJWT.parse(jweObject.serialize()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -81,7 +81,9 @@ class AMCAuthorizeHandlerTest {
 
     private static final String AMC_COOKIE = "some-cookie";
     private static final RSAKey TEST_RSA_JWK =
-            new RSAKey.Builder((RSAPublicKey) GENERATE_RSA_KEY_PAIR().getPublic()).build();
+            new RSAKey.Builder((RSAPublicKey) GENERATE_RSA_KEY_PAIR().getPublic())
+                    .keyID("test-encryption-key-id")
+                    .build();
 
     @BeforeEach
     void setUp() throws KeySourceException {
@@ -131,6 +133,7 @@ class AMCAuthorizeHandlerTest {
                         anyString(),
                         anyList(),
                         any(RSAPublicKey.class),
+                        anyString(),
                         any(State.class)))
                 .thenReturn(
                         Result.success(new AMCAuthorizationUrlAndCookie(expectedUrl, AMC_COOKIE)));
@@ -162,6 +165,7 @@ class AMCAuthorizeHandlerTest {
                         eq(expectedRedirectUri),
                         eq(expectedAccessTokenConfigs),
                         any(RSAPublicKey.class),
+                        anyString(),
                         stateCaptor.capture());
     }
 
@@ -238,6 +242,7 @@ class AMCAuthorizeHandlerTest {
                         anyString(),
                         anyList(),
                         any(RSAPublicKey.class),
+                        anyString(),
                         any()))
                 .thenReturn(Result.failure(failureReason));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -218,6 +218,7 @@ class AMCServiceTest {
                             REDIRECT_URI,
                             accessTokenConfigs,
                             TEST_PUBLIC_ENCRYPTION_KEY,
+                            "test-key-id",
                             STATE);
 
             assertTrue(result.isSuccess());
@@ -273,6 +274,7 @@ class AMCServiceTest {
                             REDIRECT_URI,
                             ACCESS_TOKEN_CONFIG,
                             TEST_PUBLIC_ENCRYPTION_KEY,
+                            "test-key-id",
                             STATE);
 
             assertTrue(result.isFailure());
@@ -293,6 +295,7 @@ class AMCServiceTest {
                             REDIRECT_URI,
                             ACCESS_TOKEN_CONFIG,
                             TEST_PUBLIC_ENCRYPTION_KEY,
+                            "test-key-id",
                             STATE);
 
             assertTrue(result.isFailure());
@@ -339,6 +342,7 @@ class AMCServiceTest {
                             REDIRECT_URI,
                             ACCESS_TOKEN_CONFIG,
                             TEST_PUBLIC_ENCRYPTION_KEY,
+                            "test-key-id",
                             STATE);
 
             assertTrue(result.isFailure());
@@ -370,6 +374,7 @@ class AMCServiceTest {
                             REDIRECT_URI,
                             ACCESS_TOKEN_CONFIG,
                             TEST_PUBLIC_ENCRYPTION_KEY,
+                            "test-key-id",
                             STATE);
 
             assertTrue(result.isFailure());
@@ -595,20 +600,24 @@ class AMCServiceTest {
     private void mockJwtEncryption() throws KeySourceException {
         when(jwkSource.get(any(JWKSelector.class), isNull()))
                 .thenReturn(List.of(new RSAKey.Builder(TEST_PUBLIC_ENCRYPTION_KEY).build()));
-        when(jwtService.encryptJWT(any(SignedJWT.class), any(RSAPublicKey.class)))
+        when(jwtService.encryptJWT(any(SignedJWT.class), any(RSAPublicKey.class), any()))
                 .thenAnswer(
                         invocation -> {
                             SignedJWT signedJWT = invocation.getArgument(0);
                             RSAPublicKey publicKey = invocation.getArgument(1);
+                            String keyId = invocation.getArgument(2);
                             try {
+                                var headerBuilder =
+                                        new JWEHeader.Builder(
+                                                        JWEAlgorithm.RSA_OAEP_256,
+                                                        EncryptionMethod.A256GCM)
+                                                .contentType("JWT");
+                                if (keyId != null) {
+                                    headerBuilder.keyID(keyId);
+                                }
                                 JWEObject jweObject =
                                         new JWEObject(
-                                                new JWEHeader.Builder(
-                                                                JWEAlgorithm.RSA_OAEP_256,
-                                                                EncryptionMethod.A256GCM)
-                                                        .contentType("JWT")
-                                                        .build(),
-                                                new Payload(signedJWT));
+                                                headerBuilder.build(), new Payload(signedJWT));
                                 jweObject.encrypt(new RSAEncrypter(publicKey));
                                 return Result.success(EncryptedJWT.parse(jweObject.serialize()));
                             } catch (JOSEException | ParseException e) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java
@@ -174,6 +174,19 @@ class JwtServiceTest {
             assertEquals(testSignedJwt.serialize(), encryptedJWT.getPayload().toString());
         }
 
+        @Test
+        void shouldIncludeKidInJWEHeaderWhenKeyIdProvided() throws JOSEException {
+            var publicKey = (RSAPublicKey) TEST_KEY_PAIR.getPublic();
+            var privateKey = (RSAPrivateKey) TEST_KEY_PAIR.getPrivate();
+
+            var result = jwtService.encryptJWT(testSignedJwt, publicKey, "test-kid");
+            var encryptedJWT = result.getSuccess();
+            encryptedJWT.decrypt(new RSADecrypter(privateKey));
+
+            assertEquals("test-kid", encryptedJWT.getHeader().getKeyID());
+            assertEquals(testSignedJwt.serialize(), encryptedJWT.getPayload().toString());
+        }
+
         // 512-bit key too short for RSA_OAEP_256 encryption so a JOSEException will be thrown
         @Test
         void shouldReturnEncryptionErrorFailureReasonWhenEncryptionFails() throws Exception {


### PR DESCRIPTION
## What

This is required by AMC

## How to review

1. Code Review
2. Deploy to dev and test alongside stub changes

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

https://github.com/govuk-one-login/authentication-stubs/pull/684
