### PR TITLE
AUT-5367: Update staging Argon2id password hashing parameters

### DIFF
--- a/ci/cloudformation/account-management/function/update-password.yaml
+++ b/ci/cloudformation/account-management/function/update-password.yaml
@@ -11,6 +11,27 @@ Resources:
       Handler: uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler::handleRequest
       Environment:
         Variables:
+          ARGON2_MEMORY_IN_KIBIBYTES:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2MemoryInKibibytes,
+              DefaultValue: "15360",
+            ]
+          ARGON2_ITERATIONS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Iterations,
+              DefaultValue: "2",
+            ]
+          ARGON2_PARALLELISM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Parallelism,
+              DefaultValue: "1",
+            ]
           ENVIRONMENT: !Sub
             - "${env}"
             - env:

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -311,6 +311,9 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: rjlo8fsb55
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     authdev2:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ff8d97e6-69d6-4ea1-81c0-0de8d8bcac85
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/a99e39a4-0a63-4816-b222-6e7c6c318b32
@@ -345,6 +348,9 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: ez2ro7vca7
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     authdev3:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/8a67ba56-4eb2-4bfb-8254-5cc1c92a5db5
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ce9680d3-953a-4b6a-9098-a0380d0afc70
@@ -379,6 +385,9 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 5ctgxqnq37
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     dev:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f5e5d059-1581-4c5c-8d60-e168fd8a9a84
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4b475855-e71a-43a5-a836-c6cb37e9cb22
@@ -420,6 +429,9 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0aqzty84lj
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     build:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/e8fdebb6-2d33-4d0c-825c-2b5c874522d8
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/4932c4d3-bf86-4f39-a32c-b82faf9a2574
@@ -463,6 +475,9 @@ Mappings:
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.build.account.gov.uk/.well-known/jwks.json
       accountDataApiId: ac3znt5m23
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     staging:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/01f3d1a6-e66f-4eb7-a3d7-412437c8f01d
@@ -507,6 +522,9 @@ Mappings:
       legacyAccountDeletionTopicKmsKeyArn: arn:aws:kms:eu-west-2:539729775994:key/d33e9077-8d66-4f63-99a1-f90e29b4aabe
       accessTokenJwksUrl: https://oidc.staging.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 7xgl7lexy4
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     integration:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
@@ -552,6 +570,9 @@ Mappings:
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
       accountDataApiId: hoidt6wujb
+      argon2MemoryInKibibytes: "15360"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     production:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/730472f0-c7ba-4bda-a411-08cdaa65fe8a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/075774c2-b836-452f-9684-dcd742146f81
@@ -597,6 +618,9 @@ Mappings:
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.account.gov.uk/.well-known/jwks.json
       accountDataApiId: 0218o1p9tj
+      argon2MemoryInKibibytes: "15360"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
   LambdaConfiguration:
     account-recovery:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"

--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -11,6 +11,27 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest
       Environment:
         Variables:
+          ARGON2_MEMORY_IN_KIBIBYTES:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2MemoryInKibibytes,
+              DefaultValue: "15360",
+            ]
+          ARGON2_ITERATIONS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Iterations,
+              DefaultValue: "2",
+            ]
+          ARGON2_PARALLELISM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Parallelism,
+              DefaultValue: "1",
+            ]
           AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"

--- a/ci/cloudformation/auth/function/reset-password.yaml
+++ b/ci/cloudformation/auth/function/reset-password.yaml
@@ -11,6 +11,27 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler::handleRequest
       Environment:
         Variables:
+          ARGON2_MEMORY_IN_KIBIBYTES:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2MemoryInKibibytes,
+              DefaultValue: "15360",
+            ]
+          ARGON2_ITERATIONS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Iterations,
+              DefaultValue: "2",
+            ]
+          ARGON2_PARALLELISM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Parallelism,
+              DefaultValue: "1",
+            ]
           DEFAULT_OTP_CODE_EXPIRY:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/function/signup.yaml
+++ b/ci/cloudformation/auth/function/signup.yaml
@@ -11,6 +11,27 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.SignUpHandler::handleRequest
       Environment:
         Variables:
+          ARGON2_MEMORY_IN_KIBIBYTES:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2MemoryInKibibytes,
+              DefaultValue: "15360",
+            ]
+          ARGON2_ITERATIONS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Iterations,
+              DefaultValue: "2",
+            ]
+          ARGON2_PARALLELISM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              argon2Parallelism,
+              DefaultValue: "1",
+            ]
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
             - DataStoreAccountId:

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -259,6 +259,9 @@ Mappings:
       supportPasskeys: true
       bulkEmailSendingEnabled: "true"
       amcJwksUrl: https://amcstub.signin.authdev1.dev.account.gov.uk/.well-known/amc-jwks.json
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     authdev2:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ff8d97e6-69d6-4ea1-81c0-0de8d8bcac85
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/a99e39a4-0a63-4816-b222-6e7c6c318b32
@@ -312,6 +315,9 @@ Mappings:
       supportPasskeys: true
       bulkEmailSendingEnabled: "true"
       amcJwksUrl: https://amcstub.signin.authdev2.dev.account.gov.uk/.well-known/amc-jwks.json
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     authdev3:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/8a67ba56-4eb2-4bfb-8254-5cc1c92a5db5
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ce9680d3-953a-4b6a-9098-a0380d0afc70
@@ -369,6 +375,9 @@ Mappings:
       amcCreatePasskeyRedirectUri: https://signin.authdev3.dev.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "true"
       amcJwksUrl: https://amcstub.signin.authdev3.dev.account.gov.uk/.well-known/amc-jwks.json
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     dev:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f5e5d059-1581-4c5c-8d60-e168fd8a9a84
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4b475855-e71a-43a5-a836-c6cb37e9cb22
@@ -431,6 +440,9 @@ Mappings:
       supportPasskeys: true
       bulkEmailSendingEnabled: "true"
       amcJwksUrl: https://amcstub.signin.dev.account.gov.uk/.well-known/amc-jwks.json
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     build:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/e8fdebb6-2d33-4d0c-825c-2b5c874522d8
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/4932c4d3-bf86-4f39-a32c-b82faf9a2574
@@ -498,6 +510,9 @@ Mappings:
       amcCreatePasskeyRedirectUri: https://signin.build.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"
       amcJwksUrl: https://amcstub.signin.build.account.gov.uk/.well-known/amc-jwks.json
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     staging:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/01f3d1a6-e66f-4eb7-a3d7-412437c8f01d
@@ -567,6 +582,9 @@ Mappings:
       amcCreatePasskeyRedirectUri: https://signin.staging.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "true"
       amcJwksUrl: https://2hdyiuvtug.execute-api.eu-west-2.amazonaws.com/v1/.well-known/jwks.json
+      argon2MemoryInKibibytes: "32768"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     integration:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
@@ -636,6 +654,9 @@ Mappings:
       amcCreatePasskeyRedirectUri: https://signin.integration.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"
       amcJwksUrl: https://votf1tvl36.execute-api.eu-west-2.amazonaws.com/v1/.well-known/jwks.json
+      argon2MemoryInKibibytes: "15360"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
     production:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/730472f0-c7ba-4bda-a411-08cdaa65fe8a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/075774c2-b836-452f-9684-dcd742146f81
@@ -705,6 +726,9 @@ Mappings:
       amcCreatePasskeyRedirectUri: https://signin.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"
       amcJwksUrl: https://h06vqhfzgi.execute-api.eu-west-2.amazonaws.com/v1/.well-known/jwks.json
+      argon2MemoryInKibibytes: "15360"
+      argon2Iterations: "2"
+      argon2Parallelism: "1"
   LambdaConfiguration:
     account-recovery:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2EncoderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2EncoderHelper.java
@@ -1,30 +1,39 @@
 package uk.gov.di.authentication.shared.helpers;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.bouncycastle.crypto.params.Argon2Parameters;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.security.SecureRandom;
 import java.util.Base64;
 
 public class Argon2EncoderHelper {
 
-    private static final int MEMORY_IN_KIBIBYTES = 15360;
-    private static final int PARALLELISM = 1;
-    private static final int ITERATIONS = 2;
+    private static final Logger LOG = LogManager.getLogger(Argon2EncoderHelper.class);
+
     private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder().withoutPadding();
     private static final SecureRandom RANDOM = new SecureRandom();
 
     public static String argon2Hash(String raw) {
+        var config = ConfigurationService.getInstance();
+        int memoryInKibibytes = config.getArgon2MemoryInKibibytes();
+        int iterations = config.getArgon2Iterations();
+        int parallelism = config.getArgon2Parallelism();
+
+        LOG.info("Argon2id config: m={}, t={}, p={}", memoryInKibibytes, iterations, parallelism);
+
         byte[] salt = new byte[32];
         RANDOM.nextBytes(salt);
 
         var parameters =
                 new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
                         .withVersion(Argon2Parameters.ARGON2_VERSION_13)
-                        .withIterations(ITERATIONS)
+                        .withIterations(iterations)
                         .withSalt(salt)
-                        .withMemoryAsKB(MEMORY_IN_KIBIBYTES)
-                        .withParallelism(PARALLELISM)
+                        .withMemoryAsKB(memoryInKibibytes)
+                        .withParallelism(parallelism)
                         .build();
 
         var generator = new Argon2BytesGenerator();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelper.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.helpers;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.bouncycastle.crypto.params.Argon2Parameters;
 import org.bouncycastle.util.Arrays;
@@ -7,6 +9,8 @@ import org.bouncycastle.util.Arrays;
 import java.util.Base64;
 
 public class Argon2MatcherHelper {
+
+    private static final Logger LOG = LogManager.getLogger(Argon2MatcherHelper.class);
 
     private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
 
@@ -64,7 +68,16 @@ public class Argon2MatcherHelper {
         }
         paramsBuilder.withParallelism(Integer.parseInt(performanceParams[2].substring(2)));
         paramsBuilder.withSalt(BASE64_DECODER.decode(parts[currentPart++]));
-        return new Argon2Hash(BASE64_DECODER.decode(parts[currentPart]), paramsBuilder.build());
+
+        Argon2Parameters params = paramsBuilder.build();
+
+        LOG.info(
+                "Argon2id config extracted from encoded hash: m={}, t={}, p={}",
+                params.getMemory(),
+                params.getIterations(),
+                params.getLanes());
+
+        return new Argon2Hash(BASE64_DECODER.decode(parts[currentPart]), params);
     }
 
     private static class Argon2Hash {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -71,6 +71,19 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("ACCOUNT_MANAGEMENT_URI");
     }
 
+    public int getArgon2MemoryInKibibytes() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("ARGON2_MEMORY_IN_KIBIBYTES", "15360"));
+    }
+
+    public int getArgon2Iterations() {
+        return Integer.parseInt(System.getenv().getOrDefault("ARGON2_ITERATIONS", "2"));
+    }
+
+    public int getArgon2Parallelism() {
+        return Integer.parseInt(System.getenv().getOrDefault("ARGON2_PARALLELISM", "1"));
+    }
+
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Extracts the hashing config from env vars within the `Argon2Helper`.
- Sets new hashing config for the dev, build, and staging environments.
    - Integration and production should continue to use their current configuration (m=15360, t=2, p=1)

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review.
1. Verify through static analysis that the old configuration continues to apply to integration and production.
1. Deploy to a dev environment and, once deployed, run through an account creation journey, check OK, then try to sign in, check OK.
    - The final sign in check re-verifies that we support mixed hashing configs and that this is extracted and used from the encoded password string.
1. Optionally, review the lambda logs to ensure there is still sufficient memory headroom - note that I have discussed this below

## Testing

- Ran through several journeys to `Create new account -> check OK -> sign in again -> check OK` to verify things should be working as expected on the tier 1 journeys.
- Reviewed the lambda configurations for the lambdas performing Argon2 operations (LoginHandler, SignUpHandler, ResetPasswordHandler, AuthenticateHandler, UpdatePasswordHandler, BulkTestUserCreateHandler) to check their memory allocation.
- Performed a **basic** memory analysis in dev on the LoginHandler to try and assess memory headroom on the lambda before and after the change. There appeared to still be sufficient headroom.

See the [ticket comments](https://govukverify.atlassian.net/browse/AUT-5367?focusedCommentId=308986) for some more info.

Also note that this change should only apply up to staging (at least for now). Integration and production should continue to use the existing configuration.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- No session changes**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- Orchestration hashing lives within the `orchestration-shared` helpers and remains unchanged**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required) **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required) **- N/A, technical change only**