### PR TITLE
BAU: Retry calling the ADAPI once if a timeout was encountered

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
 import uk.gov.di.authentication.shared.helpers.HttpClientHelper;
 
@@ -10,12 +12,15 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 
+import static java.lang.String.format;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.interruptedException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.ioException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.timeoutException;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
 public class AccountDataApiService {
+    private static final Logger LOG = LogManager.getLogger(AccountDataApiService.class);
+    private static final int MAX_TRIES = 2;
     private final HttpClient httpClient;
     private final ConfigurationService configurationService;
 
@@ -68,16 +73,23 @@ public class AccountDataApiService {
 
     private HttpResponse<String> sendRequest(HttpRequest request)
             throws UnsuccessfulAccountDataApiResponseException {
-
-        try {
-            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        } catch (HttpTimeoutException e) {
-            throw timeoutException(configurationService.getAccountDataApiCallTimeout(), e);
-        } catch (IOException e) {
-            throw ioException(e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw interruptedException(e);
+        int count = 0;
+        while (true) {
+            try {
+                if (count > 0) LOG.warn("Retrying Account Data API request after timeout");
+                count++;
+                return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            } catch (HttpTimeoutException e) {
+                LOG.warn(format("Timeout on attempt %d when calling Account Data API", count));
+                if (count >= MAX_TRIES) {
+                    throw timeoutException(configurationService.getAccountDataApiCallTimeout(), e);
+                }
+            } catch (IOException e) {
+                throw ioException(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw interruptedException(e);
+            }
         }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -144,6 +145,62 @@ class AccountDataApiServiceTest {
             // Assert
             assertThat(resp.statusCode(), equalTo(200));
             assertThat(resp.body(), equalTo("{'deleted': true}"));
+        }
+    }
+
+    @Nested
+    class TimeoutRetry {
+        @Test
+        void shouldRetryOnceAfterTimeout()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var successResponse = mock(HttpResponse.class);
+            when(successResponse.statusCode()).thenReturn(200);
+            when(httpClient.send(any(), any()))
+                    .thenThrow(new HttpTimeoutException("timed out"))
+                    .thenReturn(successResponse);
+
+            // Act
+            var result = service.retrievePasskeys("sub", TOKEN);
+
+            // Assert
+            verify(httpClient, times(2)).send(any(), any());
+            assertThat(result.statusCode(), equalTo(200));
+        }
+
+        @Test
+        void shouldThrowAfterMaxRetriesExhausted() throws IOException, InterruptedException {
+            // Arrange
+            doThrow(new HttpTimeoutException("timed out")).when(httpClient).send(any(), any());
+
+            // Act
+            var exception =
+                    assertThrows(
+                            UnsuccessfulAccountDataApiResponseException.class,
+                            () -> service.retrievePasskeys("sub", TOKEN));
+
+            // Assert
+            verify(httpClient, times(2)).send(any(), any());
+            assertThat(exception.getMessage(), containsString("timeout of " + TIMEOUT));
+        }
+
+        @Test
+        void shouldNotRetryOnSuccess()
+                throws IOException,
+                        InterruptedException,
+                        UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var successResponse = mock(HttpResponse.class);
+            when(successResponse.statusCode()).thenReturn(200);
+            when(httpClient.send(any(), any())).thenReturn(successResponse);
+
+            // Act
+            service.retrievePasskeys("sub", TOKEN);
+
+            // Assert
+            verify(httpClient, times(1)).send(any(), any());
         }
     }
 


### PR DESCRIPTION
## What

There is a potential issue where, on the first call of an ADAPI lambda, there is no SnapStart point to restore from, so it'll take a while to warm up. Should be no more than 10s.

This will try calling the lambda once (with a timeout of 6s), and if there's a timeout try again (waiting for another 6s). That should give the lambda enough time to warm up.

For the majority of requests though, the lambda will already be warm, or will be able to restore using SnapStart, so should return in 1s/2s.

## How to review

1. Code Review
1. Deploy Account Management API to a dev environment and validate that the retrieve/delete proxy requests still work

## Initial testing
I deployed to authdev2 and tested a request from AMAPI via the API Gateway test console. I successfully got a 401 from the ADAPI Authorizer and confirmed this by checking its logs in CloudWatch.