### PR TITLE
BAU: Fix Bouncy Castle Has Covert Timing Channel Vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ buildscript {
             classpath('org.apache.commons:commons-lang3:[3.18.0,)') {
                 because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
             }
+
+            classpath('org.bouncycastle:bcprov-jdk18on:[1.84,)') {
+                because 'CVE-2026-5598 is fixed in org.bouncycastle:bcprov-jdk18on 1.84 and higher'
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Fix high vulnerability [here](https://github.com/govuk-one-login/authentication-api/security/dependabot/103) by constraining bouncycastle to be 1.84 in the root gradle classpath. This is brought in by sonar which is a root gradle plugin so this should pin the dependency.

## How to review

1. Code review

