### PR TITLE
Aut 5417/add failed event update

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -448,11 +448,7 @@ public class MFAMethodsCreateHandler
             MfaMethodCreateRequest mfaMethodCreateRequest) {
         var maybeAuditContext =
                 accountManagementAuditContext(
-                                configurationService, dynamoService, input, userProfile)
-                        .map(
-                                baseContext ->
-                                        enrichAuditContextForEvent(
-                                                auditEvent, mfaMethodCreateRequest, baseContext));
+                        configurationService, dynamoService, input, userProfile);
         if (maybeAuditContext.isFailure()) {
             LOG.error(
                     "Error when building audit context for {} audit event with error code {}. No event raised",
@@ -461,16 +457,15 @@ public class MFAMethodsCreateHandler
             return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
         }
 
-        var result =
-                AuditHelper.sendAuditEvent(
-                        auditEvent, maybeAuditContext.getSuccess(), auditService, LOG);
-
-        if (result.isFailure()) {
-            return Result.failure(result.getFailure());
-        }
-
-        LOG.info("Successfully submitted audit event: {}", auditEvent.name());
-        return Result.success(null);
+        var baseAuditContext = maybeAuditContext.getSuccess();
+        var enrichedAuditContext =
+                enrichAuditContextForEvent(auditEvent, mfaMethodCreateRequest, baseAuditContext);
+        return AuditHelper.sendAuditEvent(auditEvent, enrichedAuditContext, auditService, LOG)
+                .map(
+                        sucess -> {
+                            LOG.info("Successfully submitted audit event: {}", auditEvent.name());
+                            return sucess;
+                        });
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -382,22 +382,23 @@ public class MFAMethodsCreateHandler
             AccountManagementAuditableEvent auditEvent,
             MfaMethodCreateRequest mfaMethodCreateRequest,
             AuditContext baseAuditContext) {
-        AuditContext context = baseAuditContext;
         var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
         var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
-        context =
-                context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType))
-                        .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
+
+        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType);
+        var mfaMethodPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority);
+        var accountRecoveryPair = pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
+
+        var context =
+                baseAuditContext.withMetadataItem(mfaTypePair).withMetadataItem(mfaMethodPair);
+
+        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
+            context = context.withMetadataItem(accountRecoveryPair);
+        }
 
         if (mfaMethodCreateRequest.mfaMethod().method()
                 instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
             context = enrichWithSmsDetails(context, auditEvent, requestSmsMfaDetail);
-        }
-
-        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-            context =
-                    context.withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
         }
 
         return context;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -380,49 +380,54 @@ public class MFAMethodsCreateHandler
 
     private Result<ErrorResponse, AuditContext> buildAuditContext(
             AccountManagementAuditableEvent auditEvent,
-            UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest,
             AuditContext baseAuditContext) {
-        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
-            return getDefaultMethod(userProfile)
-                    .map(
-                            method ->
-                                    updateAuditContextForFailedMFACreation(
-                                            method, baseAuditContext));
-        } else {
-            AuditContext context = baseAuditContext;
-            var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
-            var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
-            context =
-                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType))
-                            .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
+        AuditContext context = baseAuditContext;
+        var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
+        var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
+        context =
+                context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType))
+                        .withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority));
 
-            if (mfaMethodCreateRequest.mfaMethod().method()
-                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                context = enrichWithSmsDetails(context, auditEvent, requestSmsMfaDetail);
-            }
-
-            if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-                context =
-                        context.withMetadataItem(
-                                pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
-            }
-
-            return Result.success(context);
+        if (mfaMethodCreateRequest.mfaMethod().method()
+                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+            context = enrichWithSmsDetails(context, auditEvent, requestSmsMfaDetail);
         }
+
+        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
+            context =
+                    context.withMetadataItem(
+                            pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
+        }
+
+        return Result.success(context);
     }
 
     private AuditContext enrichWithSmsDetails(
             AuditContext context,
             AccountManagementAuditableEvent auditEvent,
             RequestSmsMfaDetail smsDetail) {
-        var updatedContext =
-                context.withPhoneNumber(
-                                PhoneNumberHelper.formatPhoneNumber(smsDetail.phoneNumber()))
-                        .withMetadataItem(
-                                pair(
-                                        AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                        PhoneNumberHelper.getCountry(smsDetail.phoneNumber())));
+        String formattedPhoneNumber;
+        try {
+            formattedPhoneNumber = PhoneNumberHelper.formatPhoneNumber(smsDetail.phoneNumber());
+        } catch (RuntimeException e) {
+            LOG.warn("Couldn't format phone number, audit event using raw number from request");
+            formattedPhoneNumber = smsDetail.phoneNumber();
+        }
+
+        var updatedContext = context.withPhoneNumber(formattedPhoneNumber);
+
+        var maybeCountryCodePair =
+                PhoneNumberHelper.maybeGetCountry(smsDetail.phoneNumber())
+                        .map(
+                                country ->
+                                        pair(
+                                                AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
+                                                country));
+
+        if (maybeCountryCodePair.isPresent()) {
+            updatedContext = updatedContext.withMetadataItem(maybeCountryCodePair.get());
+        }
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED) && smsDetail.otp() != null) {
             return updatedContext
@@ -446,10 +451,7 @@ public class MFAMethodsCreateHandler
                         .flatMap(
                                 baseContext ->
                                         buildAuditContext(
-                                                auditEvent,
-                                                userProfile,
-                                                mfaMethodCreateRequest,
-                                                baseContext));
+                                                auditEvent, mfaMethodCreateRequest, baseContext));
         if (maybeAuditContext.isFailure()) {
             LOG.error(
                     "Error when building audit context for {} audit event with error code {}. No event raised",
@@ -468,49 +470,6 @@ public class MFAMethodsCreateHandler
 
         LOG.info("Successfully submitted audit event: {}", auditEvent.name());
         return Result.success(null);
-    }
-
-    private Result<ErrorResponse, MFAMethod> getDefaultMethod(UserProfile userProfile) {
-        var maybeMfaMethods = mfaMethodsService.getMfaMethods(userProfile.getEmail());
-
-        if (maybeMfaMethods.isFailure()) {
-            LOG.error("No MFA methods found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        }
-
-        var mfaMethods = maybeMfaMethods.getSuccess();
-
-        var defaultMfaMethod =
-                mfaMethods.stream()
-                        .filter(
-                                method ->
-                                        method.getPriority()
-                                                .equalsIgnoreCase(
-                                                        PriorityIdentifier.DEFAULT.name()))
-                        .findFirst();
-
-        if (defaultMfaMethod.isEmpty()) {
-            LOG.error("No default MFA method found for user");
-            return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
-        } else return Result.success(defaultMfaMethod.get());
-    }
-
-    private static AuditContext updateAuditContextForFailedMFACreation(
-            MFAMethod defaultMethod, AuditContext auditContext) {
-        var phoneNumber =
-                defaultMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())
-                        ? defaultMethod.getDestination()
-                        : null;
-        var mfaTypeExtension =
-                pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, defaultMethod.getMfaMethodType());
-        var priorityExtension =
-                pair(
-                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                        PriorityIdentifier.DEFAULT.name().toLowerCase());
-        return auditContext
-                .withPhoneNumber(phoneNumber)
-                .withMetadataItem(mfaTypeExtension)
-                .withMetadataItem(priorityExtension);
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -378,7 +378,7 @@ public class MFAMethodsCreateHandler
         };
     }
 
-    private Result<ErrorResponse, AuditContext> buildAuditContext(
+    private AuditContext enrichAuditContextForEvent(
             AccountManagementAuditableEvent auditEvent,
             MfaMethodCreateRequest mfaMethodCreateRequest,
             AuditContext baseAuditContext) {
@@ -400,7 +400,7 @@ public class MFAMethodsCreateHandler
                             pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
         }
 
-        return Result.success(context);
+        return context;
     }
 
     private AuditContext enrichWithSmsDetails(
@@ -448,9 +448,9 @@ public class MFAMethodsCreateHandler
         var maybeAuditContext =
                 accountManagementAuditContext(
                                 configurationService, dynamoService, input, userProfile)
-                        .flatMap(
+                        .map(
                                 baseContext ->
-                                        buildAuditContext(
+                                        enrichAuditContextForEvent(
                                                 auditEvent, mfaMethodCreateRequest, baseContext));
         if (maybeAuditContext.isFailure()) {
             LOG.error(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -54,7 +54,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.DEFAULT_MFA_ALREADY_EXISTS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_OTP;
@@ -418,17 +417,8 @@ public class MFAMethodsCreateHandler
 
         var updatedContext = context.withPhoneNumber(formattedPhoneNumber);
 
-        var maybeCountryCodePair =
-                PhoneNumberHelper.maybeGetCountry(smsDetail.phoneNumber())
-                        .map(
-                                country ->
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                                country));
-
-        if (maybeCountryCodePair.isPresent()) {
-            updatedContext = updatedContext.withMetadataItem(maybeCountryCodePair.get());
-        }
+        // Note: we do not need to explicitly add the phone number country code metadata pair as
+        // this is handled already by the audit service
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED) && smsDetail.otp() != null) {
             return updatedContext

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -436,18 +436,18 @@ public class MFAMethodsCreateHandler
             APIGatewayProxyRequestEvent input,
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
-        var maybeAuditContext =
+        var auditContextResult =
                 accountManagementAuditContext(
                         configurationService, dynamoService, input, userProfile);
-        if (maybeAuditContext.isFailure()) {
+        if (auditContextResult.isFailure()) {
             LOG.error(
                     "Error when building audit context for {} audit event with error code {}. No event raised",
                     auditEvent,
-                    maybeAuditContext.getFailure());
+                    auditContextResult.getFailure());
             return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
         }
 
-        var baseAuditContext = maybeAuditContext.getSuccess();
+        var baseAuditContext = auditContextResult.getSuccess();
         var enrichedAuditContext =
                 enrichAuditContextForEvent(auditEvent, mfaMethodCreateRequest, baseAuditContext);
         return AuditHelper.sendAuditEvent(auditEvent, enrichedAuditContext, auditService, LOG)

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -550,7 +550,6 @@ class MFAMethodsCreateHandlerTest {
         void shouldReturn400WhenInternationalNumberAndFeatureFlagDisabled() {
             when(configurationService.isAccountManagementInternationalSmsEnabled())
                     .thenReturn(false);
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL)).thenReturn(Result.success(List.of()));
 
             var event =
                     generateApiGatewayEvent(
@@ -563,7 +562,6 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INTERNATIONAL_PHONE_NUMBER_NOT_SUPPORTED));
             verifyNoInteractions(sqsClient);
-            verifyNoInteractions(auditService);
         }
 
         @Test
@@ -652,13 +650,6 @@ class MFAMethodsCreateHandlerTest {
                                     MfaCreateFailureReason
                                             .BACKUP_AND_DEFAULT_METHOD_ALREADY_EXIST));
 
-            var defaultMfa =
-                    MFAMethod.authAppMfaMethod(
-                            "cred", true, true, PriorityIdentifier.DEFAULT, TEST_AUTH_APP_ID);
-
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL))
-                    .thenReturn(Result.success(List.of(defaultMfa)));
-
             var result = handler.handleRequest(event, context);
 
             assertThat(result, hasStatus(400));
@@ -666,9 +657,10 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -691,12 +683,6 @@ class MFAMethodsCreateHandlerTest {
                     .thenReturn(Optional.of(userProfile));
             when(mfaMethodsService.addBackupMfa(any(), any()))
                     .thenReturn(Result.failure(MfaCreateFailureReason.INVALID_PHONE_NUMBER));
-            var defaultMfa =
-                    MFAMethod.authAppMfaMethod(
-                            "cred", true, true, PriorityIdentifier.DEFAULT, TEST_AUTH_APP_ID);
-
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL))
-                    .thenReturn(Result.success(List.of(defaultMfa)));
 
             var result = handler.handleRequest(event, context);
 
@@ -705,9 +691,9 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                            .withPhoneNumber("not a real phone number")
+                            .withMetadataItem(pair("mfa-type", SMS.toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -727,13 +713,6 @@ class MFAMethodsCreateHandlerTest {
             when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                     .thenReturn(Optional.of(userProfile));
 
-            var defaultMfa =
-                    MFAMethod.authAppMfaMethod(
-                            "cred", true, true, PriorityIdentifier.DEFAULT, TEST_AUTH_APP_ID);
-
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL))
-                    .thenReturn(Result.success(List.of(defaultMfa)));
-
             var result = handler.handleRequest(event, context);
 
             assertThat(result, hasStatus(400));
@@ -741,9 +720,9 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                            .withPhoneNumber(invalidPhoneNumber)
+                            .withMetadataItem(pair("mfa-type", SMS.toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -751,8 +730,6 @@ class MFAMethodsCreateHandlerTest {
                             expectedMfaMethodAddFailedAuditContext,
                             AUDIT_EVENT_COMPONENT_ID_HOME);
 
-            // Verify that getMfaMethods was called but addBackupMfa was not
-            verify(mfaMethodsService).getMfaMethods(TEST_EMAIL);
             verify(mfaMethodsService, org.mockito.Mockito.never()).addBackupMfa(any(), any());
         }
 
@@ -797,22 +774,15 @@ class MFAMethodsCreateHandlerTest {
 
         @Test
         void shouldReturn400WhenMfaMethodServiceReturnsSmsMfaAlreadyExistsError() {
+            var requestDetail = new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP);
             var event =
                     generateApiGatewayEvent(
-                            PriorityIdentifier.BACKUP,
-                            new RequestSmsMfaDetail(TEST_PHONE_NUMBER, TEST_OTP),
-                            TEST_INTERNAL_SUBJECT);
+                            PriorityIdentifier.BACKUP, requestDetail, TEST_INTERNAL_SUBJECT);
             when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                     .thenReturn(Optional.of(userProfile));
             when(codeStorageService.isValidOtpCode(any(), any(), any())).thenReturn(true);
             when(mfaMethodsService.addBackupMfa(any(), any()))
                     .thenReturn(Result.failure(MfaCreateFailureReason.PHONE_NUMBER_ALREADY_EXISTS));
-            var defaultMfa =
-                    MFAMethod.authAppMfaMethod(
-                            "cred", true, true, PriorityIdentifier.DEFAULT, TEST_AUTH_APP_ID);
-
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL))
-                    .thenReturn(Result.success(List.of(defaultMfa)));
 
             var result = handler.handleRequest(event, context);
 
@@ -821,9 +791,11 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
+                            .withMetadataItem(
+                                    pair("mfa-type", requestDetail.mfaMethodType().toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("phone_number_country_code", "44"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -843,12 +815,6 @@ class MFAMethodsCreateHandlerTest {
                     .thenReturn(Optional.of(userProfile));
             when(mfaMethodsService.addBackupMfa(any(), any()))
                     .thenReturn(Result.failure(MfaCreateFailureReason.AUTH_APP_EXISTS));
-            var defaultMfa =
-                    MFAMethod.authAppMfaMethod(
-                            "cred", true, true, PriorityIdentifier.DEFAULT, TEST_AUTH_APP_ID);
-
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL))
-                    .thenReturn(Result.success(List.of(defaultMfa)));
 
             var result = handler.handleRequest(event, context);
 
@@ -859,7 +825,7 @@ class MFAMethodsCreateHandlerTest {
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(null)
                             .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -882,16 +848,6 @@ class MFAMethodsCreateHandlerTest {
                     .thenReturn(Optional.of(userProfile));
             when(mfaMethodsService.addBackupMfa(any(), any()))
                     .thenReturn(Result.success(mfaMethodWithInvalidMfaType));
-            var defaultMfa =
-                    MFAMethod.smsMfaMethod(
-                            true,
-                            true,
-                            TEST_PHONE_NUMBER,
-                            PriorityIdentifier.DEFAULT,
-                            TEST_SMS_MFA_ID);
-
-            when(mfaMethodsService.getMfaMethods(TEST_EMAIL))
-                    .thenReturn(Result.success(List.of(defaultMfa)));
 
             var result = handler.handleRequest(event, context);
 
@@ -901,9 +857,9 @@ class MFAMethodsCreateHandlerTest {
 
             var expectedMfaMethodAddFailedAuditContext =
                     BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                            .withPhoneNumber(null)
+                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -288,10 +288,10 @@ class MFAMethodsCreateHandlerTest {
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("account-recovery", "false"))
                             .withMetadataItem(pair("phone_number_country_code", "44"))
                             .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
-                            .withMetadataItem(pair("notification-type", MFA_SMS.name()))
-                            .withMetadataItem(pair("account-recovery", "false"));
+                            .withMetadataItem(pair("notification-type", MFA_SMS.name()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -474,10 +474,10 @@ class MFAMethodsCreateHandlerTest {
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .withMetadataItem(pair("account-recovery", "false"))
                             .withMetadataItem(pair("phone_number_country_code", "44"))
                             .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
-                            .withMetadataItem(pair("notification-type", MFA_SMS.name()))
-                            .withMetadataItem(pair("account-recovery", "false"));
+                            .withMetadataItem(pair("notification-type", MFA_SMS.name()));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -289,7 +289,6 @@ class MFAMethodsCreateHandlerTest {
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("phone_number_country_code", "44"))
                             .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                             .withMetadataItem(pair("notification-type", MFA_SMS.name()));
 
@@ -303,8 +302,7 @@ class MFAMethodsCreateHandlerTest {
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"));
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -316,8 +314,7 @@ class MFAMethodsCreateHandlerTest {
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"));
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -475,7 +472,6 @@ class MFAMethodsCreateHandlerTest {
                             .withMetadataItem(pair("mfa-type", SMS.name()))
                             .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
                             .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("phone_number_country_code", "44"))
                             .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
                             .withMetadataItem(pair("notification-type", MFA_SMS.name()));
 
@@ -659,8 +655,7 @@ class MFAMethodsCreateHandlerTest {
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"));
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -760,8 +755,7 @@ class MFAMethodsCreateHandlerTest {
                     BASE_AUDIT_CONTEXT
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"));
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -794,8 +788,7 @@ class MFAMethodsCreateHandlerTest {
                             .withPhoneNumber(TEST_E164_PHONE_NUMBER)
                             .withMetadataItem(
                                     pair("mfa-type", requestDetail.mfaMethodType().toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("phone_number_country_code", "44"));
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -558,6 +558,16 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INTERNATIONAL_PHONE_NUMBER_NOT_SUPPORTED));
             verifyNoInteractions(sqsClient);
+            var expectedContext =
+                    BASE_AUDIT_CONTEXT
+                            .withPhoneNumber(INTERNATIONAL_MOBILE_NUMBER)
+                            .withMetadataItem(pair("mfa-type", SMS.toString()))
+                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_MFA_METHOD_ADD_FAILED,
+                            expectedContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         }
 
         @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -58,7 +58,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
-import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
 import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;
@@ -551,7 +550,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             Map<String, String> addFailedAttributes = new HashMap<>();
             addFailedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             addFailedAttributes.put(EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.name());
-            addFailedAttributes.put(EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
+            addFailedAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
             eventExpectations.put(AUTH_MFA_METHOD_ADD_FAILED.name(), addFailedAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
@@ -608,8 +607,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             Map<String, String> addFailedAttributes = new HashMap<>();
             addFailedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             addFailedAttributes.put(EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.name());
-            addFailedAttributes.put(
-                    EXTENSIONS_MFA_METHOD, PriorityIdentifier.DEFAULT.name().toLowerCase());
+            addFailedAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
             eventExpectations.put(AUTH_MFA_METHOD_ADD_FAILED.name(), addFailedAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
@@ -767,8 +765,8 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
             Map<String, String> addFailedAttributes = new HashMap<>();
             addFailedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
-            addFailedAttributes.put(EXTENSIONS_MFA_METHOD, DEFAULT.name().toLowerCase());
-            addFailedAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
+            addFailedAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
+            addFailedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
             eventExpectations.put(AUTH_MFA_METHOD_ADD_FAILED.name(), addFailedAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -196,6 +196,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             codeVerifiedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
+            codeVerifiedAttributes.put(EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "44");
             codeVerifiedAttributes.put(EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS");
             eventExpectations.put(AUTH_CODE_VERIFIED.name(), codeVerifiedAttributes);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -5,6 +5,9 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_MFA_TYPE = "mfa-type";
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY = "account-recovery";
     String AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE = "journey-type";
+    // Note: this (phone number country code) is unlikely to be needed to set explicitly on events
+    // as it is handled by the audit service: we should remove it from here when it's been removed
+    // from all the metadata pairs explicitly set in handlers to discourage use
     String AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE = "phone_number_country_code";
     String AUDIT_EVENT_EXTENSIONS_MIGRATION_SUCCEEDED = "migration-succeeded";
     String AUDIT_EVENT_EXTENSIONS_HAD_PARTIAL = "had-partial";


### PR DESCRIPTION
In the mfa methods create handler, we emit multiple audit events.

The create failed audit event currently contains an inconsistency, which is that it contains details of the user's existing mfa method, rather than the method it failed to create. This is inconsistent with all the other audit events in this handler, and is confusing to read since you might reasonably expect the details in the audit event to refer to the method which failed to create.

The [event catalogue has now been updated to reflect this](https://github.com/govuk-one-login/event-catalogue/pull/599) - the do not merge label on this PR was added while this was going through review - and internal consumers have confirmed they are happy, so we can change it in code.
