### PR TITLE
Aut 5358/delete passkey

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
@@ -60,16 +60,16 @@ class PasskeysDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
             assertEquals(2, passkeysBeforeDelete.size());
 
             // When
+            var pathParams =
+                    Map.ofEntries(
+                            Map.entry("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            Map.entry("passkeyId", PRIMARY_PASSKEY_ID));
             var response =
                     makeRequest(
                             Optional.empty(),
                             new HashMap<>(),
                             Collections.emptyMap(),
-                            Map.of(
-                                    "publicSubjectId",
-                                    PUBLIC_SUBJECT_ID,
-                                    "passkeyId",
-                                    PRIMARY_PASSKEY_ID),
+                            pathParams,
                             AUTHORIZER_PARAMS);
 
             // Then
@@ -81,6 +81,46 @@ class PasskeysDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
             var savedPasskey = passkeysAfterDelete.get(0);
 
             assertThat(savedPasskey.getCredentialId(), equalTo(otherPasskey.getCredentialId()));
+        }
+    }
+
+    @Nested
+    class Failure {
+        @Test
+        void shouldReturn404WhenPasskeyNotFound() {
+            // Given
+            Passkey existingPasskey =
+                    buildGenericPasskeyForUserWithSubjectId(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
+            dynamoPasskeyService.savePasskeyIfUnique(existingPasskey);
+
+            // Check that we definitely have both a passkey saved before we proceed with the request
+            // to delete
+            var passkeysBeforeDelete = dynamoPasskeyService.getPasskeysForUser(PUBLIC_SUBJECT_ID);
+            assertEquals(1, passkeysBeforeDelete.size());
+
+            // When
+            var pathParams =
+                    Map.ofEntries(
+                            Map.entry("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            Map.entry("passkeyId", SECONDARY_PASSKEY_ID));
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            new HashMap<>(),
+                            Collections.emptyMap(),
+                            pathParams,
+                            AUTHORIZER_PARAMS);
+
+            // Then
+            assertThat(response.getStatusCode(), equalTo(404));
+
+            var passkeysAfterDelete = dynamoPasskeyService.getPasskeysForUser(PUBLIC_SUBJECT_ID);
+            assertEquals(passkeysBeforeDelete.size(), passkeysAfterDelete.size());
+
+            var passkeyAfterDelete = passkeysAfterDelete.get(0);
+            assertThat(
+                    passkeyAfterDelete.getCredentialId(),
+                    equalTo(existingPasskey.getCredentialId()));
         }
     }
 }

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
@@ -1,0 +1,86 @@
+package uk.gov.di.accountdata.lambda;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.accountdata.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.accountdata.extensions.AuthenticatorExtension;
+import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
+import uk.gov.di.authentication.accountdata.lambda.PasskeysDeleteHandler;
+import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PRIMARY_PASSKEY_ID;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PUBLIC_SUBJECT_ID;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.SECONDARY_PASSKEY_ID;
+import static uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper.buildGenericPasskeyForUserWithSubjectId;
+
+class PasskeysDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private final ConfigurationService configurationService = ConfigurationService.getInstance();
+    DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
+    private static final Map<String, Object> AUTHORIZER_PARAMS =
+            Map.of("principalId", PUBLIC_SUBJECT_ID);
+
+    @RegisterExtension
+    protected static final AuthenticatorExtension authenticatorExtension =
+            new AuthenticatorExtension();
+
+    @BeforeEach
+    void setUp() {
+        handler = new PasskeysDeleteHandler(configurationService);
+    }
+
+    @Nested
+    class Success {
+
+        @Test
+        void shouldDeleteAPasskey() {
+            // Given
+            Passkey passkeyToDelete =
+                    buildGenericPasskeyForUserWithSubjectId(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
+            Passkey otherPasskey =
+                    buildGenericPasskeyForUserWithSubjectId(
+                            PUBLIC_SUBJECT_ID, SECONDARY_PASSKEY_ID);
+            dynamoPasskeyService.savePasskeyIfUnique(passkeyToDelete);
+            dynamoPasskeyService.savePasskeyIfUnique(otherPasskey);
+
+            // Check that we definitely have both passkeys saved before we proceed with the request
+            // to delete
+            var passkeysBeforeDelete = dynamoPasskeyService.getPasskeysForUser(PUBLIC_SUBJECT_ID);
+            assertEquals(2, passkeysBeforeDelete.size());
+
+            // When
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            new HashMap<>(),
+                            Collections.emptyMap(),
+                            Map.of(
+                                    "publicSubjectId",
+                                    PUBLIC_SUBJECT_ID,
+                                    "passkeyId",
+                                    PRIMARY_PASSKEY_ID),
+                            AUTHORIZER_PARAMS);
+
+            // Then
+            assertThat(response.getStatusCode(), equalTo(204));
+            assertThat(response.getBody(), equalTo(""));
+
+            var passkeysAfterDelete = dynamoPasskeyService.getPasskeysForUser(PUBLIC_SUBJECT_ID);
+            assertEquals(1, passkeysAfterDelete.size());
+            var savedPasskey = passkeysAfterDelete.get(0);
+
+            assertThat(savedPasskey.getCredentialId(), equalTo(otherPasskey.getCredentialId()));
+        }
+    }
+}

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountdata.extensions.AuthenticatorExtension;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
+import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.helpers.CommonTestVariables;
 import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -295,16 +296,38 @@ class DynamoPasskeyServiceIntegrationTest {
                             CommonTestVariables.ANOTHER_PUBLIC_SUBJECT_ID));
 
             // When
-            dynamoPasskeyService.deletePasskey(
-                    CommonTestVariables.PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
+            var result =
+                    dynamoPasskeyService.deletePasskey(
+                            CommonTestVariables.PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
 
             // Then
+            assertTrue(result.isSuccess());
             var usersPasskeys =
                     dynamoPasskeyService.getPasskeysForUser(CommonTestVariables.PUBLIC_SUBJECT_ID);
             assertThat(usersPasskeys.size(), equalTo(1));
             assertThat(
                     usersPasskeys.get(0).getCredentialId(),
                     equalTo(CommonTestVariables.ANOTHER_PUBLIC_SUBJECT_ID));
+        }
+
+        @Test
+        void shouldReturnFailureIfPasskeyDoesNotExists() {
+            // Given
+            var existingPasskey =
+                    buildGenericPasskeyForUserWithSubjectId(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
+            dynamoPasskeyService.savePasskeyIfUnique(existingPasskey);
+
+            // When
+            var result =
+                    dynamoPasskeyService.deletePasskey(
+                            CommonTestVariables.PUBLIC_SUBJECT_ID, "a-different-id");
+
+            // Then
+            assertEquals(Result.failure(PasskeysDeleteFailureReason.PASSKEY_NOT_FOUND), result);
+            var usersPasskeys =
+                    dynamoPasskeyService.getPasskeysForUser(CommonTestVariables.PUBLIC_SUBJECT_ID);
+            assertThat(usersPasskeys.size(), equalTo(1));
+            assertEquals(existingPasskey.getCredentialId(), usersPasskeys.get(0).getCredentialId());
         }
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysDeleteFailureReason.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysDeleteFailureReason.java
@@ -1,7 +1,8 @@
 package uk.gov.di.authentication.accountdata.entity.passkey.failurereasons;
 
 public enum PasskeysDeleteFailureReason {
-    PASSKEY_NOT_FOUND("passkey_not_found");
+    PASSKEY_NOT_FOUND("passkey_not_found"),
+    FAILED_TO_DELETE_PASSKEY("failed_to_delete_passkey");
 
     private final String value;
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysDeleteFailureReason.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysDeleteFailureReason.java
@@ -2,7 +2,10 @@ package uk.gov.di.authentication.accountdata.entity.passkey.failurereasons;
 
 public enum PasskeysDeleteFailureReason {
     PASSKEY_NOT_FOUND("passkey_not_found"),
-    FAILED_TO_DELETE_PASSKEY("failed_to_delete_passkey");
+    FAILED_TO_DELETE_PASSKEY("failed_to_delete_passkey"),
+    MISSING_SUBJECT_ID("missing_subject_id"),
+    MISSING_PASSKEY_ID("missing_passkey_id"),
+    UNAUTHORIZED_REQUEST("unauthorized_request");
 
     private final String value;
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysDeleteFailureReason.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/failurereasons/PasskeysDeleteFailureReason.java
@@ -1,0 +1,15 @@
+package uk.gov.di.authentication.accountdata.entity.passkey.failurereasons;
+
+public enum PasskeysDeleteFailureReason {
+    PASSKEY_NOT_FOUND("passkey_not_found");
+
+    private final String value;
+
+    PasskeysDeleteFailureReason(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -10,13 +10,13 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Objects;
 
 import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
-import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
@@ -55,30 +55,47 @@ public class PasskeysDeleteHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("PasskeysDeleteHandler called");
 
+        return validateRequest(input)
+                .flatMap(
+                        validDeleteParams ->
+                                passkeysService.deletePasskey(
+                                        validDeleteParams.publicSubjectId,
+                                        validDeleteParams.passkeyId))
+                .fold(this::mapDeleteFailure, success -> generateEmptySuccessApiGatewayResponse());
+    }
+
+    private record ValidDeleteParams(String publicSubjectId, String passkeyId) {}
+
+    private Result<PasskeysDeleteFailureReason, ValidDeleteParams> validateRequest(
+            APIGatewayProxyRequestEvent input) {
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
         var passkeyId = input.getPathParameters().get("passkeyId");
 
         if (Objects.isNull(publicSubjectId) || publicSubjectId.isEmpty()) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MISSING_SUBJECT_ID);
+            return Result.failure(PasskeysDeleteFailureReason.MISSING_SUBJECT_ID);
         }
 
         if (Objects.isNull(passkeyId) || passkeyId.isEmpty()) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MISSING_PASSKEY_ID);
+            return Result.failure(PasskeysDeleteFailureReason.MISSING_PASSKEY_ID);
         }
 
         if (!isSubjectIdAuthorized(
                 input.getPathParameters().get("publicSubjectId"), input.getRequestContext())) {
-            return generateApiGatewayProxyResponse(401, "");
+            return Result.failure(PasskeysDeleteFailureReason.UNAUTHORIZED_REQUEST);
         }
 
-        return passkeysService
-                .deletePasskey(publicSubjectId, passkeyId)
-                .fold(this::mapDeleteFailure, success -> generateEmptySuccessApiGatewayResponse());
+        return Result.success(new ValidDeleteParams(publicSubjectId, passkeyId));
     }
 
     private APIGatewayProxyResponseEvent mapDeleteFailure(
             PasskeysDeleteFailureReason failureReason) {
         return switch (failureReason) {
+            case MISSING_SUBJECT_ID -> generateApiGatewayProxyErrorResponse(
+                    400, ErrorResponse.MISSING_SUBJECT_ID);
+            case MISSING_PASSKEY_ID -> generateApiGatewayProxyErrorResponse(
+                    400, ErrorResponse.MISSING_PASSKEY_ID);
+            case UNAUTHORIZED_REQUEST -> generateApiGatewayProxyErrorResponse(
+                    401, ErrorResponse.UNAUTHORIZED_REQUEST);
             case PASSKEY_NOT_FOUND -> generateApiGatewayProxyErrorResponse(
                     404, ErrorResponse.PASSKEY_NOT_FOUND);
             case FAILED_TO_DELETE_PASSKEY -> generateApiGatewayProxyErrorResponse(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -24,7 +24,6 @@ public class PasskeysDeleteHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(PasskeysDeleteHandler.class);
-    private final ConfigurationService configurationService;
     private final PasskeysService passkeysService;
 
     public PasskeysDeleteHandler() {
@@ -32,13 +31,10 @@ public class PasskeysDeleteHandler
     }
 
     public PasskeysDeleteHandler(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
         this.passkeysService = new PasskeysService(configurationService);
     }
 
-    public PasskeysDeleteHandler(
-            ConfigurationService configurationService, PasskeysService passkeysService) {
-        this.configurationService = configurationService;
+    public PasskeysDeleteHandler(PasskeysService passkeysService) {
         this.passkeysService = passkeysService;
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -7,13 +7,17 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Objects;
 
 import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class PasskeysDeleteHandler
@@ -63,8 +67,17 @@ public class PasskeysDeleteHandler
             return generateApiGatewayProxyResponse(401, "");
         }
 
-        passkeysService.deletePasskey(publicSubjectId, passkeyId);
+        return passkeysService
+                .deletePasskey(publicSubjectId, passkeyId)
+                .fold(this::mapDeleteFailure, success -> generateEmptySuccessApiGatewayResponse());
+    }
 
-        return generateApiGatewayProxyResponse(204, "");
+    private APIGatewayProxyResponseEvent mapDeleteFailure(
+            PasskeysDeleteFailureReason failureReason) {
+        return switch (failureReason) {
+            case PASSKEY_NOT_FOUND -> generateApiGatewayProxyErrorResponse(
+                    404, ErrorResponse.PASSKEY_NOT_FOUND);
+            default -> throw new RuntimeException("To come in subsequent commit");
+        };
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -58,8 +58,12 @@ public class PasskeysDeleteHandler
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
         var passkeyId = input.getPathParameters().get("passkeyId");
 
-        if (Objects.isNull(publicSubjectId)) {
-            return generateApiGatewayProxyResponse(400, "");
+        if (Objects.isNull(publicSubjectId) || publicSubjectId.isEmpty()) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MISSING_SUBJECT_ID);
+        }
+
+        if (Objects.isNull(passkeyId) || passkeyId.isEmpty()) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MISSING_PASSKEY_ID);
         }
 
         if (!isSubjectIdAuthorized(
@@ -75,10 +79,10 @@ public class PasskeysDeleteHandler
     private APIGatewayProxyResponseEvent mapDeleteFailure(
             PasskeysDeleteFailureReason failureReason) {
         return switch (failureReason) {
-            case PASSKEY_NOT_FOUND ->
-                    generateApiGatewayProxyErrorResponse(404, ErrorResponse.PASSKEY_NOT_FOUND);
-            case FAILED_TO_DELETE_PASSKEY ->
-                generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
+            case PASSKEY_NOT_FOUND -> generateApiGatewayProxyErrorResponse(
+                    404, ErrorResponse.PASSKEY_NOT_FOUND);
+            case FAILED_TO_DELETE_PASSKEY -> generateApiGatewayProxyErrorResponse(
+                    500, ErrorResponse.INTERNAL_SERVER_ERROR);
         };
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Objects;
@@ -20,6 +21,7 @@ public class PasskeysDeleteHandler
 
     private static final Logger LOG = LogManager.getLogger(PasskeysDeleteHandler.class);
     private final ConfigurationService configurationService;
+    private final PasskeysService passkeysService;
 
     public PasskeysDeleteHandler() {
         this(ConfigurationService.getInstance());
@@ -27,6 +29,13 @@ public class PasskeysDeleteHandler
 
     public PasskeysDeleteHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+        this.passkeysService = new PasskeysService(configurationService);
+    }
+
+    public PasskeysDeleteHandler(
+            ConfigurationService configurationService, PasskeysService passkeysService) {
+        this.configurationService = configurationService;
+        this.passkeysService = passkeysService;
     }
 
     @Override
@@ -42,7 +51,10 @@ public class PasskeysDeleteHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("PasskeysDeleteHandler called");
 
-        if (Objects.isNull(input.getPathParameters().get("publicSubjectId"))) {
+        var publicSubjectId = input.getPathParameters().get("publicSubjectId");
+        var passkeyId = input.getPathParameters().get("passkeyId");
+
+        if (Objects.isNull(publicSubjectId)) {
             return generateApiGatewayProxyResponse(400, "");
         }
 
@@ -50,6 +62,8 @@ public class PasskeysDeleteHandler
                 input.getPathParameters().get("publicSubjectId"), input.getRequestContext())) {
             return generateApiGatewayProxyResponse(401, "");
         }
+
+        passkeysService.deletePasskey(publicSubjectId, passkeyId);
 
         return generateApiGatewayProxyResponse(204, "");
     }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -75,9 +75,10 @@ public class PasskeysDeleteHandler
     private APIGatewayProxyResponseEvent mapDeleteFailure(
             PasskeysDeleteFailureReason failureReason) {
         return switch (failureReason) {
-            case PASSKEY_NOT_FOUND -> generateApiGatewayProxyErrorResponse(
-                    404, ErrorResponse.PASSKEY_NOT_FOUND);
-            default -> throw new RuntimeException("To come in subsequent commit");
+            case PASSKEY_NOT_FOUND ->
+                    generateApiGatewayProxyErrorResponse(404, ErrorResponse.PASSKEY_NOT_FOUND);
+            case FAILED_TO_DELETE_PASSKEY ->
+                generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
         };
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/DynamoPasskeyService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/DynamoPasskeyService.java
@@ -4,6 +4,7 @@ import uk.gov.di.authentication.accountdata.constants.AccountDataConstants;
 import uk.gov.di.authentication.accountdata.entity.Authenticator;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
+import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.BaseDynamoService;
@@ -52,8 +53,14 @@ public class DynamoPasskeyService extends BaseDynamoService<Passkey> {
                 .orElseGet(() -> Result.failure(PasskeysUpdateFailureReason.PASSKEY_NOT_FOUND));
     }
 
-    public void deletePasskey(String publicSubjectId, String passkeyId) {
-        var sortKey = buildSortKey(passkeyId);
-        delete(publicSubjectId, sortKey);
+    public Result<PasskeysDeleteFailureReason, Void> deletePasskey(
+            String publicSubjectId, String passkeyId) {
+        return getPasskeyForUserWithPasskeyId(publicSubjectId, passkeyId)
+                .map(
+                        passkey -> {
+                            delete(passkey);
+                            return Result.<PasskeysDeleteFailureReason, Void>success(null);
+                        })
+                .orElseGet(() -> Result.failure(PasskeysDeleteFailureReason.PASSKEY_NOT_FOUND));
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysCreateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
+import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -92,6 +93,16 @@ public class PasskeysService {
         } catch (Exception e) {
             LOG.error("Failed to retrieve passkeys", e);
             return Result.failure(PasskeysRetrieveFailureReasons.FAILED_TO_GET_PASSKEYS);
+        }
+    }
+
+    public Result<PasskeysDeleteFailureReason, Void> deletePasskey(
+            String publicSubjectId, String passkeyIdentifier) {
+        try {
+            return dynamoPasskeyService.deletePasskey(publicSubjectId, passkeyIdentifier);
+        } catch (Exception e) {
+            LOG.error("An exception occurred when attempting to delete passkey", e);
+            return Result.failure(PasskeysDeleteFailureReason.FAILED_TO_DELETE_PASSKEY);
         }
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -12,7 +12,6 @@ import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.Passke
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 import java.util.stream.Stream;
@@ -30,14 +29,13 @@ import static uk.gov.di.authentication.accountdata.helpers.RequestHelper.context
 class PasskeysDeleteHandlerTest {
 
     private final Context context = mock(Context.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeysService passkeysService = mock(PasskeysService.class);
 
     private PasskeysDeleteHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new PasskeysDeleteHandler(configurationService, passkeysService);
+        handler = new PasskeysDeleteHandler(passkeysService);
     }
 
     @Nested

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -79,6 +79,25 @@ class PasskeysDeleteHandlerTest {
         }
 
         @Test
+        void shouldReturn500WhenDatabaseOperationFails() {
+            // Given
+            var pathParams =
+                    Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
+            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
+                    .thenReturn(Result.failure(PasskeysDeleteFailureReason.FAILED_TO_DELETE_PASSKEY));
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(500));
+            assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+        }
+
+        @Test
         void shouldReturn400WhenPublicSubjectIdNotPresent() {
             // Given
             var pathParams = Map.of("passkeyId", PRIMARY_PASSKEY_ID);

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -5,6 +5,9 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -12,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -85,7 +89,8 @@ class PasskeysDeleteHandlerTest {
                     Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
             var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
             when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
-                    .thenReturn(Result.failure(PasskeysDeleteFailureReason.FAILED_TO_DELETE_PASSKEY));
+                    .thenReturn(
+                            Result.failure(PasskeysDeleteFailureReason.FAILED_TO_DELETE_PASSKEY));
 
             // When
             var result =
@@ -97,25 +102,46 @@ class PasskeysDeleteHandlerTest {
             assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
         }
 
-        @Test
-        void shouldReturn400WhenPublicSubjectIdNotPresent() {
+        private static Stream<Arguments> pathParamsWithMissingFields() {
+            return Stream.of(
+                    Arguments.of(
+                            Map.of("passkeyId", PRIMARY_PASSKEY_ID),
+                            ErrorResponse.MISSING_SUBJECT_ID),
+                    Arguments.of(
+                            Map.of("publicSubjectId", "", "passkeyId", PRIMARY_PASSKEY_ID),
+                            ErrorResponse.MISSING_SUBJECT_ID),
+                    Arguments.of(
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID),
+                            ErrorResponse.MISSING_PASSKEY_ID),
+                    Arguments.of(
+                            Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", ""),
+                            ErrorResponse.MISSING_PASSKEY_ID));
+        }
+
+        @ParameterizedTest
+        @MethodSource("pathParamsWithMissingFields")
+        void shouldReturn400WhenPathParamsHaveMissingFields(
+                Map<String, String> pathParamsWithMissingFields,
+                ErrorResponse expectedErrorResponse) {
             // Given
-            var pathParams = Map.of("passkeyId", PRIMARY_PASSKEY_ID);
             var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
 
             // When
             var result =
                     handler.handleRequest(
-                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+                            passkeysDeleteRequest(pathParamsWithMissingFields, authorizerParams),
+                            context);
 
             // Then
             assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(expectedErrorResponse));
         }
 
         @Test
         void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
             // Given
-            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
+            var pathParams =
+                    Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
             var authorizerParams = Map.<String, Object>of("principalId", "another-subject-id");
 
             // When

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -5,7 +5,9 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -14,6 +16,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PRIMARY_PASSKEY_ID;
@@ -56,6 +59,25 @@ class PasskeysDeleteHandlerTest {
 
     @Nested
     class Failure {
+        @Test
+        void shouldReturn404WhenPasskeyNotFound() {
+            // Given
+            var pathParams =
+                    Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
+            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
+                    .thenReturn(Result.failure(PasskeysDeleteFailureReason.PASSKEY_NOT_FOUND));
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(404));
+            assertThat(result, hasJsonBody(ErrorResponse.PASSKEY_NOT_FOUND));
+        }
+
         @Test
         void shouldReturn400WhenPublicSubjectIdNotPresent() {
             // Given

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.accountdata.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -27,31 +28,55 @@ class PasskeysDeleteHandlerTest {
         handler = new PasskeysDeleteHandler(configurationService);
     }
 
-    @Test
-    void shouldReturn204ForValidRequest() {
-        var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
-        var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
-        var result =
-                handler.handleRequest(passkeysDeleteRequest(pathParams, authorizerParams), context);
-        assertThat(result, hasStatus(204));
+    @Nested
+    class Success {
+        @Test
+        void shouldReturn204ForValidRequest() {
+            // Given
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(204));
+        }
     }
 
-    @Test
-    void shouldReturn400WhenPublicSubjectIdNotPresent() {
-        var pathParams = Map.<String, String>of();
-        var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
-        var result =
-                handler.handleRequest(passkeysDeleteRequest(pathParams, authorizerParams), context);
-        assertThat(result, hasStatus(400));
-    }
+    @Nested
+    class Failure {
+        @Test
+        void shouldReturn400WhenPublicSubjectIdNotPresent() {
+            // Given
+            var pathParams = Map.<String, String>of();
+            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
 
-    @Test
-    void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
-        var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
-        var authorizerParams = Map.<String, Object>of("principalId", "another-subject-id");
-        var result =
-                handler.handleRequest(passkeysDeleteRequest(pathParams, authorizerParams), context);
-        assertThat(result, hasStatus(401));
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(400));
+        }
+
+        @Test
+        void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
+            // Given
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var authorizerParams = Map.<String, Object>of("principalId", "another-subject-id");
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(401));
+        }
     }
 
     private APIGatewayProxyRequestEvent passkeysDeleteRequest(

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -5,14 +5,18 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PRIMARY_PASSKEY_ID;
 import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.accountdata.helpers.RequestHelper.contextWithSourceIp;
 
@@ -20,21 +24,25 @@ class PasskeysDeleteHandlerTest {
 
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final PasskeysService passkeysService = mock(PasskeysService.class);
 
     private PasskeysDeleteHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new PasskeysDeleteHandler(configurationService);
+        handler = new PasskeysDeleteHandler(configurationService, passkeysService);
     }
 
     @Nested
     class Success {
         @Test
-        void shouldReturn204ForValidRequest() {
+        void shouldReturn204WhenPasskeyCanBeDeleted() {
             // Given
-            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var pathParams =
+                    Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
             var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
+                    .thenReturn(Result.success(null));
 
             // When
             var result =
@@ -51,7 +59,7 @@ class PasskeysDeleteHandlerTest {
         @Test
         void shouldReturn400WhenPublicSubjectIdNotPresent() {
             // Given
-            var pathParams = Map.<String, String>of();
+            var pathParams = Map.of("passkeyId", PRIMARY_PASSKEY_ID);
             var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
 
             // When
@@ -66,7 +74,7 @@ class PasskeysDeleteHandlerTest {
         @Test
         void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
             // Given
-            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
             var authorizerParams = Map.<String, Object>of("principalId", "another-subject-id");
 
             // When

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/PasskeysServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/PasskeysServiceTest.java
@@ -3,9 +3,12 @@ package uk.gov.di.authentication.accountdata.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysCreateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
+import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.accountdata.helpers.CommonTestVariables;
@@ -15,6 +18,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -131,6 +135,28 @@ class PasskeysServiceTest {
                         result.getFailure(),
                         equalTo(PasskeysCreateFailureReason.FAILED_TO_SAVE_PASSKEY));
             }
+        }
+
+        private PasskeysCreateRequest buildPasskeysCreateRequest(
+                String credential,
+                String passkeyId,
+                String aaguid,
+                boolean isAttested,
+                int signCount,
+                List<String> transports,
+                boolean isBackUpEligible,
+                boolean isBackedUp,
+                boolean isResidentKey) {
+            return new PasskeysCreateRequest(
+                    credential,
+                    passkeyId,
+                    aaguid,
+                    isAttested,
+                    signCount,
+                    transports,
+                    isBackUpEligible,
+                    isBackedUp,
+                    isResidentKey);
         }
     }
 
@@ -249,25 +275,55 @@ class PasskeysServiceTest {
         }
     }
 
-    public PasskeysCreateRequest buildPasskeysCreateRequest(
-            String credential,
-            String passkeyId,
-            String aaguid,
-            boolean isAttested,
-            int signCount,
-            List<String> transports,
-            boolean isBackUpEligible,
-            boolean isBackedUp,
-            boolean isResidentKey) {
-        return new PasskeysCreateRequest(
-                credential,
-                passkeyId,
-                aaguid,
-                isAttested,
-                signCount,
-                transports,
-                isBackUpEligible,
-                isBackedUp,
-                isResidentKey);
+    @Nested
+    class DeletePasskey {
+
+        @Nested
+        class Success {
+            private static Stream<Result<PasskeysDeleteFailureReason, Void>> deleteResults() {
+                return Stream.of(
+                        Result.success(null),
+                        Result.failure(PasskeysDeleteFailureReason.PASSKEY_NOT_FOUND));
+            }
+
+            @MethodSource("deleteResults")
+            @ParameterizedTest
+            void shouldReturnResultFromDynamoServiceWhenNoErrorOccurs(
+                    Result<PasskeysDeleteFailureReason, Void> passkeyDeleteResult) {
+                // Given
+                when(persistentService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
+                        .thenReturn(passkeyDeleteResult);
+
+                // When
+                var result =
+                        passkeysService.deletePasskey(
+                                CommonTestVariables.PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
+
+                // Then
+                assertEquals(passkeyDeleteResult, result);
+            }
+        }
+
+        @Nested
+        class Failure {
+            @Test
+            void shouldReturnFailedToDeletePasskeysIfExceptionThrown() {
+                // Given
+                when(persistentService.deletePasskey(
+                                CommonTestVariables.PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
+                        .thenThrow(RuntimeException.class);
+
+                // When
+                var result =
+                        passkeysService.deletePasskey(
+                                CommonTestVariables.PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
+
+                // Then
+                assertTrue(result.isFailure());
+                assertThat(
+                        result.getFailure(),
+                        equalTo(PasskeysDeleteFailureReason.FAILED_TO_DELETE_PASSKEY));
+            }
+        }
     }
 }

--- a/ci/openAPI/AccountDataApi.yaml
+++ b/ci/openAPI/AccountDataApi.yaml
@@ -216,6 +216,17 @@ paths:
       responses:
         "204":
           description: Passkey deleted successfully
+        "400":
+          description: Bad request - path params missing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                invalid_request_body:
+                  value:
+                    code: 4000
+                    message: "Invalid request body"
         "404":
           description: Not found
           content:


### PR DESCRIPTION
## What

Implement delete passkey endpoint. The barebones lambda already exists, but does not have any of the delete logic in.

This implements this along with appropriate error handling. It also updates the open api spec to detail the 400 response from this endpoint.

## How to review

1. Code Review commit by commit

