### PR TITLE
AUT-5134: move the Lambda Permission to active alias

### DIFF
--- a/ci/cloudformation/utils/api/test-services-api.yaml
+++ b/ci/cloudformation/utils/api/test-services-api.yaml
@@ -85,7 +85,7 @@ Resources:
   DeleteSyntheticsUserLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Ref DeleteSyntheticsUserFunction
+      FunctionName: !Sub "${DeleteSyntheticsUserFunction}:active"
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${TestServicesApi}/*/*"


### PR DESCRIPTION
## What

AUT-5134: move the Lambda Permission to active alias

## How to review


1. Code Review
