### PR TITLE
Ato 2506 log client secret misconfiguration

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -167,6 +167,7 @@ public abstract class BaseAuthorizeValidator {
             if (vtrError.isPresent()) {
                 return vtrError;
             }
+            logIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(vtrList, client);
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()
                     && !client.isTestClient()) {
@@ -204,6 +205,26 @@ public abstract class BaseAuthorizeValidator {
                             OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
         }
         return Optional.empty();
+    }
+
+    protected void logIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(
+            List<VectorOfTrust> vtrList, ClientRegistry client) {
+        List<LevelOfConfidence> identityLoCs =
+                List.of(
+                        LevelOfConfidence.LOW_LEVEL,
+                        LevelOfConfidence.MEDIUM_LEVEL,
+                        LevelOfConfidence.HIGH_LEVEL,
+                        LevelOfConfidence.VERY_HIGH_LEVEL);
+        boolean hasRequestedIdentityLoC =
+                vtrList.stream()
+                        .map(VectorOfTrust::getLevelOfConfidence)
+                        .filter(Objects::nonNull)
+                        .anyMatch(identityLoCs::contains);
+        if ((hasRequestedIdentityLoC)
+                && ("client_secret_post".equals(client.getTokenAuthMethod()))) {
+            LOG.info(
+                    "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.");
+        }
     }
 
     protected void validateResponseMode(String responseMode) throws InvalidResponseModeException {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -149,6 +149,13 @@ public abstract class BaseAuthorizeValidator {
         return Optional.empty();
     }
 
+    private boolean requestContainsIdentityLoC(List<VectorOfTrust> vtrList) {
+        return vtrList.stream()
+                .map(VectorOfTrust::getLevelOfConfidence)
+                .filter(Objects::nonNull)
+                .anyMatch(LevelOfConfidence.listOfIdentityLoCs()::contains);
+    }
+
     protected Optional<ErrorObject> validateVtr(
             List<String> authRequestVtr, ClientRegistry client) {
         try {
@@ -186,18 +193,7 @@ public abstract class BaseAuthorizeValidator {
 
     protected Optional<ErrorObject> errorIfIdentityLoCAndIdentityUnsupported(
             List<VectorOfTrust> vtrList, ClientRegistry client) {
-        List<LevelOfConfidence> identityLoCs =
-                List.of(
-                        LevelOfConfidence.LOW_LEVEL,
-                        LevelOfConfidence.MEDIUM_LEVEL,
-                        LevelOfConfidence.HIGH_LEVEL,
-                        LevelOfConfidence.VERY_HIGH_LEVEL);
-        boolean hasRequestedIdentityLoC =
-                vtrList.stream()
-                        .map(VectorOfTrust::getLevelOfConfidence)
-                        .filter(Objects::nonNull)
-                        .anyMatch(identityLoCs::contains);
-        if (hasRequestedIdentityLoC && !client.isIdentityVerificationSupported()) {
+        if (requestContainsIdentityLoC(vtrList) && !client.isIdentityVerificationSupported()) {
             logErrorInProdElseWarn(
                     "Level of confidence values for an identity journey have been requested, but identity is not supported for this client.");
             return Optional.of(
@@ -209,18 +205,7 @@ public abstract class BaseAuthorizeValidator {
 
     protected void logIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(
             List<VectorOfTrust> vtrList, ClientRegistry client) {
-        List<LevelOfConfidence> identityLoCs =
-                List.of(
-                        LevelOfConfidence.LOW_LEVEL,
-                        LevelOfConfidence.MEDIUM_LEVEL,
-                        LevelOfConfidence.HIGH_LEVEL,
-                        LevelOfConfidence.VERY_HIGH_LEVEL);
-        boolean hasRequestedIdentityLoC =
-                vtrList.stream()
-                        .map(VectorOfTrust::getLevelOfConfidence)
-                        .filter(Objects::nonNull)
-                        .anyMatch(identityLoCs::contains);
-        if ((hasRequestedIdentityLoC)
+        if (requestContainsIdentityLoC(vtrList)
                 && ("client_secret_post".equals(client.getTokenAuthMethod()))) {
             LOG.info(
                     "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -531,6 +531,35 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
+    void validatorLogsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod() {
+        when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
+        List<String> clientLoCs = List.of("P0", "P2");
+        var vtr = jsonArrayOf("Cl.Cm.P2");
+        when(dynamoClientService.getClient(CLIENT_ID.toString()))
+                .thenReturn(
+                        Optional.of(
+                                generateClientRegistry(
+                                                REDIRECT_URI.toString(),
+                                                clientLoCs,
+                                                CLIENT_ID.toString())
+                                        .withIdentityVerificationSupported(true)
+                                        .withTokenAuthMethod("client_secret_post")));
+        AuthenticationRequest authRequest =
+                new AuthenticationRequest.Builder(
+                                VALID_RESPONSE_TYPE, VALID_SCOPES, CLIENT_ID, REDIRECT_URI)
+                        .state(STATE)
+                        .nonce(new Nonce())
+                        .customParameter("vtr", vtr)
+                        .build();
+        var errorObject = queryParamsAuthorizeValidator.validate(authRequest);
+
+        assertFalse(errorObject.isPresent());
+        String expectedLogMessage =
+                "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.";
+        assertThat(baseClassLogging.events(), hasItem(withMessageContaining(expectedLogMessage)));
+    }
+
+    @Test
     void shouldNotReturnErrorWhenPkceIsNotEnforcedAndCodeChallengeAndMethodAreMissing() {
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
@@ -835,6 +864,7 @@ class QueryParamsAuthorizeValidatorTest {
                 .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
                 .withPublicKey(null)
                 .withTestClient(testClient)
+                .withTokenAuthMethod("private_key_jwt")
                 .withClientLoCs(clientLoCs)
                 .withScopes(scopes)
                 .withIdentityVerificationSupported(true);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -212,6 +212,33 @@ class RequestObjectAuthorizeValidatorTest {
             assertThat(
                     baseClassLogging.events(), hasItem(withMessageContaining(expectedLogMessage)));
         }
+
+        @Test
+        void validatorLogsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod()
+                throws ClientSignatureValidationException, JwksException, JOSEException {
+            var jwtClaimsSet =
+                    getDefaultJWTClaimsSetBuilder().claim("vtr", jsonArrayOf("Cl.Cm.P2")).build();
+            var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+            when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
+            var clientRegistry =
+                    generateClientRegistry(
+                                    ClientType.APP.getValue(),
+                                    new Scope(
+                                            OIDCScopeValue.OPENID.getValue(),
+                                            CustomScopeValue.DOC_CHECKING_APP.getValue()))
+                            .withIdentityVerificationSupported(true)
+                            .withTokenAuthMethod("client_secret_post");
+            when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                    .thenReturn(Optional.of(clientRegistry));
+
+            var requestObjectError = validator.validate(authRequest);
+
+            assertFalse(requestObjectError.isPresent());
+            String expectedLogMessage =
+                    "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.";
+            assertThat(
+                    baseClassLogging.events(), hasItem(withMessageContaining(expectedLogMessage)));
+        }
     }
 
     @Nested
@@ -1012,6 +1039,7 @@ class RequestObjectAuthorizeValidatorTest {
                 .withRedirectUrls(singletonList(REDIRECT_URI))
                 .withSectorIdentifierUri("https://test.com")
                 .withSubjectType("pairwise")
+                .withTokenAuthMethod("private_key_jwt")
                 .withClientLoCs(singletonList(LevelOfConfidence.MEDIUM_LEVEL.getValue()))
                 .withClientType(clientType)
                 .withClaims(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidence.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/LevelOfConfidence.java
@@ -59,4 +59,12 @@ public enum LevelOfConfidence {
                 .map(LevelOfConfidence::getValue)
                 .toList();
     }
+
+    public static List<LevelOfConfidence> listOfIdentityLoCs() {
+        return List.of(
+                LevelOfConfidence.LOW_LEVEL,
+                LevelOfConfidence.MEDIUM_LEVEL,
+                LevelOfConfidence.HIGH_LEVEL,
+                LevelOfConfidence.VERY_HIGH_LEVEL);
+    }
 }


### PR DESCRIPTION
### Wider context of change

client_post_secret is not considered sufficiently secure for use with identity journeys, so we should reject requests of that nature. This PR is to log occurrences of that, to make sure bringing in this extra check doesn't break any live RP configurations

### What’s changed

Introduces logging in the authorisation request validator to find out whether we need to contact any RPs before making the desired change.

### Checklist


- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.


