### PR TITLE
AUT-4939: Possibly return hasActivePasskey=null

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -13,6 +13,6 @@ public record CheckUserExistsResponse(
         @SerializedName("mfaMethodType") @Expose MFAMethodType mfaMethodType,
         @SerializedName("phoneNumberLastThree") @Expose String phoneNumberLastThree,
         @SerializedName("lockoutInformation") @Expose List<LockoutInformation> lockoutInformation,
-        @SerializedName("hasActivePasskey") @Expose boolean hasActivePasskey,
+        @SerializedName("hasActivePasskey") @Expose Boolean hasActivePasskey,
         @SerializedName("needsForcedMFAResetAfterMFACheck") @Expose
                 boolean needsForcedMFAResetAfterMFACheck) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -176,7 +176,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             AuditableEvent auditableEvent;
             var rpPairwiseId = AuditService.UNKNOWN;
             var userMfaDetail = UserMfaDetail.noMfa();
-            var hasActivePasskey = false;
+            Optional<Boolean> hasActivePasskey = Optional.empty();
             var needsForcedMFAResetAfterMFACheck = false;
 
             AuthSessionItem authSession = userContext.getAuthSession();
@@ -232,7 +232,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             userMfaDetail.mfaMethodType(),
                             getLastDigitsOfPhoneNumber(userMfaDetail),
                             lockoutInformation,
-                            hasActivePasskey,
+                            hasActivePasskey.orElse(null),
                             needsForcedMFAResetAfterMFACheck);
 
             authSessionService.updateSession(authSession);
@@ -246,20 +246,23 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         }
     }
 
-    private boolean hasActivePasskey(String publicSubjectId, AuthSessionItem authSession) {
+    private Optional<Boolean> hasActivePasskey(
+            String publicSubjectId, AuthSessionItem authSession) {
         if (configurationService.supportPasskeys()) {
             LOG.info("Checking if user has active passkey");
 
             var hasActivePasskeyResult =
                     passkeysService.hasActivePasskey(publicSubjectId, authSession.getSessionId());
-            if (hasActivePasskeyResult.isFailure()) {
+            if (hasActivePasskeyResult.isSuccess()) {
+                return Optional.of(hasActivePasskeyResult.getSuccess());
+            } else {
                 LOG.warn(
                         "Error retrieving passkey information for user. Error: {}",
                         hasActivePasskeyResult.getFailure());
-                return false;
             }
-            return hasActivePasskeyResult.getSuccess();
-        } else return false;
+        }
+
+        return Optional.empty();
     }
 
     private boolean requiresMfaResetForInternationalNumber(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -197,7 +197,7 @@ class CheckUserExistsHandlerTest {
                     "mfaMethodType":"SMS",
                     "phoneNumberLastThree":"%s",
                     "lockoutInformation":[],
-                    "hasActivePasskey":false,
+                    "hasActivePasskey":null,
                     "needsForcedMFAResetAfterMFACheck":false}
                     """,
                             EMAIL_ADDRESS, phoneNumber.substring(phoneNumber.length() - 3));
@@ -254,7 +254,7 @@ class CheckUserExistsHandlerTest {
                     "mfaMethodType":"%s",
                     "phoneNumberLastThree": %s,
                     "lockoutInformation":[],
-                    "hasActivePasskey":false,
+                    "hasActivePasskey":null,
                     "needsForcedMFAResetAfterMFACheck":false}
                     """,
                             EMAIL_ADDRESS,
@@ -352,7 +352,7 @@ class CheckUserExistsHandlerTest {
                                             MFAMethodType.AUTH_APP,
                                             lockoutExpiry.getEpochSecond(),
                                             JourneyType.PASSWORD_RESET_MFA)),
-                            false,
+                            null,
                             false);
             assertThat(result, hasJsonBody(expectedResponse));
         }
@@ -639,7 +639,7 @@ class CheckUserExistsHandlerTest {
         }
 
         @Test
-        void shouldReturnFalseForHasActivePasskeyIfPasskeysServiceReturnsFailure()
+        void shouldReturnNullForHasActivePasskeyIfPasskeysServiceReturnsFailure()
                 throws Json.JsonException {
             when(configurationService.supportPasskeys()).thenReturn(true);
             var userProfile = generateUserProfile();
@@ -659,7 +659,7 @@ class CheckUserExistsHandlerTest {
             assertThat(result, hasStatus(200));
             var checkUserExistsResponse =
                     objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
-            assertFalse(checkUserExistsResponse.hasActivePasskey());
+            assertNull(checkUserExistsResponse.hasActivePasskey());
         }
 
         @Test
@@ -701,7 +701,7 @@ class CheckUserExistsHandlerTest {
                 objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
         assertThat(checkUserExistsResponse.email(), equalTo(EMAIL_ADDRESS));
         assertFalse(checkUserExistsResponse.doesUserExist());
-        assertFalse(checkUserExistsResponse.hasActivePasskey());
+        assertNull(checkUserExistsResponse.hasActivePasskey());
         assertNull(authSession.getInternalCommonSubjectId());
         verify(authSessionService).updateSession(any(AuthSessionItem.class));
         verify(auditService)


### PR DESCRIPTION
## What

Previously, we were always returning `hasActivePasskey=true` or `=false`. However, in the case where the `PasskeyService` request failed, we lied and still sent back a `false`.

This changes the `hasActivePasskey` check to only return a boolean response if passkeys are enabled, and if we successfully make the request to get the user's current state. Otherwise, we'll always return `null`, to represent the "unknown" state.

The response object will either include the `true`/`false` value if it's available, or `null` if it's not.

## How to review

1. Code Review
2. Test

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3378