### PR TITLE
BAU: Rename journey to action

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
@@ -87,9 +87,9 @@ class AMCCallbackHandlerTest {
                               "email": "user@example.com",
                               "scope": "account-delete",
                               "success": true,
-                              "journeys": [
+                              "actions": [
                                 {
-                                  "journey": "account-delete",
+                                  "action": "account-delete",
                                   "timestamp": 1760718467000,
                                   "success": true,
                                   "details": {}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCCallbackHandlerIntegrationTest.java
@@ -67,9 +67,9 @@ class AMCCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                               "email": "user@example.com",
                               "scope": "account-delete",
                               "success": true,
-                              "journeys": [
+                              "actions": [
                                 {
-                                  "journey": "account-delete",
+                                  "action": "account-delete",
                                   "timestamp": 1760718467000,
                                   "success": true,
                                   "details": {}


### PR DESCRIPTION
- This is to match schema changes in AMC:
  - `journeys` to `actions`
  - `journey` to `action`