### PR TITLE
BAU: Remove unused token service methods

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -12,7 +12,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetRequest;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetResponse;
 import uk.gov.di.authentication.frontendapi.services.IPVReverificationService;
-import uk.gov.di.authentication.frontendapi.services.JwtService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -26,12 +25,7 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.IDReverificationStateService;
-import uk.gov.di.authentication.shared.services.KmsConnectionService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.TokenService;
 import uk.gov.di.authentication.shared.state.UserContext;
-
-import java.net.MalformedURLException;
 
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_REVERIFY_AUTHORISATION_REQUESTED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -74,21 +68,6 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.idReverificationStateService = new IDReverificationStateService(configurationService);
         this.ipvReverificationService = new IPVReverificationService(configurationService);
-    }
-
-    public MfaResetAuthorizeHandler(RedisConnectionService redisConnectionService)
-            throws MalformedURLException {
-        super(MfaResetRequest.class, ConfigurationService.getInstance());
-        KmsConnectionService kmsConnectionService = new KmsConnectionService(configurationService);
-        JwtService jwtService = new JwtService(kmsConnectionService);
-        TokenService tokenService =
-                new TokenService(
-                        configurationService, redisConnectionService, kmsConnectionService);
-        this.auditService = new AuditService(configurationService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.ipvReverificationService =
-                new IPVReverificationService(configurationService, jwtService, tokenService);
-        this.idReverificationStateService = new IDReverificationStateService(configurationService);
     }
 
     public MfaResetAuthorizeHandler() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationService.java
@@ -29,7 +29,6 @@ import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenService;
 
 import java.net.MalformedURLException;
@@ -61,14 +60,10 @@ public class IPVReverificationService {
     public IPVReverificationService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         try {
-            RedisConnectionService redisConnectionService =
-                    new RedisConnectionService(configurationService);
             KmsConnectionService kmsConnectionService =
                     new KmsConnectionService(configurationService);
             this.jwtService = new JwtService(kmsConnectionService);
-            this.tokenService =
-                    new TokenService(
-                            configurationService, redisConnectionService, kmsConnectionService);
+            this.tokenService = new TokenService(configurationService, kmsConnectionService);
             this.nowClock = new NowClock(Clock.systemUTC());
             this.jwkSource =
                     configurationService.isIpvJwksCallEnabled()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -204,7 +204,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void shouldAuthenticateMfaReset(boolean isIpvJwksCallEnabled) throws MalformedURLException {
+    void shouldAuthenticateMfaReset(boolean isIpvJwksCallEnabled) {
         environment.set("IPV_JWKS_CALL_ENABLED", String.valueOf(isIpvJwksCallEnabled));
 
         handler = new MfaResetAuthorizeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -27,12 +27,9 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IDReverificationStateExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
-import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -91,10 +88,6 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
     @RegisterExtension
     private static final KmsKeyExtension ipvReverificationRequestsSigningKey =
             new KmsKeyExtension("mfa-reset-jar-signing-key", KeyUsageType.SIGN_VERIFY);
-
-    @RegisterExtension
-    public static final RedisExtension redisExtension =
-            new RedisExtension(new SerializationService(), new ConfigurationService());
 
     @RegisterExtension
     private static final IDReverificationStateExtension idReverificationStateExtension =
@@ -214,7 +207,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
     void shouldAuthenticateMfaReset(boolean isIpvJwksCallEnabled) throws MalformedURLException {
         environment.set("IPV_JWKS_CALL_ENABLED", String.valueOf(isIpvJwksCallEnabled));
 
-        handler = new MfaResetAuthorizeHandler(redisConnectionService);
+        handler = new MfaResetAuthorizeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
 
         idReverificationStateExtension.store("orch-redirect-url", "client-session-id");
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -305,10 +305,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return false;
     }
 
-    public long getIDTokenExpiry() {
-        return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
-    }
-
     public Optional<String> getNotifyApiUrl() {
         return Optional.ofNullable(System.getenv("NOTIFY_URL"));
     }
@@ -360,10 +356,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 && stringToSearch != null
                 && !stringToSearch.isBlank()
                 && Arrays.stream(stringToSearch.split(",")).anyMatch(id -> id.equals(searchTerm)));
-    }
-
-    public Optional<String> getOidcApiBaseURL() {
-        return Optional.ofNullable(System.getenv("OIDC_API_BASE_URL"));
     }
 
     public Optional<String> getPasswordPepper() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -62,7 +62,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         this.systemService = systemService;
     }
 
-    // Please keep the method names in alphabetical order so we can find stuff more easily.
     public long getAccessTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ACCESS_TOKEN_EXPIRY", "180"));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -79,36 +79,6 @@ public class TokenService {
         this.kmsConnectionService = kmsConnectionService;
     }
 
-    public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {
-        Map<String, String> requestBody = RequestBodyHelper.parseRequestBody(tokenRequestBody);
-        if (!requestBody.containsKey("grant_type")) {
-            return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE,
-                            "Request is missing grant_type parameter"));
-        }
-        if (!ALLOWED_GRANTS.contains(requestBody.get("grant_type"))) {
-            return Optional.of(OAuth2Error.UNSUPPORTED_GRANT_TYPE);
-        }
-        if (requestBody.get("grant_type").equals(GrantType.AUTHORIZATION_CODE.getValue())) {
-            if (!requestBody.containsKey("redirect_uri")) {
-                return Optional.of(
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE,
-                                "Request is missing redirect_uri parameter"));
-            }
-            if (!requestBody.containsKey("code")) {
-                return Optional.of(
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE,
-                                "Request is missing code parameter"));
-            }
-        } else if (requestBody.get("grant_type").equals(GrantType.REFRESH_TOKEN.getValue())) {
-            return validateRefreshRequestParams(requestBody);
-        }
-        return Optional.empty();
-    }
-
     private Optional<ErrorObject> validateRefreshRequestParams(Map<String, String> requestBody) {
         if (!requestBody.containsKey("refresh_token")) {
             return Optional.of(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -79,67 +79,6 @@ public class TokenService {
         this.kmsConnectionService = kmsConnectionService;
     }
 
-    public OIDCTokenResponse generateTokenResponse(
-            String clientID,
-            Subject internalSubject,
-            Scope authRequestScopes,
-            Map<String, Object> additionalTokenClaims,
-            Subject rpPairwiseSubject,
-            Subject internalPairwiseSubject,
-            OIDCClaimsRequest claimsRequest,
-            boolean isDocAppJourney,
-            JWSAlgorithm signingAlgorithm,
-            String journeyId,
-            String vot) {
-        List<String> scopesForToken = authRequestScopes.toStringList();
-        AccessToken accessToken =
-                segmentedFunctionCall(
-                        "generateAndStoreAccessToken",
-                        () ->
-                                generateAndStoreAccessToken(
-                                        clientID,
-                                        internalSubject,
-                                        scopesForToken,
-                                        rpPairwiseSubject,
-                                        internalPairwiseSubject,
-                                        claimsRequest,
-                                        signingAlgorithm));
-        AccessTokenHash accessTokenHash =
-                segmentedFunctionCall(
-                        "AccessTokenHash.compute",
-                        () -> AccessTokenHash.compute(accessToken, TOKEN_ALGORITHM, null));
-
-        SignedJWT idToken =
-                segmentedFunctionCall(
-                        "generateIDToken",
-                        () ->
-                                generateIDToken(
-                                        clientID,
-                                        rpPairwiseSubject,
-                                        additionalTokenClaims,
-                                        accessTokenHash,
-                                        vot,
-                                        isDocAppJourney,
-                                        signingAlgorithm,
-                                        journeyId));
-        if (scopesForToken.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
-            RefreshToken refreshToken =
-                    segmentedFunctionCall(
-                            "generateAndStoreRefreshToken",
-                            () ->
-                                    generateAndStoreRefreshToken(
-                                            clientID,
-                                            internalSubject,
-                                            scopesForToken,
-                                            rpPairwiseSubject,
-                                            internalPairwiseSubject,
-                                            signingAlgorithm));
-            return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, refreshToken));
-        } else {
-            return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, null));
-        }
-    }
-
     public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {
         Map<String, String> requestBody = RequestBodyHelper.parseRequestBody(tokenRequestBody);
         if (!requestBody.containsKey("grant_type")) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -8,24 +8,9 @@ import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.ErrorObject;
-import com.nimbusds.oauth2.sdk.GrantType;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
-import com.nimbusds.oauth2.sdk.Scope;
-import com.nimbusds.oauth2.sdk.id.Audience;
-import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
-import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
-import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
-import com.nimbusds.openid.connect.sdk.claims.AccessTokenHash;
-import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
-import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
-import com.nimbusds.openid.connect.sdk.claims.SessionID;
-import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
@@ -33,42 +18,23 @@ import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.authentication.shared.entity.AccessTokenStore;
-import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
-import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
-import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class TokenService {
 
     private final ConfigurationService configService;
     private final RedisConnectionService redisConnectionService;
     private final KmsConnectionService kmsConnectionService;
-    private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
     private static final Logger LOG = LogManager.getLogger(TokenService.class);
-    private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
-    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
-    private static final List<String> ALLOWED_GRANTS =
-            List.of(GrantType.AUTHORIZATION_CODE.getValue(), GrantType.REFRESH_TOKEN.getValue());
-
-    private final Json objectMapper = SerializationService.getInstance();
 
     public TokenService(
             ConfigurationService configService,
@@ -77,61 +43,6 @@ public class TokenService {
         this.configService = configService;
         this.redisConnectionService = redisConnectionService;
         this.kmsConnectionService = kmsConnectionService;
-    }
-
-    private Optional<ErrorObject> validateRefreshRequestParams(Map<String, String> requestBody) {
-        if (!requestBody.containsKey("refresh_token")) {
-            return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE, "Request is missing refresh token"));
-        }
-        try {
-            new RefreshToken(requestBody.get("refresh_token"));
-        } catch (IllegalArgumentException e) {
-            LOG.warn("Invalid RefreshToken", e);
-            return Optional.of(
-                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid refresh token"));
-        }
-        return Optional.empty();
-    }
-
-    private SignedJWT generateIDToken(
-            String clientId,
-            Subject subject,
-            Map<String, Object> additionalTokenClaims,
-            AccessTokenHash accessTokenHash,
-            String vot,
-            boolean isDocAppJourney,
-            JWSAlgorithm signingAlgorithm,
-            String journeyId) {
-
-        LOG.info("Generating IdToken");
-        URI trustMarkUri = buildURI(configService.getOidcApiBaseURL().get(), "/trustmark");
-        Date expiryDate = NowHelper.nowPlus(configService.getIDTokenExpiry(), ChronoUnit.SECONDS);
-        IDTokenClaimsSet idTokenClaims =
-                new IDTokenClaimsSet(
-                        new Issuer(configService.getOidcApiBaseURL().get()),
-                        subject,
-                        List.of(new Audience(clientId)),
-                        expiryDate,
-                        NowHelper.now());
-
-        idTokenClaims.setAccessTokenHash(accessTokenHash);
-        idTokenClaims.setSessionID(new SessionID(journeyId));
-
-        idTokenClaims.putAll(additionalTokenClaims);
-        if (!isDocAppJourney) {
-            idTokenClaims.setClaim("vot", vot);
-        }
-        idTokenClaims.setClaim("vtm", trustMarkUri.toString());
-
-        try {
-            return generateSignedJwtUsingExternalKey(
-                    idTokenClaims.toJWTClaimsSet(), Optional.empty(), signingAlgorithm);
-        } catch (com.nimbusds.oauth2.sdk.ParseException e) {
-            LOG.error("Error when trying to parse IDTokenClaims to JWTClaimSet", e);
-            throw new RuntimeException(e);
-        }
     }
 
     public AccessToken generateStorageTokenForMfaReset(Subject internalPairwiseSubject) {
@@ -159,117 +70,6 @@ public class TokenService {
 
         return new BearerAccessToken(
                 signedJWT.serialize(), configService.getAccessTokenExpiry(), null);
-    }
-
-    private AccessToken generateAndStoreAccessToken(
-            String clientId,
-            Subject internalSubject,
-            List<String> scopes,
-            Subject rpPairwiseSubject,
-            Subject internalPairwiseSubject,
-            OIDCClaimsRequest claimsRequest,
-            JWSAlgorithm signingAlgorithm) {
-
-        LOG.info("Generating AccessToken");
-        Date expiryDate =
-                NowHelper.nowPlus(configService.getAccessTokenExpiry(), ChronoUnit.SECONDS);
-        var jwtID = UUID.randomUUID().toString();
-
-        LOG.info("AccessToken being created with JWTID: {}", jwtID);
-
-        JWTClaimsSet.Builder claimSetBuilder =
-                new JWTClaimsSet.Builder()
-                        .claim("scope", scopes)
-                        .issuer(configService.getOidcApiBaseURL().get())
-                        .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
-                        .claim("client_id", clientId)
-                        .subject(rpPairwiseSubject.getValue())
-                        .jwtID(jwtID);
-
-        if (Objects.nonNull(claimsRequest)) {
-            LOG.info("Populating identity claims in access token");
-            claimSetBuilder.claim(
-                    "claims",
-                    claimsRequest.getUserInfoClaimsRequest().getEntries().stream()
-                            .map(ClaimsSetRequest.Entry::getClaimName)
-                            .collect(Collectors.toList()));
-        } else {
-            LOG.info("No identity claims to populate in access token");
-        }
-
-        SignedJWT signedJWT =
-                generateSignedJwtUsingExternalKey(
-                        claimSetBuilder.build(), Optional.empty(), signingAlgorithm);
-        AccessToken accessToken =
-                new BearerAccessToken(
-                        signedJWT.serialize(), configService.getAccessTokenExpiry(), null);
-
-        try {
-            redisConnectionService.saveWithExpiry(
-                    ACCESS_TOKEN_PREFIX + clientId + "." + rpPairwiseSubject.getValue(),
-                    objectMapper.writeValueAsString(
-                            new AccessTokenStore(
-                                    accessToken.getValue(),
-                                    internalSubject.getValue(),
-                                    internalPairwiseSubject.getValue())),
-                    configService.getAccessTokenExpiry());
-        } catch (JsonException e) {
-            LOG.error("Unable to save access token to Redis");
-            throw new RuntimeException(e);
-        }
-        return accessToken;
-    }
-
-    private RefreshToken generateAndStoreRefreshToken(
-            String clientId,
-            Subject internalSubject,
-            List<String> scopes,
-            Subject rpPairwiseSubject,
-            Subject internalPairwiseSubject,
-            JWSAlgorithm signingAlgorithm) {
-        LOG.info("Generating RefreshToken");
-        Date expiryDate = NowHelper.nowPlus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
-        var jwtId = IdGenerator.generate();
-        JWTClaimsSet claimsSet =
-                new JWTClaimsSet.Builder()
-                        .claim("scope", scopes)
-                        .issuer(configService.getOidcApiBaseURL().get())
-                        .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
-                        .claim("client_id", clientId)
-                        .subject(rpPairwiseSubject.getValue())
-                        .jwtID(jwtId)
-                        .build();
-        SignedJWT signedJWT =
-                generateSignedJwtUsingExternalKey(claimsSet, Optional.empty(), signingAlgorithm);
-        RefreshToken refreshToken = new RefreshToken(signedJWT.serialize());
-
-        String redisKey = REFRESH_TOKEN_PREFIX + jwtId;
-        var store =
-                new RefreshTokenStore(
-                        refreshToken.getValue(),
-                        internalSubject.toString(),
-                        internalPairwiseSubject.toString());
-        try {
-            redisConnectionService.saveWithExpiry(
-                    redisKey,
-                    objectMapper.writeValueAsString(store),
-                    configService.getSessionExpiry());
-        } catch (JsonException e) {
-            throw new RuntimeException("Error serializing refresh token store", e);
-        }
-
-        return refreshToken;
-    }
-
-    private SignedJWT generateSignedJwtUsingExternalKey(
-            JWTClaimsSet claimsSet, Optional<String> type, JWSAlgorithm algorithm) {
-        String alias =
-                algorithm == JWSAlgorithm.ES256
-                        ? configService.getTokenSigningKeyAlias()
-                        : configService.getTokenSigningKeyRsaAlias();
-        return generateSignedJWT(claimsSet, type, algorithm, alias);
     }
 
     private SignedJWT generateSignedJwtUsingStorageKey(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -140,33 +140,6 @@ public class TokenService {
         }
     }
 
-    public OIDCTokenResponse generateRefreshTokenResponse(
-            String clientID,
-            Subject internalSubject,
-            List<String> scopes,
-            Subject rpPaiwiseSubject,
-            Subject internalPairwiseSubject,
-            JWSAlgorithm signingAlgorithm) {
-        AccessToken accessToken =
-                generateAndStoreAccessToken(
-                        clientID,
-                        internalSubject,
-                        scopes,
-                        rpPaiwiseSubject,
-                        internalPairwiseSubject,
-                        null,
-                        signingAlgorithm);
-        RefreshToken refreshToken =
-                generateAndStoreRefreshToken(
-                        clientID,
-                        internalSubject,
-                        scopes,
-                        rpPaiwiseSubject,
-                        internalPairwiseSubject,
-                        signingAlgorithm);
-        return new OIDCTokenResponse(new OIDCTokens(accessToken, refreshToken));
-    }
-
     public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {
         Map<String, String> requestBody = RequestBodyHelper.parseRequestBody(tokenRequestBody);
         if (!requestBody.containsKey("grant_type")) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -32,16 +32,12 @@ import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256Strin
 public class TokenService {
 
     private final ConfigurationService configService;
-    private final RedisConnectionService redisConnectionService;
     private final KmsConnectionService kmsConnectionService;
     private static final Logger LOG = LogManager.getLogger(TokenService.class);
 
     public TokenService(
-            ConfigurationService configService,
-            RedisConnectionService redisConnectionService,
-            KmsConnectionService kmsConnectionService) {
+            ConfigurationService configService, KmsConnectionService kmsConnectionService) {
         this.configService = configService;
-        this.redisConnectionService = redisConnectionService;
         this.kmsConnectionService = kmsConnectionService;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -309,11 +309,6 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void getIDTokenExpiryShouldDefault() {
-        assertEquals(120, configurationService.getIDTokenExpiry());
-    }
-
-    @Test
     void getNotifyApiUrlShouldDefault() {
         assertFalse(configurationService.getNotifyApiUrl().isPresent());
     }
@@ -389,11 +384,6 @@ class ConfigurationServiceTest {
                 Optional.of(DeliveryReceiptsNotificationType.REPORT_SUSPICIOUS_ACTIVITY),
                 configurationServiceWithSystemService.getNotificationTypeFromTemplateId(
                         "report-template-id"));
-    }
-
-    @Test
-    void getOidcApiBaseURLShouldNotDefault() {
-        assertTrue(configurationService.getOidcApiBaseURL().isEmpty());
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.google.gson.Gson;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -18,15 +17,11 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.oauth2.sdk.util.JSONArrayUtils;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import com.nimbusds.openid.connect.sdk.Nonce;
-import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.claims.AccessTokenHash;
-import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
-import net.minidev.json.JSONArray;
 import org.approvaltests.JsonApprovals;
 import org.approvaltests.core.Options;
 import org.approvaltests.scrubbers.GuidScrubber;
@@ -36,7 +31,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
@@ -45,8 +39,6 @@ import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
-import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
-import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.helper.SubjectHelper;
@@ -61,7 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -70,12 +61,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -142,53 +130,6 @@ public class TokenServiceTest {
     }
 
     @Test
-    void shouldGenerateTokenResponseWithRefreshToken()
-            throws ParseException, JOSEException, Json.JsonException {
-        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-        createSignedIdToken();
-        createSignedToken();
-        Map<String, Object> additionalTokenClaims = new HashMap<>();
-        additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
-
-        OIDCTokenResponse tokenResponse =
-                tokenService.generateTokenResponse(
-                        CLIENT_ID,
-                        INTERNAL_SUBJECT,
-                        SCOPES_OFFLINE_ACCESS,
-                        additionalTokenClaims,
-                        PUBLIC_SUBJECT,
-                        INTERNAL_PAIRWISE_SUBJECT,
-                        null,
-                        false,
-                        JWSAlgorithm.ES256,
-                        "client-session-id",
-                        VOT);
-
-        assertSuccessfulTokenResponse(tokenResponse);
-
-        assertNotNull(tokenResponse.getOIDCTokens().getRefreshToken());
-        RefreshTokenStore refreshTokenStore =
-                new RefreshTokenStore(
-                        tokenResponse.getOIDCTokens().getRefreshToken().getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
-        ArgumentCaptor<String> redisKey = ArgumentCaptor.forClass(String.class);
-        verify(redisConnectionService)
-                .saveWithExpiry(
-                        redisKey.capture(),
-                        eq(objectMapper.writeValueAsString(refreshTokenStore)),
-                        eq(300L));
-
-        var refreshToken =
-                SignedJWT.parse(tokenResponse.getOIDCTokens().getRefreshToken().getValue());
-        var jti = refreshToken.getJWTClaimsSet().getJWTID();
-        assertThat(redisKey.getValue(), startsWith(REFRESH_TOKEN_PREFIX));
-        assertThat(redisKey.getValue().split(":")[1], equalTo(jti));
-    }
-
-    @Test
     void shouldGenerateWellFormedStorageTokenForMfaReset() throws JOSEException, ParseException {
         when(configurationService.getEVCSAudience()).thenReturn(EVCS_AUDIENCE);
         when(configurationService.getIPVAudience()).thenReturn(IPV_AUDIENCE);
@@ -208,146 +149,6 @@ public class TokenServiceTest {
                 new Options(Scrubbers.scrubAll(unixTimestampScrubber, guidScrubber)));
     }
 
-    @Test
-    void shouldOnlyIncludeIdentityClaimsInAccessTokenWhenRequested()
-            throws ParseException,
-                    JOSEException,
-                    Json.JsonException,
-                    com.nimbusds.oauth2.sdk.ParseException {
-        var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
-        var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
-
-        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-        createSignedIdToken();
-        createSignedToken();
-        Map<String, Object> additionalTokenClaims = new HashMap<>();
-        additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
-
-        OIDCTokenResponse tokenResponse =
-                tokenService.generateTokenResponse(
-                        CLIENT_ID,
-                        INTERNAL_SUBJECT,
-                        SCOPES_OFFLINE_ACCESS,
-                        additionalTokenClaims,
-                        PUBLIC_SUBJECT,
-                        INTERNAL_PAIRWISE_SUBJECT,
-                        oidcClaimsRequest,
-                        false,
-                        JWSAlgorithm.ES256,
-                        "client-session-id",
-                        VOT);
-
-        assertSuccessfulTokenResponse(tokenResponse);
-
-        assertNotNull(tokenResponse.getOIDCTokens().getRefreshToken());
-        assertNull(
-                SignedJWT.parse(tokenResponse.getOIDCTokens().getRefreshToken().getValue())
-                        .getJWTClaimsSet()
-                        .getClaim("claims"));
-        JSONArray jsonarray =
-                JSONArrayUtils.parse(
-                        new Gson()
-                                .toJson(
-                                        SignedJWT.parse(
-                                                        tokenResponse
-                                                                .getOIDCTokens()
-                                                                .getAccessToken()
-                                                                .getValue())
-                                                .getJWTClaimsSet()
-                                                .getClaim("claims")));
-
-        assertTrue(jsonarray.contains("nickname"));
-        assertTrue(jsonarray.contains("birthdate"));
-
-        RefreshTokenStore refreshTokenStore =
-                new RefreshTokenStore(
-                        tokenResponse.getOIDCTokens().getRefreshToken().getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
-
-        ArgumentCaptor<String> redisKey = ArgumentCaptor.forClass(String.class);
-        verify(redisConnectionService)
-                .saveWithExpiry(
-                        redisKey.capture(),
-                        eq(objectMapper.writeValueAsString(refreshTokenStore)),
-                        eq(300L));
-
-        var refreshToken =
-                SignedJWT.parse(tokenResponse.getOIDCTokens().getRefreshToken().getValue());
-        var jti = refreshToken.getJWTClaimsSet().getJWTID();
-        assertThat(redisKey.getValue(), startsWith(REFRESH_TOKEN_PREFIX));
-        assertThat(redisKey.getValue().split(":")[1], equalTo(jti));
-    }
-
-    @Test
-    void shouldGenerateTokenResponseWithoutRefreshTokenWhenOfflineAccessScopeIsMissing()
-            throws ParseException, JOSEException, Json.JsonException {
-        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-        when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
-        createSignedIdToken();
-        createSignedToken();
-        Map<String, Object> additionalTokenClaims = new HashMap<>();
-        additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
-        OIDCTokenResponse tokenResponse =
-                tokenService.generateTokenResponse(
-                        CLIENT_ID,
-                        INTERNAL_SUBJECT,
-                        SCOPES,
-                        additionalTokenClaims,
-                        PUBLIC_SUBJECT,
-                        INTERNAL_PAIRWISE_SUBJECT,
-                        null,
-                        false,
-                        JWSAlgorithm.ES256,
-                        "client-session-id",
-                        VOT);
-
-        assertSuccessfulTokenResponse(tokenResponse);
-
-        assertNull(tokenResponse.getOIDCTokens().getRefreshToken());
-    }
-
-    @Test
-    void shouldNotIncludeInternalIdentifiersInTokens() throws ParseException, JOSEException {
-        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-        when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
-        createSignedIdToken();
-        createSignedToken();
-        Map<String, Object> additionalTokenClaims = new HashMap<>();
-        additionalTokenClaims.put("nonce", nonce);
-        Set<String> claimsForListOfScopes =
-                ValidScopes.getClaimsForListOfScopes(SCOPES_OFFLINE_ACCESS.toStringList());
-        OIDCTokenResponse tokenResponse =
-                tokenService.generateTokenResponse(
-                        CLIENT_ID,
-                        INTERNAL_SUBJECT,
-                        SCOPES_OFFLINE_ACCESS,
-                        additionalTokenClaims,
-                        PUBLIC_SUBJECT,
-                        INTERNAL_PAIRWISE_SUBJECT,
-                        null,
-                        false,
-                        JWSAlgorithm.ES256,
-                        "client-session-id",
-                        VOT);
-
-        var parsedAccessToken =
-                SignedJWT.parse(tokenResponse.getOIDCTokens().getAccessToken().getValue())
-                        .getPayload()
-                        .toString();
-        assertFalse(parsedAccessToken.contains(INTERNAL_SUBJECT.getValue()));
-        assertFalse(parsedAccessToken.contains(INTERNAL_PAIRWISE_SUBJECT.getValue()));
-        var parsedRefreshToken =
-                SignedJWT.parse(tokenResponse.getOIDCTokens().getRefreshToken().getValue())
-                        .getPayload()
-                        .toString();
-        assertFalse(parsedRefreshToken.contains(INTERNAL_SUBJECT.getValue()));
-        assertFalse(parsedRefreshToken.contains(INTERNAL_PAIRWISE_SUBJECT.getValue()));
-    }
 
     @Test
     void shouldSuccessfullyValidateTokenRequest() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -11,7 +11,6 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.approvaltests.JsonApprovals;
 import org.approvaltests.core.Options;
@@ -57,7 +56,6 @@ class TokenServiceTest {
             new Subject("urn:fdc:gov.uk:2022:TJLt3WaiGkLh8UqeisH2zVKGAP0");
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
-    private Nonce nonce;
     private static final String CLIENT_ID = "client-id";
     private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
@@ -78,8 +76,6 @@ class TokenServiceTest {
         when(configurationService.getEnvironment()).thenReturn("test");
         when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
                 .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
-
-        nonce = new Nonce();
     }
 
     @AfterEach

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -2,26 +2,17 @@ package uk.gov.di.authentication.shared.services;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.ErrorObject;
-import com.nimbusds.oauth2.sdk.GrantType;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.oauth2.sdk.util.URLUtils;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
-import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
-import com.nimbusds.openid.connect.sdk.claims.AccessTokenHash;
 import org.approvaltests.JsonApprovals;
 import org.approvaltests.core.Options;
 import org.approvaltests.scrubbers.GuidScrubber;
@@ -37,37 +28,22 @@ import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.authentication.shared.entity.AccessTokenStore;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.helper.SubjectHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.text.ParseException;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 public class TokenServiceTest {
@@ -79,34 +55,18 @@ public class TokenServiceTest {
     private final TokenService tokenService =
             new TokenService(configurationService, redisConnectionService, kmsConnectionService);
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
-    private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
-    private static final Subject INTERNAL_PAIRWISE_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject FIXED_INTERNAL_PAIRWISE_SUBJECT =
             new Subject("urn:fdc:gov.uk:2022:TJLt3WaiGkLh8UqeisH2zVKGAP0");
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
-    private static final String VOT = CredentialTrustLevel.MEDIUM_LEVEL.getValue();
-    private static final Scope SCOPES_OFFLINE_ACCESS =
-            new Scope(
-                    OIDCScopeValue.OPENID,
-                    OIDCScopeValue.EMAIL,
-                    OIDCScopeValue.PHONE,
-                    OIDCScopeValue.OFFLINE_ACCESS);
     private Nonce nonce;
     private static final String CLIENT_ID = "client-id";
-    private static final String AUTH_CODE = new AuthorizationCode().toString();
-    private static final String REDIRECT_URI = "http://localhost/redirect";
     private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
-    private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
-    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final String STORAGE_TOKEN_PREFIX =
             "eyJraWQiOiIxZDUwNGFlY2UyOThhMTRkNzRlZTBhMDJiNjc0MGI0MzcyYTFmYWI0MjA2Nzc4ZTQ4NmJhNzI3NzBmZjRiZWI4IiwiYWxnIjoiRVMyNTYifQ.";
-    private static final String CREDENTIAL_STORE_URI = "https://credential-store.account.gov.uk";
     private static final String IPV_AUDIENCE = "https://identity.test.account.gov.uk";
     private static final String EVCS_AUDIENCE = "https://credential-store.test.account.gov.uk";
-
-    private static final Json objectMapper = SerializationService.getInstance();
 
     @RegisterExtension
     public final CaptureLoggingExtension logging = new CaptureLoggingExtension(TokenService.class);
@@ -149,148 +109,6 @@ public class TokenServiceTest {
                 new Options(Scrubbers.scrubAll(unixTimestampScrubber, guidScrubber)));
     }
 
-
-    @Test
-    void shouldSuccessfullyValidateTokenRequest() {
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put(
-                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("code", Collections.singletonList(AUTH_CODE));
-        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-
-        assertThat(errorObject, equalTo(Optional.empty()));
-    }
-
-    @Test
-    void shouldReturnErrorIfRedirectUriIsMissingWhenValidatingTokenRequest() {
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put(
-                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("code", Collections.singletonList(AUTH_CODE));
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-
-        assertThat(
-                errorObject,
-                equalTo(
-                        Optional.of(
-                                new ErrorObject(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Request is missing redirect_uri parameter"))));
-    }
-
-    @Test
-    void shouldReturnErrorIfGrantTypeIsMissingWhenValidatingTokenRequest() {
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("code", Collections.singletonList(AUTH_CODE));
-        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-
-        assertThat(
-                errorObject,
-                equalTo(
-                        Optional.of(
-                                new ErrorObject(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Request is missing grant_type parameter"))));
-    }
-
-    @Test
-    void shouldReturnErrorIfCodeIsMissingWhenValidatingTokenRequest() {
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put(
-                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-
-        assertThat(
-                errorObject,
-                equalTo(
-                        Optional.of(
-                                new ErrorObject(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Request is missing code parameter"))));
-    }
-
-    @Test
-    void shouldReturnErrorIfGrantIsInvalidWhenValidatingTokenRequest() {
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put("grant_type", Collections.singletonList("client_credentials"));
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("code", Collections.singletonList(AUTH_CODE));
-        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-
-        assertThat(errorObject, equalTo(Optional.of(OAuth2Error.UNSUPPORTED_GRANT_TYPE)));
-    }
-
-    @Test
-    void shouldSuccessfullyValidateRefreshTokenRequest() {
-        Scope scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
-        RefreshToken refreshToken = new RefreshToken();
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put(
-                "grant_type", Collections.singletonList(GrantType.REFRESH_TOKEN.getValue()));
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("scope", Collections.singletonList(scope.toString()));
-        customParams.put("refresh_token", Collections.singletonList(refreshToken.getValue()));
-
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-        assertTrue(errorObject.isEmpty());
-    }
-
-    @Test
-    void shouldReturnErrorWhenValidatingRefreshTokenRequestWithWrongGrant() {
-        Scope scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
-        RefreshToken refreshToken = new RefreshToken();
-        Map<String, List<String>> customParams = new HashMap<>();
-        customParams.put(
-                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
-        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
-        customParams.put("scope", Collections.singletonList(scope.toString()));
-        customParams.put("refresh_token", Collections.singletonList(refreshToken.getValue()));
-
-        Optional<ErrorObject> errorObject =
-                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
-
-        assertTrue(errorObject.isPresent());
-    }
-
-    private void createSignedIdToken() throws JOSEException {
-        ECKey ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID(KEY_ID)
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        SignedJWT signedIdToken = createSignedIdToken(ecSigningKey);
-        byte[] idTokenSignatureDer =
-                ECDSA.transcodeSignatureToDER(signedIdToken.getSignature().decode());
-        SignResponse idTokenSignedResult =
-                SignResponse.builder()
-                        .signature(SdkBytes.fromByteArray(idTokenSignatureDer))
-                        .keyId(KEY_ID)
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
-                        .build();
-
-        when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(idTokenSignedResult);
-    }
-
-    private SignedJWT createSignedIdToken(ECKey ecSigningKey) {
-        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-        return TokenGeneratorHelper.generateIDToken(
-                CLIENT_ID, PUBLIC_SUBJECT, BASE_URL, ecSigningKey, expiryDate);
-    }
-
     private void createSignedToken() throws JOSEException {
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256)
@@ -315,52 +133,5 @@ public class TokenServiceTest {
                         .build();
 
         when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(tokenResult);
-    }
-
-    private void assertSuccessfulTokenResponse(OIDCTokenResponse tokenResponse)
-            throws ParseException, Json.JsonException {
-        String accessTokenKey = ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT;
-        assertNotNull(tokenResponse.getOIDCTokens().getAccessToken());
-        AccessTokenStore accessTokenStore =
-                new AccessTokenStore(
-                        tokenResponse.getOIDCTokens().getAccessToken().getValue(),
-                        INTERNAL_SUBJECT.getValue(),
-                        INTERNAL_PAIRWISE_SUBJECT.getValue());
-        verify(redisConnectionService)
-                .saveWithExpiry(
-                        accessTokenKey, objectMapper.writeValueAsString(accessTokenStore), 300L);
-
-        var header = (JWSHeader) tokenResponse.getOIDCTokens().getIDToken().getHeader();
-
-        assertThat(tokenResponse.getOIDCTokens().getAccessToken().getLifetime(), is(300L));
-
-        assertThat(
-                header.getKeyID(),
-                is("1d504aece298a14d74ee0a02b6740b4372a1fab4206778e486ba72770ff4beb8"));
-
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("sub"),
-                equalTo(PUBLIC_SUBJECT.getValue()));
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("nonce"),
-                equalTo(nonce.getValue()));
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("vtm"),
-                equalTo(buildURI(BASE_URL, "/trustmark").toString()));
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getIssuer(),
-                equalTo(BASE_URL));
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("at_hash"),
-                equalTo(
-                        AccessTokenHash.compute(
-                                        tokenResponse.getOIDCTokens().getAccessToken(),
-                                        JWSAlgorithm.ES256,
-                                        null)
-                                .toString()));
-
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getStringClaim("sid"),
-                is("client-session-id"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -32,7 +32,6 @@ import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.text.ParseException;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -69,11 +68,6 @@ class TokenServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(BASE_URL));
-        when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
-        when(configurationService.getIDTokenExpiry()).thenReturn(120L);
-        when(configurationService.getSessionExpiry()).thenReturn(300L);
-        when(configurationService.getEnvironment()).thenReturn("test");
         when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
                 .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
-public class TokenServiceTest {
+class TokenServiceTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -50,10 +50,8 @@ class TokenServiceTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
-    private final RedisConnectionService redisConnectionService =
-            mock(RedisConnectionService.class);
     private final TokenService tokenService =
-            new TokenService(configurationService, redisConnectionService, kmsConnectionService);
+            new TokenService(configurationService, kmsConnectionService);
     private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Subject FIXED_INTERNAL_PAIRWISE_SUBJECT =
             new Subject("urn:fdc:gov.uk:2022:TJLt3WaiGkLh8UqeisH2zVKGAP0");


### PR DESCRIPTION
## What

Removes methods from the auth token service which are unused as of the orch/auth split. Since the orch / auth split, it's only the external api in the auth estate that handles OIDC tokens, and it has its own Token Service. Orch have their own copy of the auth TokenService which contains copies of all these methods, which are now used on the orch side.

You can see these methods are unused since this PR in its green state only touches the TokenService and the TokenService tests. The only other changes are related to removing the redis connection service when constructing the token service, since this is no longer required.

Also removed some related methods from the configuration service which are also no longer used.

## How to review

1. Code Review

