### PR TITLE
BAU: bump jUnit to v6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 awsSdk = "2.44.4"
-junit = "5.13.4"
+junit = "6.0.3"
 pact = "4.6.20"
 spotbugs = "4.9.8"
 xray = "2.21.0"

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -136,6 +136,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import static uk.gov.di.orchestration.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
@@ -159,7 +160,8 @@ class AuthenticationCallbackHandlerTest {
     private final AuthenticationUserInfoStorageService userInfoStorageService =
             mock(AuthenticationUserInfoStorageService.class);
     private final Metrics metrics = mock(Metrics.class);
-    private static final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
+    private final OrchAuthCodeService orchAuthCodeService =
+            mock(OrchAuthCodeService.class, withSettings().verboseLogging());
     private static final InitiateIPVAuthorisationService initiateIPVAuthorisationService =
             mock(InitiateIPVAuthorisationService.class);
     private static final AccountInterventionService accountInterventionService =
@@ -734,6 +736,13 @@ class AuthenticationCallbackHandlerTest {
     @Nested
     class AuthTime {
 
+        @BeforeEach
+        void setup() {
+            when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                            anyString(), anyString(), anyString(), any(), anyString()))
+                    .thenReturn((AUTH_CODE_RP_TO_ORCH));
+        }
+
         private static Stream<Arguments> authenticatedAndUpliftParams() {
             return Stream.of(
                     Arguments.of(false, false, true),
@@ -766,7 +775,7 @@ class AuthenticationCallbackHandlerTest {
             handler.handleRequest(event, CONTEXT);
 
             var captor = ArgumentCaptor.forClass(OrchSessionItem.class);
-            verify(orchSessionService, times(2)).updateSession(captor.capture());
+            verify(orchSessionService, times(3)).updateSession(captor.capture());
 
             if (authTimeSet) {
                 assertNotEquals(null, captor.getAllValues().get(0).getAuthTime());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -160,12 +160,11 @@ class AuthenticationCallbackHandlerTest {
     private final AuthenticationUserInfoStorageService userInfoStorageService =
             mock(AuthenticationUserInfoStorageService.class);
     private final Metrics metrics = mock(Metrics.class);
-    private final OrchAuthCodeService orchAuthCodeService =
-            mock(OrchAuthCodeService.class, withSettings().verboseLogging());
+    private final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
     private static final InitiateIPVAuthorisationService initiateIPVAuthorisationService =
             mock(InitiateIPVAuthorisationService.class);
     private static final AccountInterventionService accountInterventionService =
-            mock(AccountInterventionService.class);
+            mock(AccountInterventionService.class, withSettings().verboseLogging());
     private static final CrossBrowserOrchestrationService CROSS_BROWSER_ORCHESTRATION_SERVICE =
             mock(CrossBrowserOrchestrationService.class);
     private static final LogoutService logoutService = mock(LogoutService.class);
@@ -772,7 +771,7 @@ class AuthenticationCallbackHandlerTest {
 
             var event = new APIGatewayProxyRequestEvent();
             setValidHeadersAndQueryParameters(event);
-            handler.handleRequest(event, CONTEXT);
+            var response = handler.handleRequest(event, CONTEXT);
 
             var captor = ArgumentCaptor.forClass(OrchSessionItem.class);
             verify(orchSessionService, times(3)).updateSession(captor.capture());
@@ -1126,6 +1125,11 @@ class AuthenticationCallbackHandlerTest {
         void setup() {
             usingValidClientSession();
             usingValidClient();
+            // HACK: Leaky test state from above
+            when(accountInterventionService.getAccountIntervention(anyString(), anyLong(), any()))
+                    .thenReturn(
+                            new AccountIntervention(
+                                    new AccountInterventionState(false, false, false, false)));
         }
 
         @Test


### PR DESCRIPTION
### Wider context of change

We'd like to update to JUnit6. There aren't any obvious breaking changes, but it did require us to make some test changes due to the way our tests are written,

### What’s changed

- Bumps JUnit to v6
- Fixes some of our tests with leaky state between them. An ideal fix would be to eliminate this, but this was not obvious, so I've opted for fixing the tests. We should come back and investigate why our tests have this leaky state at some point.

### Manual testing

- N/A just run the tests!
- 
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
