### PR TITLE
BAU: Fix CVE-2026-42577

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,10 @@ subprojects {
                         because 'CVE-2025-58057 is fixed in io.netty:netty-codec:4.1.125.Final and higher'
                     }
 
+                    add(conf.name, 'io.netty:netty-transport-native-epoll:[4.2.13.Final,5.0)') {
+                        because 'CVE-2026-42577 is fixed in io.netty:netty-transport-native-epoll:4.2.13.Final and higher'
+                    }
+
                     // Jetty constraints
                     add(conf.name, 'org.eclipse.jetty.http2:jetty-http2-common:[12.0.25,12.1.0)') {
                         because 'CVE-2025-5115 is fixed in org.eclipse.jetty.http2:jetty-http2-common:12.0.25 and higher'


### PR DESCRIPTION
## What

- Add constraint for io.netty:netty-transport-native-epoll. Set the minimum to 4.2.13 but limit the version to less than 5.0

## How to review

1. Code review
