### PR TITLE
ATO-2506 error on identity journey request with client_post_secret

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -174,7 +174,12 @@ public abstract class BaseAuthorizeValidator {
             if (vtrError.isPresent()) {
                 return vtrError;
             }
-            logIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(vtrList, client);
+            var tokenAuthMethodError =
+                    errorForIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(
+                            vtrList, client);
+            if (tokenAuthMethodError.isPresent()) {
+                return tokenAuthMethodError;
+            }
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()
                     && !client.isTestClient()) {
@@ -203,13 +208,18 @@ public abstract class BaseAuthorizeValidator {
         return Optional.empty();
     }
 
-    protected void logIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(
-            List<VectorOfTrust> vtrList, ClientRegistry client) {
+    protected Optional<ErrorObject>
+            errorForIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(
+                    List<VectorOfTrust> vtrList, ClientRegistry client) {
         if (requestContainsIdentityLoC(vtrList)
                 && ("client_secret_post".equals(client.getTokenAuthMethod()))) {
-            LOG.info(
+            logErrorInProdElseWarn(
                     "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.");
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
         }
+        return Optional.empty();
     }
 
     protected void validateResponseMode(String responseMode) throws InvalidResponseModeException {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -33,6 +33,7 @@ public abstract class BaseAuthorizeValidator {
     protected final DynamoClientService dynamoClientService;
     protected final IPVCapacityService ipvCapacityService;
     protected static final Logger LOG = LogManager.getLogger(BaseAuthorizeValidator.class);
+    protected static final String VTR_NOT_PERMITTED = "Request vtr is not permitted";
 
     protected BaseAuthorizeValidator(
             ConfigurationService configurationService,
@@ -167,8 +168,7 @@ public abstract class BaseAuthorizeValidator {
                                 "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: %s",
                                 levelOfConfidenceValues));
                 return Optional.of(
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
+                        new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, VTR_NOT_PERMITTED));
             }
             var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
             if (vtrError.isPresent()) {
@@ -202,8 +202,7 @@ public abstract class BaseAuthorizeValidator {
             logErrorInProdElseWarn(
                     "Level of confidence values for an identity journey have been requested, but identity is not supported for this client.");
             return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, VTR_NOT_PERMITTED));
         }
         return Optional.empty();
     }
@@ -216,8 +215,7 @@ public abstract class BaseAuthorizeValidator {
             logErrorInProdElseWarn(
                     "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.");
             return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, VTR_NOT_PERMITTED));
         }
         return Optional.empty();
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -531,7 +531,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void validatorLogsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod() {
+    void validatorErrorsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod() {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         List<String> clientLoCs = List.of("P0", "P2");
         var vtr = jsonArrayOf("Cl.Cm.P2");
@@ -553,7 +553,14 @@ class QueryParamsAuthorizeValidatorTest {
                         .build();
         var errorObject = queryParamsAuthorizeValidator.validate(authRequest);
 
-        assertFalse(errorObject.isPresent());
+        assertTrue(errorObject.isPresent());
+        assertThat(
+                errorObject.get().errorObject().toJSONObject(),
+                equalTo(
+                        new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request vtr is not permitted")
+                                .toJSONObject()));
         String expectedLogMessage =
                 "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.";
         assertThat(baseClassLogging.events(), hasItem(withMessageContaining(expectedLogMessage)));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -214,7 +214,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void validatorLogsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod()
+        void validatorErrorsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod()
                 throws ClientSignatureValidationException, JwksException, JOSEException {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("vtr", jsonArrayOf("Cl.Cm.P2")).build();
@@ -233,7 +233,15 @@ class RequestObjectAuthorizeValidatorTest {
 
             var requestObjectError = validator.validate(authRequest);
 
-            assertFalse(requestObjectError.isPresent());
+            assertTrue(requestObjectError.isPresent());
+            assertThat(
+                    requestObjectError.get().errorObject().toJSONObject(),
+                    equalTo(
+                            new ErrorObject(
+                                            OAuth2Error.INVALID_REQUEST_CODE,
+                                            "Request vtr is not permitted")
+                                    .toJSONObject()));
+
             String expectedLogMessage =
                     "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.";
             assertThat(


### PR DESCRIPTION
RPs should not request identity journeys if they use client_post_secret as that tokenAuthMethod is considered insufficiently secure. There is already logging for such requests, and now the AuthorizeValidator will return an error in those cases.

### What’s changed

To the existing logging, this adds actual rejection of the request through an error raised by the validator

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.


