### PR TITLE
ATO-2525: alternate domain params

### DIFF
--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -37,7 +37,7 @@ function usage {
 
   Options:
     -e, --environment        The environment you wish to deploy to i.e dev, build, staging, integration, or production
-    -c, --certificate        Creates certificate in us-east-1 region for CloudFront Distribution.
+    -c, --certificate         Creates certificate in us-east-1 region for CloudFront Distribution.
     -d, --distribution       Creates the CloudFront distribution
     -m, --monitoring         Deploys CloudFront Extended Monitoring stack in us-east-1
     -n, --notification        Deploys a stack which allows us to forward our Cloudfront alarms to Slack in our non-prod envs, or PagerDuty in

--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -16,6 +16,8 @@ PROVISION_CLOUDFRONT_NOTIFICATION_STACK=false
 SYNC_SECRETS=false
 # Matches the dev-platform stack default
 PREVIOUS_ORIGIN_CLOAKING_SECRET="none"
+CERT_TO_DEPLOY="live"
+CLOUDFRONT_PARAMS_TO_USE="live"
 
 PROVISION_COMMAND="../../../devplatform-deploy/stack-orchestration-tool/provisioner.sh"
 
@@ -37,8 +39,9 @@ function usage {
 
   Options:
     -e, --environment        The environment you wish to deploy to i.e dev, build, staging, integration, or production
-    -c, --certificate         Creates certificate in us-east-1 region for CloudFront Distribution.
-    -d, --distribution       Creates the CloudFront distribution
+    -c, --certificate         Creates certificate in us-east-1 region for CloudFront Distribution. Can choose between deploying a cert for the
+                             live or alternate domains.
+    -d, --distribution       Creates the CloudFront distribution. Must provide a parameter for the live or alternative parameters to be used.
     -m, --monitoring         Deploys CloudFront Extended Monitoring stack in us-east-1
     -n, --notification        Deploys a stack which allows us to forward our Cloudfront alarms to Slack in our non-prod envs, or PagerDuty in
                              the production environment. This requires us to setup some manual secrets for the relevant webhooks/slack channel IDs.
@@ -63,9 +66,27 @@ while [[ $# -gt 0 ]]; do
       ;;
     -c | --certificate)
       PROVISION_CLOUDFRONT_TLS_CERT=true
+      CERT_TO_DEPLOY="${2}"
+
+      PERMITTED_VALUES="live alternative"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${CERT_TO_DEPLOY}( |$) ]]; then
+        echo "Certificate arg provided: ${CERT_TO_DEPLOY} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
       ;;
     -d | --distribution)
       PROVISION_CLOUDFRONT=true
+      CLOUDFRONT_PARAMS_TO_USE="${2}"
+
+      PERMITTED_VALUES="live alternative"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${CLOUDFRONT_PARAMS_TO_USE}( |$) ]]; then
+        echo "Cloudfront distribution arg provided: ${CLOUDFRONT_PARAMS_TO_USE} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
       ;;
     -m | --monitoring)
       PROVISION_CLOUDFRONT_MONITORING=true
@@ -137,6 +158,10 @@ function provision_cloudfront_distribution() {
     jq -s 'add | group_by(.Key) | map(last)' "${TAGS_FILE}" "${stack_tags_file}" > "${tmp_tags_file}"
   fi
 
+  if [ "${CLOUDFRONT_PARAMS_TO_USE}" == "alternative" ]; then
+    params_file="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-oidc-cloudfront/alternative-parameters.json"
+  fi
+
   if [ "${SYNC_SECRETS}" == "true" ]; then
     echo "Syncing secrets from auth account"
     sync_secret_from_auth_account
@@ -164,7 +189,16 @@ function provision_cloudfront_monitoring() {
 function provision_cloudfront_certificate() {
 
   echo "Provisioning cloudfront certificate stack"
-  AWS_REGION="us-east-1" PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/cloudfront-tls-certificate/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "cloudfront-tls-certificate" "certificate" "${CERTIFICATE_STACK_VERSION}"
+  # shellcheck disable=SC2155
+  local params_file="$(pwd)/configuration/${ENVIRONMENT}/cloudfront-tls-certificate/parameters.json"
+  local stack_name="cloudfront-tls-certificate"
+
+  if [ "${CERT_TO_DEPLOY}" == "alternative" ]; then
+    params_file="$(pwd)/configuration/${ENVIRONMENT}/cloudfront-tls-certificate/alternative-parameters.json"
+    stack_name="cloudfront-tls-certificate-alt-domain"
+  fi
+
+  AWS_REGION="us-east-1" PARAMETERS_FILE="${params_file}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "${stack_name}" "certificate" "${CERTIFICATE_STACK_VERSION}"
 
   echo "Provisioned cloudfront certificate stack"
 }

--- a/ci/stack-orchestration/deploy-dev.sh
+++ b/ci/stack-orchestration/deploy-dev.sh
@@ -18,7 +18,7 @@ PROVISION_PIPELINE_STACK=false
 PROVISION_TXMA_STACK=false
 PROVISION_CLOUDWATCH_ALARM_STACK=false
 PROVISION_HOSTED_ZONE=false
-
+DOMAIN_TO_PROVISION="live"
 ENVIRONMENT=dev
 
 TAGS_FILE="$(pwd)/configuration/${ENVIRONMENT}/tags.json"
@@ -108,6 +108,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     -h | --hosted-zone)
       PROVISION_HOSTED_ZONE=true
+      DOMAIN_TO_PROVISION=${2}
+
+      PERMITTED_VALUES="live alternative"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${DOMAIN_TO_PROVISION}( |$) ]]; then
+        echo "Hosted zone arg provided: ${DOMAIN_TO_PROVISION} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
+      shift
       ;;
     *)
       usage
@@ -187,6 +197,9 @@ function provision_pipeline_stack() {
 function provision_hosted_zone_stack() {
   export AWS_REGION="eu-west-2"
 
+  # shellcheck disable=SC2155
+  local parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/parameters.json"
+
   echo "Provisioning hosted zone stack"
   TEMPLATE_FILE="$(pwd)/manual-stacks/domains/template.yaml"
   if [ ! -f "${TEMPLATE_FILE}" ]; then
@@ -194,7 +207,11 @@ function provision_hosted_zone_stack() {
     exit 1
   fi
 
-  ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
+  if [ "${DOMAIN_TO_PROVISION}" == "alternative" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/alternative-domain-parameters.json"
+  fi
+
+  PARAMETERS_FILE="${parameters_file}" ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
   echo "Provisioned hosted zone stack"
 }
 


### PR DESCRIPTION
### Wider context of change:

As part of our migration, we would like to deploy our infrastructure on an alternate domain to facilitate testing. To do this we may need to be able alternate the parameters we pass to our 

### What’s changed:
- Adds a parameter to our deploy-dev script for the hosted zone to alternate the parameters we use for the live or alternate domain
- Does the same for cloudfront for the distribution and TLS cert

### Manual testing:

- N/A will test when using to deploy

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
