### PR TITLE
AUT-4577: Move VerifyCodeHandler lockout logic to managers

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -256,7 +256,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                         codeRequest.code(),
                         codeStorageService,
                         authSession.getEmailAddress(),
-                        configurationService);
+                        configurationService,
+                        true);
 
         if (errorResponse.stream().anyMatch(ErrorResponse.INVALID_NOTIFICATION_TYPE::equals)) {
             return generateApiGatewayProxyErrorResponse(400, errorResponse.get());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
+import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
@@ -325,17 +326,18 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             }
         }
 
-        processSuccessfulCodeRequest(
-                codeRequest,
-                userContext,
-                subjectId,
-                journeyType,
-                auditContext,
-                maybeRpPairwiseId,
-                maybeRequestedSmsMfaMethod,
-                retrievedMfaMethods);
+        var maybeErrorResponse =
+                processSuccessfulCodeRequest(
+                        codeRequest,
+                        userContext,
+                        subjectId,
+                        journeyType,
+                        auditContext,
+                        maybeRpPairwiseId,
+                        maybeRequestedSmsMfaMethod,
+                        retrievedMfaMethods);
 
-        return generateEmptySuccessApiGatewayResponse();
+        return maybeErrorResponse.orElseGet(() -> generateEmptySuccessApiGatewayResponse());
     }
 
     private boolean userHasExceededAllowedAttemptsForReauthenticationJourney(
@@ -479,7 +481,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         LOG.info("IncorrectMfaCodeAttemptsCount reset");
     }
 
-    private void processSuccessfulCodeRequest(
+    private Optional<APIGatewayProxyResponseEvent> processSuccessfulCodeRequest(
             VerifyCodeRequest codeRequest,
             UserContext userContext,
             String subjectId,
@@ -538,8 +540,19 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
             LOG.info("Setting hasVerifiedMfa to true");
             var permissionContext =
-                    PermissionContext.builder().withAuthSessionItem(authSession).build();
-            userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);
+                    PermissionContext.builder()
+                            .withAuthSessionItem(authSession)
+                            .withEmailAddress(authSession.getEmailAddress())
+                            .withInternalSubjectId(subjectId)
+                            .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
+                            .build();
+            var result = userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct SMS OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
 
             authSessionService.updateSession(
                     authSession
@@ -576,6 +589,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, false);
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
+
+        return Optional.empty();
     }
 
     void preserveReauthCountsForAuditIfJourneyIsReauth(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -15,11 +15,9 @@ import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
-import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -30,14 +28,12 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -51,10 +47,9 @@ import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,7 +73,6 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethodOrDefaultMfaMethod;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT;
@@ -92,7 +86,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final DynamoAccountModifiersService accountModifiersService;
-    private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
     private final PermissionDecisionManager permissionDecisionManager;
@@ -105,7 +98,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuditService auditService,
             CloudwatchMetricsService cloudwatchMetricsService,
             DynamoAccountModifiersService accountModifiersService,
-            AuthenticationAttemptsService authenticationAttemptsService,
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
@@ -120,7 +112,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.accountModifiersService = accountModifiersService;
-        this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
         this.permissionDecisionManager = permissionDecisionManager;
@@ -137,8 +128,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
@@ -152,8 +141,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.accountModifiersService = new DynamoAccountModifiersService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
@@ -207,15 +194,18 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                         .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
                         .build();
 
-        var maybePermissionError =
+        var permissionCheck =
                 checkPermission(
                         journeyType,
                         permissionContext,
                         auditContext,
                         maybeRpPairwiseId,
-                        codeRequest);
-        if (maybePermissionError.isPresent()) {
-            return maybePermissionError.get();
+                        false,
+                        codeRequest,
+                        Optional.empty());
+        var initialPermissionError = permissionCheck.errorResponse();
+        if (initialPermissionError.isPresent()) {
+            return initialPermissionError.get();
         }
 
         var retrieveMfaMethods = mfaMethodsService.getMfaMethods(authSession.getEmailAddress());
@@ -254,14 +244,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         var errorResponse =
                 ValidationHelper.validateVerificationCode(
-                        notificationType,
-                        journeyType,
-                        code,
-                        codeRequest.code(),
-                        codeStorageService,
-                        authSession.getEmailAddress(),
-                        configurationService,
-                        true);
+                        notificationType, code, codeRequest.code());
 
         if (errorResponse.stream().anyMatch(ErrorResponse.INVALID_NOTIFICATION_TYPE::equals)) {
             return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
@@ -270,26 +253,45 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         authSessionService.updateSession(authSession);
 
         if (errorResponse.isPresent()) {
-            handleInvalidVerificationCode(
-                    codeRequest,
-                    journeyType,
-                    notificationType,
-                    subjectId,
-                    errorResponse.get(),
-                    authSession,
-                    auditContext,
-                    maybeRequestedSmsMfaMethod);
+            Result<TrackingError, Void> trackingResult = Result.success(null);
+            if (notificationType.isForPhoneNumber()) {
+                trackingResult =
+                        userActionsManager.incorrectSmsOtpReceived(journeyType, permissionContext);
+            } else if (notificationType.isEmail()) {
+                trackingResult =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                journeyType, permissionContext);
+            }
+            if (trackingResult.isFailure()) {
+                LOG.error(
+                        "Failed to record incorrect OTP for {}: {}",
+                        notificationType,
+                        trackingResult.getFailure());
+                return TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                        trackingResult.getFailure());
+            }
 
-            var maybePostFailureError =
+            var permissionCheckAfterIncrement =
                     checkPermission(
                             journeyType,
                             permissionContext,
                             auditContext,
                             maybeRpPairwiseId,
-                            codeRequest);
-            if (maybePostFailureError.isPresent()) {
-                return maybePostFailureError.get();
+                            true,
+                            codeRequest,
+                            maybeRequestedSmsMfaMethod);
+            var permissionErrorResponse = permissionCheckAfterIncrement.errorResponse();
+            if (permissionErrorResponse.isPresent()) {
+                return permissionErrorResponse.get();
             }
+
+            emitInvalidCodeAuditEvent(
+                    codeRequest,
+                    journeyType,
+                    auditContext,
+                    maybeRequestedSmsMfaMethod,
+                    permissionCheckAfterIncrement.attemptCount());
+
             return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
         }
 
@@ -298,18 +300,16 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     userContext, authSessionService, authenticationService, configurationService);
         }
 
-        var maybeErrorResponse =
-                processSuccessfulCodeRequest(
+        return processSuccessfulCodeRequest(
                         codeRequest,
                         userContext,
-                        subjectId,
                         journeyType,
                         auditContext,
-                        maybeRpPairwiseId,
                         maybeRequestedSmsMfaMethod,
-                        retrievedMfaMethods);
-
-        return maybeErrorResponse.orElseGet(() -> generateEmptySuccessApiGatewayResponse());
+                        retrievedMfaMethods,
+                        permissionContext,
+                        permissionCheck.attemptCount())
+                .orElseGet(() -> generateEmptySuccessApiGatewayResponse());
     }
 
     private Optional<String> getCode(
@@ -332,44 +332,17 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         return codeStorageService.getOtpCode(identifier, notificationType);
     }
 
-    private void handleInvalidVerificationCode(
-            VerifyCodeRequest codeRequest,
-            JourneyType journeyType,
-            NotificationType notificationType,
-            String subjectId,
-            ErrorResponse errorResponse,
-            AuthSessionItem authSession,
-            AuditContext auditContext,
-            Optional<MFAMethod> maybeRequestedSmsMfaMethod) {
-        if (journeyType == REAUTHENTICATION && notificationType == MFA_SMS) {
-            if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
-                authenticationAttemptsService.createOrIncrementCount(
-                        subjectId,
-                        NowHelper.nowPlus(
-                                        configurationService.getReauthEnterSMSCodeCountTTL(),
-                                        ChronoUnit.SECONDS)
-                                .toInstant()
-                                .getEpochSecond(),
-                        REAUTHENTICATION,
-                        CountType.ENTER_MFA_CODE);
-            }
-        } else {
-            processBlockedCodeSession(
-                    errorResponse,
-                    authSession,
-                    codeRequest,
-                    journeyType,
-                    auditContext,
-                    maybeRequestedSmsMfaMethod);
-        }
-    }
+    private record PermissionCheckResult(
+            Optional<APIGatewayProxyResponseEvent> errorResponse, int attemptCount) {}
 
-    private Optional<APIGatewayProxyResponseEvent> checkPermission(
+    private PermissionCheckResult checkPermission(
             JourneyType journeyType,
             PermissionContext permissionContext,
             AuditContext auditContext,
             Optional<String> maybeRpPairwiseId,
-            VerifyCodeRequest codeRequest) {
+            boolean afterActionRecorded,
+            VerifyCodeRequest codeRequest,
+            Optional<MFAMethod> maybeRequestedSmsMfaMethod) {
         var notificationType = codeRequest.notificationType();
         Result<DecisionError, Decision> canVerifyOtpResult =
                 Result.success(new Decision.Permitted(0));
@@ -385,8 +358,11 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             LOG.error(
                     "Failed to check OTP verification permission: {}",
                     canVerifyOtpResult.getFailure());
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    500, ErrorResponse.INTERNAL_SERVER_ERROR)),
+                    0);
         }
 
         var decision = canVerifyOtpResult.getSuccess();
@@ -411,18 +387,67 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             FAILURE_REASON.getValue(),
                             reauthFailureReason.getValue()));
 
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(
-                            400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS)),
+                    reauthLockedOut.attemptCount());
         }
 
-        if (decision instanceof Decision.TemporarilyLockedOut) {
+        if (decision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
             LOG.info("User is temporarily locked out from OTP verification");
+            if (afterActionRecorded) {
+                if (maybeRequestedSmsMfaMethod.isPresent()) {
+                    auditContext =
+                            auditContext.withMetadataItem(
+                                    pair(
+                                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                            maybeRequestedSmsMfaMethod
+                                                    .get()
+                                                    .getPriority()
+                                                    .toLowerCase()));
+                }
+                // loginFailureCount is hardcoded to 0 because the previous implementation
+                // reset the incorrect attempts counter before reading it for the audit event,
+                // so this field was always emitted as 0 on the max-retries path.
+                var metadataPairArray =
+                        metadataPairs(notificationType, journeyType, codeRequest, 0, true);
+                auditService.submitAuditEvent(
+                        FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
+                        auditContext,
+                        metadataPairArray);
+            }
             var errorResponse = blockedCodeBehaviour(notificationType);
-            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+            return new PermissionCheckResult(
+                    Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse)),
+                    temporarilyLockedOut.attemptCount());
         }
 
-        return Optional.empty();
+        if (decision instanceof Decision.Permitted permitted) {
+            return new PermissionCheckResult(Optional.empty(), permitted.attemptCount());
+        }
+
+        return new PermissionCheckResult(Optional.empty(), 0);
+    }
+
+    private void emitInvalidCodeAuditEvent(
+            VerifyCodeRequest codeRequest,
+            JourneyType journeyType,
+            AuditContext auditContext,
+            Optional<MFAMethod> maybeRequestedSmsMfaMethod,
+            int loginFailureCount) {
+        var notificationType = codeRequest.notificationType();
+        if (maybeRequestedSmsMfaMethod.isPresent()) {
+            auditContext =
+                    auditContext.withMetadataItem(
+                            pair(
+                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                    maybeRequestedSmsMfaMethod.get().getPriority().toLowerCase()));
+        }
+        var metadataPairArray =
+                metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, true);
+        auditService.submitAuditEvent(
+                FrontendAuditableEvent.AUTH_INVALID_CODE_SENT, auditContext, metadataPairArray);
     }
 
     private ErrorResponse blockedCodeBehaviour(NotificationType notificationType) {
@@ -438,32 +463,17 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 .get(notificationType);
     }
 
-    private void blockCodeForSession(AuthSessionItem authSession, String codeBlockPrefix) {
-        codeStorageService.saveBlockedForEmail(
-                authSession.getEmailAddress(),
-                codeBlockPrefix,
-                configurationService.getLockoutDuration());
-        LOG.info("Email is blocked");
-    }
-
-    private void resetIncorrectMfaCodeAttemptsCount(AuthSessionItem authSession) {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
-        LOG.info("IncorrectMfaCodeAttemptsCount reset");
-    }
-
     private Optional<APIGatewayProxyResponseEvent> processSuccessfulCodeRequest(
             VerifyCodeRequest codeRequest,
             UserContext userContext,
-            String subjectId,
             JourneyType journeyType,
             AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId,
             Optional<MFAMethod> maybeRequestedSmsMfaMethod,
-            List<MFAMethod> retrievedMfaMethods) {
+            List<MFAMethod> retrievedMfaMethods,
+            PermissionContext permissionContext,
+            int loginFailureCount) {
         var authSession = userContext.getAuthSession();
         var notificationType = codeRequest.notificationType();
-        int loginFailureCount =
-                codeStorageService.getIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
         var clientId = authSession.getClientId();
         var levelOfConfidence =
                 Optional.ofNullable(authSession.getRequestedLevelOfConfidence()).orElse(NONE);
@@ -481,9 +491,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         String emailAddress = authSession.getEmailAddress();
         String otpCodeIdentifier = emailAddress;
-        MFAMethod smsMfaMethod = null;
         if (notificationType.isForPhoneNumber()) {
-            smsMfaMethod = maybeRequestedSmsMfaMethod.orElseThrow();
+            MFAMethod smsMfaMethod = maybeRequestedSmsMfaMethod.orElseThrow();
             String formattedPhoneNumber =
                     PhoneNumberHelper.formatPhoneNumber(smsMfaMethod.getDestination());
             otpCodeIdentifier = emailAddress.concat(formattedPhoneNumber);
@@ -492,15 +501,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             pair(
                                     AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
                                     smsMfaMethod.getPriority().toLowerCase()));
-        }
 
-        if (notificationType.equals(MFA_SMS)) {
             String countryCode =
-                    Optional.ofNullable(smsMfaMethod)
-                            .flatMap(
-                                    method ->
-                                            PhoneNumberHelper.maybeGetCountry(
-                                                    method.getDestination()))
+                    PhoneNumberHelper.maybeGetCountry(smsMfaMethod.getDestination())
                             .orElse("unknown");
             LOG.info(
                     "MFA code has been successfully verified for MFA type: {}. JourneyType: {}. CountryCode: {}",
@@ -509,13 +512,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     countryCode);
 
             LOG.info("Setting hasVerifiedMfa to true");
-            var permissionContext =
-                    PermissionContext.builder()
-                            .withAuthSessionItem(authSession)
-                            .withEmailAddress(authSession.getEmailAddress())
-                            .withInternalSubjectId(subjectId)
-                            .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
-                            .build();
             var result = userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);
             if (result.isFailure()) {
                 LOG.error("Failed to record correct SMS OTP: {}", result.getFailure());
@@ -536,21 +532,18 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     levelOfConfidence.getValue(),
                     testUserHelper.isTestJourney(authSession.getEmailAddress()),
                     journeyType,
-                    smsMfaMethod != null
-                            ? MFAMethodType.valueOf(smsMfaMethod.getMfaMethodType())
-                            : null,
-                    smsMfaMethod != null
-                            ? PriorityIdentifier.valueOf(smsMfaMethod.getPriority())
-                            : null);
+                    MFAMethodType.valueOf(smsMfaMethod.getMfaMethodType()),
+                    PriorityIdentifier.valueOf(smsMfaMethod.getPriority()));
         }
 
-        if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
-            preserveReauthCountsForAuditIfJourneyIsReauth(
-                    journeyType, subjectId, authSession, maybeRpPairwiseId);
-            clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
-            maybeRpPairwiseId.ifPresentOrElse(
-                    this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
-                    () -> LOG.warn("Unable to clear rp pairwise id reauth counts"));
+        if (notificationType.isEmail()) {
+            var result = userActionsManager.correctEmailOtpReceived(journeyType, permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct email OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
         }
 
         codeStorageService.deleteOtpCode(otpCodeIdentifier, notificationType);
@@ -559,36 +552,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, false);
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
-
         return Optional.empty();
-    }
-
-    void preserveReauthCountsForAuditIfJourneyIsReauth(
-            JourneyType journeyType,
-            String subjectId,
-            AuthSessionItem authSession,
-            Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.supportReauthSignoutEnabled()
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            var counts =
-                    maybeRpPairwiseId.isPresent()
-                            ? authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            subjectId, maybeRpPairwiseId.get(), REAUTHENTICATION)
-                            : authenticationAttemptsService.getCountsByJourney(
-                                    subjectId, REAUTHENTICATION);
-            var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
-            authSessionService.updateSession(updatedAuthSession);
-        }
-    }
-
-    void clearReauthErrorCountsForSuccessfullyAuthenticatedUser(String identifier) {
-        Arrays.stream(CountType.values())
-                .forEach(
-                        countType ->
-                                authenticationAttemptsService.deleteCount(
-                                        identifier, REAUTHENTICATION, countType));
     }
 
     private AuditService.MetadataPair[] metadataPairs(
@@ -610,50 +574,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             metadataPairs.add(pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
         }
         return metadataPairs.toArray(AuditService.MetadataPair[]::new);
-    }
-
-    private void processBlockedCodeSession(
-            ErrorResponse errorResponse,
-            AuthSessionItem authSession,
-            VerifyCodeRequest codeRequest,
-            JourneyType journeyType,
-            AuditContext auditContext,
-            Optional<MFAMethod> maybeRequestedSmsMfaMethod) {
-        var notificationType = codeRequest.notificationType();
-        var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        AuditableEvent auditableEvent;
-        switch (errorResponse) {
-            case TOO_MANY_INVALID_MFA_OTPS_ENTERED,
-                    TOO_MANY_INVALID_PW_RESET_CODES_ENTERED,
-                    TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED:
-                if (!configurationService.supportReauthSignoutEnabled()
-                        || journeyType != REAUTHENTICATION) {
-                    blockCodeForSession(authSession, codeBlockedKeyPrefix);
-                }
-                resetIncorrectMfaCodeAttemptsCount(authSession);
-                auditableEvent = FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
-                break;
-            case TOO_MANY_EMAIL_CODES_ENTERED:
-                resetIncorrectMfaCodeAttemptsCount(authSession);
-                auditableEvent = FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
-                break;
-            default:
-                auditableEvent = FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
-                break;
-        }
-        if (maybeRequestedSmsMfaMethod.isPresent()) {
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    maybeRequestedSmsMfaMethod.get().getPriority().toLowerCase()));
-        }
-        var loginFailureCount =
-                codeStorageService.getIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
-        var metadataPairArray =
-                metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, true);
-        auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairArray);
     }
 
     private Optional<String> getOtpCodeForTestClient(NotificationType notificationType) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
+import uk.gov.di.authentication.frontendapi.errormapper.ForbiddenReasonErrorMapper;
 import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
@@ -23,6 +24,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
@@ -30,7 +32,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
-import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
@@ -45,7 +46,10 @@ import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
 import java.time.temporal.ChronoUnit;
@@ -57,14 +61,12 @@ import java.util.Optional;
 
 import static java.util.Map.entry;
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
-import static uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder.getReauthFailureReasonFromCountTypes;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.PHONE_NUMBER_NOT_REGISTERED;
-import static uk.gov.di.authentication.shared.entity.JourneyType.PASSWORD_RESET_MFA;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
 import static uk.gov.di.authentication.shared.entity.JourneyType.SIGN_IN;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
@@ -77,7 +79,6 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethodOrDefaultMfaMethod;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.UNEXPECTED_ERROR_CREATING_MFA_IDENTIFIER_FOR_NON_MIGRATED_AUTH_APP;
 import static uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT;
@@ -94,6 +95,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
+    private final PermissionDecisionManager permissionDecisionManager;
     private final TestUserHelper testUserHelper;
 
     protected VerifyCodeHandler(
@@ -107,6 +109,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
+            PermissionDecisionManager permissionDecisionManager,
             TestUserHelper testUserHelper) {
         super(
                 VerifyCodeRequest.class,
@@ -120,6 +123,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
+        this.permissionDecisionManager = permissionDecisionManager;
         this.testUserHelper = testUserHelper;
     }
 
@@ -137,6 +141,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
         this.testUserHelper = new TestUserHelper(configurationService);
     }
 
@@ -151,6 +156,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 new AuthenticationAttemptsService(configurationService);
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
         this.testUserHelper = new TestUserHelper(configurationService);
     }
 
@@ -173,7 +179,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         var notificationType = codeRequest.notificationType();
         var journeyType = getJourneyType(codeRequest, notificationType);
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
@@ -194,25 +199,23 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     400, ErrorResponse.EMAIL_HAS_NO_USER_PROFILE);
         }
 
-        if (checkReauthErrorCountsAndEmitReauthFailedAuditEvent(
-                journeyType, subjectId, auditContext, maybeRpPairwiseId))
-            return generateApiGatewayProxyErrorResponse(
-                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
+        var permissionContext =
+                PermissionContext.builder()
+                        .withAuthSessionItem(authSession)
+                        .withEmailAddress(authSession.getEmailAddress())
+                        .withInternalSubjectId(subjectId)
+                        .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
+                        .build();
 
-        if (isCodeBlockedForSession(authSession, codeBlockedKeyPrefix)) {
-            ErrorResponse errorResponse = blockedCodeBehaviour(codeRequest);
-            return generateApiGatewayProxyErrorResponse(400, errorResponse);
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(
-                        notificationType.getMfaMethodType(), journeyType);
-        if (deprecatedCodeRequestType != null
-                && isCodeBlockedForSession(
-                        authSession, CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            ErrorResponse errorResponse = blockedCodeBehaviour(codeRequest);
-            return generateApiGatewayProxyErrorResponse(400, errorResponse);
+        var maybePermissionError =
+                checkPermission(
+                        journeyType,
+                        permissionContext,
+                        auditContext,
+                        maybeRpPairwiseId,
+                        codeRequest);
+        if (maybePermissionError.isPresent()) {
+            return maybePermissionError.get();
         }
 
         var retrieveMfaMethods = mfaMethodsService.getMfaMethods(authSession.getEmailAddress());
@@ -277,10 +280,15 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     auditContext,
                     maybeRequestedSmsMfaMethod);
 
-            if (userHasExceededAllowedAttemptsForReauthenticationJourney(
-                    journeyType, subjectId, auditContext, maybeRpPairwiseId)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
+            var maybePostFailureError =
+                    checkPermission(
+                            journeyType,
+                            permissionContext,
+                            auditContext,
+                            maybeRpPairwiseId,
+                            codeRequest);
+            if (maybePostFailureError.isPresent()) {
+                return maybePostFailureError.get();
             }
             return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
         }
@@ -288,42 +296,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         if (codeRequestType.equals(CodeRequestType.MFA_PW_RESET_MFA)) {
             SessionHelper.updateSessionWithSubject(
                     userContext, authSessionService, authenticationService, configurationService);
-        }
-
-        if (notificationType.equals(RESET_PASSWORD_WITH_CODE)) {
-            var mfaCodeRequestType =
-                    CodeRequestType.getCodeRequestType(
-                            CodeRequestType.SupportedCodeType.MFA, PASSWORD_RESET_MFA);
-            // TODO remove temporary ZDD measure to reference existing deprecated keys when
-            //  expired
-            var deprecatedMfaCodeRequestType =
-                    CodeRequestType.getDeprecatedCodeRequestTypeString(
-                            MFAMethodType.SMS, PASSWORD_RESET_MFA);
-
-            if (isCodeBlockedForSession(
-                    authSession, CODE_REQUEST_BLOCKED_KEY_PREFIX + mfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS);
-            }
-            if (deprecatedMfaCodeRequestType != null
-                    && isCodeBlockedForSession(
-                            authSession,
-                            CODE_REQUEST_BLOCKED_KEY_PREFIX + deprecatedMfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS);
-            }
-
-            if (isCodeBlockedForSession(
-                    authSession, CODE_BLOCKED_KEY_PREFIX + mfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-            }
-            if (deprecatedMfaCodeRequestType != null
-                    && isCodeBlockedForSession(
-                            authSession, CODE_BLOCKED_KEY_PREFIX + deprecatedMfaCodeRequestType)) {
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-            }
         }
 
         var maybeErrorResponse =
@@ -338,16 +310,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                         retrievedMfaMethods);
 
         return maybeErrorResponse.orElseGet(() -> generateEmptySuccessApiGatewayResponse());
-    }
-
-    private boolean userHasExceededAllowedAttemptsForReauthenticationJourney(
-            JourneyType journeyType,
-            String subjectId,
-            AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId) {
-        return journeyType == REAUTHENTICATION
-                && checkReauthErrorCountsAndEmitReauthFailedAuditEvent(
-                        journeyType, subjectId, auditContext, maybeRpPairwiseId);
     }
 
     private Optional<String> getCode(
@@ -402,54 +364,68 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         }
     }
 
-    private boolean checkReauthErrorCountsAndEmitReauthFailedAuditEvent(
+    private Optional<APIGatewayProxyResponseEvent> checkPermission(
             JourneyType journeyType,
-            String subjectId,
+            PermissionContext permissionContext,
             AuditContext auditContext,
-            Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            var countsByJourney =
-                    maybeRpPairwiseId.isEmpty()
-                            ? authenticationAttemptsService.getCountsByJourney(
-                                    subjectId, REAUTHENTICATION)
-                            : authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            subjectId, maybeRpPairwiseId.get(), REAUTHENTICATION);
-
-            var countTypesWhereBlocked =
-                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
-                            countsByJourney, configurationService);
-
-            if (!countTypesWhereBlocked.isEmpty()) {
-                ReauthFailureReasons failureReason =
-                        getReauthFailureReasonFromCountTypes(countTypesWhereBlocked);
-                auditService.submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                        auditContext,
-                        ReauthMetadataBuilder.builder(
-                                        maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
-                                .withAllIncorrectAttemptCounts(countsByJourney)
-                                .withFailureReason(failureReason)
-                                .build());
-                cloudwatchMetricsService.incrementCounter(
-                        CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                        Map.of(
-                                ENVIRONMENT.getValue(),
-                                configurationService.getEnvironment(),
-                                FAILURE_REASON.getValue(),
-                                failureReason == null ? "unknown" : failureReason.getValue()));
-                LOG.info(
-                        "Re-authentication locked due to {} counts exceeded.",
-                        countTypesWhereBlocked);
-                return true;
-            }
+            Optional<String> maybeRpPairwiseId,
+            VerifyCodeRequest codeRequest) {
+        var notificationType = codeRequest.notificationType();
+        Result<DecisionError, Decision> canVerifyOtpResult =
+                Result.success(new Decision.Permitted(0));
+        if (notificationType.isForPhoneNumber()) {
+            canVerifyOtpResult =
+                    permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
+        } else if (notificationType.isEmail()) {
+            canVerifyOtpResult =
+                    permissionDecisionManager.canVerifyEmailOtp(journeyType, permissionContext);
         }
 
-        return false;
+        if (canVerifyOtpResult.isFailure()) {
+            LOG.error(
+                    "Failed to check OTP verification permission: {}",
+                    canVerifyOtpResult.getFailure());
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+        }
+
+        var decision = canVerifyOtpResult.getSuccess();
+
+        if (decision instanceof Decision.ReauthLockedOut reauthLockedOut) {
+            ReauthFailureReasons reauthFailureReason =
+                    ForbiddenReasonErrorMapper.toReauthFailureReason(
+                            reauthLockedOut.forbiddenReason());
+
+            auditService.submitAuditEvent(
+                    FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                    auditContext,
+                    ReauthMetadataBuilder.builder(maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
+                            .withAllIncorrectAttemptCounts(reauthLockedOut.detailedCounts())
+                            .withFailureReason(reauthFailureReason)
+                            .build());
+            cloudwatchMetricsService.incrementCounter(
+                    CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            FAILURE_REASON.getValue(),
+                            reauthFailureReason.getValue()));
+
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(
+                            400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+        }
+
+        if (decision instanceof Decision.TemporarilyLockedOut) {
+            LOG.info("User is temporarily locked out from OTP verification");
+            var errorResponse = blockedCodeBehaviour(notificationType);
+            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+        }
+
+        return Optional.empty();
     }
 
-    private ErrorResponse blockedCodeBehaviour(VerifyCodeRequest codeRequest) {
+    private ErrorResponse blockedCodeBehaviour(NotificationType notificationType) {
         return Map.ofEntries(
                         entry(
                                 VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
@@ -459,13 +435,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                                 RESET_PASSWORD_WITH_CODE,
                                 ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED),
                         entry(MFA_SMS, ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED))
-                .get(codeRequest.notificationType());
-    }
-
-    private boolean isCodeBlockedForSession(
-            AuthSessionItem authSession, String codeBlockedKeyPrefix) {
-        return codeStorageService.isBlockedForEmail(
-                authSession.getEmailAddress(), codeBlockedKeyPrefix);
+                .get(notificationType);
     }
 
     private void blockCodeForSession(AuthSessionItem authSession, String codeBlockPrefix) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.errormapper.ForbiddenReasonErrorMapper;
+import uk.gov.di.authentication.frontendapi.errormapper.TrackingErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
@@ -26,13 +27,13 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
@@ -52,8 +53,8 @@ import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -81,7 +82,6 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.PhoneNumberHelper.formatPhoneNumber;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethodOrDefaultMfaMethod;
 
 public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeRequest>
@@ -238,7 +238,13 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         try {
             String subjectID = userProfileMaybe.map(UserProfile::getSubjectID).orElse(null);
             return verifyCode(
-                    input, codeRequest, userContext, subjectID, maybeRpPairwiseId, userProfile);
+                    input,
+                    codeRequest,
+                    userContext,
+                    subjectID,
+                    maybeRpPairwiseId,
+                    userProfile,
+                    permissionContext);
         } catch (Exception e) {
             LOG.error("Unexpected exception thrown", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.REQUEST_MISSING_PARAMS);
@@ -337,7 +343,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             UserContext userContext,
             String subjectId,
             Optional<String> maybeRpPairwiseId,
-            UserProfile userProfile) {
+            UserProfile userProfile,
+            PermissionContext permissionContext) {
 
         var authSession = userContext.getAuthSession();
         var auditContext =
@@ -410,27 +417,35 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         400, ErrorResponse.INVALID_AUTH_APP_SECRET);
             }
 
-            if (errorResponse.equals(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)
-                    || errorResponse.equals(
-                            ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED)) {
-                blockCodeForSessionAndResetCountIfBlockDoesNotExist(
-                        userContext.getAuthSession().getEmailAddress(),
+            Result<TrackingError, Void> trackingResult = Result.success(null);
+            if (errorResponse.equals(ErrorResponse.INVALID_PHONE_CODE_ENTERED)) {
+                trackingResult =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                codeRequest.getJourneyType(), permissionContext);
+            }
+            if (errorResponse.equals(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED)) {
+                trackingResult =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                codeRequest.getJourneyType(), permissionContext);
+            }
+            if (trackingResult.isFailure()) {
+                LOG.error(
+                        "Failed to record incorrect {} OTP: {}",
                         codeRequest.getMfaMethodType(),
-                        codeRequest.getJourneyType());
+                        trackingResult.getFailure());
+                return TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                        trackingResult.getFailure());
             }
 
-            if (isInvalidReauthAuthAppAttempt(errorResponse, codeRequest)
-                    && configurationService.isAuthenticationAttemptsServiceEnabled()
-                    && subjectId != null) {
-                authenticationAttemptsService.createOrIncrementCount(
-                        subjectId,
-                        NowHelper.nowPlus(
-                                        configurationService.getReauthEnterAuthAppCodeCountTTL(),
-                                        ChronoUnit.SECONDS)
-                                .toInstant()
-                                .getEpochSecond(),
-                        REAUTHENTICATION,
-                        CountType.ENTER_MFA_CODE);
+            var permissionCheckAfterIncrement =
+                    getResponseIfNotPermitted(
+                            codeRequest.getJourneyType(),
+                            codeRequest.getMfaMethodType(),
+                            permissionContext,
+                            auditContext,
+                            maybeRpPairwiseId);
+            if (permissionCheckAfterIncrement.isPresent()) {
+                return permissionCheckAfterIncrement.get();
             }
 
             auditFailure(codeRequest, errorResponse, authSession, auditContext, activeMfaMethod);
@@ -657,47 +672,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
             authSessionService.updateSession(updatedAuthSession);
         }
-    }
-
-    private static boolean isInvalidReauthAuthAppAttempt(
-            ErrorResponse errorResponse, VerifyMfaCodeRequest codeRequest) {
-        return errorResponse == ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED
-                && codeRequest.getJourneyType() == REAUTHENTICATION;
-    }
-
-    private void blockCodeForSessionAndResetCountIfBlockDoesNotExist(
-            String emailAddress, MFAMethodType mfaMethodType, JourneyType journeyType) {
-
-        var codeRequestType = CodeRequestType.getCodeRequestType(mfaMethodType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-
-        if (codeStorageService.isBlockedForEmail(emailAddress, codeBlockedKeyPrefix)) {
-            return;
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(mfaMethodType, journeyType);
-        if (codeStorageService.isBlockedForEmail(
-                emailAddress, CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            return;
-        }
-
-        boolean reducedLockout =
-                List.of(CodeRequestType.MFA_REGISTRATION, CodeRequestType.MFA_ACCOUNT_RECOVERY)
-                        .contains(CodeRequestType.getCodeRequestType(mfaMethodType, journeyType));
-        long blockDuration =
-                reducedLockout
-                        ? configurationService.getReducedLockoutDuration()
-                        : configurationService.getLockoutDuration();
-
-        if (!configurationService.supportReauthSignoutEnabled()
-                || journeyType != REAUTHENTICATION) {
-            codeStorageService.saveBlockedForEmail(
-                    emailAddress, codeBlockedKeyPrefix, blockDuration);
-        }
-
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
     private AuditService.MetadataPair[] metadataPairsForEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -39,7 +38,6 @@ import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -56,7 +54,6 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -92,7 +89,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private final AuditService auditService;
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory;
     private final CloudwatchMetricsService cloudwatchMetricsService;
-    private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
     private final PermissionDecisionManager permissionDecisionManager;
@@ -105,7 +101,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuditService auditService,
             MfaCodeProcessorFactory mfaCodeProcessorFactory,
             CloudwatchMetricsService cloudwatchMetricsService,
-            AuthenticationAttemptsService authenticationAttemptsService,
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
@@ -120,7 +115,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.auditService = auditService;
         this.mfaCodeProcessorFactory = mfaCodeProcessorFactory;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
-        this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
         this.permissionDecisionManager = permissionDecisionManager;
@@ -147,8 +141,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         this.mfaMethodsService,
                         this.testUserHelper);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
@@ -170,8 +162,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         this.mfaMethodsService,
                         this.testUserHelper);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
@@ -452,14 +442,17 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         } else {
             auditSuccess(codeRequest, authSession, auditContext, activeMfaMethod);
 
-            processSuccessfulCodeSession(
-                    userContext.getAuthSession(),
-                    input,
-                    subjectId,
-                    codeRequest,
-                    mfaCodeProcessor,
-                    maybeRpPairwiseId,
-                    userProfile);
+            var maybeError =
+                    processSuccessfulCodeSession(
+                            userContext.getAuthSession(),
+                            input,
+                            codeRequest,
+                            mfaCodeProcessor,
+                            userProfile,
+                            permissionContext);
+            if (maybeError.isPresent()) {
+                return maybeError.get();
+            }
         }
 
         authSessionService.updateSession(authSession);
@@ -588,25 +581,14 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         return ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse();
     }
 
-    private void processSuccessfulCodeSession(
+    private Optional<APIGatewayProxyResponseEvent> processSuccessfulCodeSession(
             AuthSessionItem authSession,
             APIGatewayProxyRequestEvent input,
-            String subjectId,
             VerifyMfaCodeRequest codeRequest,
             MfaCodeProcessor mfaCodeProcessor,
-            Optional<String> maybeRpPairwiseId,
-            UserProfile userProfile) {
+            UserProfile userProfile,
+            PermissionContext permissionContext) {
 
-        if (configurationService.isAuthenticationAttemptsServiceEnabled()
-                && codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP
-                && subjectId != null) {
-            preserveReauthCountsForAuditIfJourneyIsReauth(
-                    codeRequest.getJourneyType(), subjectId, authSession, maybeRpPairwiseId);
-            clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
-            maybeRpPairwiseId.ifPresentOrElse(
-                    this::clearReauthErrorCountsForSuccessfullyAuthenticatedUser,
-                    () -> LOG.warn("Unable to clear rp pairwise id reauth counts"));
-        }
         mfaCodeProcessor.processSuccessfulCodeRequest(
                 IpAddressHelper.extractIpAddress(input),
                 extractPersistentIdFromHeaders(input.getHeaders()),
@@ -618,15 +600,28 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
 
         LOG.info("Setting hasVerifiedMfa to true");
-        PermissionContext permissionContext =
-                PermissionContext.builder().withAuthSessionItem(authSession).build();
         if (codeRequest.getMfaMethodType() == MFAMethodType.SMS) {
-            userActionsManager.correctSmsOtpReceived(
-                    codeRequest.getJourneyType(), permissionContext);
+            var result =
+                    userActionsManager.correctSmsOtpReceived(
+                            codeRequest.getJourneyType(), permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct SMS OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
         } else if (codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP) {
-            userActionsManager.correctAuthAppOtpReceived(
-                    codeRequest.getJourneyType(), permissionContext);
+            var result =
+                    userActionsManager.correctAuthAppOtpReceived(
+                            codeRequest.getJourneyType(), permissionContext);
+            if (result.isFailure()) {
+                LOG.error("Failed to record correct Auth App OTP: {}", result.getFailure());
+                return Optional.of(
+                        TrackingErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                                result.getFailure()));
+            }
         }
+        return Optional.empty();
     }
 
     private FrontendAuditableEvent errorResponseAsFrontendAuditableEvent(
@@ -644,34 +639,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         entry(ErrorResponse.INVALID_PHONE_CODE_ENTERED, AUTH_INVALID_CODE_SENT));
 
         return map.getOrDefault(errorResponse, FrontendAuditableEvent.AUTH_INVALID_CODE_SENT);
-    }
-
-    private void clearReauthErrorCountsForSuccessfullyAuthenticatedUser(String uniqueIdentifier) {
-        Arrays.stream(CountType.values())
-                .forEach(
-                        countType ->
-                                authenticationAttemptsService.deleteCount(
-                                        uniqueIdentifier, REAUTHENTICATION, countType));
-    }
-
-    void preserveReauthCountsForAuditIfJourneyIsReauth(
-            JourneyType journeyType,
-            String subjectId,
-            AuthSessionItem authSession,
-            Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.supportReauthSignoutEnabled()
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
-            var counts =
-                    maybeRpPairwiseId.isPresent()
-                            ? authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            subjectId, maybeRpPairwiseId.get(), REAUTHENTICATION)
-                            : authenticationAttemptsService.getCountsByJourney(
-                                    subjectId, REAUTHENTICATION);
-            var updatedAuthSession = authSession.withPreservedReauthCountsForAuditMap(counts);
-            authSessionService.updateSession(updatedAuthSession);
-        }
     }
 
     private AuditService.MetadataPair[] metadataPairsForEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
+import uk.gov.di.authentication.frontendapi.errormapper.ForbiddenReasonErrorMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ForcedMfaResetHelper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.helpers.SessionHelper;
@@ -33,7 +34,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
-import uk.gov.di.authentication.shared.helpers.ReauthAuthenticationAttemptsHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -48,7 +48,9 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
 import java.time.temporal.ChronoUnit;
@@ -64,7 +66,6 @@ import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
-import static uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder.getReauthFailureReasonFromCountTypes;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
@@ -94,6 +95,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private final AuthenticationAttemptsService authenticationAttemptsService;
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
+    private final PermissionDecisionManager permissionDecisionManager;
     private final TestUserHelper testUserHelper;
 
     public VerifyMfaCodeHandler(
@@ -107,6 +109,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
+            PermissionDecisionManager permissionDecisionManager,
             TestUserHelper testUserHelper) {
         super(
                 VerifyMfaCodeRequest.class,
@@ -120,6 +123,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService = authenticationAttemptsService;
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
+        this.permissionDecisionManager = permissionDecisionManager;
         this.testUserHelper = testUserHelper;
     }
 
@@ -146,6 +150,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
 
     public VerifyMfaCodeHandler(
@@ -168,6 +173,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.permissionDecisionManager = new PermissionDecisionManager(configurationService);
     }
 
     @Override
@@ -209,10 +215,25 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             return generateApiGatewayProxyErrorResponse(
                     400, ErrorResponse.EMAIL_HAS_NO_USER_PROFILE);
 
-        if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
-                journeyType, userProfile, auditContext, maybeRpPairwiseId))
-            return generateApiGatewayProxyErrorResponse(
-                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
+        var permissionContext =
+                PermissionContext.builder()
+                        .withAuthSessionItem(authSession)
+                        .withEmailAddress(authSession.getEmailAddress())
+                        .withInternalSubjectId(
+                                userProfileMaybe.map(UserProfile::getSubjectID).orElse(null))
+                        .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
+                        .build();
+
+        var maybeResponseIfNotPermitted =
+                getResponseIfNotPermitted(
+                        journeyType,
+                        codeRequest.getMfaMethodType(),
+                        permissionContext,
+                        auditContext,
+                        maybeRpPairwiseId);
+        if (maybeResponseIfNotPermitted.isPresent()) {
+            return maybeResponseIfNotPermitted.get();
+        }
 
         try {
             String subjectID = userProfileMaybe.map(UserProfile::getSubjectID).orElse(null);
@@ -244,53 +265,70 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         return userProfile == null && journeyType == REAUTHENTICATION;
     }
 
-    private boolean checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
+    private Optional<APIGatewayProxyResponseEvent> getResponseIfNotPermitted(
             JourneyType journeyType,
-            UserProfile userProfile,
+            MFAMethodType mfaMethodType,
+            PermissionContext permissionContext,
             AuditContext auditContext,
             Optional<String> maybeRpPairwiseId) {
-        if (configurationService.isAuthenticationAttemptsServiceEnabled()
-                && REAUTHENTICATION.equals(journeyType)
-                && userProfile != null) {
-            var counts =
-                    maybeRpPairwiseId.isEmpty()
-                            ? authenticationAttemptsService.getCountsByJourney(
-                                    userProfile.getSubjectID(), REAUTHENTICATION)
-                            : authenticationAttemptsService
-                                    .getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                                            userProfile.getSubjectID(),
-                                            maybeRpPairwiseId.get(),
-                                            REAUTHENTICATION);
-            var countTypesWhereLimitExceeded =
-                    ReauthAuthenticationAttemptsHelper.countTypesWhereUserIsBlockedForReauth(
-                            counts, configurationService);
+        var canVerifyOtpResult =
+                permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
 
-            if (!countTypesWhereLimitExceeded.isEmpty()) {
-                ReauthFailureReasons failureReason =
-                        getReauthFailureReasonFromCountTypes(countTypesWhereLimitExceeded);
-                auditService.submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                        auditContext,
-                        ReauthMetadataBuilder.builder(
-                                        maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
-                                .withAllIncorrectAttemptCounts(counts)
-                                .withFailureReason(failureReason)
-                                .build());
-                cloudwatchMetricsService.incrementCounter(
-                        CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                        Map.of(
-                                ENVIRONMENT.getValue(),
-                                configurationService.getEnvironment(),
-                                FAILURE_REASON.getValue(),
-                                failureReason == null ? "unknown" : failureReason.getValue()));
-
-                LOG.info(
-                        "Re-authentication locked due to {} counts exceeded.",
-                        countTypesWhereLimitExceeded);
-                return true;
-            }
+        if (canVerifyOtpResult.isFailure()) {
+            LOG.error(
+                    "Failed to check MFA OTP verification permission: {}",
+                    canVerifyOtpResult.getFailure());
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
         }
-        return false;
+
+        var decision = canVerifyOtpResult.getSuccess();
+
+        if (decision instanceof Decision.ReauthLockedOut reauthLockedOut) {
+            ReauthFailureReasons reauthFailureReason =
+                    ForbiddenReasonErrorMapper.toReauthFailureReason(
+                            reauthLockedOut.forbiddenReason());
+
+            auditService.submitAuditEvent(
+                    FrontendAuditableEvent.AUTH_REAUTH_FAILED,
+                    auditContext,
+                    ReauthMetadataBuilder.builder(maybeRpPairwiseId.orElse(AuditService.UNKNOWN))
+                            .withAllIncorrectAttemptCounts(reauthLockedOut.detailedCounts())
+                            .withFailureReason(reauthFailureReason)
+                            .build());
+            cloudwatchMetricsService.incrementCounter(
+                    CloudwatchMetrics.REAUTH_FAILED.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            FAILURE_REASON.getValue(),
+                            reauthFailureReason.getValue()));
+
+            return Optional.of(
+                    generateApiGatewayProxyErrorResponse(
+                            400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+        }
+
+        if (decision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
+            LOG.info("User is temporarily locked out from MFA OTP verification");
+            auditService.submitAuditEvent(
+                    AUTH_CODE_MAX_RETRIES_REACHED,
+                    auditContext,
+                    pair("mfa-type", mfaMethodType.getValue()),
+                    pair("account-recovery", journeyType == JourneyType.ACCOUNT_RECOVERY),
+                    pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, journeyType),
+                    pair(
+                            AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT,
+                            temporarilyLockedOut.attemptCount()),
+                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"));
+            var errorResponse =
+                    mfaMethodType == MFAMethodType.AUTH_APP
+                            ? ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED
+                            : ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED;
+            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+        }
+
+        return Optional.empty();
     }
 
     private APIGatewayProxyResponseEvent verifyCode(
@@ -410,15 +448,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
 
         authSessionService.updateSession(authSession);
-
-        if (checkErrorCountsForReauthAndEmitFailedAuditEventIfBlocked(
-                codeRequest.getJourneyType(),
-                userContext.getUserProfile().orElse(null),
-                auditContext,
-                maybeRpPairwiseId)) {
-            return generateApiGatewayProxyErrorResponse(
-                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS);
-        }
 
         return errorResponseMaybe
                 .map(response -> generateApiGatewayProxyErrorResponse(400, response))

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -91,8 +91,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             LOG.info("Auth code is not valid");
             return Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED);
         }
-        LOG.info("Auth code valid. Resetting code request count");
-        resetCodeIncorrectEntryCount();
+        LOG.info("Auth code valid");
 
         return Optional.empty();
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -36,7 +36,6 @@ import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVER
 import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
@@ -72,27 +71,12 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
     public Optional<ErrorResponse> validateCode() {
         var codeRequestType =
                 CodeRequestType.getCodeRequestType(AUTH_APP, codeRequest.getJourneyType());
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
 
         var nonRegistrationJourneyTypes =
                 List.of(
                         JourneyType.SIGN_IN,
                         JourneyType.PASSWORD_RESET_MFA,
                         JourneyType.REAUTHENTICATION);
-
-        if (isCodeBlockedForSession(codeBlockedKeyPrefix)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED);
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(
-                        AUTH_APP, codeRequest.getJourneyType());
-        if (isCodeBlockedForSession(CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED);
-        }
 
         if (codeRequestType.getJourneyType() != JourneyType.REAUTHENTICATION) {
             incrementRetryCount();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -4,7 +4,6 @@ import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -49,7 +48,6 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
-            int maxRetries,
             CodeRequest codeRequest,
             AuditService auditService,
             DynamoAccountModifiersService accountModifiersService,
@@ -57,7 +55,6 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
         super(
                 userContext,
                 codeStorageService,
-                maxRetries,
                 authenticationService,
                 auditService,
                 accountModifiersService,
@@ -69,23 +66,11 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
     @Override
     public Optional<ErrorResponse> validateCode() {
-        var codeRequestType =
-                CodeRequestType.getCodeRequestType(AUTH_APP, codeRequest.getJourneyType());
-
         var nonRegistrationJourneyTypes =
                 List.of(
                         JourneyType.SIGN_IN,
                         JourneyType.PASSWORD_RESET_MFA,
                         JourneyType.REAUTHENTICATION);
-
-        if (codeRequestType.getJourneyType() != JourneyType.REAUTHENTICATION) {
-            incrementRetryCount();
-        }
-
-        if (hasExceededRetryLimit()) {
-            LOG.info("Exceeded code retry limit");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED);
-        }
 
         var authAppSecret =
                 nonRegistrationJourneyTypes.contains(codeRequest.getJourneyType())

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -23,7 +23,6 @@ public abstract class MfaCodeProcessor {
     protected final Logger LOG = LogManager.getLogger(this.getClass());
     public final CodeStorageService codeStorageService;
     public final DynamoAccountModifiersService accountModifiersService;
-    private final int maxRetries;
     public final String emailAddress;
     private final UserContext userContext;
     protected final AuthenticationService authenticationService;
@@ -33,7 +32,6 @@ public abstract class MfaCodeProcessor {
     MfaCodeProcessor(
             UserContext userContext,
             CodeStorageService codeStorageService,
-            int maxRetries,
             AuthenticationService authenticationService,
             AuditService auditService,
             DynamoAccountModifiersService accountModifiersService,
@@ -41,24 +39,10 @@ public abstract class MfaCodeProcessor {
         this.emailAddress = userContext.getAuthSession().getEmailAddress();
         this.userContext = userContext;
         this.codeStorageService = codeStorageService;
-        this.maxRetries = maxRetries;
         this.authenticationService = authenticationService;
         this.auditService = auditService;
         this.accountModifiersService = accountModifiersService;
         this.mfaMethodsService = mfaMethodsService;
-    }
-
-    boolean isCodeBlockedForSession(String codeBlockedKeyPrefix) {
-        return codeStorageService.isBlockedForEmail(emailAddress, codeBlockedKeyPrefix);
-    }
-
-    boolean hasExceededRetryLimit() {
-        LOG.info("Max retries: {}", maxRetries);
-        return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress) >= maxRetries;
-    }
-
-    void incrementRetryCount() {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
     }
 
     void resetCodeIncorrectEntryCount() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -45,10 +45,6 @@ public abstract class MfaCodeProcessor {
         this.mfaMethodsService = mfaMethodsService;
     }
 
-    void resetCodeIncorrectEntryCount() {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
-    }
-
     void submitAuditEvent(
             AuditableEvent auditableEvent,
             MFAMethodType mfaMethodType,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.frontendapi.validation;
 
 import uk.gov.di.authentication.entity.CodeRequest;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -12,7 +11,6 @@ import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.List;
 import java.util.Optional;
 
 public class MfaCodeProcessorFactory {
@@ -45,24 +43,16 @@ public class MfaCodeProcessorFactory {
     public Optional<MfaCodeProcessor> getMfaCodeProcessor(
             MFAMethodType mfaMethodType, CodeRequest codeRequest, UserContext userContext) {
         return switch (mfaMethodType) {
-            case AUTH_APP -> {
-                int codeMaxRetries =
-                        List.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY)
-                                        .contains(codeRequest.getJourneyType())
-                                ? configurationService.getIncreasedCodeMaxRetries()
-                                : configurationService.getCodeMaxRetries();
-                yield Optional.of(
-                        new AuthAppCodeProcessor(
-                                userContext,
-                                codeStorageService,
-                                configurationService,
-                                authenticationService,
-                                codeMaxRetries,
-                                codeRequest,
-                                auditService,
-                                accountModifiersService,
-                                mfaMethodsService));
-            }
+            case AUTH_APP -> Optional.of(
+                    new AuthAppCodeProcessor(
+                            userContext,
+                            codeStorageService,
+                            configurationService,
+                            authenticationService,
+                            codeRequest,
+                            auditService,
+                            accountModifiersService,
+                            mfaMethodsService));
             case SMS -> Optional.of(
                     new PhoneNumberCodeProcessor(
                             codeStorageService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -58,7 +58,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         super(
                 userContext,
                 codeStorageService,
-                configurationService.getCodeMaxRetries(),
                 authenticationService,
                 auditService,
                 dynamoAccountModifiersService,
@@ -88,7 +87,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
         super(
                 userContext,
                 codeStorageService,
-                configurationService.getCodeMaxRetries(),
                 authenticationService,
                 auditService,
                 dynamoAccountModifiersService,
@@ -133,7 +131,8 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         codeRequest.getCode(),
                         codeStorageService,
                         emailAddress,
-                        configurationService);
+                        configurationService,
+                        false);
 
         if (errorResponse.isEmpty()) {
             codeStorageService.deleteOtpCode(codeIdentifier, notificationType);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -34,7 +34,6 @@ import java.util.UUID;
 
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
@@ -115,21 +114,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         : NotificationType.VERIFY_PHONE_NUMBER;
 
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-
-        if (isCodeBlockedForSession(codeBlockedKeyPrefix)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED);
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        var deprecatedCodeRequestType =
-                CodeRequestType.getDeprecatedCodeRequestTypeString(
-                        notificationType.getMfaMethodType(), journeyType);
-        if (isCodeBlockedForSession(CODE_BLOCKED_KEY_PREFIX + deprecatedCodeRequestType)) {
-            LOG.info("Code blocked for session");
-            return Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED);
-        }
 
         boolean isTestClient = testUserHelper.isTestJourney(userContext);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -125,14 +125,7 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
         var errorResponse =
                 ValidationHelper.validateVerificationCode(
-                        notificationType,
-                        journeyType,
-                        storedCode,
-                        codeRequest.getCode(),
-                        codeStorageService,
-                        emailAddress,
-                        configurationService,
-                        false);
+                        notificationType, storedCode, codeRequest.getCode());
 
         if (errorResponse.isEmpty()) {
             codeStorageService.deleteOtpCode(codeIdentifier, notificationType);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -49,6 +49,7 @@ import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -225,6 +226,8 @@ class VerifyCodeHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
     }
 
     @Test
@@ -1316,5 +1319,20 @@ class VerifyCodeHandlerTest {
                                     MFA_RESET_TYPE.getValue(),
                                     MfaResetType.FORCED_INTERNATIONAL_NUMBERS.toString()));
         }
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectSmsOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(
+                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
+                .thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var result = makeCallWithCode(CODE, MFA_SMS.name(), JourneyType.SIGN_IN);
+
+        assertThat(result, hasStatus(500));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -48,7 +48,10 @@ import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
@@ -103,7 +106,6 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHA
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
@@ -163,6 +165,8 @@ class VerifyCodeHandlerTest {
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
     private final TestUserHelper testUserHelper = mock(TestUserHelper.class);
 
     private final AuditContext AUDIT_CONTEXT =
@@ -208,6 +212,7 @@ class VerifyCodeHandlerTest {
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
+                        permissionDecisionManager,
                         testUserHelper);
 
         when(authenticationService.getUserProfileFromEmail(EMAIL))
@@ -226,6 +231,10 @@ class VerifyCodeHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
     }
@@ -482,66 +491,60 @@ class VerifyCodeHandlerTest {
 
     @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenAccountRecoveryEmailCodeIsBlocked() {
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        ForbiddenReason
+                                                .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                                        0,
+                                        null,
+                                        false)));
 
         var result = makeCallWithCode(CODE, VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED));
         verifyNoInteractions(accountModifiersService);
-        verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenPasswordResetEmailCodeIsBlocked() {
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_PASSWORD_RESET;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        ForbiddenReason
+                                                .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                                        0,
+                                        null,
+                                        false)));
 
         var result = makeCallWithCode(CODE, RESET_PASSWORD_WITH_CODE.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
         verifyNoInteractions(accountModifiersService);
-        verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndNotSetBlockWhenSignInCodeIsBlocked(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                        0,
+                                        null,
+                                        false)));
 
         var result = makeCallWithCode(CODE, MFA_SMS.name(), journeyType);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED));
         verifyNoInteractions(accountModifiersService);
-        verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @Test
-    void shouldReturnMaxReachedAndNotSetBlockWhenSignInCodeIsBlockedUsingDeprecatedKey() {
-        JourneyType journeyType = JourneyType.SIGN_IN;
-
-        var codeBlockedKeyPrefix =
-                CODE_BLOCKED_KEY_PREFIX
-                        + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                MFAMethodType.SMS, journeyType);
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(true);
-
-        var result = makeCallWithCode(CODE, MFA_SMS.name(), journeyType);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED));
-        verifyNoInteractions(accountModifiersService);
-        verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -903,76 +906,6 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
     }
 
-    private static Stream<Arguments> expectedMfaCodeBlocks() {
-        return Stream.of(
-                Arguments.of(
-                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.MFA_PW_RESET_MFA,
-                        ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED),
-                Arguments.of(
-                        CODE_BLOCKED_KEY_PREFIX + "PW_RESET_MFA_" + MFAMethodType.SMS,
-                        ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED),
-                Arguments.of(
-                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.MFA_PW_RESET_MFA,
-                        ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS),
-                Arguments.of(
-                        CODE_REQUEST_BLOCKED_KEY_PREFIX + "PW_RESET_MFA_" + MFAMethodType.SMS,
-                        ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS));
-    }
-
-    @ParameterizedTest
-    @MethodSource("expectedMfaCodeBlocks")
-    void shouldReturn400ForValidResetPasswordRequestWhenUserHasAnMFACodeBlock(
-            String blockKeyPrefix, ErrorResponse expectedError) {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-        when(testUserHelper.isTestJourney(any(UserContext.class))).thenReturn(true);
-        when(configurationService.getTestClientVerifyEmailOTP())
-                .thenReturn(Optional.of(TEST_CLIENT_CODE));
-        when(codeStorageService.getOtpCode(
-                        TEST_CLIENT_EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()),
-                        RESET_PASSWORD_WITH_CODE))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(TEST_CLIENT_EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.isBlockedForEmail(TEST_CLIENT_EMAIL, blockKeyPrefix))
-                .thenReturn(true);
-
-        authSession.setEmailAddress(TEST_CLIENT_EMAIL);
-        authSession.setClientId(TEST_CLIENT_ID);
-        String body =
-                format(
-                        "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
-                        TEST_CLIENT_CODE, RESET_PASSWORD_WITH_CODE);
-        APIGatewayProxyResponseEvent result = makeCallWithCode(body, Optional.of(authSession));
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(expectedError));
-    }
-
-    @Test
-    void shouldNotCheckForMFACodeBlocksOnANonePasswordResetJourney() {
-        when(configurationService.isTestClientsEnabled()).thenReturn(true);
-        when(configurationService.getTestClientVerifyEmailOTP())
-                .thenReturn(Optional.of(TEST_CLIENT_CODE));
-        when(codeStorageService.getOtpCode(
-                        TEST_CLIENT_EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(TEST_CLIENT_EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-
-        authSession.setEmailAddress(TEST_CLIENT_EMAIL);
-        authSession.setClientId(TEST_CLIENT_ID);
-        String body =
-                format(
-                        "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
-                        TEST_CLIENT_CODE, SIGN_IN);
-        makeCallWithCode(body, Optional.of(authSession));
-
-        verify(codeStorageService, never())
-                .isBlockedForEmail(
-                        TEST_CLIENT_EMAIL,
-                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.MFA_PW_RESET_MFA);
-    }
-
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
     void shouldDeleteCountOnSuccessfulSMSCodeRequest(
@@ -1077,9 +1010,25 @@ class VerifyCodeHandlerTest {
         try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
                 Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
             withReauthTurnedOn();
-            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                            any(), any(), eq(REAUTHENTICATION)))
-                    .thenReturn(Map.of(countType, MAX_RETRIES));
+            var detailedCounts = Map.of(countType, MAX_RETRIES);
+            var forbiddenReason =
+                    switch (countType) {
+                        case ENTER_EMAIL -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT;
+                        case ENTER_PASSWORD -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT;
+                        default -> ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+                    };
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            forbiddenReason,
+                                            0,
+                                            null,
+                                            false,
+                                            detailedCounts,
+                                            List.of(countType))));
             when(configurationService.getInternalSectorUri())
                     .thenReturn("https://test.account.gov.uk");
             Subject subject = new Subject(TEST_SUBJECT_ID);
@@ -1215,6 +1164,21 @@ class VerifyCodeHandlerTest {
                 .correctSmsOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
     }
 
+    @Test
+    void shouldReturn500WhenCorrectSmsOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(
+                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
+                .thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var result = makeCallWithCode(CODE, MFA_SMS.name(), JourneyType.SIGN_IN);
+
+        assertThat(result, hasStatus(500));
+    }
+
     private void withReauthTurnedOn() {
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
@@ -1319,20 +1283,5 @@ class VerifyCodeHandlerTest {
                                     MFA_RESET_TYPE.getValue(),
                                     MfaResetType.FORCED_INTERNATIONAL_NUMBERS.toString()));
         }
-    }
-
-    @Test
-    void shouldReturn500WhenCorrectSmsOtpReceivedFails() {
-        when(codeStorageService.getOtpCode(
-                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(userActionsManager.correctSmsOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
-
-        var result = makeCallWithCode(CODE, MFA_SMS.name(), JourneyType.SIGN_IN);
-
-        assertThat(result, hasStatus(500));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -33,12 +33,10 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -51,17 +49,16 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
+import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -105,7 +102,6 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASS
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DEFAULT_SMS_METHOD;
@@ -137,15 +133,11 @@ class VerifyCodeHandlerTest {
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final String TEST_SUBJECT_ID = "test-subject-id";
     private static final long CODE_EXPIRY_TIME = 900;
-    private static final long LOCKOUT_DURATION = 799;
     private static final int MAX_RETRIES = 6;
     private final Context context = mock(Context.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final UserProfile userProfile = mock(UserProfile.class);
-    private final String expectedPairwiseId =
-            ClientSubjectHelper.calculatePairwiseIdentifier(
-                    TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -160,8 +152,6 @@ class VerifyCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
     private final DynamoAccountModifiersService accountModifiersService =
             mock(DynamoAccountModifiersService.class);
-    private final AuthenticationAttemptsService authenticationAttemptsService =
-            mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
@@ -208,7 +198,6 @@ class VerifyCodeHandlerTest {
                         auditService,
                         cloudwatchMetricsService,
                         accountModifiersService,
-                        authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
@@ -231,12 +220,18 @@ class VerifyCodeHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
+        when(userActionsManager.correctEmailOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectEmailOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
     }
 
     @Test
@@ -301,7 +296,6 @@ class VerifyCodeHandlerTest {
                                 emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                                         ? "ACCOUNT_RECOVERY"
                                         : "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -335,7 +329,6 @@ class VerifyCodeHandlerTest {
                                 emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                                         ? "ACCOUNT_RECOVERY"
                                         : "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -371,7 +364,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         eq(FrontendAuditableEvent.AUTH_INVALID_CODE_SENT),
-                        any(AuditContext.class),
+                        eq(AUDIT_CONTEXT),
                         metadataCaptor.capture());
 
         List<AuditService.MetadataPair> expected =
@@ -386,8 +379,6 @@ class VerifyCodeHandlerTest {
 
         assertTrue(expected.containsAll(actual));
         assertTrue(actual.containsAll(expected));
-
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -424,7 +415,6 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -460,25 +450,26 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
-    void
-            shouldReturnMaxReachedAndNotSetBlockWhenRegistrationEmailCodeAttemptsExceedMaxRetryCount() {
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+    void shouldReturnMaxReachedAndSetBlockWhenRegistrationEmailCodeAttemptsExceedMaxRetryCount() {
         when(codeStorageService.getOtpCode(EMAIL, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
+
         var result = makeCallWithCode(INVALID_CODE, VERIFY_EMAIL.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED));
         verifyNoInteractions(accountModifiersService);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-        verify(codeStorageService, never())
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, LOCKOUT_DURATION);
+        verify(userActionsManager).incorrectEmailOtpReceived(eq(JourneyType.REGISTRATION), any());
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
@@ -486,86 +477,78 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenAccountRecoveryEmailCodeIsBlocked() {
-        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+        when(permissionDecisionManager.canVerifyEmailOtp(
+                        eq(JourneyType.ACCOUNT_RECOVERY), any(PermissionContext.class)))
                 .thenReturn(
                         Result.success(
                                 new Decision.TemporarilyLockedOut(
-                                        ForbiddenReason
-                                                .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
-                                        0,
-                                        null,
-                                        false)));
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED));
         verifyNoInteractions(accountModifiersService);
+        verifyNoInteractions(auditService);
     }
 
     @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenPasswordResetEmailCodeIsBlocked() {
-        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+        when(permissionDecisionManager.canVerifyEmailOtp(
+                        eq(JourneyType.PASSWORD_RESET), any(PermissionContext.class)))
                 .thenReturn(
                         Result.success(
                                 new Decision.TemporarilyLockedOut(
-                                        ForbiddenReason
-                                                .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
-                                        0,
-                                        null,
-                                        false)));
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, RESET_PASSWORD_WITH_CODE.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
         verifyNoInteractions(accountModifiersService);
+        verifyNoInteractions(auditService);
     }
 
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndNotSetBlockWhenSignInCodeIsBlocked(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any(PermissionContext.class)))
                 .thenReturn(
                         Result.success(
                                 new Decision.TemporarilyLockedOut(
-                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
-                                        0,
-                                        null,
-                                        false)));
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, MFA_SMS.name(), journeyType);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED));
         verifyNoInteractions(accountModifiersService);
+        verifyNoInteractions(auditService);
     }
 
     @Test
     void
             shouldReturnMaxReachedAndSetBlockWhenAccountRecoveryEmailCodeAttemptsExceedMaxRetryCount() {
-        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
-
-        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY;
-        when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedKeyPrefix)).thenReturn(false);
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(CODE, VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED));
-        verify(codeStorageService)
-                .saveBlockedForEmail(EMAIL, codeBlockedKeyPrefix, LOCKOUT_DURATION);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+        verify(userActionsManager)
+                .incorrectEmailOtpReceived(eq(JourneyType.ACCOUNT_RECOVERY), any());
         verifyNoInteractions(accountModifiersService);
         verify(auditService)
                 .submitAuditEvent(
@@ -574,7 +557,6 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_CHANGE_HOW_GET_SECURITY_CODES.name()),
                         pair("account-recovery", true),
                         pair("journey-type", "ACCOUNT_RECOVERY"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -586,8 +568,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
         when(accountModifiersService.isAccountRecoveryBlockPresent(anyString())).thenReturn(true);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
@@ -640,7 +622,6 @@ class VerifyCodeHandlerTest {
                         journeyType != null ? journeyType : JourneyType.SIGN_IN,
                         MFAMethodType.SMS,
                         PriorityIdentifier.DEFAULT);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -650,8 +631,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD, BACKUP_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
         when(accountModifiersService.isAccountRecoveryBlockPresent(anyString())).thenReturn(true);
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
@@ -680,7 +661,6 @@ class VerifyCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("loginFailureCount", MAX_RETRIES - 1),
                         pair("MFACodeEntered", "123456"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -688,13 +668,12 @@ class VerifyCodeHandlerTest {
         when(codeStorageService.getOtpCode(
                         EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
                 .thenReturn(Optional.of(CODE));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
         when(accountModifiersService.isAccountRecoveryBlockPresent(INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(false);
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        withReauthTurnedOn();
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -739,11 +718,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
         when(accountModifiersService.isAccountRecoveryBlockPresent(INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(false);
-        withReauthTurnedOn();
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
 
@@ -765,8 +741,9 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES - 1);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(Result.success(new Decision.Permitted(MAX_RETRIES - 1)));
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString());
 
@@ -805,15 +782,19 @@ class VerifyCodeHandlerTest {
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenSignInExceedMaxRetryCount(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        withReauthTurnedOn();
-        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(
                         EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+        if (journeyType != REAUTHENTICATION) {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(0)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+        }
 
         var result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString(), journeyType);
 
@@ -824,57 +805,52 @@ class VerifyCodeHandlerTest {
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_MFA_CODE_ENTERED));
         }
 
-        if (codeRequestType != CodeRequestType.MFA_REAUTHENTICATION) {
-            verify(codeStorageService)
-                    .saveBlockedForEmail(
-                            EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, LOCKOUT_DURATION);
-        }
+        verify(userActionsManager).incorrectSmsOtpReceived(any(), any());
 
         verifyNoInteractions(accountModifiersService);
 
         if (journeyType != REAUTHENTICATION) {
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                            AUDIT_CONTEXT.withMetadataItem(pair("mfa-method", "default")),
+                            AUDIT_CONTEXT.withMetadataItem(
+                                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
                             pair("notification-type", MFA_SMS.name()),
                             pair("account-recovery", false),
                             pair(
                                     "journey-type",
                                     journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
                             pair("mfa-type", MFAMethodType.SMS.getValue()),
-                            pair("loginFailureCount", MAX_RETRIES + 1),
-                            pair("MFACodeEntered", "6543221"),
+                            pair("loginFailureCount", 0),
+                            pair("MFACodeEntered", INVALID_CODE),
                             pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
         }
     }
 
     @Test
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenPasswordResetExceedMaxRetryCount() {
-        when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(EMAIL, RESET_PASSWORD_WITH_CODE))
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
 
         var result = makeCallWithCode(INVALID_CODE, RESET_PASSWORD_WITH_CODE.toString());
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
-        verify(codeStorageService)
-                .saveBlockedForEmail(
-                        EMAIL,
-                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_PASSWORD_RESET,
-                        LOCKOUT_DURATION);
+        verify(userActionsManager).incorrectEmailOtpReceived(eq(JourneyType.PASSWORD_RESET), any());
         verifyNoInteractions(accountModifiersService);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                        AUDIT_CONTEXT.withMetadataItem(pair("mfa-method", "default")),
+                        AUDIT_CONTEXT.withMetadataItem(
+                                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
                         pair("notification-type", RESET_PASSWORD_WITH_CODE.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "PASSWORD_RESET"));
@@ -906,75 +882,16 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
     }
 
-    @ParameterizedTest
-    @MethodSource("codeRequestTypes")
-    void shouldDeleteCountOnSuccessfulSMSCodeRequest(
-            CodeRequestType codeRequestType, JourneyType journeyType) {
-        when(codeStorageService.getOtpCode(
-                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
-                .thenReturn(Optional.of(CODE));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        withReauthTurnedOn();
-        var existingCounts = Map.of(ENTER_EMAIL, 5, ENTER_PASSWORD, 1);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        any(), any(), eq(REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-        when(configurationService.getInternalSectorUri()).thenReturn("http://" + SECTOR_HOST);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        var result = makeCallWithCode(CODE, MFA_SMS.toString(), journeyType);
-
-        List.of(TEST_SUBJECT_ID, expectedPairwiseId)
-                .forEach(
-                        identifier ->
-                                verify(
-                                                authenticationAttemptsService,
-                                                times(CountType.values().length))
-                                        .deleteCount(
-                                                eq(identifier),
-                                                eq(JourneyType.REAUTHENTICATION),
-                                                any()));
-
-        if (journeyType == REAUTHENTICATION) {
-            verify(authSessionService, atLeastOnce())
-                    .updateSession(
-                            argThat(
-                                    s ->
-                                            s.getPreservedReauthCountsForAuditMap()
-                                                    .equals(existingCounts)));
-        } else {
-            verify(authSessionService, never())
-                    .updateSession(
-                            argThat(
-                                    s ->
-                                            Objects.equals(
-                                                    s.getPreservedReauthCountsForAuditMap(),
-                                                    existingCounts)));
-        }
-
-        assertThat(result, hasStatus(204));
-    }
-
     @Test
     void shouldIncrementEnterMFAAuthenticationAttemptCountOnFailedReauthenticationAttempt() {
-        long ttl = 120L;
-        withReauthTurnedOn();
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(ttl);
-        MockedStatic<NowHelper> mockedNowHelperClass = Mockito.mockStatic(NowHelper.class);
-        mockedNowHelperClass
-                .when(() -> NowHelper.nowPlus(ttl, ChronoUnit.SECONDS))
-                .thenReturn(Date.from(Instant.parse("2099-01-01T00:00:00.00Z")));
 
         var result = makeCallWithCode(INVALID_CODE, MFA_SMS.name(), REAUTHENTICATION);
 
-        verify(authenticationAttemptsService, times(1))
-                .createOrIncrementCount(
-                        TEST_SUBJECT_ID, 4070908800L, REAUTHENTICATION, ENTER_MFA_CODE);
+        verify(userActionsManager).incorrectSmsOtpReceived(eq(REAUTHENTICATION), any());
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.INVALID_MFA_CODE_ENTERED));
-        mockedNowHelperClass.close();
     }
 
     private static Stream<Arguments> reauthCountTypesAndMetadata() {
@@ -1009,7 +926,6 @@ class VerifyCodeHandlerTest {
             String expectedFailureReason) {
         try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
                 Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            withReauthTurnedOn();
             var detailedCounts = Map.of(countType, MAX_RETRIES);
             var forbiddenReason =
                     switch (countType) {
@@ -1017,15 +933,19 @@ class VerifyCodeHandlerTest {
                                 .EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT;
                         case ENTER_PASSWORD -> ForbiddenReason
                                 .EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT;
-                        default -> ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+                        case ENTER_MFA_CODE,
+                                ENTER_AUTH_APP_CODE,
+                                ENTER_SMS_CODE,
+                                ENTER_EMAIL_CODE -> ForbiddenReason
+                                .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
                     };
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+            when(permissionDecisionManager.canVerifyMfaOtp(eq(REAUTHENTICATION), any()))
                     .thenReturn(
                             Result.success(
                                     new Decision.ReauthLockedOut(
                                             forbiddenReason,
-                                            0,
-                                            null,
+                                            MAX_RETRIES,
+                                            Instant.now(),
                                             false,
                                             detailedCounts,
                                             List.of(countType))));
@@ -1153,7 +1073,8 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
 
         // Act
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -1165,23 +1086,86 @@ class VerifyCodeHandlerTest {
     }
 
     @Test
-    void shouldReturn500WhenCorrectSmsOtpReceivedFails() {
+    void shouldReturn500WhenCorrectSmsOtpReceivedReturnsInvalidUserContext() {
+        // Arrange
         when(codeStorageService.getOtpCode(
                         EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
 
-        var result = makeCallWithCode(CODE, MFA_SMS.name(), JourneyType.SIGN_IN);
+        // Act
+        var result = makeCallWithCode(CODE, MFA_SMS.toString());
+
+        // Assert
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectEmailOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(EMAIL, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
+        when(userActionsManager.correctEmailOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        var result = makeCallWithCode(CODE, VERIFY_EMAIL.name());
 
         assertThat(result, hasStatus(500));
     }
 
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+    @Test
+    void shouldReturn500WhenIncorrectSmsOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(
+                        EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
+                .thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        var result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString());
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenIncorrectEmailOtpReceivedFails() {
+        when(codeStorageService.getOtpCode(EMAIL, VERIFY_EMAIL)).thenReturn(Optional.of(CODE));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.failure(MfaRetrieveFailureReason.USER_DOES_NOT_HAVE_ACCOUNT));
+        when(userActionsManager.incorrectEmailOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+
+        var result = makeCallWithCode(INVALID_CODE, VERIFY_EMAIL.name());
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenCanVerifyEmailOtpReturnsFailure() {
+        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+        var result = makeCallWithCode(CODE, VERIFY_EMAIL.name());
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    void shouldReturn500WhenCanVerifyMfaOtpReturnsFailure() {
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+        var result = makeCallWithCode(CODE, MFA_SMS.name());
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
     }
 
     @Nested
@@ -1198,7 +1182,6 @@ class VerifyCodeHandlerTest {
                     .thenReturn(Optional.of(CODE));
             when(mfaMethodsService.getMfaMethods(EMAIL))
                     .thenReturn(Result.success(List.of(INTERNATIONAL_SMS_METHOD)));
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(0);
             authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -14,18 +13,15 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetType;
-import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
-import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -52,7 +48,10 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -94,14 +93,11 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
-import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_METHOD_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_RESET_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_COMPLETED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_INITIATED;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_EMAIL;
 import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
@@ -177,6 +173,8 @@ class VerifyMfaCodeHandlerTest {
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
+    private final PermissionDecisionManager permissionDecisionManager =
+            mock(PermissionDecisionManager.class);
     private final TestUserHelper testUserHelper = mock(TestUserHelper.class);
 
     @RegisterExtension
@@ -212,6 +210,8 @@ class VerifyMfaCodeHandlerTest {
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -225,6 +225,7 @@ class VerifyMfaCodeHandlerTest {
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
+                        permissionDecisionManager,
                         testUserHelper);
     }
 
@@ -1402,80 +1403,64 @@ class VerifyMfaCodeHandlerTest {
                                                 existingCounts)));
     }
 
-    private static Stream<Arguments> reauthCountTypesAndMetadata() {
-        return Stream.of(
-                Arguments.arguments(
-                        ENTER_EMAIL,
-                        MAX_RETRIES,
-                        0,
-                        0,
-                        ReauthFailureReasons.INCORRECT_EMAIL.getValue()),
-                Arguments.arguments(
-                        ENTER_PASSWORD,
-                        0,
-                        MAX_RETRIES,
-                        0,
-                        ReauthFailureReasons.INCORRECT_PASSWORD.getValue()),
-                Arguments.arguments(
-                        ENTER_MFA_CODE,
-                        0,
-                        0,
-                        MAX_RETRIES,
-                        ReauthFailureReasons.INCORRECT_OTP.getValue()));
+    @Test
+    void shouldReturn400WhenReauthLockedOutViaPermissionDecisionManager()
+            throws Json.JsonException {
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(
+                        Result.success(
+                                new Decision.ReauthLockedOut(
+                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                        5,
+                                        null,
+                                        false,
+                                        Map.of(),
+                                        List.of())));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
+        var result = makeCallWithCode(codeRequest);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
     }
 
-    @ParameterizedTest
-    @MethodSource("reauthCountTypesAndMetadata")
-    void shouldReturnErrorIfUserHasTooManyReauthAttemptCountsOfAnyType(
-            CountType countType,
-            int expectedEmailAttemptCount,
-            int expectedPasswordAttemptCount,
-            int expectedOtpAttemptCount,
-            String expectedFailureReason)
-            throws Json.JsonException {
-        try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
-                Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                            any(), any(), eq(REAUTHENTICATION)))
-                    .thenReturn(Map.of(countType, MAX_RETRIES));
-            when(configurationService.getInternalSectorUri())
-                    .thenReturn("https://test.account.gov.uk");
-            Subject subject = new Subject(TEST_SUBJECT_ID);
-            mockedClientSubjectHelperClass
-                    .when(
-                            () ->
-                                    ClientSubjectHelper.getSubject(
-                                            eq(userProfile),
-                                            any(AuthSessionItem.class),
-                                            any(AuthenticationService.class)))
-                    .thenReturn(subject);
+    @Test
+    void shouldReturn400WithAuthAppErrorWhenTemporarilyLockedOut() throws Json.JsonException {
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(
+                        Result.success(new Decision.TemporarilyLockedOut(null, 5, null, false)));
 
-            var codeRequest =
-                    new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-            var result = makeCallWithCode(codeRequest);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+        var result = makeCallWithCode(codeRequest);
 
-            verify(auditService, times(1))
-                    .submitAuditEvent(
-                            FrontendAuditableEvent.AUTH_REAUTH_FAILED,
-                            AUDIT_CONTEXT,
-                            pair("rpPairwiseId", subject.getValue()),
-                            pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
-                            pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
-                            pair("incorrect_otp_code_attempt_count", expectedOtpAttemptCount),
-                            pair("failure-reason", expectedFailureReason));
-            verify(cloudwatchMetricsService)
-                    .incrementCounter(
-                            CloudwatchMetrics.REAUTH_FAILED.getValue(),
-                            Map.of(
-                                    ENVIRONMENT.getValue(),
-                                    configurationService.getEnvironment(),
-                                    FAILURE_REASON.getValue(),
-                                    expectedFailureReason));
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+    }
 
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
-        }
+    @Test
+    void shouldReturn400WithSmsErrorWhenTemporarilyLockedOut() throws Json.JsonException {
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(
+                        Result.success(new Decision.TemporarilyLockedOut(null, 5, null, false)));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        CODE,
+                        JourneyType.SIGN_IN,
+                        DEFAULT_SMS_METHOD.getDestination());
+        var result = makeCallWithCode(codeRequest);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
     }
 
     private APIGatewayProxyResponseEvent makeCallWithCode(CodeRequest mfaCodeRequest)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CountType;
@@ -33,7 +34,6 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -52,12 +52,11 @@ import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
+import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -71,7 +70,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -212,6 +210,10 @@ class VerifyMfaCodeHandlerTest {
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
         when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -893,308 +895,6 @@ class VerifyMfaCodeHandlerTest {
             verifyNoInteractions(cloudwatchMetricsService);
         }
 
-        private static Stream<Arguments> blockedCodeForAuthAppOTPEnteredTooManyTimes() {
-            return Stream.of(
-                    Arguments.of(
-                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
-                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
-                    Arguments.of(JourneyType.SIGN_IN, CodeRequestType.MFA_SIGN_IN),
-                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
-                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
-        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            withReauthTurnedOn();
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
-            var authAppSecret =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            if (journeyType.equals(REAUTHENTICATION)) {
-                verify(codeStorageService, never())
-                        .saveBlockedForEmail(
-                                eq(EMAIL),
-                                eq(CODE_BLOCKED_KEY_PREFIX + codeRequestType),
-                                anyLong());
-            } else {
-                long expectedCodeBlockedTime =
-                        (journeyType.equals(REGISTRATION) || journeyType.equals(ACCOUNT_RECOVERY))
-                                ? 300L
-                                : 900L;
-                verify(codeStorageService)
-                        .saveBlockedForEmail(
-                                EMAIL,
-                                CODE_BLOCKED_KEY_PREFIX + codeRequestType,
-                                expectedCodeBlockedTime);
-                verifyNoInteractions(authenticationAttemptsService);
-            }
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @EnumSource(JourneyType.class)
-        void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists(
-                JourneyType journeyType) throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            when(codeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                    .thenReturn(true);
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_AUTH_APP_METHOD)));
-            var authAppSecret =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, authAppSecret);
-
-            if (!CodeRequestType.isValidCodeRequestType(
-                    CodeRequestType.SupportedCodeType.getFromMfaMethodType(
-                            codeRequest.getMfaMethodType()),
-                    codeRequest.getJourneyType())) {
-                return;
-            }
-
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @EnumSource(JourneyType.class)
-        void shouldReturn400WhenUserEnteredInvalidAuthAppOtpCode(JourneyType journeyType)
-                throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(authAppCodeProcessor));
-            var profileInformation =
-                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA, REAUTHENTICATION)
-                                    .contains(journeyType)
-                            ? null
-                            : AUTH_APP_SECRET;
-            when(authAppCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
-
-            if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
-                when(mfaMethodsService.getMfaMethods(EMAIL))
-                        .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-            }
-
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.AUTH_APP, CODE, journeyType, profileInformation);
-            if (!CodeRequestType.isValidCodeRequestType(
-                    CodeRequestType.SupportedCodeType.getFromMfaMethodType(
-                            codeRequest.getMfaMethodType()),
-                    codeRequest.getJourneyType())) {
-                return;
-            }
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
-
-            ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
-                    ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
-
-            verify(auditService)
-                    .submitAuditEvent(
-                            eq(FrontendAuditableEvent.AUTH_INVALID_CODE_SENT),
-                            eq(AUDIT_CONTEXT),
-                            metadataCaptor.capture());
-
-            boolean accountRecovery = journeyType.equals(ACCOUNT_RECOVERY);
-
-            List<AuditService.MetadataPair> expected =
-                    List.of(
-                            pair("MFACodeEntered", CODE),
-                            pair("account-recovery", accountRecovery),
-                            pair("journey-type", journeyType),
-                            pair("loginFailureCount", 3),
-                            pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
-                            pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
-
-            List<AuditService.MetadataPair> actual = Arrays.asList(metadataCaptor.getValue());
-
-            assertTrue(expected.containsAll(actual));
-            assertTrue(actual.containsAll(expected));
-        }
-
-        private static Stream<Arguments> blockedCodeForInvalidPhoneNumberTooManyTimes() {
-            return Stream.of(
-                    Arguments.of(
-                            JourneyType.ACCOUNT_RECOVERY, CodeRequestType.MFA_ACCOUNT_RECOVERY),
-                    Arguments.of(JourneyType.PASSWORD_RESET_MFA, CodeRequestType.MFA_PW_RESET_MFA),
-                    Arguments.of(REGISTRATION, CodeRequestType.MFA_REGISTRATION),
-                    Arguments.of(REAUTHENTICATION, CodeRequestType.MFA_REAUTHENTICATION));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
-        void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            withReauthTurnedOn();
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_SMS_METHOD)));
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            long blockTime = 900L;
-            if (List.of(CodeRequestType.MFA_REGISTRATION, CodeRequestType.MFA_ACCOUNT_RECOVERY)
-                    .contains(codeRequestType)) {
-                blockTime = 300L;
-            }
-            if (journeyType != REAUTHENTICATION) {
-                verify(codeStorageService)
-                        .saveBlockedForEmail(
-                                EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType, blockTime);
-            }
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        @ParameterizedTest
-        @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
-        void shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExists(
-                JourneyType journeyType, CodeRequestType codeRequestType)
-                throws Json.JsonException {
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            var codeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
-            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
-            when(mfaMethodsService.getMfaMethods(any()))
-                    .thenReturn(
-                            Result.success(
-                                    List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)
-                                            ? List.of()
-                                            : List.of(DEFAULT_SMS_METHOD)));
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            verifyNoInteractions(cloudwatchMetricsService);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)),
-                    pair("journey-type", journeyType),
-                    pair("attemptNoFailedAt", configurationService.getCodeMaxRetries()),
-                    pair("mfa-method", "default"));
-        }
-
-        // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-        @Test
-        void
-                shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExistsWithDeprecatedPrefix()
-                        throws Json.JsonException {
-            JourneyType journeyType = JourneyType.PASSWORD_RESET_MFA;
-            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
-            when(phoneNumberCodeProcessor.validateCode())
-                    .thenReturn(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            var codeBlockedPrefix =
-                    CODE_BLOCKED_KEY_PREFIX
-                            + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                    MFAMethodType.SMS, journeyType);
-            when(codeStorageService.isBlockedForEmail(EMAIL, codeBlockedPrefix)).thenReturn(true);
-            var codeRequest =
-                    new VerifyMfaCodeRequest(
-                            MFAMethodType.SMS, CODE, journeyType, UK_MOBILE_NUMBER);
-            var result = makeCallWithCode(codeRequest);
-
-            assertThat(result, hasStatus(400));
-            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never()).saveBlockedForEmail(EMAIL, codeBlockedPrefix, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-        }
-
         private static Stream<Arguments> invalidOtpSmsJourneyTypesWithMfaNotificationType() {
             return Stream.of(
                     Arguments.of(JourneyType.SIGN_IN, MFA_SMS.name()),
@@ -1214,6 +914,8 @@ class VerifyMfaCodeHandlerTest {
             when(phoneNumberCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
             when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(6)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1306,32 +1008,6 @@ class VerifyMfaCodeHandlerTest {
             verifyNoInteractions(auditService);
             verifyNoInteractions(cloudwatchMetricsService);
         }
-    }
-
-    @Test
-    void shouldIncrementMFAAuthenticationAttemptsCountIfIncorrectCodeEntered()
-            throws Json.JsonException {
-        long ttl = 3600L;
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(ttl);
-        MockedStatic<NowHelper> mockedNowHelperClass = mockStatic(NowHelper.class);
-        mockedNowHelperClass
-                .when(() -> NowHelper.nowPlus(ttl, ChronoUnit.SECONDS))
-                .thenReturn(Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-        makeCallWithCode(codeRequest);
-
-        verify(authenticationAttemptsService, times(1))
-                .createOrIncrementCount(
-                        TEST_SUBJECT_ID, 1704067200L, REAUTHENTICATION, ENTER_MFA_CODE);
-
-        mockedNowHelperClass.close();
     }
 
     @Test
@@ -1615,5 +1291,194 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verify(userActionsManager)
                 .correctAuthAppOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
+    }
+
+    @Test
+    void shouldCallIncorrectSmsOtpReceivedWhenSmsCodeIsInvalid() throws Json.JsonException {
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(phoneNumberCodeProcessor));
+        when(phoneNumberCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        CODE,
+                        JourneyType.SIGN_IN,
+                        DEFAULT_SMS_METHOD.getDestination());
+
+        makeCallWithCode(codeRequest);
+
+        verify(userActionsManager).incorrectSmsOtpReceived(eq(JourneyType.SIGN_IN), any());
+    }
+
+    @Test
+    void shouldCallIncorrectAuthAppOtpReceivedWhenAuthAppCodeIsInvalid() throws Json.JsonException {
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+
+        makeCallWithCode(codeRequest);
+
+        verify(userActionsManager).incorrectAuthAppOtpReceived(eq(JourneyType.SIGN_IN), any());
+    }
+
+    @Test
+    void shouldReturn400WithLockoutErrorWhenAuthAppCodeBecomesBlockedByThisRequest()
+            throws Json.JsonException {
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+        // First check passes (not blocked), second check after increment returns blocked
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(5)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                        any(AuditContext.class),
+                        any(AuditService.MetadataPair[].class));
+    }
+
+    @Test
+    void shouldReturn400WithLockoutErrorWhenSmsCodeBecomesBlockedByThisRequest()
+            throws Json.JsonException {
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(phoneNumberCodeProcessor));
+        when(phoneNumberCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        // First check passes (not blocked), second check after increment returns blocked
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(5)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.TemporarilyLockedOut(
+                                        null, MAX_RETRIES, Instant.now(), false)));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS,
+                                CODE,
+                                JourneyType.SIGN_IN,
+                                DEFAULT_SMS_METHOD.getDestination()));
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                        any(AuditContext.class),
+                        any(AuditService.MetadataPair[].class));
+    }
+
+    @Test
+    void shouldReturn400WithReauthLockedOutWhenAuthAppCodeBecomesReauthBlockedByThisRequest()
+            throws Json.JsonException {
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+        var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(5)))
+                .thenReturn(
+                        Result.success(
+                                new Decision.ReauthLockedOut(
+                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                        MAX_RETRIES,
+                                        Instant.now(),
+                                        false,
+                                        detailedCounts,
+                                        List.of(ENTER_MFA_CODE))));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+        verify(userActionsManager).incorrectAuthAppOtpReceived(any(), any());
+        verify(auditService)
+                .submitAuditEvent(
+                        eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
+                        any(AuditContext.class),
+                        any(AuditService.MetadataPair[].class));
+        verify(cloudwatchMetricsService)
+                .incrementCounter(eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
+    }
+
+    @Test
+    void shouldReturn500WhenIncorrectSmsOtpReceivedFails() throws Json.JsonException {
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(phoneNumberCodeProcessor));
+        when(phoneNumberCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        CODE,
+                        JourneyType.SIGN_IN,
+                        DEFAULT_SMS_METHOD.getDestination());
+
+        var result = makeCallWithCode(codeRequest);
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenIncorrectAuthAppOtpReceivedFails() throws Json.JsonException {
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+
+        var result = makeCallWithCode(codeRequest);
+
+        assertThat(result, hasStatus(500));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -39,7 +39,6 @@ import uk.gov.di.authentication.shared.helpers.TestUserHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
-import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -51,6 +50,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
@@ -59,7 +59,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -73,7 +72,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -95,7 +93,6 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_RESET_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_COMPLETED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_INITIATED;
-import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
@@ -139,9 +136,6 @@ class VerifyMfaCodeHandlerTest {
     private static final String TEST_SUBJECT_ID = "test-subject-id";
     private static final int MAX_RETRIES = 6;
 
-    private final String expectedRpPairwiseSubjectId =
-            ClientSubjectHelper.calculatePairwiseIdentifier(
-                    TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -166,8 +160,6 @@ class VerifyMfaCodeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final AuthenticationAttemptsService authenticationAttemptsService =
-            mock(AuthenticationAttemptsService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
@@ -214,6 +206,10 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Result.success(null));
         when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -223,7 +219,6 @@ class VerifyMfaCodeHandlerTest {
                         auditService,
                         mfaCodeProcessorFactory,
                         cloudwatchMetricsService,
-                        authenticationAttemptsService,
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
@@ -1011,75 +1006,6 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Test
-    void
-            shouldDeleteAuthAppAuthenticationAttemptsCountAndStoreCountsInSessionIfCorrectCodeEnteredForReauthJourney()
-                    throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, CODE, JourneyType.REAUTHENTICATION, null);
-        makeCallWithCode(codeRequest);
-
-        List.of(TEST_SUBJECT_ID, expectedRpPairwiseSubjectId)
-                .forEach(
-                        identifier ->
-                                verify(
-                                                authenticationAttemptsService,
-                                                times(CountType.values().length))
-                                        .deleteCount(
-                                                eq(identifier),
-                                                eq(JourneyType.REAUTHENTICATION),
-                                                any()));
-
-        verify(authSessionService, atLeastOnce())
-                .updateSession(
-                        argThat(
-                                s ->
-                                        s.getPreservedReauthCountsForAuditMap()
-                                                .equals(existingCounts)));
-    }
-
-    @Test
-    void
-            shouldDeleteAuthAppAuthenticationAttemptsCountAndNotStoreCountsInSessionIfCorrectCodeEnteredForSigninJourney()
-                    throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-
-        var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        eq(SUBJECT_ID), any(), eq(JourneyType.REAUTHENTICATION)))
-                .thenReturn(existingCounts);
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
-        makeCallWithCode(codeRequest);
-
-        verify(authenticationAttemptsService, times(1))
-                .deleteCount(TEST_SUBJECT_ID, JourneyType.REAUTHENTICATION, ENTER_MFA_CODE);
-
-        verify(authSessionService, never())
-                .updateSession(
-                        argThat(
-                                s ->
-                                        Objects.equals(
-                                                s.getPreservedReauthCountsForAuditMap(),
-                                                existingCounts)));
-    }
-
-    @Test
     void shouldReturn400WhenReauthLockedOutViaPermissionDecisionManager()
             throws Json.JsonException {
         when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1149,11 +1075,6 @@ class VerifyMfaCodeHandlerTest {
     private void assertAuditEventSubmittedWithMetadata(
             AuditableEvent event, AuditService.MetadataPair... pairs) {
         verify(auditService).submitAuditEvent(event, AUDIT_CONTEXT, pairs);
-    }
-
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
     }
 
     @Test
@@ -1294,6 +1215,74 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Test
+    void shouldReturn500WhenPermissionDecisionManagerFails() throws Json.JsonException {
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "123456", JourneyType.SIGN_IN, null));
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenIncorrectOtpTrackingFails() throws Json.JsonException {
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode())
+                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "123456", JourneyType.SIGN_IN, null));
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectSmsOtpTrackingFails() throws Json.JsonException {
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS, "123456", JourneyType.SIGN_IN, null));
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
+    void shouldReturn500WhenCorrectAuthAppOtpTrackingFails() throws Json.JsonException {
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(authAppCodeProcessor));
+        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "123456", JourneyType.SIGN_IN, null));
+
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
     void shouldCallIncorrectSmsOtpReceivedWhenSmsCodeIsInvalid() throws Json.JsonException {
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
@@ -1410,7 +1399,7 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-        var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+        var detailedCounts = Map.of(CountType.ENTER_MFA_CODE, MAX_RETRIES);
         when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(5)))
                 .thenReturn(
@@ -1421,7 +1410,7 @@ class VerifyMfaCodeHandlerTest {
                                         Instant.now(),
                                         false,
                                         detailedCounts,
-                                        List.of(ENTER_MFA_CODE))));
+                                        List.of(CountType.ENTER_MFA_CODE))));
 
         var result =
                 makeCallWithCode(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -233,49 +233,6 @@ class AuthAppCodeProcessorTest {
 
     @ParameterizedTest
     @MethodSource("validatorParams")
-    void returnsCorrectErrorWhenCodeBlockedForEmailAddress(
-            JourneyType journeyType, String authAppSecret, CodeRequestType codeRequestType) {
-        setUpBlockedUser(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, "000000", journeyType, authAppSecret),
-                codeRequestType);
-
-        assertEquals(
-                Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED),
-                authAppCodeProcessor.validateCode());
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @Test
-    void returnsCorrectErrorWhenCodeBlockedForEmailAddressWithDeprecatedPrefix() {
-        JourneyType journeyType = JourneyType.SIGN_IN;
-        when(mockCodeStorageService.isBlockedForEmail(
-                        EMAIL,
-                        CODE_BLOCKED_KEY_PREFIX
-                                + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                        MFAMethodType.AUTH_APP, journeyType)))
-                .thenReturn(true);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        MAX_RETRIES,
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, "000000", journeyType, "credential"),
-                        mockAuditService,
-                        mockAccountModifiersService,
-                        mockMfaMethodsService);
-
-        assertEquals(
-                Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED),
-                authAppCodeProcessor.validateCode());
-    }
-
-    @ParameterizedTest
-    @MethodSource("validatorParams")
     void returnsCorrectErrorWhenRetryLimitExceeded(JourneyType journeyType, String authAppSecret) {
         setUpRetryLimitExceededUser(
                 new VerifyMfaCodeRequest(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -185,7 +185,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -222,25 +221,12 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
                         mockMfaMethodsService);
 
         assertEquals(Optional.empty(), authAppCodeProcessor.validateCode());
-    }
-
-    @ParameterizedTest
-    @MethodSource("validatorParams")
-    void returnsCorrectErrorWhenRetryLimitExceeded(JourneyType journeyType, String authAppSecret) {
-        setUpRetryLimitExceededUser(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, "000000", journeyType, authAppSecret));
-
-        assertEquals(
-                Optional.of(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED),
-                authAppCodeProcessor.validateCode());
     }
 
     @ParameterizedTest
@@ -488,7 +474,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -506,7 +491,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -525,7 +509,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -544,7 +527,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,
@@ -569,7 +551,6 @@ class AuthAppCodeProcessorTest {
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
-                        MAX_RETRIES,
                         codeRequest,
                         mockAuditService,
                         mockAccountModifiersService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -262,55 +262,6 @@ class PhoneNumberCodeProcessorTest {
                 equalTo(Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED)));
     }
 
-    @ParameterizedTest
-    @MethodSource("codeRequestTypes")
-    void shouldReturnErrorWhenUserIsBlockedFromEnteringRegistrationPhoneNumberCodes(
-            CodeRequestType codeRequestType, JourneyType journeyType) {
-        setUpBlockedPhoneNumberCode(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)));
-    }
-
-    // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
-    @Test
-    void
-            shouldReturnErrorWhenUserIsBlockedFromEnteringRegistrationPhoneNumberCodesWithDeprecatedPrefix() {
-        var codeRequestType = CodeRequestType.MFA_PW_RESET_MFA;
-        var journeyType = JourneyType.PASSWORD_RESET_MFA;
-        var mfaMethodType = MFAMethodType.SMS;
-
-        setUpBlockedPhoneNumberCode(
-                new VerifyMfaCodeRequest(
-                        mfaMethodType,
-                        INVALID_CODE,
-                        journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
-
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(false);
-
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL,
-                        CODE_BLOCKED_KEY_PREFIX
-                                + CodeRequestType.getDeprecatedCodeRequestTypeString(
-                                        mfaMethodType, journeyType)))
-                .thenReturn(true);
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)));
-    }
-
     @Test
     void shouldThrowExceptionForSignInPhoneNumberCode() {
         setupPhoneNumberCode(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -221,48 +221,6 @@ class PhoneNumberCodeProcessorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenInvalidRegistrationPhoneNumberCodeUsedTooManyTimes() {
-        setUpPhoneNumberCodeRetryLimitExceeded(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        REGISTRATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER));
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED)));
-    }
-
-    @Test
-    void shouldReturnErrorWhenInvalidMfaPhoneNumberCodeUsedTooManyTimes() {
-        setUpPhoneNumberCodeRetryLimitExceeded(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        JourneyType.PASSWORD_RESET_MFA,
-                        CommonTestVariables.UK_MOBILE_NUMBER));
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED)));
-    }
-
-    @Test
-    void shouldReturnErrorWhenInvalidReauthenticateMfaPhoneNumberCodeUsedTooManyTimes() {
-        setUpPhoneNumberCodeRetryLimitExceeded(
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        INVALID_CODE,
-                        JourneyType.REAUTHENTICATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER));
-
-        assertThat(
-                phoneNumberCodeProcessor.validateCode(),
-                equalTo(Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED)));
-    }
-
-    @Test
     void shouldThrowExceptionForSignInPhoneNumberCode() {
         setupPhoneNumberCode(
                 new VerifyMfaCodeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -463,6 +463,12 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @Test
     void shouldReturnMaxReachedAndSingalLogoutWhenReauthSmsCodeAttemptsExceedMaxRetryCount() {
+        var internalCommonSubjectId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
+        authSessionExtension.addInternalCommonSubjectIdToSession(
+                this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithSignUp(sessionId);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         for (int i = 0; i < 5; i++) {
@@ -548,6 +554,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         SUBJECT.getValue(), INTERNAl_SECTOR_HOST, SaltHelper.generateNewSalt());
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithoutSignUp(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
@@ -634,6 +641,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithoutSignUp(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password", SUBJECT);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
@@ -722,6 +730,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);
+        authSessionExtension.addRpSectorIdentifierHostToSession(this.sessionId, RP_SECTOR_HOST);
         setUpTestWithSignUp(sessionId);
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, PHONE_NUMBER);
         userStore.updateTermsAndConditions(EMAIL_ADDRESS, "1.0");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -279,7 +279,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     }
 
     @Test
-    void shouldReturnMaxReachedButNotSetBlockWhenVerifyEmailCodeAttemptsExceedMaxRetryCount() {
+    void shouldReturnMaxReachedAndSetBlockWhenVerifyEmailCodeAttemptsExceedMaxRetryCount() {
         setUpTestWithoutSignUp(sessionId);
         for (int i = 0; i < ConfigurationService.getInstance().getCodeMaxRetries(); i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
@@ -301,7 +301,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED));
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
-                equalTo(false));
+                equalTo(true));
         assertAuditEventExpectations(
                 txmaAuditQueue,
                 List.of(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -38,7 +38,6 @@ class AuthAppStubTest {
                         mock(CodeStorageService.class),
                         configurationService,
                         mock(DynamoService.class),
-                        99999,
                         mock(CodeRequest.class),
                         mock(AuditService.class),
                         mock(DynamoAccountModifiersService.class),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -8,10 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,7 +19,6 @@ import java.util.regex.Pattern;
 import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE;
 import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.MOBILE;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
-import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 
 public class ValidationHelper {
     private static final Logger LOG = LogManager.getLogger(ValidationHelper.class);
@@ -135,70 +131,6 @@ public class ValidationHelper {
             return Optional.of(ErrorResponse.INVALID_EMAIL_FORMAT);
         }
         return Optional.empty();
-    }
-
-    public static Optional<ErrorResponse> validateVerificationCode(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            Optional<String> code,
-            String input,
-            CodeStorageService codeStorageService,
-            String emailAddress,
-            ConfigurationService configurationService,
-            boolean incrementCountOnFailure) {
-
-        var codeCheckResult = validateVerificationCode(notificationType, code, input);
-        if (codeCheckResult.isEmpty()) {
-            if (journeyType != JourneyType.REAUTHENTICATION) {
-                codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
-            }
-            return Optional.empty();
-        }
-
-        return getErrorResponse(
-                notificationType,
-                journeyType,
-                codeStorageService,
-                emailAddress,
-                configurationService,
-                incrementCountOnFailure);
-    }
-
-    private static @NotNull Optional<ErrorResponse> getErrorResponse(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            CodeStorageService codeStorageService,
-            String emailAddress,
-            ConfigurationService configurationService,
-            boolean incrementCountOnFailure) {
-        if (incrementCountOnFailure && journeyType != JourneyType.REAUTHENTICATION) {
-            if (configurationService.supportAccountCreationTTL()
-                    && notificationType == VERIFY_EMAIL) {
-                codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(
-                        emailAddress);
-            } else {
-                codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
-            }
-
-            if (codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress)
-                    >= configurationService.getCodeMaxRetries()) {
-                switch (notificationType) {
-                    case MFA_SMS:
-                        return Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-                    case VERIFY_EMAIL:
-                        return Optional.of(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED);
-                    case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
-                        return Optional.of(
-                                ErrorResponse.TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED);
-                    case VERIFY_PHONE_NUMBER:
-                        return Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED);
-                    case RESET_PASSWORD_WITH_CODE:
-                        return Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED);
-                }
-            }
-        }
-
-        return getErrorResponse(notificationType);
     }
 
     public static Optional<ErrorResponse> validateVerificationCode(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -147,20 +147,12 @@ public class ValidationHelper {
             ConfigurationService configurationService,
             boolean incrementCountOnFailure) {
 
-        if (code.filter(input::equals).isPresent()) {
+        var codeCheckResult = validateVerificationCode(notificationType, code, input);
+        if (codeCheckResult.isEmpty()) {
             if (journeyType != JourneyType.REAUTHENTICATION) {
                 codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
             }
-
-            switch (notificationType) {
-                case MFA_SMS:
-                case VERIFY_EMAIL:
-                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
-                case VERIFY_PHONE_NUMBER:
-                case RESET_PASSWORD_WITH_CODE:
-                    return Optional.empty();
-            }
-            return Optional.of(ErrorResponse.INVALID_NOTIFICATION_TYPE);
+            return Optional.empty();
         }
 
         return getErrorResponse(
@@ -206,6 +198,29 @@ public class ValidationHelper {
             }
         }
 
+        return getErrorResponse(notificationType);
+    }
+
+    public static Optional<ErrorResponse> validateVerificationCode(
+            NotificationType notificationType, Optional<String> code, String input) {
+
+        if (code.filter(input::equals).isPresent()) {
+            switch (notificationType) {
+                case MFA_SMS:
+                case VERIFY_EMAIL:
+                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                case VERIFY_PHONE_NUMBER:
+                case RESET_PASSWORD_WITH_CODE:
+                    return Optional.empty();
+            }
+            return Optional.of(ErrorResponse.INVALID_NOTIFICATION_TYPE);
+        }
+
+        return getErrorResponse(notificationType);
+    }
+
+    private static @NotNull Optional<ErrorResponse> getErrorResponse(
+            NotificationType notificationType) {
         switch (notificationType) {
             case MFA_SMS:
                 return Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -144,7 +144,8 @@ public class ValidationHelper {
             String input,
             CodeStorageService codeStorageService,
             String emailAddress,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            boolean incrementCountOnFailure) {
 
         if (code.filter(input::equals).isPresent()) {
             if (journeyType != JourneyType.REAUTHENTICATION) {
@@ -167,7 +168,8 @@ public class ValidationHelper {
                 journeyType,
                 codeStorageService,
                 emailAddress,
-                configurationService);
+                configurationService,
+                incrementCountOnFailure);
     }
 
     private static @NotNull Optional<ErrorResponse> getErrorResponse(
@@ -175,8 +177,9 @@ public class ValidationHelper {
             JourneyType journeyType,
             CodeStorageService codeStorageService,
             String emailAddress,
-            ConfigurationService configurationService) {
-        if (journeyType != JourneyType.REAUTHENTICATION) {
+            ConfigurationService configurationService,
+            boolean incrementCountOnFailure) {
+        if (incrementCountOnFailure && journeyType != JourneyType.REAUTHENTICATION) {
             if (configurationService.supportAccountCreationTTL()
                     && notificationType == VERIFY_EMAIL) {
                 codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -50,15 +50,15 @@ public class CodeStorageService {
         this.redisConnectionService = redisConnectionService;
     }
 
-    public void increaseIncorrectMfaCodeAttemptsCount(String email) {
-        increaseCount(
+    public int increaseIncorrectMfaCodeAttemptsCount(String email) {
+        return increaseCount(
                 email,
                 MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX,
                 configurationService.getLockoutCountTTL());
     }
 
-    public void increaseIncorrectMfaCodeAttemptsCountAccountCreation(String email) {
-        increaseCount(
+    public int increaseIncorrectMfaCodeAttemptsCountAccountCreation(String email) {
+        return increaseCount(
                 email,
                 MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX,
                 configurationService.getAccountCreationLockoutCountTTL());

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -437,7 +437,8 @@ class ValidationHelperTest {
                         input,
                         codeStorageService,
                         EMAIL_ADDRESS,
-                        configurationServiceMock));
+                        configurationServiceMock,
+                        true));
     }
 
     @ParameterizedTest
@@ -463,7 +464,8 @@ class ValidationHelperTest {
                 input,
                 codeStorageService,
                 EMAIL_ADDRESS,
-                configurationServiceMock);
+                configurationServiceMock,
+                true);
 
         if (journeyType != JourneyType.REAUTHENTICATION) {
             if (notificationType == VERIFY_EMAIL) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -23,9 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
@@ -37,12 +32,8 @@ class ValidationHelperTest {
     public static final Optional<String> STORED_VALID_CODE = Optional.of(VALID_CODE);
     public static final String INVALID_CODE = "654321";
     private static final Optional<String> NO_CODE_STORED = Optional.empty();
-    private static final String EMAIL_ADDRESS = "test@test.com";
     private static final String PRODUCTION = "production";
     private static final String INTEGRATION = "integration";
-
-    private static final ConfigurationService configurationServiceMock =
-            mock(ConfigurationService.class);
 
     @Nested
     class PhoneNumberValidatorTests {
@@ -366,42 +357,42 @@ class ValidationHelperTest {
                 arguments(
                         VERIFY_EMAIL,
                         JourneyType.PASSWORD_RESET,
-                        Optional.of(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_EMAIL_CODE_ENTERED),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
                         JourneyType.REGISTRATION,
-                        Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         MFA_SMS,
                         JourneyType.PASSWORD_RESET_MFA,
-                        Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
                         JourneyType.PASSWORD_RESET,
-                        Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PW_RESET_CODE),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
                         JourneyType.PASSWORD_RESET_MFA,
-                        Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
                         INVALID_CODE,
                         100,
                         STORED_VALID_CODE),
                 arguments(
                         VERIFY_PHONE_NUMBER,
                         JourneyType.PASSWORD_RESET_MFA,
-                        Optional.of(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED),
+                        Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
                         INVALID_CODE,
                         100,
                         STORED_VALID_CODE));
@@ -417,138 +408,8 @@ class ValidationHelperTest {
             int previousAttempts,
             Optional<String> storedCode) {
 
-        var codeStorageService = mock(CodeStorageService.class);
-
-        // This simulates the Redis increment counter's side effect which isn't captured
-        previousAttempts++;
-
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS))
-                .thenReturn(previousAttempts);
-
-        when(configurationServiceMock.getCodeMaxRetries()).thenReturn(5);
-        when(configurationServiceMock.supportAccountCreationTTL()).thenReturn(false);
-
         assertEquals(
                 expectedResult,
-                ValidationHelper.validateVerificationCode(
-                        notificationType,
-                        journeyType,
-                        storedCode,
-                        input,
-                        codeStorageService,
-                        EMAIL_ADDRESS,
-                        configurationServiceMock,
-                        true));
-    }
-
-    @ParameterizedTest
-    @MethodSource("validateCodeTestParameters")
-    void shouldIncreaseRetryCountWithCorrectTTL(
-            NotificationType notificationType,
-            JourneyType journeyType,
-            Optional<ErrorResponse> expectedResult,
-            String input,
-            int previousAttempts,
-            Optional<String> storedCode) {
-
-        var codeStorageService = mock(CodeStorageService.class);
-
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS)).thenReturn(1);
-        when(configurationServiceMock.getCodeMaxRetries()).thenReturn(5);
-        when(configurationServiceMock.supportAccountCreationTTL()).thenReturn(true);
-
-        ValidationHelper.validateVerificationCode(
-                notificationType,
-                journeyType,
-                Optional.empty(),
-                input,
-                codeStorageService,
-                EMAIL_ADDRESS,
-                configurationServiceMock,
-                true);
-
-        if (journeyType != JourneyType.REAUTHENTICATION) {
-            if (notificationType == VERIFY_EMAIL) {
-                verify(codeStorageService)
-                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL_ADDRESS);
-            } else {
-                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS);
-            }
-        }
-    }
-
-    @Nested
-    class PureCodeComparisonTests {
-
-        @Test
-        void shouldReturnEmptyWhenCodeMatchesForMfaSms() {
-            assertEquals(
-                    Optional.empty(),
-                    ValidationHelper.validateVerificationCode(
-                            MFA_SMS, Optional.of("123456"), "123456"));
-        }
-
-        @Test
-        void shouldReturnEmptyWhenCodeMatchesForVerifyEmail() {
-            assertEquals(
-                    Optional.empty(),
-                    ValidationHelper.validateVerificationCode(
-                            VERIFY_EMAIL, Optional.of("123456"), "123456"));
-        }
-
-        @Test
-        void shouldReturnEmptyWhenCodeMatchesForVerifyPhoneNumber() {
-            assertEquals(
-                    Optional.empty(),
-                    ValidationHelper.validateVerificationCode(
-                            VERIFY_PHONE_NUMBER, Optional.of("123456"), "123456"));
-        }
-
-        @Test
-        void shouldReturnEmptyWhenCodeMatchesForResetPassword() {
-            assertEquals(
-                    Optional.empty(),
-                    ValidationHelper.validateVerificationCode(
-                            RESET_PASSWORD_WITH_CODE, Optional.of("123456"), "123456"));
-        }
-
-        @Test
-        void shouldReturnInvalidMfaCodeWhenCodeDoesNotMatchForMfaSms() {
-            assertEquals(
-                    Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED),
-                    ValidationHelper.validateVerificationCode(
-                            MFA_SMS, Optional.of("123456"), "654321"));
-        }
-
-        @Test
-        void shouldReturnInvalidEmailCodeWhenCodeDoesNotMatchForVerifyEmail() {
-            assertEquals(
-                    Optional.of(ErrorResponse.INVALID_EMAIL_CODE_ENTERED),
-                    ValidationHelper.validateVerificationCode(
-                            VERIFY_EMAIL, Optional.of("123456"), "654321"));
-        }
-
-        @Test
-        void shouldReturnInvalidPhoneCodeWhenCodeDoesNotMatchForVerifyPhoneNumber() {
-            assertEquals(
-                    Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
-                    ValidationHelper.validateVerificationCode(
-                            VERIFY_PHONE_NUMBER, Optional.of("123456"), "654321"));
-        }
-
-        @Test
-        void shouldReturnInvalidPwResetCodeWhenCodeDoesNotMatchForResetPassword() {
-            assertEquals(
-                    Optional.of(ErrorResponse.INVALID_PW_RESET_CODE),
-                    ValidationHelper.validateVerificationCode(
-                            RESET_PASSWORD_WITH_CODE, Optional.of("123456"), "654321"));
-        }
-
-        @Test
-        void shouldReturnInvalidCodeWhenNoCodeStored() {
-            assertEquals(
-                    Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED),
-                    ValidationHelper.validateVerificationCode(MFA_SMS, Optional.empty(), "123456"));
-        }
+                ValidationHelper.validateVerificationCode(notificationType, storedCode, input));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -476,4 +476,79 @@ class ValidationHelperTest {
             }
         }
     }
+
+    @Nested
+    class PureCodeComparisonTests {
+
+        @Test
+        void shouldReturnEmptyWhenCodeMatchesForMfaSms() {
+            assertEquals(
+                    Optional.empty(),
+                    ValidationHelper.validateVerificationCode(
+                            MFA_SMS, Optional.of("123456"), "123456"));
+        }
+
+        @Test
+        void shouldReturnEmptyWhenCodeMatchesForVerifyEmail() {
+            assertEquals(
+                    Optional.empty(),
+                    ValidationHelper.validateVerificationCode(
+                            VERIFY_EMAIL, Optional.of("123456"), "123456"));
+        }
+
+        @Test
+        void shouldReturnEmptyWhenCodeMatchesForVerifyPhoneNumber() {
+            assertEquals(
+                    Optional.empty(),
+                    ValidationHelper.validateVerificationCode(
+                            VERIFY_PHONE_NUMBER, Optional.of("123456"), "123456"));
+        }
+
+        @Test
+        void shouldReturnEmptyWhenCodeMatchesForResetPassword() {
+            assertEquals(
+                    Optional.empty(),
+                    ValidationHelper.validateVerificationCode(
+                            RESET_PASSWORD_WITH_CODE, Optional.of("123456"), "123456"));
+        }
+
+        @Test
+        void shouldReturnInvalidMfaCodeWhenCodeDoesNotMatchForMfaSms() {
+            assertEquals(
+                    Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED),
+                    ValidationHelper.validateVerificationCode(
+                            MFA_SMS, Optional.of("123456"), "654321"));
+        }
+
+        @Test
+        void shouldReturnInvalidEmailCodeWhenCodeDoesNotMatchForVerifyEmail() {
+            assertEquals(
+                    Optional.of(ErrorResponse.INVALID_EMAIL_CODE_ENTERED),
+                    ValidationHelper.validateVerificationCode(
+                            VERIFY_EMAIL, Optional.of("123456"), "654321"));
+        }
+
+        @Test
+        void shouldReturnInvalidPhoneCodeWhenCodeDoesNotMatchForVerifyPhoneNumber() {
+            assertEquals(
+                    Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED),
+                    ValidationHelper.validateVerificationCode(
+                            VERIFY_PHONE_NUMBER, Optional.of("123456"), "654321"));
+        }
+
+        @Test
+        void shouldReturnInvalidPwResetCodeWhenCodeDoesNotMatchForResetPassword() {
+            assertEquals(
+                    Optional.of(ErrorResponse.INVALID_PW_RESET_CODE),
+                    ValidationHelper.validateVerificationCode(
+                            RESET_PASSWORD_WITH_CODE, Optional.of("123456"), "654321"));
+        }
+
+        @Test
+        void shouldReturnInvalidCodeWhenNoCodeStored() {
+            assertEquals(
+                    Optional.of(ErrorResponse.INVALID_MFA_CODE_ENTERED),
+                    ValidationHelper.validateVerificationCode(MFA_SMS, Optional.empty(), "123456"));
+        }
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -284,8 +284,9 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(null);
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
+        int count = codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
+        assertThat(count, equalTo(1));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
@@ -298,8 +299,9 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(String.valueOf(3));
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
+        int count = codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
+        assertThat(count, equalTo(4));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
@@ -313,8 +315,10 @@ class CodeStorageServiceTest {
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(String.valueOf(0));
 
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
+        int count =
+                codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
 
+        assertThat(count, equalTo(1));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
@@ -322,9 +323,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
-        getAuthSessionService().updateSession(updatedSession);
-        return Result.success(null);
+        return correctMfaOtpReceived(journeyType, permissionContext);
     }
 
     @Override
@@ -387,9 +386,67 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        return correctMfaOtpReceived(journeyType, permissionContext);
+    }
+
+    private Result<TrackingError, Void> correctMfaOtpReceived(
+            JourneyType journeyType, PermissionContext permissionContext) {
+        if (permissionContext == null) {
+            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+        }
+        var authSession = permissionContext.authSessionItem();
+        if (authSession == null) {
+            return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+        }
+
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            var internalSubjectId = permissionContext.internalSubjectId();
+            var rpPairwiseId = permissionContext.rpPairwiseId();
+            if (internalSubjectId == null || rpPairwiseId == null) {
+                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+            }
+
+            if (configurationService.supportReauthSignoutEnabled()
+                    && configurationService.isAuthenticationAttemptsServiceEnabled()) {
+                var counts =
+                        getAuthenticationAttemptsService()
+                                .getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                                        internalSubjectId,
+                                        rpPairwiseId,
+                                        JourneyType.REAUTHENTICATION);
+                authSession = authSession.withPreservedReauthCountsForAuditMap(counts);
+            }
+        } else {
+            if (permissionContext.emailAddress() == null) {
+                return Result.failure(TrackingError.INVALID_USER_CONTEXT);
+            }
+            getCodeStorageService()
+                    .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        }
+
+        clearReauthCounts(permissionContext);
+
+        var updatedSession = authSession.withHasVerifiedMfa(true);
         getAuthSessionService().updateSession(updatedSession);
+
         return Result.success(null);
+    }
+
+    private void clearReauthCounts(PermissionContext permissionContext) {
+        var identifiers = new ArrayList<String>();
+        if (permissionContext.internalSubjectIds() != null) {
+            identifiers.addAll(permissionContext.internalSubjectIds());
+        }
+        if (permissionContext.rpPairwiseId() != null) {
+            identifiers.add(permissionContext.rpPairwiseId());
+        }
+
+        for (String identifier : identifiers) {
+            for (CountType countType : CountType.values()) {
+                getAuthenticationAttemptsService()
+                        .deleteCount(identifier, JourneyType.REAUTHENTICATION, countType);
+            }
+        }
     }
 
     private AuthenticationAttemptsService getAuthenticationAttemptsService() {

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -120,6 +120,15 @@ public class UserActionsManager implements UserActions {
             return Result.success(null);
         }
 
+        if (journeyType == JourneyType.REGISTRATION) {
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(SupportedCodeType.EMAIL, journeyType);
+            getCodeStorageService()
+                    .deleteBlockForEmail(
+                            permissionContext.emailAddress(),
+                            CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType);
+        }
+
         var updatedSession =
                 permissionContext
                         .authSessionItem()
@@ -156,6 +165,45 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectEmailOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            return Result.success(null);
+        }
+
+        int updatedCount;
+        if (configurationService.supportAccountCreationTTL()
+                && journeyType == JourneyType.REGISTRATION) {
+            updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCountAccountCreation(
+                                    permissionContext.emailAddress());
+        } else {
+            updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCount(
+                                    permissionContext.emailAddress());
+        }
+        if (updatedCount >= configurationService.getCodeMaxRetries()) {
+            LOG.info("Setting block for email as user has exceeded max email OTP retries");
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(
+                            CodeRequestType.SupportedCodeType.EMAIL, journeyType);
+
+            boolean reducedLockout =
+                    journeyType == JourneyType.REGISTRATION
+                            || journeyType == JourneyType.ACCOUNT_RECOVERY;
+            long blockDuration =
+                    reducedLockout
+                            ? configurationService.getReducedLockoutDuration()
+                            : configurationService.getLockoutDuration();
+
+            getCodeStorageService()
+                    .saveBlockedForEmail(
+                            permissionContext.emailAddress(),
+                            CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                            blockDuration);
+            getCodeStorageService()
+                    .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+        }
         return Result.success(null);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -269,6 +270,52 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            try {
+                getAuthenticationAttemptsService()
+                        .createOrIncrementCount(
+                                permissionContext.internalSubjectId(),
+                                NowHelper.nowPlus(
+                                                configurationService
+                                                        .getReauthEnterSMSCodeCountTTL(),
+                                                ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond(),
+                                journeyType,
+                                CountType.ENTER_MFA_CODE);
+            } catch (RuntimeException e) {
+                LOG.error(
+                        "Failed to store incorrect SMS OTP count in AuthenticationAttemptsService",
+                        e);
+                return Result.failure(TrackingError.STORAGE_SERVICE_ERROR);
+            }
+        } else {
+            var updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCount(
+                                    permissionContext.emailAddress());
+            if (updatedCount >= configurationService.getCodeMaxRetries()) {
+                var codeRequestType =
+                        CodeRequestType.getCodeRequestType(SupportedCodeType.MFA, journeyType);
+                LOG.info("Setting block for email as user has exceeded max MFA code retries");
+
+                boolean reducedLockout =
+                        journeyType == JourneyType.REGISTRATION
+                                || journeyType == JourneyType.ACCOUNT_RECOVERY;
+                long blockDuration =
+                        reducedLockout
+                                ? configurationService.getReducedLockoutDuration()
+                                : configurationService.getLockoutDuration();
+
+                getCodeStorageService()
+                        .saveBlockedForEmail(
+                                permissionContext.emailAddress(),
+                                CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                                blockDuration);
+                getCodeStorageService()
+                        .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+            }
+        }
         return Result.success(null);
     }
 
@@ -283,6 +330,57 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        if (journeyType == JourneyType.REAUTHENTICATION) {
+            try {
+                getAuthenticationAttemptsService()
+                        .createOrIncrementCount(
+                                permissionContext.internalSubjectId(),
+                                NowHelper.nowPlus(
+                                                configurationService
+                                                        .getReauthEnterAuthAppCodeCountTTL(),
+                                                ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond(),
+                                journeyType,
+                                CountType.ENTER_MFA_CODE);
+            } catch (RuntimeException e) {
+                LOG.error(
+                        "Failed to store incorrect Auth App OTP count in AuthenticationAttemptsService",
+                        e);
+                return Result.failure(TrackingError.STORAGE_SERVICE_ERROR);
+            }
+        } else {
+            var updatedCount =
+                    getCodeStorageService()
+                            .increaseIncorrectMfaCodeAttemptsCount(
+                                    permissionContext.emailAddress());
+            int maxRetries =
+                    (journeyType == JourneyType.REGISTRATION
+                                    || journeyType == JourneyType.ACCOUNT_RECOVERY)
+                            ? configurationService.getIncreasedCodeMaxRetries()
+                            : configurationService.getCodeMaxRetries();
+            if (updatedCount >= maxRetries) {
+                var codeRequestType =
+                        CodeRequestType.getCodeRequestType(MFAMethodType.AUTH_APP, journeyType);
+                LOG.info("Setting block for email as user has exceeded max MFA code retries");
+
+                boolean reducedLockout =
+                        journeyType == JourneyType.REGISTRATION
+                                || journeyType == JourneyType.ACCOUNT_RECOVERY;
+                long blockDuration =
+                        reducedLockout
+                                ? configurationService.getReducedLockoutDuration()
+                                : configurationService.getLockoutDuration();
+
+                getCodeStorageService()
+                        .saveBlockedForEmail(
+                                permissionContext.emailAddress(),
+                                CodeStorageService.CODE_BLOCKED_KEY_PREFIX + codeRequestType,
+                                blockDuration);
+                getCodeStorageService()
+                        .deleteIncorrectMfaCodeAttemptsCount(permissionContext.emailAddress());
+            }
+        }
         return Result.success(null);
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -265,6 +265,18 @@ class UserActionsManagerTest {
                                 .getCodeRequestCount(notificationType, journeyType));
                 assertTrue(result.isSuccess());
             }
+
+            @Test
+            void shouldClearVerificationBlockForRegistration() {
+                userActionsManager.sentEmailOtpNotification(
+                        JourneyType.REGISTRATION, permissionContext);
+
+                verify(codeStorageService)
+                        .deleteBlockForEmail(
+                                EMAIL,
+                                CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                        + CodeRequestType.EMAIL_REGISTRATION);
+            }
         }
 
         @Nested

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.userpermissions.entity.InMemoryLockoutStateHolde
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -413,19 +414,70 @@ class UserActionsManagerTest {
 
     @Nested
     class CorrectSmsOtpReceived {
+
         @Test
-        void correctSmsOtpReceivedShouldSetHasVerifiedMfaToTrue() {
-            // Arrange
+        void shouldReturnErrorWhenPermissionContextIsNull() {
+            var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, null);
+            assertTrue(result.isFailure());
+            assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+        }
+
+        @Test
+        void shouldSetHasVerifiedMfaAndClearCountForStandardJourney() {
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
-            // Act
-            var result = userActionsManager.correctSmsOtpReceived(null, permissionContext);
+            var result =
+                    userActionsManager.correctSmsOtpReceived(
+                            JourneyType.SIGN_IN, permissionContext);
 
-            // Assert
             verify(authSessionService).updateSession(captor.capture());
-            AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(captor.getValue().getHasVerifiedMfa());
+            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldClearReauthCountsAndSetHasVerifiedMfaForReauth() {
+            var context =
+                    PermissionContext.builder()
+                            .withInternalSubjectId("subject-123")
+                            .withRpPairwiseId("rp-pairwise-456")
+                            .withAuthSessionItem(authSession)
+                            .build();
+
+            var result =
+                    userActionsManager.correctSmsOtpReceived(JourneyType.REAUTHENTICATION, context);
+
+            for (CountType countType : CountType.values()) {
+                verify(authenticationAttemptsService)
+                        .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
+                verify(authenticationAttemptsService)
+                        .deleteCount("rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+            }
+            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(anyString());
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldPreserveReauthCountsForAuditWhenFeatureFlagsEnabled() {
+            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
+            var counts = Map.of(CountType.ENTER_PASSWORD, 2, CountType.ENTER_SMS_CODE, 1);
+            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                            "subject-123", "rp-pairwise-456", JourneyType.REAUTHENTICATION))
+                    .thenReturn(counts);
+            var context =
+                    PermissionContext.builder()
+                            .withInternalSubjectId("subject-123")
+                            .withRpPairwiseId("rp-pairwise-456")
+                            .withAuthSessionItem(authSession)
+                            .build();
+
+            userActionsManager.correctSmsOtpReceived(JourneyType.REAUTHENTICATION, context);
+
+            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
+            verify(authSessionService).updateSession(captor.capture());
+            assertEquals(counts, captor.getValue().getPreservedReauthCountsForAuditMap());
         }
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.entity.CodeRequestType.SupportedCodeType;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -68,6 +69,7 @@ class UserActionsManagerTest {
                         authSessionService,
                         authenticationAttemptsService);
         when(configurationService.getCodeMaxRetries()).thenReturn(6);
+        when(configurationService.getIncreasedCodeMaxRetries()).thenReturn(999999);
         when(configurationService.getLockoutDuration()).thenReturn(900L);
     }
 
@@ -423,6 +425,121 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(result.isSuccess());
+        }
+    }
+
+    @Nested
+    class IncorrectSmsOtpReceived {
+
+        @Test
+        void shouldIncrementCount() {
+            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+            var result =
+                    userActionsManager.incorrectSmsOtpReceived(
+                            JourneyType.SIGN_IN, permissionContext);
+
+            verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldBlockWhenMaxRetriesReached() {
+            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+            var result =
+                    userActionsManager.incorrectSmsOtpReceived(
+                            JourneyType.SIGN_IN, permissionContext);
+
+            var expectedBlockedKey =
+                    CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                            + CodeRequestType.getCodeRequestType(
+                                    SupportedCodeType.MFA, JourneyType.SIGN_IN);
+            verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldIncrementCountViaAuthAttemptsServiceForReauth() {
+            var context = PermissionContext.builder().withInternalSubjectId("subject-123").build();
+            when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(120L);
+
+            var result =
+                    userActionsManager.incorrectSmsOtpReceived(
+                            JourneyType.REAUTHENTICATION, context);
+
+            verify(authenticationAttemptsService)
+                    .createOrIncrementCount(
+                            eq("subject-123"),
+                            anyLong(),
+                            eq(JourneyType.REAUTHENTICATION),
+                            eq(CountType.ENTER_MFA_CODE));
+            assertTrue(result.isSuccess());
+        }
+    }
+
+    @Nested
+    class IncorrectAuthAppOtpReceived {
+
+        @Test
+        void shouldIncrementCount() {
+            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+            var result =
+                    userActionsManager.incorrectAuthAppOtpReceived(
+                            JourneyType.SIGN_IN, permissionContext);
+
+            verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldBlockWhenMaxRetriesReached() {
+            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+            var result =
+                    userActionsManager.incorrectAuthAppOtpReceived(
+                            JourneyType.SIGN_IN, permissionContext);
+
+            var expectedBlockedKey =
+                    CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                            + CodeRequestType.getCodeRequestType(
+                                    MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
+            verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldUseIncreasedMaxRetriesForRegistration() {
+            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL))
+                    .thenReturn(999998);
+
+            var result =
+                    userActionsManager.incorrectAuthAppOtpReceived(
+                            JourneyType.REGISTRATION, permissionContext);
+
+            verify(codeStorageService, never()).saveBlockedForEmail(any(), any(), anyLong());
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void shouldIncrementCountViaAuthAttemptsServiceForReauth() {
+            var context = PermissionContext.builder().withInternalSubjectId("subject-123").build();
+            when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(120L);
+
+            var result =
+                    userActionsManager.incorrectAuthAppOtpReceived(
+                            JourneyType.REAUTHENTICATION, context);
+
+            verify(authenticationAttemptsService)
+                    .createOrIncrementCount(
+                            eq("subject-123"),
+                            anyLong(),
+                            eq(JourneyType.REAUTHENTICATION),
+                            eq(CountType.ENTER_MFA_CODE));
             assertTrue(result.isSuccess());
         }
     }


### PR DESCRIPTION
## What

Apply the same pattern established in PR 1 to VerifyCodeHandler: replace inline lockout checks and count tracking with `PermissionDecisionManager` (pre-check) and `UserActionsManager` (action recording).

This is the last handler to be migrated. After this, all OTP lockout logic flows through the two manager classes. `ValidationHelper` is stripped down to pure code comparison.

### Things to note

- `AUTH_CODE_MAX_RETRIES_REACHED` audit event from VerifyCodeHandler still emits a hardcoded `loginFailureCount` of 0. This matches existing behaviour — the count was always reset before the block was recorded. Fixing this is deferred.
- `incorrectEmailOtpReceived` now sets a `CODE_BLOCKED` block for REGISTRATION where previously no block was set (count just reset). To complete the lockout cycle, `sentEmailOtpNotification` gains `deleteBlockForEmail` for REGISTRATION so that requesting a new code clears the verification block.
- `correctEmailOtpReceived` is intentionally a no-op — existing behaviour doesn't track correct email OTP received. For email OTP the lockout is reset when a new code is sent, not when a correct code is received.
- Email OTP REAUTHENTICATION is a no-op because email OTP is never sent with journeyType=REAUTHENTICATION. Even during a reauth flow, password reset uses PASSWORD_RESET as the journey type.

## How to review

Review commit-by-commit.

1. Code Review
2. Deploy to a dev environment
3. Test lockouts on email verification journeys (registration, account recovery, password reset) and SMS verification via VerifyCodeHandler

## Checklist

- [x] Deployment of this PR will not break active user journeys
- [x] Impact on orch and auth mutual dependencies has been checked
- [x] No changes required or changes have been made to stub-orchestration