### PR TITLE
AUT-4577: Unify send/verify permission checks and simplify callers

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -498,29 +498,17 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         }
 
         Decision canSendSmsOtpDecision = canSendSmsOtpResult.getSuccess();
-        if (canSendSmsOtpDecision instanceof Decision.TemporarilyLockedOut) {
+        if (canSendSmsOtpDecision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
+            if (temporarilyLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                LOG.info("User is blocked from entering any OTP codes");
+                return Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
+            }
             LOG.info("User is blocked from requesting any OTP codes");
             return Optional.of(ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS);
         } else if (canSendSmsOtpDecision instanceof Decision.IndefinitelyLockedOut) {
             LOG.info("User is indefinitely blocked from requesting OTP codes");
             return Optional.of(ErrorResponse.INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS);
         } else if (!(canSendSmsOtpDecision instanceof Decision.Permitted)) {
-            return Optional.of(ErrorResponse.UNHANDLED_NEGATIVE_DECISION);
-        }
-
-        var canVerifyMfaOtpResult =
-                permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
-        if (canVerifyMfaOtpResult.isFailure()) {
-            DecisionError failure = canVerifyMfaOtpResult.getFailure();
-            LOG.error("Failure to get canVerifyMfaOtp decision due to {}", failure);
-            return Optional.of(DecisionErrorMapper.toErrorResponse(failure));
-        }
-
-        Decision canVerifyMfaOtpDecision = canVerifyMfaOtpResult.getSuccess();
-        if (canVerifyMfaOtpDecision instanceof Decision.TemporarilyLockedOut) {
-            LOG.info("User is blocked from entering any OTP codes");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED);
-        } else if (!(canVerifyMfaOtpDecision instanceof Decision.Permitted)) {
             return Optional.of(ErrorResponse.UNHANDLED_NEGATIVE_DECISION);
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -350,42 +350,51 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         var canSendSmsResult =
                 permissionDecisionManager.canSendSmsOtpNotification(
                         journeyType, permissionContext, lockoutStateHolder);
+
         if (canSendSmsResult.isFailure()) {
             return Optional.of(
                     DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
                             canSendSmsResult.getFailure()));
         }
+
         if (canSendSmsResult.getSuccess() instanceof Decision.IndefinitelyLockedOut) {
             return Optional.of(
                     generateApiGatewayProxyErrorResponse(
                             400, INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS));
         }
-        if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut
-                || canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+
+        if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut reauthLockedOut) {
+            if (reauthLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                LOG.warn(
+                        "Unexpected ReauthLockedOut for verification from canSendSmsOtpNotification");
+                return Optional.of(
+                        generateApiGatewayProxyErrorResponse(
+                                500, ErrorResponse.INTERNAL_SERVER_ERROR));
+            }
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
             var errorResponse =
                     afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;
             return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
         }
 
-        var canVerifyResult =
-                permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext);
-        if (canVerifyResult.isFailure()) {
-            return Optional.of(
-                    DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
-                            canVerifyResult.getFailure()));
-        }
-        if (canVerifyResult.getSuccess() instanceof Decision.ReauthLockedOut) {
-            LOG.warn(
-                    "Unexpected ReauthLockedOut from canVerifyMfaOtp - "
-                            + "should have been checked in an earlier handler in the journey");
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
-        }
-        if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+        if (canSendSmsResult.getSuccess()
+                instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
             auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
+
+            ErrorResponse errorResponse;
+            if (temporarilyLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                errorResponse = TOO_MANY_INVALID_MFA_OTPS_ENTERED;
+            } else {
+                errorResponse =
+                        afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;
+            }
+            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+        }
+
+        if (!(canSendSmsResult.getSuccess() instanceof Decision.Permitted)) {
             return Optional.of(
-                    generateApiGatewayProxyErrorResponse(400, TOO_MANY_INVALID_MFA_OTPS_ENTERED));
+                    generateApiGatewayProxyErrorResponse(
+                            500, ErrorResponse.UNHANDLED_NEGATIVE_DECISION));
         }
 
         return Optional.empty();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.authentication.frontendapi.entity.PasswordResetType;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequest;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequestHandlerResponse;
+import uk.gov.di.authentication.frontendapi.errormapper.DecisionErrorHttpMapper;
 import uk.gov.di.authentication.frontendapi.exceptions.SerializationException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -40,7 +41,6 @@ import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSWORD_RESET_REQUESTED;
@@ -327,82 +327,38 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                 permissionDecisionManager.canSendEmailOtpNotification(
                         JourneyType.PASSWORD_RESET, permissionContext);
 
-        if (canSendResult.isSuccess()) {
-            var decision = canSendResult.getSuccess();
-            if (decision instanceof Decision.TemporarilyLockedOut lockedOut) {
-                var result = handleTemporarilyLockedOut(lockedOut, permissionContext);
-                if (result.isFailure()) {
-                    return result;
-                }
-            }
-        }
-
-        var userIsAlreadyLockedOutOfPasswordReset =
-                hasUserExceededMaxAllowedRequests(email, userContext);
-        if (userIsAlreadyLockedOutOfPasswordReset.isPresent()) {
+        if (canSendResult.isFailure()) {
             return Result.failure(
-                    generateApiGatewayProxyErrorResponse(
-                            400, userIsAlreadyLockedOutOfPasswordReset.get()));
+                    DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
+                            canSendResult.getFailure()));
         }
 
-        return Result.success(null);
-    }
-
-    private Result<APIGatewayProxyResponseEvent, Void> handleTemporarilyLockedOut(
-            Decision.TemporarilyLockedOut lockedOut, PermissionContext permissionContext) {
-        if (lockedOut.forbiddenReason()
-                == ForbiddenReason.EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT) {
-            userActionsManager.sentEmailOtpNotification(
-                    JourneyType.PASSWORD_RESET, permissionContext);
-            var errorResponse =
-                    lockedOut.isFirstTimeLimit()
-                            ? ErrorResponse.TOO_MANY_PW_RESET_REQUESTS
-                            : ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST;
-            return Result.failure(generateApiGatewayProxyErrorResponse(400, errorResponse));
-        }
-        return Result.success(null);
-    }
-
-    private Optional<ErrorResponse> hasUserExceededMaxAllowedRequests(
-            String email, UserContext userContext) {
-        LOG.info("Validating Password Reset Count");
-        var permissionContext =
-                PermissionContext.builder()
-                        .withInternalSubjectId(
-                                userContext.getAuthSession().getInternalCommonSubjectId())
-                        .withEmailAddress(email)
-                        .withAuthSessionItem(userContext.getAuthSession())
-                        .build();
-
-        var canSendResult =
-                permissionDecisionManager.canSendEmailOtpNotification(
-                        JourneyType.PASSWORD_RESET, permissionContext);
-
-        if (canSendResult.isSuccess()
-                && canSendResult.getSuccess() instanceof Decision.TemporarilyLockedOut lockedOut) {
-
-            if (lockedOut.forbiddenReason() == ForbiddenReason.BLOCKED_FOR_PW_RESET_REQUEST) {
-                LOG.info("Code is blocked for email as user has requested too many OTPs");
-                return Optional.of(ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST);
-            } else if (lockedOut.forbiddenReason()
+        if (canSendResult.getSuccess() instanceof Decision.TemporarilyLockedOut lockedOut) {
+            if (lockedOut.forbiddenReason()
                     == ForbiddenReason.EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT) {
-                return lockedOut.isFirstTimeLimit()
-                        ? Optional.of(ErrorResponse.TOO_MANY_PW_RESET_REQUESTS)
-                        : Optional.of(ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST);
+                userActionsManager.sentEmailOtpNotification(
+                        JourneyType.PASSWORD_RESET, permissionContext);
+                var errorResponse =
+                        lockedOut.isFirstTimeLimit()
+                                ? ErrorResponse.TOO_MANY_PW_RESET_REQUESTS
+                                : ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST;
+                return Result.failure(generateApiGatewayProxyErrorResponse(400, errorResponse));
+            } else if (lockedOut.forbiddenReason()
+                    == ForbiddenReason.BLOCKED_FOR_PW_RESET_REQUEST) {
+                LOG.info("Code is blocked for email as user has requested too many OTPs");
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                400, ErrorResponse.BLOCKED_FOR_PW_RESET_REQUEST));
+            } else if (lockedOut.forbiddenReason()
+                    == ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT) {
+                LOG.info("Code is blocked for email as user has entered too many invalid OTPs");
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                400, ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED));
             }
         }
 
-        var canVerifyResult =
-                permissionDecisionManager.canVerifyEmailOtp(
-                        JourneyType.PASSWORD_RESET, permissionContext);
-
-        if (canVerifyResult.isSuccess()
-                && canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
-            LOG.info("Code is blocked for email as user has entered too many invalid OTPs");
-            return Optional.of(ErrorResponse.TOO_MANY_INVALID_PW_RESET_CODES_ENTERED);
-        }
-
-        return Optional.empty();
+        return Result.success(null);
     }
 
     private String serialiseNotifyRequest(Object request) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -485,38 +485,21 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                             400, INDEFINITELY_BLOCKED_SENDING_INT_NUMBERS_SMS));
         }
 
-        boolean isTemporarilyLockedOutOfSendingNotification =
-                canSendResult.getSuccess() instanceof Decision.TemporarilyLockedOut;
-        if (isTemporarilyLockedOutOfSendingNotification) {
+        if (canSendResult.getSuccess()
+                instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
             auditService.submitAuditEvent(
                     getInvalidCodeAuditEventFromNotificationType(notificationType), auditContext);
-            var errorResponse =
-                    afterActionRecorded
-                            ? getErrorResponseForCodeRequestLimitReached(notificationType)
-                            : getErrorResponseForMaxCodeRequests(notificationType);
+
+            ErrorResponse errorResponse;
+            if (temporarilyLockedOut.forbiddenReason().hasExceededOtpSubmissionLimit()) {
+                errorResponse = getErrorResponseForMaxCodeAttempts(notificationType);
+            } else {
+                errorResponse =
+                        afterActionRecorded
+                                ? getErrorResponseForCodeRequestLimitReached(notificationType)
+                                : getErrorResponseForMaxCodeRequests(notificationType);
+            }
             return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
-        }
-
-        Result<DecisionError, Decision> canVerifyResult =
-                notificationType.isForPhoneNumber()
-                        ? permissionDecisionManager.canVerifyMfaOtp(journeyType, permissionContext)
-                        : permissionDecisionManager.canVerifyEmailOtp(
-                                journeyType, permissionContext);
-
-        if (canVerifyResult.isFailure()) {
-            return Optional.of(
-                    DecisionErrorHttpMapper.toApiGatewayProxyErrorResponse(
-                            canVerifyResult.getFailure()));
-        }
-
-        boolean isTemporarilyLockedOutOfVerifyingOtp =
-                canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut;
-        if (isTemporarilyLockedOutOfVerifyingOtp) {
-            auditService.submitAuditEvent(
-                    getInvalidCodeAuditEventFromNotificationType(notificationType), auditContext);
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(
-                            400, getErrorResponseForMaxCodeAttempts(notificationType)));
         }
 
         return Optional.empty();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -214,15 +214,16 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         .withRpPairwiseId(maybeRpPairwiseId.orElse(null))
                         .build();
 
-        var maybeResponseIfNotPermitted =
-                getResponseIfNotPermitted(
+        var permissionCheck =
+                checkPermission(
                         journeyType,
                         codeRequest.getMfaMethodType(),
                         permissionContext,
                         auditContext,
                         maybeRpPairwiseId);
-        if (maybeResponseIfNotPermitted.isPresent()) {
-            return maybeResponseIfNotPermitted.get();
+        var permissionError = permissionCheck.errorResponse();
+        if (permissionError.isPresent()) {
+            return permissionError.get();
         }
 
         try {
@@ -261,7 +262,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         return userProfile == null && journeyType == REAUTHENTICATION;
     }
 
-    private Optional<APIGatewayProxyResponseEvent> getResponseIfNotPermitted(
+    private record PermissionCheckResult(
+            Optional<APIGatewayProxyResponseEvent> errorResponse, int attemptCount) {}
+
+    private PermissionCheckResult checkPermission(
             JourneyType journeyType,
             MFAMethodType mfaMethodType,
             PermissionContext permissionContext,
@@ -274,8 +278,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             LOG.error(
                     "Failed to check MFA OTP verification permission: {}",
                     canVerifyOtpResult.getFailure());
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    500, ErrorResponse.INTERNAL_SERVER_ERROR)),
+                    0);
         }
 
         var decision = canVerifyOtpResult.getSuccess();
@@ -300,9 +307,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                             FAILURE_REASON.getValue(),
                             reauthFailureReason.getValue()));
 
-            return Optional.of(
-                    generateApiGatewayProxyErrorResponse(
-                            400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            return new PermissionCheckResult(
+                    Optional.of(
+                            generateApiGatewayProxyErrorResponse(
+                                    400, ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS)),
+                    reauthLockedOut.attemptCount());
         }
 
         if (decision instanceof Decision.TemporarilyLockedOut temporarilyLockedOut) {
@@ -321,10 +330,16 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     mfaMethodType == MFAMethodType.AUTH_APP
                             ? ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED
                             : ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED;
-            return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
+            return new PermissionCheckResult(
+                    Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse)),
+                    temporarilyLockedOut.attemptCount());
         }
 
-        return Optional.empty();
+        if (decision instanceof Decision.Permitted permitted) {
+            return new PermissionCheckResult(Optional.empty(), permitted.attemptCount());
+        }
+
+        return new PermissionCheckResult(Optional.empty(), 0);
     }
 
     private APIGatewayProxyResponseEvent verifyCode(
@@ -428,21 +443,27 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
 
             var permissionCheckAfterIncrement =
-                    getResponseIfNotPermitted(
+                    checkPermission(
                             codeRequest.getJourneyType(),
                             codeRequest.getMfaMethodType(),
                             permissionContext,
                             auditContext,
                             maybeRpPairwiseId);
-            if (permissionCheckAfterIncrement.isPresent()) {
-                return permissionCheckAfterIncrement.get();
+            var permissionErrorAfterIncrement = permissionCheckAfterIncrement.errorResponse();
+            if (permissionErrorAfterIncrement.isPresent()) {
+                return permissionErrorAfterIncrement.get();
             }
 
-            auditFailure(codeRequest, errorResponse, authSession, auditContext, activeMfaMethod);
+            auditFailure(
+                    codeRequest,
+                    errorResponse,
+                    auditContext,
+                    activeMfaMethod,
+                    permissionCheckAfterIncrement.attemptCount());
         } else {
-            auditSuccess(codeRequest, authSession, auditContext, activeMfaMethod);
+            auditSuccess(codeRequest, auditContext, activeMfaMethod);
 
-            var maybeError =
+            var successProcessingErrorResponse =
                     processSuccessfulCodeSession(
                             userContext.getAuthSession(),
                             input,
@@ -450,8 +471,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                             mfaCodeProcessor,
                             userProfile,
                             permissionContext);
-            if (maybeError.isPresent()) {
-                return maybeError.get();
+            if (successProcessingErrorResponse.isPresent()) {
+                return successProcessingErrorResponse.get();
             }
         }
 
@@ -472,31 +493,22 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     private void auditSuccess(
             VerifyMfaCodeRequest codeRequest,
-            AuthSessionItem authSession,
             AuditContext auditContext,
             Optional<MFAMethod> activeMfaMethod) {
         var metadataPairs =
-                metadataPairsForEvent(
-                        AUTH_CODE_VERIFIED,
-                        authSession.getEmailAddress(),
-                        codeRequest,
-                        activeMfaMethod);
+                metadataPairsForEvent(AUTH_CODE_VERIFIED, codeRequest, activeMfaMethod, 0);
         auditService.submitAuditEvent(AUTH_CODE_VERIFIED, auditContext, metadataPairs);
     }
 
     private void auditFailure(
             VerifyMfaCodeRequest codeRequest,
             ErrorResponse errorResponse,
-            AuthSessionItem authSession,
             AuditContext auditContext,
-            Optional<MFAMethod> activeMfaMethod) {
+            Optional<MFAMethod> activeMfaMethod,
+            int failureCount) {
         var auditableEvent = errorResponseAsFrontendAuditableEvent(errorResponse);
         var metadataPairs =
-                metadataPairsForEvent(
-                        auditableEvent,
-                        authSession.getEmailAddress(),
-                        codeRequest,
-                        activeMfaMethod);
+                metadataPairsForEvent(auditableEvent, codeRequest, activeMfaMethod, failureCount);
         auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairs);
     }
 
@@ -600,6 +612,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         }
 
         LOG.info("Setting hasVerifiedMfa to true");
+
         if (codeRequest.getMfaMethodType() == MFAMethodType.SMS) {
             var result =
                     userActionsManager.correctSmsOtpReceived(
@@ -643,9 +656,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     private AuditService.MetadataPair[] metadataPairsForEvent(
             FrontendAuditableEvent auditableEvent,
-            String email,
             VerifyMfaCodeRequest codeRequest,
-            Optional<MFAMethod> activeMfaMethod) {
+            Optional<MFAMethod> activeMfaMethod,
+            int failureCount) {
         var methodType = codeRequest.getMfaMethodType();
         var metadataPairs = new ArrayList<AuditService.MetadataPair>();
         metadataPairs.add(pair("mfa-type", methodType.getValue()));
@@ -657,10 +670,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         switch (auditableEvent) {
             case AUTH_CODE_MAX_RETRIES_REACHED -> {
-                metadataPairs.add(
-                        pair(
-                                AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT,
-                                configurationService.getCodeMaxRetries()));
+                metadataPairs.add(pair(AUDIT_EVENT_EXTENSIONS_ATTEMPT_NO_FAILED_AT, failureCount));
 
                 getPriorityIdentifier(codeRequest, activeMfaMethod)
                         .ifPresent(
@@ -672,7 +682,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             }
             case AUTH_INVALID_CODE_SENT, AUTH_CODE_VERIFIED -> {
                 if (auditableEvent.equals(AUTH_INVALID_CODE_SENT)) {
-                    var failureCount = codeStorageService.getIncorrectMfaCodeAttemptsCount(email);
                     metadataPairs.add(pair("loginFailureCount", failureCount));
                 }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -6,7 +6,6 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PhoneNumberRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -110,8 +109,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                                 .contains(journeyType)
                         ? NotificationType.MFA_SMS
                         : NotificationType.VERIFY_PHONE_NUMBER;
-
-        var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
 
         boolean isTestClient = testUserHelper.isTestJourney(userContext);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -215,8 +215,6 @@ class LoginHandlerTest {
                 .thenReturn(Result.success(new Decision.Permitted(0)));
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
         handler =
                 new LoginHandler(
                         configurationService,
@@ -1265,8 +1263,6 @@ class LoginHandlerTest {
 
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -1274,7 +1270,6 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(200));
 
         verify(permissionDecisionManager).canSendSmsOtpNotification(any(), any());
-        verify(permissionDecisionManager).canVerifyMfaOtp(any(), any());
     }
 
     @ParameterizedTest
@@ -1292,7 +1287,6 @@ class LoginHandlerTest {
         assertThat(result, hasStatus(200));
 
         verify(permissionDecisionManager, never()).canSendSmsOtpNotification(any(), any());
-        verify(permissionDecisionManager, never()).canVerifyMfaOtp(any(), any());
     }
 
     private static Stream<Arguments> validMfaMethodsWithExpectedBlock() {
@@ -1333,21 +1327,13 @@ class LoginHandlerTest {
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
 
-        if (expectedError == ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS) {
-            when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.TemporarilyLockedOut(null, 0, null, false)));
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(0)));
-        } else {
-            when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(0)));
-            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(
-                            Result.success(
-                                    new Decision.TemporarilyLockedOut(null, 0, null, false)));
-        }
+        ForbiddenReason reason =
+                expectedError == ErrorResponse.BLOCKED_FOR_SENDING_MFA_OTPS
+                        ? ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT
+                        : ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any()))
+                .thenReturn(
+                        Result.success(new Decision.TemporarilyLockedOut(reason, 0, null, false)));
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -1370,8 +1356,6 @@ class LoginHandlerTest {
                                 new Decision.IndefinitelyLockedOut(
                                         ForbiddenReason.EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
                                         10)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -212,8 +212,6 @@ class MfaHandlerTest {
 
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActionsManager.sentSmsOtpNotification(any(), any(), any()))
                 .thenReturn(Result.success(null));
 
@@ -792,7 +790,7 @@ class MfaHandlerTest {
             JourneyType journeyType, boolean reauthEnabled) {
         usingValidSession();
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(reauthEnabled);
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new Decision.TemporarilyLockedOut(
@@ -930,26 +928,10 @@ class MfaHandlerTest {
     }
 
     @Test
-    void shouldReturn500WhenCanVerifyMfaOtpReturnsError() {
+    void shouldReturn500WhenCanSendSmsOtpNotificationReturnsReauthLockedOut() {
         usingValidSession();
 
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
-
-        var body = format("{ \"email\": \"%s\"}", EMAIL);
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(500));
-        verify(sqsClient, never()).send(any());
-    }
-
-    @Test
-    void shouldReturn500WhenCanVerifyMfaOtpReturnsReauthLockedOut() {
-        usingValidSession();
-
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+        when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(
                         Result.success(
                                 new Decision.ReauthLockedOut(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
+import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
 
 import java.time.Instant;
@@ -164,8 +165,6 @@ class ResetPasswordRequestHandlerTest {
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(6);
         when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
         when(userActionsManager.sentEmailOtpNotification(any(), any()))
                 .thenReturn(Result.success(null));
@@ -469,7 +468,7 @@ class ResetPasswordRequestHandlerTest {
         @Test
         void shouldReturn400IfUserIsBlockedFromEnteringAnyMoreInvalidPasswordResetsOTPs() {
             usingSessionWithPasswordResetCount(0);
-            when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
+            when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
                     .thenReturn(
                             Result.success(
                                     new Decision.TemporarilyLockedOut(
@@ -490,9 +489,7 @@ class ResetPasswordRequestHandlerTest {
         void shouldReturn400IfUserIsNewlyBlockedFromEnteringAnyMoreInvalidPasswordResetsOTPs() {
             when(configurationService.getCodeMaxRetries()).thenReturn(6);
             usingSessionWithPasswordResetCount(5);
-            // First call returns permitted, second call (after increment) returns locked out
             when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(5)))
                     .thenReturn(
                             Result.success(
                                     new Decision.TemporarilyLockedOut(
@@ -501,13 +498,23 @@ class ResetPasswordRequestHandlerTest {
                                             6,
                                             Instant.now(),
                                             true)));
-            when(permissionDecisionManager.canVerifyEmailOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(0)));
 
             var result = handler.handleRequest(validEvent, context);
 
             assertEquals(400, result.getStatusCode());
             assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PW_RESET_REQUESTS));
+            verifyNoInteractions(awsSqsClient);
+        }
+
+        @Test
+        void shouldReturn500IfPermissionCheckFails() {
+            usingSessionWithPasswordResetCount(0);
+            when(permissionDecisionManager.canSendEmailOtpNotification(any(), any()))
+                    .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+            var result = handler.handleRequest(validEvent, context);
+
+            assertEquals(500, result.getStatusCode());
             verifyNoInteractions(awsSqsClient);
         }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -1328,18 +1328,8 @@ class SendNotificationHandlerTest {
             }
 
             @Test
-            void shouldReturn400IfUserIsBlockedFromEnteringRegistrationEmailOtpCodes() {
+            void shouldAllowRegistrationEmailOtpRequestEvenWhenVerificationBlockExists() {
                 usingValidSession();
-                when(permissionDecisionManager.canVerifyEmailOtp(
-                                eq(REGISTRATION), any(PermissionContext.class)))
-                        .thenReturn(
-                                Result.success(
-                                        new Decision.TemporarilyLockedOut(
-                                                ForbiddenReason
-                                                        .EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
-                                                6,
-                                                Instant.now(),
-                                                false)));
 
                 var body =
                         format(
@@ -1349,17 +1339,13 @@ class SendNotificationHandlerTest {
 
                 var result = handler.handleRequest(event, context);
 
-                assertEquals(400, result.getStatusCode());
-                assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_EMAIL_CODES_ENTERED));
-                verifyNoInteractions(emailSqsClient);
-                verify(auditService)
-                        .submitAuditEvent(AUTH_EMAIL_INVALID_CODE_REQUEST, auditContext);
+                assertEquals(204, result.getStatusCode());
             }
 
             @Test
             void shouldReturn400IfUserIsBlockedFromEnteringAccountRecoveryEmailOtpCodes() {
                 usingValidSession();
-                when(permissionDecisionManager.canVerifyEmailOtp(
+                when(permissionDecisionManager.canSendEmailOtpNotification(
                                 eq(JourneyType.ACCOUNT_RECOVERY), any(PermissionContext.class)))
                         .thenReturn(
                                 Result.success(
@@ -1392,7 +1378,7 @@ class SendNotificationHandlerTest {
 
             @Test
             void shouldReturn400IfUserIsBlockedFromEnteringPhoneOtpCodes() {
-                when(permissionDecisionManager.canVerifyMfaOtp(
+                when(permissionDecisionManager.canSendSmsOtpNotification(
                                 eq(REGISTRATION), any(PermissionContext.class)))
                         .thenReturn(
                                 Result.success(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
-import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -52,6 +51,7 @@ import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.DecisionError;
 import uk.gov.di.authentication.userpermissions.entity.ForbiddenReason;
+import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 
 import java.time.Instant;
@@ -93,6 +93,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.MFA_RESET_TYPE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_COMPLETED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.FORCED_MFA_RESET_INITIATED;
+import static uk.gov.di.authentication.shared.entity.CountType.ENTER_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REAUTHENTICATION;
@@ -100,7 +101,6 @@ import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
@@ -135,6 +135,9 @@ class VerifyMfaCodeHandlerTest {
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final String TEST_SUBJECT_ID = "test-subject-id";
     private static final int MAX_RETRIES = 6;
+    private final String expectedRpPairwiseSubjectId =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
 
     private final AuthSessionItem authSession =
             new AuthSessionItem()
@@ -192,24 +195,20 @@ class VerifyMfaCodeHandlerTest {
 
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
         when(configurationService.getEnvironment()).thenReturn("test");
-        when(configurationService.getLockoutDuration()).thenReturn(900L);
-        when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
-                .thenReturn(Result.success(null));
-        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
-                .thenReturn(Result.success(null));
         when(userActionsManager.correctSmsOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
         when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
                 .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
+        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                .thenReturn(Result.success(new Decision.Permitted(0)));
 
         handler =
                 new VerifyMfaCodeHandler(
@@ -258,9 +257,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -335,9 +331,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -380,9 +373,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -424,9 +414,6 @@ class VerifyMfaCodeHandlerTest {
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
             verify(authAppCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -486,9 +473,6 @@ class VerifyMfaCodeHandlerTest {
             assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
             verify(phoneNumberCodeProcessor)
                     .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
@@ -554,9 +538,6 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(204));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_VERIFIED,
                     pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
@@ -890,6 +871,69 @@ class VerifyMfaCodeHandlerTest {
             verifyNoInteractions(cloudwatchMetricsService);
         }
 
+        @ParameterizedTest
+        @EnumSource(JourneyType.class)
+        void shouldReturn400WhenUserEnteredInvalidAuthAppOtpCode(JourneyType journeyType)
+                throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            var profileInformation =
+                    List.of(JourneyType.SIGN_IN, JourneyType.PASSWORD_RESET_MFA, REAUTHENTICATION)
+                                    .contains(journeyType)
+                            ? null
+                            : AUTH_APP_SECRET;
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(3)));
+
+            if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
+                when(mfaMethodsService.getMfaMethods(EMAIL))
+                        .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            }
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, journeyType, profileInformation);
+            if (!CodeRequestType.isValidCodeRequestType(
+                    CodeRequestType.SupportedCodeType.getFromMfaMethodType(
+                            codeRequest.getMfaMethodType()),
+                    codeRequest.getJourneyType())) {
+                return;
+            }
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
+            verifyNoInteractions(cloudwatchMetricsService);
+
+            ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
+                    ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_INVALID_CODE_SENT),
+                            eq(AUDIT_CONTEXT),
+                            metadataCaptor.capture());
+
+            boolean accountRecovery = journeyType.equals(ACCOUNT_RECOVERY);
+
+            List<AuditService.MetadataPair> expected =
+                    List.of(
+                            pair("MFACodeEntered", CODE),
+                            pair("account-recovery", accountRecovery),
+                            pair("journey-type", journeyType),
+                            pair("loginFailureCount", 3),
+                            pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
+                            pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
+
+            List<AuditService.MetadataPair> actual = Arrays.asList(metadataCaptor.getValue());
+
+            assertTrue(expected.containsAll(actual));
+            assertTrue(actual.containsAll(expected));
+        }
+
         private static Stream<Arguments> invalidOtpSmsJourneyTypesWithMfaNotificationType() {
             return Stream.of(
                     Arguments.of(JourneyType.SIGN_IN, MFA_SMS.name()),
@@ -908,9 +952,8 @@ class VerifyMfaCodeHandlerTest {
                     .thenReturn(Optional.of(phoneNumberCodeProcessor));
             when(phoneNumberCodeProcessor.validateCode())
                     .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-            when(codeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(3);
             when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                    .thenReturn(Result.success(new Decision.Permitted(6)));
+                    .thenReturn(Result.success(new Decision.Permitted(3)));
 
             if (!List.of(ACCOUNT_RECOVERY, REGISTRATION).contains(journeyType)) {
                 when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -936,9 +979,6 @@ class VerifyMfaCodeHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
             assertThat(authSession.getVerifiedMfaMethodType(), equalTo(null));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
@@ -997,72 +1037,9 @@ class VerifyMfaCodeHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_AUTH_APP_SECRET));
-            verify(codeStorageService, never())
-                    .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(auditService);
             verifyNoInteractions(cloudwatchMetricsService);
         }
-    }
-
-    @Test
-    void shouldReturn400WhenReauthLockedOutViaPermissionDecisionManager()
-            throws Json.JsonException {
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(
-                        Result.success(
-                                new Decision.ReauthLockedOut(
-                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
-                                        5,
-                                        null,
-                                        false,
-                                        Map.of(),
-                                        List.of())));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null);
-        var result = makeCallWithCode(codeRequest);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
-    }
-
-    @Test
-    void shouldReturn400WithAuthAppErrorWhenTemporarilyLockedOut() throws Json.JsonException {
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(
-                        Result.success(new Decision.TemporarilyLockedOut(null, 5, null, false)));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
-        var result = makeCallWithCode(codeRequest);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-    }
-
-    @Test
-    void shouldReturn400WithSmsErrorWhenTemporarilyLockedOut() throws Json.JsonException {
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(
-                        Result.success(new Decision.TemporarilyLockedOut(null, 5, null, false)));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        CODE,
-                        JourneyType.SIGN_IN,
-                        DEFAULT_SMS_METHOD.getDestination());
-        var result = makeCallWithCode(codeRequest);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
     }
 
     private APIGatewayProxyResponseEvent makeCallWithCode(CodeRequest mfaCodeRequest)
@@ -1151,9 +1128,6 @@ class VerifyMfaCodeHandlerTest {
         assertEquals(MEDIUM_LEVEL, authSession.getAchievedCredentialStrength());
         verify(phoneNumberCodeProcessor)
                 .processSuccessfulCodeRequest(anyString(), anyString(), eq(userProfile));
-        verify(codeStorageService, never())
-                .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
         boolean isAccountRecoveryJourney = journeyType.equals(ACCOUNT_RECOVERY);
 
@@ -1175,6 +1149,8 @@ class VerifyMfaCodeHandlerTest {
         when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var codeRequest =
@@ -1194,11 +1170,40 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Test
+    void shouldReturn500WhenCorrectSmsOtpReceivedReturnsInvalidUserContext()
+            throws Json.JsonException {
+        // Arrange
+        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                .thenReturn(Optional.of(phoneNumberCodeProcessor));
+        when(phoneNumberCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+        when(userActionsManager.correctSmsOtpReceived(any(), any()))
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+        authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
+
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS,
+                        CODE,
+                        JourneyType.SIGN_IN,
+                        DEFAULT_SMS_METHOD.getDestination());
+
+        // Act
+        var result = makeCallWithCode(codeRequest);
+
+        // Assert
+        assertThat(result, hasStatus(500));
+    }
+
+    @Test
     void shouldCallCorrectAuthAppOtpReceivedWhenAuthAppCodeIsValid() throws Json.JsonException {
         // Arrange
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
+        when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
+                .thenReturn(Result.success(null));
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var codeRequest =
@@ -1215,259 +1220,365 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Test
-    void shouldReturn500WhenPermissionDecisionManagerFails() throws Json.JsonException {
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, "123456", JourneyType.SIGN_IN, null));
-
-        assertThat(result, hasStatus(500));
-    }
-
-    @Test
-    void shouldReturn500WhenIncorrectOtpTrackingFails() throws Json.JsonException {
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, "123456", JourneyType.SIGN_IN, null));
-
-        assertThat(result, hasStatus(500));
-    }
-
-    @Test
-    void shouldReturn500WhenCorrectSmsOtpTrackingFails() throws Json.JsonException {
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
-        when(userActionsManager.correctSmsOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, "123456", JourneyType.SIGN_IN, null));
-
-        assertThat(result, hasStatus(500));
-    }
-
-    @Test
-    void shouldReturn500WhenCorrectAuthAppOtpTrackingFails() throws Json.JsonException {
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(0)));
+    void shouldReturn500WhenCorrectAuthAppOtpReceivedReturnsInvalidUserContext()
+            throws Json.JsonException {
+        // Arrange
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
         when(userActionsManager.correctAuthAppOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, "123456", JourneyType.SIGN_IN, null));
-
-        assertThat(result, hasStatus(500));
-    }
-
-    @Test
-    void shouldCallIncorrectSmsOtpReceivedWhenSmsCodeIsInvalid() throws Json.JsonException {
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(phoneNumberCodeProcessor));
-        when(phoneNumberCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+                .thenReturn(Result.failure(TrackingError.INVALID_USER_CONTEXT));
+        authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var codeRequest =
                 new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        CODE,
-                        JourneyType.SIGN_IN,
-                        DEFAULT_SMS_METHOD.getDestination());
+                        MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, AUTH_APP_SECRET);
 
-        makeCallWithCode(codeRequest);
-
-        verify(userActionsManager).incorrectSmsOtpReceived(eq(JourneyType.SIGN_IN), any());
-    }
-
-    @Test
-    void shouldCallIncorrectAuthAppOtpReceivedWhenAuthAppCodeIsInvalid() throws Json.JsonException {
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
-
-        makeCallWithCode(codeRequest);
-
-        verify(userActionsManager).incorrectAuthAppOtpReceived(eq(JourneyType.SIGN_IN), any());
-    }
-
-    @Test
-    void shouldReturn400WithLockoutErrorWhenAuthAppCodeBecomesBlockedByThisRequest()
-            throws Json.JsonException {
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-        // First check passes (not blocked), second check after increment returns blocked
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(5)))
-                .thenReturn(
-                        Result.success(
-                                new Decision.TemporarilyLockedOut(
-                                        null, MAX_RETRIES, Instant.now(), false)));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
-        verify(auditService)
-                .submitAuditEvent(
-                        eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
-                        any(AuditContext.class),
-                        any(AuditService.MetadataPair[].class));
-    }
-
-    @Test
-    void shouldReturn400WithLockoutErrorWhenSmsCodeBecomesBlockedByThisRequest()
-            throws Json.JsonException {
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(phoneNumberCodeProcessor));
-        when(phoneNumberCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        // First check passes (not blocked), second check after increment returns blocked
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(5)))
-                .thenReturn(
-                        Result.success(
-                                new Decision.TemporarilyLockedOut(
-                                        null, MAX_RETRIES, Instant.now(), false)));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS,
-                                CODE,
-                                JourneyType.SIGN_IN,
-                                DEFAULT_SMS_METHOD.getDestination()));
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
-        verify(auditService)
-                .submitAuditEvent(
-                        eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
-                        any(AuditContext.class),
-                        any(AuditService.MetadataPair[].class));
-    }
-
-    @Test
-    void shouldReturn400WithReauthLockedOutWhenAuthAppCodeBecomesReauthBlockedByThisRequest()
-            throws Json.JsonException {
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-        var detailedCounts = Map.of(CountType.ENTER_MFA_CODE, MAX_RETRIES);
-        when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
-                .thenReturn(Result.success(new Decision.Permitted(5)))
-                .thenReturn(
-                        Result.success(
-                                new Decision.ReauthLockedOut(
-                                        ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
-                                        MAX_RETRIES,
-                                        Instant.now(),
-                                        false,
-                                        detailedCounts,
-                                        List.of(CountType.ENTER_MFA_CODE))));
-
-        var result =
-                makeCallWithCode(
-                        new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
-        verify(userActionsManager).incorrectAuthAppOtpReceived(any(), any());
-        verify(auditService)
-                .submitAuditEvent(
-                        eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
-                        any(AuditContext.class),
-                        any(AuditService.MetadataPair[].class));
-        verify(cloudwatchMetricsService)
-                .incrementCounter(eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
-    }
-
-    @Test
-    void shouldReturn500WhenIncorrectSmsOtpReceivedFails() throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(phoneNumberCodeProcessor));
-        when(phoneNumberCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
-
-        var codeRequest =
-                new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS,
-                        CODE,
-                        JourneyType.SIGN_IN,
-                        DEFAULT_SMS_METHOD.getDestination());
-
+        // Act
         var result = makeCallWithCode(codeRequest);
 
+        // Assert
         assertThat(result, hasStatus(500));
     }
 
-    @Test
-    void shouldReturn500WhenIncorrectAuthAppOtpReceivedFails() throws Json.JsonException {
-        when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
-                .thenReturn(Optional.of(authAppCodeProcessor));
-        when(authAppCodeProcessor.validateCode())
-                .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
-        when(mfaMethodsService.getMfaMethods(EMAIL))
-                .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
-        when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
-                .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+    @Nested
+    class PermissionHandling {
 
-        var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+        @Test
+        void shouldReturn400WithAuthAppErrorWhenTemporarilyLockedOut() throws Json.JsonException {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
 
-        var result = makeCallWithCode(codeRequest);
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
 
-        assertThat(result, hasStatus(500));
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        @Test
+        void shouldReturn400WithSmsErrorWhenTemporarilyLockedOut() throws Json.JsonException {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.SMS, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        @Test
+        void shouldReturn400WhenReauthLockedOut() throws Json.JsonException {
+            var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            ForbiddenReason
+                                                    .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                            MAX_RETRIES,
+                                            Instant.now(),
+                                            false,
+                                            detailedCounts,
+                                            List.of(ENTER_MFA_CODE))));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        @Test
+        void shouldReturn500WhenPermissionDecisionManagerFails() throws Json.JsonException {
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.failure(DecisionError.STORAGE_SERVICE_ERROR));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(500));
+            assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+            verifyNoInteractions(mfaCodeProcessorFactory);
+        }
+
+        private boolean hasExpectedPermissionContext(PermissionContext pc) {
+            return EMAIL.equals(pc.emailAddress())
+                    && SUBJECT_ID.equals(pc.internalSubjectId())
+                    && expectedRpPairwiseSubjectId.equals(pc.rpPairwiseId());
+        }
+
+        @Test
+        void shouldCallIncorrectSmsOtpReceivedWhenSmsCodeIsInvalid() throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS,
+                            CODE,
+                            JourneyType.SIGN_IN,
+                            DEFAULT_SMS_METHOD.getDestination());
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            verify(userActionsManager)
+                    .incorrectSmsOtpReceived(
+                            eq(JourneyType.SIGN_IN), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldCallIncorrectSmsOtpReceivedWithSubjectIdForReauth() throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS,
+                            CODE,
+                            REAUTHENTICATION,
+                            DEFAULT_SMS_METHOD.getDestination());
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            verify(userActionsManager)
+                    .incorrectSmsOtpReceived(
+                            eq(REAUTHENTICATION), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldCallIncorrectAuthAppOtpReceivedWhenAuthAppCodeIsInvalid()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(400));
+            verify(userActionsManager)
+                    .incorrectAuthAppOtpReceived(
+                            eq(JourneyType.SIGN_IN), argThat(this::hasExpectedPermissionContext));
+        }
+
+        @Test
+        void shouldReturn400WithLockoutErrorWhenAuthAppCodeBecomesBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            // First check passes (not blocked), second check after increment returns blocked
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_AUTH_APP_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+        }
+
+        @Test
+        void shouldReturn400WithLockoutErrorWhenSmsCodeBecomesBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            // First check passes (not blocked), second check after increment returns blocked
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.TemporarilyLockedOut(
+                                            null, MAX_RETRIES, Instant.now(), false)));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.SMS,
+                                    CODE,
+                                    JourneyType.SIGN_IN,
+                                    DEFAULT_SMS_METHOD.getDestination()));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_PHONE_CODES_ENTERED));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+        }
+
+        @Test
+        void shouldReturn400WithReauthLockedOutWhenAuthAppCodeBecomesReauthBlockedByThisRequest()
+                throws Json.JsonException {
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT);
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.success(null));
+            var detailedCounts = Map.of(ENTER_MFA_CODE, MAX_RETRIES);
+            when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
+                    .thenReturn(Result.success(new Decision.Permitted(5)))
+                    .thenReturn(
+                            Result.success(
+                                    new Decision.ReauthLockedOut(
+                                            ForbiddenReason
+                                                    .EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                                            MAX_RETRIES,
+                                            Instant.now(),
+                                            false,
+                                            detailedCounts,
+                                            List.of(ENTER_MFA_CODE))));
+
+            var result =
+                    makeCallWithCode(
+                            new VerifyMfaCodeRequest(
+                                    MFAMethodType.AUTH_APP, CODE, REAUTHENTICATION, null));
+
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_REAUTH_ATTEMPTS));
+            verify(userActionsManager).incorrectAuthAppOtpReceived(any(), any());
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(FrontendAuditableEvent.AUTH_REAUTH_FAILED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
+        }
+
+        @Test
+        void shouldReturn500WhenIncorrectSmsOtpReceivedFails() throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(phoneNumberCodeProcessor));
+            when(phoneNumberCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_PHONE_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
+            when(userActionsManager.incorrectSmsOtpReceived(any(), any()))
+                    .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.SMS,
+                            CODE,
+                            JourneyType.SIGN_IN,
+                            DEFAULT_SMS_METHOD.getDestination());
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(500));
+        }
+
+        @Test
+        void shouldReturn500WhenIncorrectAuthAppOtpReceivedFails() throws Json.JsonException {
+            when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
+                    .thenReturn(Optional.of(authAppCodeProcessor));
+            when(authAppCodeProcessor.validateCode())
+                    .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
+            when(mfaMethodsService.getMfaMethods(EMAIL))
+                    .thenReturn(Result.success(List.of(DEFAULT_AUTH_APP_METHOD)));
+            when(userActionsManager.incorrectAuthAppOtpReceived(any(), any()))
+                    .thenReturn(Result.failure(TrackingError.STORAGE_SERVICE_ERROR));
+
+            var codeRequest =
+                    new VerifyMfaCodeRequest(
+                            MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, null);
+
+            var result = makeCallWithCode(codeRequest);
+
+            assertThat(result, hasStatus(500));
+        }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -56,7 +55,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_AUTH_APP_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.BACKUP_SMS_METHOD;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
@@ -84,7 +82,6 @@ class AuthAppCodeProcessorTest {
     private static final String IP_ADDRESS = "123.123.123.123";
     private static final String INTERNAL_SUB_ID = "urn:fdc:gov.uk:2022:" + IdGenerator.generate();
     private static final String TXMA_ENCODED_HEADER_VALUE = "txma-test-value";
-    private final int MAX_RETRIES = 5;
 
     private final AuditContext auditContext =
             new AuditContext(
@@ -124,15 +121,10 @@ class AuthAppCodeProcessorTest {
 
     private static Stream<Arguments> validatorParams() {
         return Stream.of(
-                Arguments.of(JourneyType.SIGN_IN, null, CodeRequestType.MFA_SIGN_IN),
-                Arguments.of(
-                        JourneyType.PASSWORD_RESET_MFA, null, CodeRequestType.MFA_PW_RESET_MFA),
-                Arguments.of(
-                        JourneyType.REGISTRATION,
-                        AUTH_APP_SECRET,
-                        CodeRequestType.MFA_REGISTRATION),
-                Arguments.of(
-                        JourneyType.REAUTHENTICATION, null, CodeRequestType.MFA_REAUTHENTICATION));
+                Arguments.of(JourneyType.SIGN_IN, null),
+                Arguments.of(JourneyType.PASSWORD_RESET_MFA, null),
+                Arguments.of(JourneyType.REGISTRATION, AUTH_APP_SECRET),
+                Arguments.of(JourneyType.REAUTHENTICATION, null));
     }
 
     @ParameterizedTest
@@ -150,19 +142,14 @@ class AuthAppCodeProcessorTest {
 
     private static Stream<Arguments> validatorParamsWithoutRegistrationJourney() {
         return Stream.of(
-                Arguments.of(JourneyType.SIGN_IN, null, CodeRequestType.MFA_SIGN_IN),
-                Arguments.of(
-                        JourneyType.PASSWORD_RESET_MFA, null, CodeRequestType.MFA_PW_RESET_MFA),
-                Arguments.of(
-                        JourneyType.REAUTHENTICATION, null, CodeRequestType.MFA_REAUTHENTICATION));
+                Arguments.of(JourneyType.SIGN_IN),
+                Arguments.of(JourneyType.PASSWORD_RESET_MFA),
+                Arguments.of(JourneyType.REAUTHENTICATION));
     }
 
     @ParameterizedTest
     @MethodSource("validatorParamsWithoutRegistrationJourney")
     void returnsNoErrorOnValidAuthCodeForMigratedUser(JourneyType journeyType) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
         var userCredentials =
                 new UserCredentials()
                         .withMfaMethods(List.of(DEFAULT_AUTH_APP_METHOD, BACKUP_SMS_METHOD));
@@ -196,9 +183,6 @@ class AuthAppCodeProcessorTest {
     @ParameterizedTest
     @MethodSource("validatorParamsWithoutRegistrationJourney")
     void returnsNoErrorOnValidAuthCodeToBackupMethodForMigratedUser(JourneyType journeyType) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
         var userCredentials =
                 new UserCredentials()
                         .withMfaMethods(List.of(BACKUP_AUTH_APP_METHOD, DEFAULT_SMS_METHOD));
@@ -228,6 +212,8 @@ class AuthAppCodeProcessorTest {
 
         assertEquals(Optional.empty(), authAppCodeProcessor.validateCode());
     }
+
+    // Lockout checks are now done by PermissionDecisionManager in the handler, not the processor
 
     @ParameterizedTest
     @MethodSource("validatorParams")
@@ -480,44 +466,7 @@ class AuthAppCodeProcessorTest {
                         mockMfaMethodsService);
     }
 
-    private void setUpBlockedUser(CodeRequest codeRequest, CodeRequestType codeRequestType) {
-        when(mockCodeStorageService.isBlockedForEmail(
-                        EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(true);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        codeRequest,
-                        mockAuditService,
-                        mockAccountModifiersService,
-                        mockMfaMethodsService);
-    }
-
-    private void setUpRetryLimitExceededUser(CodeRequest codeRequest) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL))
-                .thenReturn(MAX_RETRIES + 1);
-
-        this.authAppCodeProcessor =
-                new AuthAppCodeProcessor(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        codeRequest,
-                        mockAuditService,
-                        mockAccountModifiersService,
-                        mockMfaMethodsService);
-    }
-
     private void setUpNoAuthCodeForUser(CodeRequest codeRequest) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
         when(mockDynamoService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn(new UserCredentials().withMfaMethods(List.of()));
 
@@ -534,9 +483,6 @@ class AuthAppCodeProcessorTest {
     }
 
     private void setUpValidAuthCode(CodeRequest codeRequest) {
-        when(mockCodeStorageService.isBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
         var mfaMethod =
                 new MFAMethod()
                         .withMfaMethodType(MFAMethodType.AUTH_APP.name())

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.PhoneNumberRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -63,7 +62,6 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.entity.JourneyType.REGISTRATION;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.UK_NOTIFY_MOBILE_TEST_NUMBER;
@@ -111,7 +109,6 @@ class PhoneNumberCodeProcessorTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getCodeMaxRetries()).thenReturn(3);
         when(userContext.getTxmaAuditEncoded()).thenReturn(TXMA_ENCODED_HEADER_VALUE);
 
         var userCredentials =
@@ -135,15 +132,13 @@ class PhoneNumberCodeProcessorTest {
 
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
-    void shouldReturnNoErrorForValidPhoneNumberCode(
-            CodeRequestType codeRequestType, JourneyType journeyType) {
+    void shouldReturnNoErrorForValidPhoneNumberCode(JourneyType journeyType) {
         setupPhoneNumberCode(
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS,
                         VALID_CODE,
                         journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         assertThat(phoneNumberCodeProcessor.validateCode(), equalTo(Optional.empty()));
     }
@@ -151,16 +146,13 @@ class PhoneNumberCodeProcessorTest {
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
     void shouldDeleteMfaCodeFromDataStoreWhenValidRegistrationPhoneNumberCode(
-            CodeRequestType codeRequestType,
-            JourneyType journeyType,
-            NotificationType notificationType) {
+            JourneyType journeyType, NotificationType notificationType) {
         setupPhoneNumberCode(
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS,
                         VALID_CODE,
                         journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.validateCode();
         verify(codeStorageService)
@@ -176,8 +168,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         INVALID_CODE,
                         REGISTRATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_REGISTRATION);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         assertThat(
                 phoneNumberCodeProcessor.validateCode(),
@@ -191,8 +182,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         INVALID_CODE,
                         JourneyType.PASSWORD_RESET_MFA,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_PW_RESET_MFA);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         assertThat(
                 phoneNumberCodeProcessor.validateCode(),
@@ -202,16 +192,13 @@ class PhoneNumberCodeProcessorTest {
     @ParameterizedTest
     @MethodSource("codeRequestTypes")
     void shouldNotDeleteMfaCodeFromDataStoreWhenInvalidRegistrationPhoneNumberCode(
-            CodeRequestType codeRequestType,
-            JourneyType journeyType,
-            NotificationType notificationType) {
+            JourneyType journeyType, NotificationType notificationType) {
         setupPhoneNumberCode(
                 new VerifyMfaCodeRequest(
                         MFAMethodType.SMS,
                         INVALID_CODE,
                         journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                codeRequestType);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.validateCode();
         verify(codeStorageService, never())
@@ -227,9 +214,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         INVALID_CODE,
                         JourneyType.SIGN_IN,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_SIGN_IN);
-
+                        CommonTestVariables.UK_MOBILE_NUMBER));
         var expectedException =
                 assertThrows(
                         RuntimeException.class,
@@ -248,8 +233,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         REGISTRATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_REGISTRATION);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
                 IP_ADDRESS, PERSISTENT_ID, userProfile);
@@ -294,8 +278,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         JourneyType.ACCOUNT_RECOVERY,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_ACCOUNT_RECOVERY);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
                 IP_ADDRESS, PERSISTENT_ID, userProfile);
@@ -336,8 +319,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         JourneyType.SIGN_IN,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_REGISTRATION);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
                 IP_ADDRESS, PERSISTENT_ID, userProfile);
@@ -355,8 +337,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         journeyType,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_REGISTRATION);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
                 IP_ADDRESS, PERSISTENT_ID, userProfile);
@@ -382,8 +363,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         JourneyType.ACCOUNT_RECOVERY,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_ACCOUNT_RECOVERY);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
         when(userProfile.getPhoneNumber()).thenReturn(CommonTestVariables.UK_MOBILE_NUMBER);
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
@@ -400,8 +380,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         REGISTRATION,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_REGISTRATION);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
                 IP_ADDRESS, PERSISTENT_ID, userProfile);
@@ -416,8 +395,7 @@ class PhoneNumberCodeProcessorTest {
         when(configurationService.isPhoneCheckerWithReplyEnabled()).thenReturn(true);
         setupPhoneNumberCode(
                 new VerifyMfaCodeRequest(
-                        MFAMethodType.SMS, VALID_CODE, journeyType, UK_NOTIFY_MOBILE_TEST_NUMBER),
-                CodeRequestType.MFA_REGISTRATION);
+                        MFAMethodType.SMS, VALID_CODE, journeyType, UK_NOTIFY_MOBILE_TEST_NUMBER));
         authSession.setIsSmokeTest(true);
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
@@ -436,8 +414,7 @@ class PhoneNumberCodeProcessorTest {
                         MFAMethodType.SMS,
                         VALID_CODE,
                         JourneyType.ACCOUNT_RECOVERY,
-                        CommonTestVariables.UK_MOBILE_NUMBER),
-                CodeRequestType.MFA_ACCOUNT_RECOVERY);
+                        CommonTestVariables.UK_MOBILE_NUMBER));
 
         phoneNumberCodeProcessor.processSuccessfulCodeRequest(
                 IP_ADDRESS, PERSISTENT_ID, userProfile);
@@ -472,8 +449,7 @@ class PhoneNumberCodeProcessorTest {
                             MFAMethodType.SMS,
                             CommonTestVariables.TEST_OTP_CODE,
                             JourneyType.ACCOUNT_RECOVERY,
-                            CommonTestVariables.UK_MOBILE_NUMBER),
-                    CodeRequestType.MFA_ACCOUNT_RECOVERY);
+                            CommonTestVariables.UK_MOBILE_NUMBER));
 
             var response = phoneNumberCodeProcessor.validateCode();
             assertTrue(response.isEmpty());
@@ -489,8 +465,7 @@ class PhoneNumberCodeProcessorTest {
                             MFAMethodType.SMS,
                             CommonTestVariables.TEST_OTP_CODE.replace("456", "321"),
                             JourneyType.ACCOUNT_RECOVERY,
-                            CommonTestVariables.UK_MOBILE_NUMBER),
-                    CodeRequestType.MFA_ACCOUNT_RECOVERY);
+                            CommonTestVariables.UK_MOBILE_NUMBER));
 
             var response = phoneNumberCodeProcessor.validateCode();
             assertTrue(response.isPresent());
@@ -499,7 +474,7 @@ class PhoneNumberCodeProcessorTest {
         }
     }
 
-    public void setupPhoneNumberCode(CodeRequest codeRequest, CodeRequestType codeRequestType) {
+    public void setupPhoneNumberCode(CodeRequest codeRequest) {
         var differentPhoneNumber = CommonTestVariables.UK_MOBILE_NUMBER.replace("789", "987");
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getAuthSession()).thenReturn(authSession);
@@ -515,60 +490,6 @@ class PhoneNumberCodeProcessorTest {
                         CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
                         NotificationType.MFA_SMS))
                 .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(false);
-        phoneNumberCodeProcessor =
-                new PhoneNumberCodeProcessor(
-                        codeStorageService,
-                        userContext,
-                        configurationService,
-                        codeRequest,
-                        authenticationService,
-                        auditService,
-                        accountModifiersService,
-                        sqsClient,
-                        mfaMethodsService,
-                        testUserHelper);
-    }
-
-    public void setUpPhoneNumberCodeRetryLimitExceeded(CodeRequest codeRequest) {
-        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(CommonTestVariables.EMAIL))
-                .thenReturn(6);
-        when(userContext.getAuthSession()).thenReturn(authSession);
-        when(configurationService.isTestClientsEnabled()).thenReturn(false);
-        when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
-                        NotificationType.VERIFY_PHONE_NUMBER))
-                .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-        phoneNumberCodeProcessor =
-                new PhoneNumberCodeProcessor(
-                        codeStorageService,
-                        userContext,
-                        configurationService,
-                        codeRequest,
-                        authenticationService,
-                        auditService,
-                        accountModifiersService,
-                        sqsClient,
-                        mfaMethodsService,
-                        testUserHelper);
-    }
-
-    public void setUpBlockedPhoneNumberCode(
-            CodeRequest codeRequest, CodeRequestType codeRequestType) {
-        when(userContext.getAuthSession()).thenReturn(authSession);
-        when(configurationService.isTestClientsEnabled()).thenReturn(false);
-        when(codeStorageService.getOtpCode(
-                        CommonTestVariables.EMAIL.concat(codeRequest.getProfileInformation()),
-                        NotificationType.VERIFY_PHONE_NUMBER))
-                .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(
-                        CommonTestVariables.EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
-                .thenReturn(true);
         phoneNumberCodeProcessor =
                 new PhoneNumberCodeProcessor(
                         codeStorageService,
@@ -585,17 +506,8 @@ class PhoneNumberCodeProcessorTest {
 
     private static Stream<Arguments> codeRequestTypes() {
         return Stream.of(
-                Arguments.of(
-                        CodeRequestType.MFA_PW_RESET_MFA,
-                        JourneyType.PASSWORD_RESET_MFA,
-                        NotificationType.MFA_SMS),
-                Arguments.of(
-                        CodeRequestType.MFA_REAUTHENTICATION,
-                        JourneyType.REAUTHENTICATION,
-                        NotificationType.MFA_SMS),
-                Arguments.of(
-                        CodeRequestType.MFA_REGISTRATION,
-                        REGISTRATION,
-                        NotificationType.VERIFY_PHONE_NUMBER));
+                Arguments.of(JourneyType.PASSWORD_RESET_MFA, NotificationType.MFA_SMS),
+                Arguments.of(JourneyType.REAUTHENTICATION, NotificationType.MFA_SMS),
+                Arguments.of(REGISTRATION, NotificationType.VERIFY_PHONE_NUMBER));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -8,11 +8,13 @@ import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
@@ -255,6 +257,28 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .withAttribute(USER_PHONE, UK_MOBILE_NUMBER)
                                 .withAttribute(EXTENSIONS_MFA_METHOD, "default")
                                 .withAttribute(EXTENSIONS_JOURNEY_TYPE, "REGISTRATION")));
+    }
+
+    @Test
+    void shouldClearIncorrectEmailOtpBlockWhenNewCodeRequestedForRegistration() {
+        var codeBlockedKeyPrefix =
+                CodeStorageService.CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_REGISTRATION;
+        redis.blockMfaCodesForEmail(EMAIL, codeBlockedKeyPrefix);
+
+        assertThat(redis.isBlockedMfaCodesForEmail(EMAIL, codeBlockedKeyPrefix), equalTo(true));
+
+        var response =
+                makeRequest(
+                        Optional.of(
+                                new SendNotificationRequest(
+                                        EMAIL,
+                                        NotificationType.VERIFY_EMAIL,
+                                        JourneyType.REGISTRATION)),
+                        constructFrontendHeaders(SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(204));
+        assertThat(redis.isBlockedMfaCodesForEmail(EMAIL, codeBlockedKeyPrefix), equalTo(false));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -284,9 +284,10 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(null);
+
         int count = codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
-        assertThat(count, equalTo(1));
+        assertThat(count, is(1));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
@@ -299,9 +300,10 @@ class CodeStorageServiceTest {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
                 .thenReturn(String.valueOf(3));
+
         int count = codeStorageService.increaseIncorrectMfaCodeAttemptsCount(TEST_EMAIL);
 
-        assertThat(count, equalTo(4));
+        assertThat(count, is(4));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
@@ -310,19 +312,36 @@ class CodeStorageServiceTest {
     }
 
     @Test
-    void shouldIncrementCountForIncorrectMfaCodeAttemptsCountAccountCreation() {
+    void shouldCreateCountAndReturnOneForIncorrectMfaCodeAttemptsCountAccountCreation() {
         when(redisConnectionService.getValue(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
-                .thenReturn(String.valueOf(0));
+                .thenReturn(null);
 
         int count =
                 codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
 
-        assertThat(count, equalTo(1));
+        assertThat(count, is(1));
         verify(redisConnectionService)
                 .saveWithExpiry(
                         RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
                         String.valueOf(1),
+                        ACCOUNT_CREATION_CODE_EXPIRY_TIME);
+    }
+
+    @Test
+    void shouldIncrementCountAndReturnNewValueForIncorrectMfaCodeAttemptsCountAccountCreation() {
+        when(redisConnectionService.getValue(
+                        RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash()))
+                .thenReturn(String.valueOf(3));
+
+        int count =
+                codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(TEST_EMAIL);
+
+        assertThat(count, is(4));
+        verify(redisConnectionService)
+                .saveWithExpiry(
+                        RedisKeys.INCORRECT_MFA_COUNTER.getKeyWithTestEmailHash(),
+                        String.valueOf(4),
                         ACCOUNT_CREATION_CODE_EXPIRY_TIME);
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -106,6 +106,16 @@ public class PermissionDecisionManager implements PermissionDecisions {
             return Result.success(createTemporarilyLockedOut(reason, 0, false));
         }
 
+        if (journeyType != JourneyType.REGISTRATION) {
+            var canVerifyResult = canVerifyEmailOtp(journeyType, permissionContext);
+            if (canVerifyResult.isFailure()) {
+                return canVerifyResult;
+            }
+            if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+                return canVerifyResult;
+            }
+        }
+
         // PASSWORD_RESET has additional count-based check.
         //
         // This exists because ResetPasswordRequestHandler used to do one check of the count
@@ -283,6 +293,14 @@ public class PermissionDecisionManager implements PermissionDecisions {
                                 configurationService.getCodeMaxRetries(),
                                 Instant.ofEpochSecond(ttl),
                                 false));
+            }
+
+            var canVerifyResult = canVerifyMfaOtp(journeyType, permissionContext);
+            if (canVerifyResult.isFailure()) {
+                return canVerifyResult;
+            }
+            if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
+                return canVerifyResult;
             }
 
             return Result.success(new Decision.Permitted(0));

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -165,6 +165,27 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectEmailOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
+        /*
+         * REAUTHENTICATION journey type: Currently a no-op.
+         *
+         * AuthenticationAttemptsService supports tracking email OTP attempts via
+         * CountType.ENTER_EMAIL_CODE (wired into ReauthAuthenticationAttemptsHelper),
+         * but this is not currently used.
+         *
+         * Previously, ValidationHelper.getErrorResponse() explicitly skipped count
+         * increment when journeyType was REAUTHENTICATION, expecting
+         * authenticationAttemptsService to be used instead (as done for MFA_SMS).
+         *
+         * However, email OTP notifications (VERIFY_EMAIL, RESET_PASSWORD_WITH_CODE, etc.)
+         * are never sent with journeyType=REAUTHENTICATION. Even during a reauth flow,
+         * RESET_PASSWORD_WITH_CODE uses PASSWORD_RESET as the journey type because the
+         * frontend does not send a journeyType, so the backend defaults based on
+         * notification type.
+         *
+         * When lockout data storage is consolidated, consider what should happen for
+         * password reset sub-journeys within a reauthentication flow, and whether the
+         * existing CountType.ENTER_EMAIL_CODE should be utilised.
+         */
         if (journeyType == JourneyType.REAUTHENTICATION) {
             return Result.success(null);
         }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReason.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReason.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.userpermissions.entity;
 
+import java.util.Set;
+
 public enum ForbiddenReason {
     EXCEEDED_INCORRECT_EMAIL_ADDRESS_SUBMISSION_LIMIT,
     EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT,
@@ -7,5 +9,14 @@ public enum ForbiddenReason {
     EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
     EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT,
     EXCEEDED_SEND_MFA_OTP_NOTIFICATION_LIMIT,
-    EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+    EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT;
+
+    private static final Set<ForbiddenReason> EXCEEDED_OTP_SUBMISSION_LIMIT_REASONS =
+            Set.of(
+                    EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                    EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT);
+
+    public boolean hasExceededOtpSubmissionLimit() {
+        return EXCEEDED_OTP_SUBMISSION_LIMIT_REASONS.contains(this);
+    }
 }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -172,6 +173,37 @@ class PermissionDecisionManagerTest {
                                 ? ForbiddenReason.BLOCKED_FOR_PW_RESET_REQUEST
                                 : ForbiddenReason.EXCEEDED_SEND_EMAIL_OTP_NOTIFICATION_LIMIT;
                 assertEquals(expectedReason, lockedOut.forbiddenReason());
+            }
+
+            @ParameterizedTest
+            @EnumSource(
+                    value = JourneyType.class,
+                    names = {"REGISTRATION", "ACCOUNT_RECOVERY", "PASSWORD_RESET"})
+            void shouldReturnVerificationBlockForAllJourneysExceptRegistration(
+                    JourneyType journeyType) {
+                var userContext = createUserContext(0);
+                var codeRequestType =
+                        CodeRequestType.getCodeRequestType(
+                                CodeRequestType.SupportedCodeType.EMAIL, journeyType);
+                when(codeStorageService.isBlockedForEmail(
+                                EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
+                        .thenReturn(true);
+
+                var result =
+                        permissionDecisionManager.canSendEmailOtpNotification(
+                                journeyType, userContext);
+
+                assertTrue(result.isSuccess());
+                if (journeyType == JourneyType.REGISTRATION) {
+                    assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+                } else {
+                    var lockedOut =
+                            assertInstanceOf(
+                                    Decision.TemporarilyLockedOut.class, result.getSuccess());
+                    assertEquals(
+                            ForbiddenReason.EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT,
+                            lockedOut.forbiddenReason());
+                }
             }
         }
 
@@ -720,6 +752,29 @@ class PermissionDecisionManagerTest {
 
             assertTrue(result.isSuccess());
             assertInstanceOf(Decision.Permitted.class, result.getSuccess());
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+                value = JourneyType.class,
+                names = {"SIGN_IN", "REGISTRATION", "PASSWORD_RESET_MFA"})
+        void shouldReturnLockedOutWhenVerificationBlockExists(JourneyType journeyType) {
+            var userContext = createUserContext(0);
+            var codeRequestType =
+                    CodeRequestType.getCodeRequestType(
+                            CodeRequestType.SupportedCodeType.MFA, journeyType);
+            when(codeStorageService.getTTL(EMAIL, CODE_BLOCKED_KEY_PREFIX + codeRequestType))
+                    .thenReturn(300L);
+
+            var result =
+                    permissionDecisionManager.canSendSmsOtpNotification(journeyType, userContext);
+
+            assertTrue(result.isSuccess());
+            var lockedOut =
+                    assertInstanceOf(Decision.TemporarilyLockedOut.class, result.getSuccess());
+            assertEquals(
+                    ForbiddenReason.EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT,
+                    lockedOut.forbiddenReason());
         }
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
@@ -267,7 +268,7 @@ class UserActionsManagerTest {
             }
 
             @Test
-            void shouldClearVerificationBlockForRegistration() {
+            void shouldClearIncorrectEmailOtpBlockWhenNewCodeRequestedForRegistration() {
                 userActionsManager.sentEmailOtpNotification(
                         JourneyType.REGISTRATION, permissionContext);
 
@@ -427,184 +428,217 @@ class UserActionsManagerTest {
     @Nested
     class CorrectSmsOtpReceived {
 
-        @Test
-        void shouldReturnErrorWhenPermissionContextIsNull() {
-            var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, null);
-            assertTrue(result.isFailure());
-            assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
-        }
+        @Nested
+        class SharedValidation {
 
-        @Test
-        void shouldSetHasVerifiedMfaAndClearCountForStandardJourney() {
-            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
+            @Test
+            void shouldReturnErrorWhenPermissionContextIsNull() {
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, null);
 
-            var result =
-                    userActionsManager.correctSmsOtpReceived(
-                            JourneyType.SIGN_IN, permissionContext);
-
-            verify(authSessionService).updateSession(captor.capture());
-            assertTrue(captor.getValue().getHasVerifiedMfa());
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            assertTrue(result.isSuccess());
-        }
-
-        @Test
-        void shouldClearReauthCountsAndSetHasVerifiedMfaForReauth() {
-            var context =
-                    PermissionContext.builder()
-                            .withInternalSubjectId("subject-123")
-                            .withRpPairwiseId("rp-pairwise-456")
-                            .withAuthSessionItem(authSession)
-                            .build();
-
-            var result =
-                    userActionsManager.correctSmsOtpReceived(JourneyType.REAUTHENTICATION, context);
-
-            for (CountType countType : CountType.values()) {
-                verify(authenticationAttemptsService)
-                        .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
-                verify(authenticationAttemptsService)
-                        .deleteCount("rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
             }
-            verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(anyString());
-            assertTrue(result.isSuccess());
+
+            @Test
+            void shouldReturnErrorWhenAuthSessionItemIsNull() {
+                var context = PermissionContext.builder().withEmailAddress(EMAIL).build();
+
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
         }
 
-        @Test
-        void shouldPreserveReauthCountsForAuditWhenFeatureFlagsEnabled() {
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-            var counts = Map.of(CountType.ENTER_PASSWORD, 2, CountType.ENTER_SMS_CODE, 1);
-            when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                            "subject-123", "rp-pairwise-456", JourneyType.REAUTHENTICATION))
-                    .thenReturn(counts);
-            var context =
-                    PermissionContext.builder()
-                            .withInternalSubjectId("subject-123")
-                            .withRpPairwiseId("rp-pairwise-456")
-                            .withAuthSessionItem(authSession)
-                            .build();
+        @Nested
+        class ReauthenticationJourney {
 
-            userActionsManager.correctSmsOtpReceived(JourneyType.REAUTHENTICATION, context);
+            @Test
+            void shouldReturnErrorWhenInternalSubjectIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
 
-            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
-            verify(authSessionService).updateSession(captor.capture());
-            assertEquals(counts, captor.getValue().getPreservedReauthCountsForAuditMap());
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenRpPairwiseIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearAllReauthCountsForBothIdentifiers() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                for (CountType countType : CountType.values()) {
+                    verify(authenticationAttemptsService)
+                            .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
+                    verify(authenticationAttemptsService)
+                            .deleteCount(
+                                    "rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+                }
+                verify(codeStorageService, never())
+                        .deleteIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldPreserveReauthCountsForAuditWhenFeatureFlagsEnabled() {
+                when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+                when(configurationService.isAuthenticationAttemptsServiceEnabled())
+                        .thenReturn(true);
+                var counts = Map.of(CountType.ENTER_PASSWORD, 2, CountType.ENTER_SMS_CODE, 1);
+                when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
+                                "subject-123", "rp-pairwise-456", JourneyType.REAUTHENTICATION))
+                        .thenReturn(counts);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+                verify(authSessionService).updateSession(captor.capture());
+                assertEquals(counts, captor.getValue().getPreservedReauthCountsForAuditMap());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldNotPreserveReauthCountsWhenFeatureFlagsDisabled() {
+                when(configurationService.supportReauthSignoutEnabled()).thenReturn(false);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authenticationAttemptsService, never())
+                        .getCountsByJourneyForSubjectIdAndRpPairwiseId(any(), any(), any());
+                assertTrue(result.isSuccess());
+            }
         }
-    }
 
-    @Nested
-    class IncorrectSmsOtpReceived {
+        @Nested
+        class StandardJourneys {
 
-        @Test
-        void shouldIncrementCount() {
-            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+            @Test
+            void shouldReturnErrorWhenEmailAddressIsNull() {
+                var authSessionWithoutEmail = new AuthSessionItem().withSessionId(SESSION_ID);
+                var context =
+                        PermissionContext.builder()
+                                .withAuthSessionItem(authSessionWithoutEmail)
+                                .build();
 
-            var result =
-                    userActionsManager.incorrectSmsOtpReceived(
-                            JourneyType.SIGN_IN, permissionContext);
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, context);
 
-            verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
-            assertTrue(result.isSuccess());
-        }
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
 
-        @Test
-        void shouldBlockWhenMaxRetriesReached() {
-            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
 
-            var result =
-                    userActionsManager.incorrectSmsOtpReceived(
-                            JourneyType.SIGN_IN, permissionContext);
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
 
-            var expectedBlockedKey =
-                    CodeStorageService.CODE_BLOCKED_KEY_PREFIX
-                            + CodeRequestType.getCodeRequestType(
-                                    SupportedCodeType.MFA, JourneyType.SIGN_IN);
-            verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            assertTrue(result.isSuccess());
-        }
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
 
-        @Test
-        void shouldIncrementCountViaAuthAttemptsServiceForReauth() {
-            var context = PermissionContext.builder().withInternalSubjectId("subject-123").build();
-            when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(120L);
+            @Test
+            void shouldClearIncorrectMfaCodeAttemptsCount() {
+                var result =
+                        userActionsManager.correctSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
 
-            var result =
-                    userActionsManager.incorrectSmsOtpReceived(
-                            JourneyType.REAUTHENTICATION, context);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
 
-            verify(authenticationAttemptsService)
-                    .createOrIncrementCount(
-                            eq("subject-123"),
-                            anyLong(),
-                            eq(JourneyType.REAUTHENTICATION),
-                            eq(CountType.ENTER_MFA_CODE));
-            assertTrue(result.isSuccess());
-        }
-    }
+            @Test
+            void shouldClearReauthCountsWhenIdentifiersAvailable() {
+                var context =
+                        PermissionContext.builder()
+                                .withEmailAddress(EMAIL)
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
 
-    @Nested
-    class IncorrectAuthAppOtpReceived {
+                var result = userActionsManager.correctSmsOtpReceived(JourneyType.SIGN_IN, context);
 
-        @Test
-        void shouldIncrementCount() {
-            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
-
-            var result =
-                    userActionsManager.incorrectAuthAppOtpReceived(
-                            JourneyType.SIGN_IN, permissionContext);
-
-            verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
-            assertTrue(result.isSuccess());
-        }
-
-        @Test
-        void shouldBlockWhenMaxRetriesReached() {
-            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
-
-            var result =
-                    userActionsManager.incorrectAuthAppOtpReceived(
-                            JourneyType.SIGN_IN, permissionContext);
-
-            var expectedBlockedKey =
-                    CodeStorageService.CODE_BLOCKED_KEY_PREFIX
-                            + CodeRequestType.getCodeRequestType(
-                                    MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
-            verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
-            verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            assertTrue(result.isSuccess());
-        }
-
-        @Test
-        void shouldUseIncreasedMaxRetriesForRegistration() {
-            when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL))
-                    .thenReturn(999998);
-
-            var result =
-                    userActionsManager.incorrectAuthAppOtpReceived(
-                            JourneyType.REGISTRATION, permissionContext);
-
-            verify(codeStorageService, never()).saveBlockedForEmail(any(), any(), anyLong());
-            assertTrue(result.isSuccess());
-        }
-
-        @Test
-        void shouldIncrementCountViaAuthAttemptsServiceForReauth() {
-            var context = PermissionContext.builder().withInternalSubjectId("subject-123").build();
-            when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(120L);
-
-            var result =
-                    userActionsManager.incorrectAuthAppOtpReceived(
-                            JourneyType.REAUTHENTICATION, context);
-
-            verify(authenticationAttemptsService)
-                    .createOrIncrementCount(
-                            eq("subject-123"),
-                            anyLong(),
-                            eq(JourneyType.REAUTHENTICATION),
-                            eq(CountType.ENTER_MFA_CODE));
-            assertTrue(result.isSuccess());
+                assertTrue(result.isSuccess());
+                for (CountType countType : CountType.values()) {
+                    verify(authenticationAttemptsService)
+                            .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
+                    verify(authenticationAttemptsService)
+                            .deleteCount(
+                                    "rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+                }
+            }
         }
     }
 
@@ -752,19 +786,534 @@ class UserActionsManagerTest {
 
     @Nested
     class CorrectAuthAppOtpReceived {
-        @Test
-        void correctAuthAppOtpReceivedShouldSetHasVerifiedMfaToTrue() {
-            // Arrange
-            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
-            // Act
-            var result = userActionsManager.correctAuthAppOtpReceived(null, permissionContext);
+        @Nested
+        class SharedValidation {
 
-            // Assert
-            verify(authSessionService).updateSession(captor.capture());
-            AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
-            assertTrue(result.isSuccess());
+            @Test
+            void shouldReturnErrorWhenPermissionContextIsNull() {
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(JourneyType.SIGN_IN, null);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthSessionItemIsNull() {
+                var context = PermissionContext.builder().withEmailAddress(EMAIL).build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldReturnErrorWhenInternalSubjectIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldReturnErrorWhenRpPairwiseIdIsNull() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearAllReauthCountsForBothIdentifiers() {
+                var context =
+                        PermissionContext.builder()
+                                .withInternalSubjectId("subject-123")
+                                .withRpPairwiseId("rp-pairwise-456")
+                                .withAuthSessionItem(authSession)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                for (CountType countType : CountType.values()) {
+                    verify(authenticationAttemptsService)
+                            .deleteCount("subject-123", JourneyType.REAUTHENTICATION, countType);
+                    verify(authenticationAttemptsService)
+                            .deleteCount(
+                                    "rp-pairwise-456", JourneyType.REAUTHENTICATION, countType);
+                }
+                verify(codeStorageService, never())
+                        .deleteIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldReturnErrorWhenEmailAddressIsNull() {
+                var authSessionWithoutEmail = new AuthSessionItem().withSessionId(SESSION_ID);
+                var context =
+                        PermissionContext.builder()
+                                .withAuthSessionItem(authSessionWithoutEmail)
+                                .build();
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(JourneyType.SIGN_IN, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.INVALID_USER_CONTEXT, result.getFailure());
+            }
+
+            @Test
+            void shouldSetHasVerifiedMfaToTrue() {
+                ArgumentCaptor<AuthSessionItem> captor =
+                        ArgumentCaptor.forClass(AuthSessionItem.class);
+
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(authSessionService).updateSession(captor.capture());
+                assertTrue(captor.getValue().getHasVerifiedMfa());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldClearIncorrectMfaCodeAttemptsCount() {
+                var result =
+                        userActionsManager.correctAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+        }
+    }
+
+    @Nested
+    class IncorrectSmsOtpReceived {
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldIncrementCount() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWhenMaxRetriesReached() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        SupportedCodeType.MFA, JourneyType.SIGN_IN);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @ParameterizedTest
+            @MethodSource("reducedIncorrectSmsOtpReceivedLockoutJourneyTypes")
+            void shouldUseReducedLockoutDurationForReducedLockoutJourneys(JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(journeyType, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        SupportedCodeType.MFA, journeyType);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                assertTrue(result.isSuccess());
+            }
+
+            static Stream<JourneyType> reducedIncorrectSmsOtpReceivedLockoutJourneyTypes() {
+                return Stream.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY);
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldIncrementCountViaAuthAttemptsService() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(120L);
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authenticationAttemptsService)
+                        .createOrIncrementCount(
+                                eq("subject-123"),
+                                anyLong(),
+                                eq(JourneyType.REAUTHENTICATION),
+                                eq(CountType.ENTER_MFA_CODE));
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthAttemptsServiceThrows() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(120L);
+                doThrow(new RuntimeException("Storage error"))
+                        .when(authenticationAttemptsService)
+                        .createOrIncrementCount(anyString(), anyLong(), any(), any());
+
+                var result =
+                        userActionsManager.incorrectSmsOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.STORAGE_SERVICE_ERROR, result.getFailure());
+            }
+        }
+    }
+
+    @Nested
+    class IncorrectAuthAppOtpReceived {
+
+        @Nested
+        class StandardJourneys {
+
+            @Test
+            void shouldIncrementCount() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWhenMaxRetriesReached() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.SIGN_IN, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        MFAMethodType.AUTH_APP, JourneyType.SIGN_IN);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @ParameterizedTest
+            @MethodSource("reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes")
+            void shouldAllowSignificantlyHigherAttemptsForRegistrationAndAccountRecovery(
+                    JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL))
+                        .thenReturn(999998);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                journeyType, permissionContext);
+
+                verify(codeStorageService, never()).saveBlockedForEmail(any(), any(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @ParameterizedTest
+            @MethodSource("reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes")
+            void shouldUseReducedLockoutDurationForReducedLockoutJourneys(JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL))
+                        .thenReturn(999999);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                journeyType, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        MFAMethodType.AUTH_APP, journeyType);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                assertTrue(result.isSuccess());
+            }
+
+            static Stream<JourneyType> reducedIncorrectAuthAppOtpReceivedLockoutJourneyTypes() {
+                return Stream.of(JourneyType.REGISTRATION, JourneyType.ACCOUNT_RECOVERY);
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldIncrementCountViaAuthAttemptsService() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(120L);
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                verify(authenticationAttemptsService)
+                        .createOrIncrementCount(
+                                eq("subject-123"),
+                                anyLong(),
+                                eq(JourneyType.REAUTHENTICATION),
+                                eq(CountType.ENTER_MFA_CODE));
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldReturnErrorWhenAuthAttemptsServiceThrows() {
+                var context =
+                        PermissionContext.builder().withInternalSubjectId("subject-123").build();
+                when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(120L);
+                doThrow(new RuntimeException("Storage error"))
+                        .when(authenticationAttemptsService)
+                        .createOrIncrementCount(anyString(), anyLong(), any(), any());
+
+                var result =
+                        userActionsManager.incorrectAuthAppOtpReceived(
+                                JourneyType.REAUTHENTICATION, context);
+
+                assertTrue(result.isFailure());
+                assertEquals(TrackingError.STORAGE_SERVICE_ERROR, result.getFailure());
+            }
+        }
+    }
+
+    @Nested
+    class IncorrectEmailOtpReceived {
+
+        @Nested
+        class PasswordResetAndAccountRecoveryJourneys {
+
+            @ParameterizedTest
+            @EnumSource(
+                    value = JourneyType.class,
+                    names = {"PASSWORD_RESET", "ACCOUNT_RECOVERY"})
+            void shouldIncrementCount(JourneyType journeyType) {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                journeyType, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(anyString(), anyString(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithStandardLockoutForPasswordReset() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.PASSWORD_RESET, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.PASSWORD_RESET);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithReducedLockoutForAccountRecovery() {
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.ACCOUNT_RECOVERY, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.ACCOUNT_RECOVERY);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class RegistrationJourney {
+
+            @Test
+            void shouldIncrementCountUsingAccountCreationMethodWhenConfigEnabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(true);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL))
+                        .thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                verify(codeStorageService)
+                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL);
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(anyString(), anyString(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldIncrementCountUsingStandardMethodWhenConfigDisabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(false);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(1);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                verify(codeStorageService).increaseIncorrectMfaCodeAttemptsCount(EMAIL);
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(anyString());
+                verify(codeStorageService, never())
+                        .saveBlockedForEmail(anyString(), anyString(), anyLong());
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithReducedLockoutWhenConfigEnabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(true);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCountAccountCreation(EMAIL))
+                        .thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.REGISTRATION);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+
+            @Test
+            void shouldBlockWithReducedLockoutWhenConfigDisabled() {
+                when(configurationService.supportAccountCreationTTL()).thenReturn(false);
+                when(codeStorageService.increaseIncorrectMfaCodeAttemptsCount(EMAIL)).thenReturn(6);
+                when(configurationService.getReducedLockoutDuration()).thenReturn(300L);
+
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REGISTRATION, permissionContext);
+
+                var expectedBlockedKey =
+                        CodeStorageService.CODE_BLOCKED_KEY_PREFIX
+                                + CodeRequestType.getCodeRequestType(
+                                        CodeRequestType.SupportedCodeType.EMAIL,
+                                        JourneyType.REGISTRATION);
+                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 300L);
+                verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
+                assertTrue(result.isSuccess());
+            }
+        }
+
+        @Nested
+        class ReauthenticationJourney {
+
+            @Test
+            void shouldDoNothingForReauthentication() {
+                var result =
+                        userActionsManager.incorrectEmailOtpReceived(
+                                JourneyType.REAUTHENTICATION, permissionContext);
+
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCount(anyString());
+                verify(codeStorageService, never())
+                        .increaseIncorrectMfaCodeAttemptsCountAccountCreation(anyString());
+                verify(authenticationAttemptsService, never())
+                        .createOrIncrementCount(anyString(), anyLong(), any(), any());
+                assertTrue(result.isSuccess());
+            }
         }
     }
 
@@ -783,8 +1332,6 @@ class UserActionsManagerTest {
             assertTrue(
                     userActionsManager.sentEmailOtpNotification(journeyType, context).isSuccess());
             assertTrue(
-                    userActionsManager.incorrectEmailOtpReceived(journeyType, context).isSuccess());
-            assertTrue(
                     userActionsManager.correctEmailOtpReceived(journeyType, context).isSuccess());
             assertTrue(
                     userActionsManager.incorrectPasswordReceived(journeyType, context).isSuccess());
@@ -793,9 +1340,6 @@ class UserActionsManagerTest {
                     userActionsManager.correctPasswordReceived(journeyType, context).isSuccess());
             assertTrue(userActionsManager.passwordReset(journeyType, context).isSuccess());
             assertTrue(userActionsManager.sentSmsOtpNotification(journeyType, context).isSuccess());
-            assertTrue(
-                    userActionsManager.incorrectSmsOtpReceived(journeyType, context).isSuccess());
-            assertTrue(userActionsManager.correctSmsOtpReceived(journeyType, context).isSuccess());
             assertTrue(
                     userActionsManager
                             .incorrectAuthAppOtpReceived(journeyType, context)

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReasonTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/entity/ForbiddenReasonTest.java
@@ -1,9 +1,10 @@
 package uk.gov.di.authentication.userpermissions.entity;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ForbiddenReasonTest {
 
@@ -38,5 +39,28 @@ class ForbiddenReasonTest {
         // Then
         assertNotNull(result);
         assertEquals("EXCEEDED_INCORRECT_PASSWORD_SUBMISSION_LIMIT", result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ForbiddenReason.class,
+            names = {
+                "EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT",
+                "EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT"
+            })
+    void hasExceededOtpSubmissionLimitReturnsTrueForOtpSubmissionReasons(ForbiddenReason reason) {
+        assertTrue(reason.hasExceededOtpSubmissionLimit());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ForbiddenReason.class,
+            names = {
+                "EXCEEDED_INCORRECT_EMAIL_OTP_SUBMISSION_LIMIT",
+                "EXCEEDED_INCORRECT_MFA_OTP_SUBMISSION_LIMIT"
+            },
+            mode = EnumSource.Mode.EXCLUDE)
+    void hasExceededOtpSubmissionLimitReturnsFalseForOtherReasons(ForbiddenReason reason) {
+        assertFalse(reason.hasExceededOtpSubmissionLimit());
     }
 }


### PR DESCRIPTION
## What

Now that all verify handlers use `PermissionDecisionManager`, unify send+verify checks so handlers that send notifications only need a single permission check.

Make `canSend*` methods call `canVerify*` internally — if you cannot verify, you cannot send. This simplifies LoginHandler, MfaHandler, SendNotificationHandler, and ResetPasswordRequestHandler.

### Things to note

- The `REGISTRATION` journey is a deliberate exception in `canSendEmailOtpNotification`. It skips the internal `canVerifyEmailOtp` check because users must be able to request new email codes even when blocked from verifying (the block is cleared when a new code is sent, added in the previous PR).
- Previously no block was recorded when the verify email OTP count hit the threshold on REGISTRATION — instead the count reset and the frontend received an HTTP error. Now the expectation is explicit: if a user hits the verify email OTP limit on registration, they can no longer verify email OTPs until they have requested a new email OTP.
- `ResetPasswordRequestHandler` had its own inline permission checking that duplicated logic now available in `PermissionDecisionManager`. Aligned with the pattern used by other handlers.
- Includes test for the scenario where a user is not locked out before code validation, but the incorrect attempt pushes them over the threshold.

## How to review

1. Code Review
2. Deploy to a dev environment
3. Test lockouts on all journeys that send OTP codes (login, MFA, send notification, reset password request)

## Checklist

- [x] Deployment of this PR will not break active user journeys
- [x] Impact on orch and auth mutual dependencies has been checked
- [x] No changes required or changes have been made to stub-orchestration
