### PR TITLE
BAU: Configure dependabot for pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,3 +94,16 @@ updates:
       prefix: BAU
     labels:
       - dependabot
+
+  - package-ecosystem: pre-commit
+    directory: "/"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    target-branch: main
+    commit-message:
+      prefix: BAU
+    labels:
+      - dependabot


### PR DESCRIPTION
### Wider context of change

Pre-commit tasks are not currently under dependabot control, meaning they can easily drift out of date and potentially include security vulnerabilities.

They should use the same update schedule as everything else.