### PR TITLE
BAU: Remove labels from pip and pre-commit dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,8 +92,6 @@ updates:
     target-branch: main
     commit-message:
       prefix: BAU
-    labels:
-      - dependabot
 
   - package-ecosystem: pre-commit
     directory: "/"
@@ -105,5 +103,3 @@ updates:
     target-branch: main
     commit-message:
       prefix: BAU
-    labels:
-      - dependabot


### PR DESCRIPTION
The labels don't exist and don't add anything - just remove them and use the default