### PR TITLE
ATO-2489: Sync API Key as secret in Orch account

### DIFF
--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -101,7 +101,7 @@ function sync_secret_from_auth_account() {
   echo "Logged into account ${account_id}"
 
   local secret_value=""
-  secret_value=$(AWS_PROFILE="${PROFILE_TO_SYNC_SECRET_WITH}" aws secrets-manager get-secret-value --secret-id "${expected_managed_secret_name}" | jq ".SecretString" || exit 1)
+  secret_value=$(AWS_PROFILE="${PROFILE_TO_SYNC_SECRET_WITH}" aws secrets-manager get-secret-value --secret-id "${expected_managed_secret_name}" | jq -r ".SecretString" || exit 1)
 
   if [ -z "${secret_value}" ]; then
     echo "Failed to get previous origin cloaking secret"

--- a/template.yaml
+++ b/template.yaml
@@ -6016,6 +6016,7 @@ Resources:
       StageKeys:
         - RestApiId: !Ref OrchestrationOidcApi
           StageName: !Sub "${Environment}"
+      Value: !Sub "{{resolve:secretsmanager:/deploy/${Environment}/client-registry-api-key}}"
 
   OrchestrationOidcApiWafAssociation:
     Type: "AWS::WAFv2::WebACLAssociation"


### PR DESCRIPTION
### Wider context of change

During the cutover of traffic from the API Gateway in the auth account to the new one in the Orchestration account, there will be some traffic which uses an API Key for specific routes (/connect/*).

These routes are not deployed in production but will affect the ability of the admin tool to manage test clients in integration. To cutover the traffic without downtime, we can sync up the API Key values from the auth account and apply it to the new API Gateway. This ensure that we do not need to have a brief period of downtime to cutover the traffic in the integration environment

### What’s changed:

- Updates the template to reference a secret in the Value field of the `AWS::ApiGateway::ApiKey` resource
- See docs here: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-apigateway-apikey.html

### Manual testing

- Deployed to dev 
- Checked,  it deployed fine and the secret value == API Key
-  Create secret in build, staging and intergration ✅ 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
