### PR TITLE
AUT-5133: Adding table name helper module to Metric lambda

### DIFF
--- a/ci/cloudformation/utils/api/test-services-api.yaml
+++ b/ci/cloudformation/utils/api/test-services-api.yaml
@@ -95,7 +95,7 @@ Resources:
   DeleteSyntheticsUserLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub "${DeleteSyntheticsUserFunction}:active"
+      FunctionName: !Ref DeleteSyntheticsUserFunction.Alias
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${TestServicesApi}/*/*"

--- a/ci/cloudformation/utils/function/bulk-user-email-audience-loader.yaml
+++ b/ci/cloudformation/utils/function/bulk-user-email-audience-loader.yaml
@@ -84,20 +84,7 @@ Resources:
                   bulkEmailAudienceLoaderScheduleExpression,
                 ]
             Description: Triggers bulk user email audience loader Lambda on schedule
-            Enabled: !Equals
-              - !If
-                - UseSubEnvironment
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref SubEnvironment,
-                    bulkEmailAudienceLoaderScheduleState,
-                  ]
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    bulkEmailAudienceLoaderScheduleState,
-                  ]
-              - ENABLED
+            Enabled: false
       Tags:
         Name: !Sub
           - "${EnvironmentName}-bulk-user-email-audience-loader-lambda"

--- a/ci/cloudformation/utils/function/bulk-user-email-send.yaml
+++ b/ci/cloudformation/utils/function/bulk-user-email-send.yaml
@@ -118,20 +118,7 @@ Resources:
                   bulkEmailSendScheduleExpression,
                 ]
             Description: Triggers bulk user email send Lambda on schedule
-            Enabled: !Equals
-              - !If
-                - UseSubEnvironment
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref SubEnvironment,
-                    bulkEmailSendScheduleState,
-                  ]
-                - !FindInMap [
-                    EnvironmentConfiguration,
-                    !Ref Environment,
-                    bulkEmailSendScheduleState,
-                  ]
-              - ENABLED
+            Enabled: false
       Tags:
         Name: !Sub
           - "${EnvironmentName}-bulk-user-email-send-lambda"

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -251,7 +251,7 @@ Mappings:
       notifyUrl: https://api.notifications.service.gov.uk
       notifyTemplateMap: "{}"
       # To enable this condition, create the bulk user tables in shared terraform
-      bulkEmailSendingEnabled: "false"
+      bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
       bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
@@ -284,7 +284,7 @@ Mappings:
       notifyUrl: https://api.notifications.service.gov.uk
       notifyTemplateMap: "{}"
       # To enable this condition, create the bulk user tables in shared terraform
-      bulkEmailSendingEnabled: "false"
+      bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
       bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
@@ -317,7 +317,7 @@ Mappings:
       notifyUrl: https://api.notifications.service.gov.uk
       notifyTemplateMap: "{}"
       # To enable this condition, create the bulk user tables in shared terraform
-      bulkEmailSendingEnabled: "false"
+      bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI *)"
       bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI *)"

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -154,9 +154,7 @@ Mappings:
       # To enable this condition, create the bulk user tables in shared terraform
       bulkEmailSendingEnabled: "false"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 0
       bulkEmailMaxAudienceLoadUserBatchSize: 0
       bulkEmailBatchSize: 108
@@ -187,9 +185,7 @@ Mappings:
       # To enable this condition, create the bulk user tables in shared terraform
       bulkEmailSendingEnabled: "false"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 0
       bulkEmailMaxAudienceLoadUserBatchSize: 0
       bulkEmailBatchSize: 108
@@ -220,9 +216,7 @@ Mappings:
       # To enable this condition, create the bulk user tables in shared terraform
       bulkEmailSendingEnabled: "false"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 0
       bulkEmailMaxAudienceLoadUserBatchSize: 0
       bulkEmailBatchSize: 108
@@ -253,9 +247,7 @@ Mappings:
       # To enable this condition, create the bulk user tables in shared terraform
       bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 0
       bulkEmailMaxAudienceLoadUserBatchSize: 0
       bulkEmailBatchSize: 108
@@ -286,9 +278,7 @@ Mappings:
       # To enable this condition, create the bulk user tables in shared terraform
       bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI 2049)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI 2049)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 0
       bulkEmailMaxAudienceLoadUserBatchSize: 0
       bulkEmailBatchSize: 108
@@ -319,16 +309,14 @@ Mappings:
       # To enable this condition, create the bulk user tables in shared terraform
       bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI *)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI *)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 1000
       bulkEmailMaxAudienceLoadUserBatchSize: 100
       bulkEmailBatchSize: 108
       bulkEmailSendMode: PENDING
       bulkEmailSenderType: INTERNATIONAL_NUMBERS_FORCED_MFA_RESET
       bulkEmailIncludedTermsAndConditions: "1.13"
-      allowBulkTestUsers: "false"
+      allowBulkTestUsers: "true"
       IsSplunkEnabled: "Yes"
       UseAlarmActions: "Yes"
       termsConditionsVersion: "1.13"
@@ -350,18 +338,16 @@ Mappings:
       notifyUrl: https://api.notifications.service.gov.uk
       notifyTemplateMap: "{}"
       # To enable this condition, create the bulk user tables in shared terraform
-      bulkEmailSendingEnabled: "false"
+      bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI *)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI *)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 5000
       bulkEmailMaxAudienceLoadUserBatchSize: 500
       bulkEmailBatchSize: 48
       bulkEmailSendMode: PENDING
       bulkEmailSenderType: INTERNATIONAL_NUMBERS_FORCED_MFA_RESET
       bulkEmailIncludedTermsAndConditions: "1.13"
-      allowBulkTestUsers: "false"
+      allowBulkTestUsers: "true"
       IsSplunkEnabled: "Yes"
       UseAlarmActions: "Yes"
       termsConditionsVersion: "1.13"
@@ -383,11 +369,9 @@ Mappings:
       notifyUrl: https://api.notifications.service.gov.uk
       notifyTemplateMap: "{}"
       # To enable this condition, create the bulk user tables in shared terraform
-      bulkEmailSendingEnabled: "false"
+      bulkEmailSendingEnabled: "true"
       bulkEmailSendScheduleExpression: "cron(0 15 ? * FRI *)"
-      bulkEmailSendScheduleState: DISABLED
       bulkEmailAudienceLoaderScheduleExpression: "cron(0 13 ? * FRI *)"
-      bulkEmailAudienceLoaderScheduleState: DISABLED
       bulkEmailMaxAudienceLoadUserCount: 10000
       bulkEmailMaxAudienceLoadUserBatchSize: 1000
       bulkEmailBatchSize: 48

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
@@ -5,12 +5,12 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 
-import static java.text.MessageFormat.format;
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
 public class AccountMetricPublishHandler implements RequestHandler<ScheduledEvent, Long> {
@@ -40,9 +40,8 @@ public class AccountMetricPublishHandler implements RequestHandler<ScheduledEven
                 client.describeTable(
                         DescribeTableRequest.builder()
                                 .tableName(
-                                        format(
-                                                "{0}-user-profile",
-                                                configurationService.getEnvironment()))
+                                        TableNameHelper.getFullTableName(
+                                                "user-profile", configurationService))
                                 .build());
         var numberOfAccounts = result.table().itemCount();
         var numberOfVerifiedAccounts =

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/MFAMethodAnalysisHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
+import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.utils.entity.MFAMethodAnalysisRequest;
@@ -30,7 +31,6 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static java.text.MessageFormat.format;
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
 public class MFAMethodAnalysisHandler
@@ -52,8 +52,9 @@ public class MFAMethodAnalysisHandler
         this.configurationService = configurationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         userCredentialsTableName =
-                format("{0}-user-credentials", configurationService.getEnvironment());
-        userProfileTableName = format("{0}-user-profile", configurationService.getEnvironment());
+                TableNameHelper.getFullTableName("user-credentials", configurationService);
+        userProfileTableName =
+                TableNameHelper.getFullTableName("user-profile", configurationService);
     }
 
     public MFAMethodAnalysisHandler() {


### PR DESCRIPTION
## What

AUT-5133: Adding table name helper module to Metric lambda

## How to review

1. Code Review
1. Deploy to a Authdevs environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -u`).
