### PR TITLE
AUT-5396: ADAPI authorizer validation

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
@@ -34,7 +34,7 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     private final ConfigurationService configurationService = ConfigurationService.getInstance();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-create");
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
@@ -29,7 +29,7 @@ class PasskeysDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     private final ConfigurationService configurationService = ConfigurationService.getInstance();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysRetrieveHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysRetrieveHandlerIntegrationTest.java
@@ -33,7 +33,7 @@ class PasskeysRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
     private final ConfigurationService configurationService = ConfigurationService.getInstance();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-retrieve");
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysUpdateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysUpdateHandlerIntegrationTest.java
@@ -42,7 +42,7 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     private static final String UPDATED_LAST_USED_AT =
             Instant.parse(LAST_USED_AT).plus(1, ChronoUnit.MINUTES).toString();
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-update");
 
     @BeforeEach
     void setUp() {

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelper.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelper.java
@@ -1,0 +1,29 @@
+package uk.gov.di.authentication.accountdata.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
+
+public class ScopeAuthorizerHelper {
+    private static final Logger LOG = LogManager.getLogger(ScopeAuthorizerHelper.class);
+    private static final String SCOPE_FIELD = "scope";
+
+    private ScopeAuthorizerHelper() {}
+
+    public static boolean isScopeAuthorized(
+            AccountDataScope expectedScope,
+            APIGatewayProxyRequestEvent.ProxyRequestContext requestContext) {
+        if (requestContext.getAuthorizer() == null
+                || !requestContext.getAuthorizer().containsKey(SCOPE_FIELD)) {
+            LOG.warn("Authorizer missing from request context or scope not present");
+            return false;
+        }
+        var scope = requestContext.getAuthorizer().get(SCOPE_FIELD).toString();
+        var matches = expectedScope.getValue().equals(scope);
+        if (!matches) {
+            LOG.warn("Scope {} does not match expected scope {}", scope, expectedScope.getValue());
+        }
+        return matches;
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.accountdata.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
+import com.amazonaws.services.lambda.runtime.events.IamPolicyResponseV1;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSVerifier;
@@ -25,10 +26,9 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.net.MalformedURLException;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 public class AuthorizeHandler
-        implements RequestHandler<APIGatewayCustomAuthorizerEvent, Map<String, Object>> {
+        implements RequestHandler<APIGatewayCustomAuthorizerEvent, IamPolicyResponseV1> {
     private static final Logger LOG = LogManager.getLogger(AuthorizeHandler.class);
     private RemoteJwksService jwksService;
 
@@ -50,7 +50,7 @@ public class AuthorizeHandler
     }
 
     @Override
-    public Map<String, Object> handleRequest(
+    public IamPolicyResponseV1 handleRequest(
             APIGatewayCustomAuthorizerEvent apiGatewayCustomAuthorizerEvent, Context context) {
         var token = apiGatewayCustomAuthorizerEvent.getAuthorizationToken();
         try {
@@ -131,19 +131,19 @@ public class AuthorizeHandler
         return Result.success(claimsSet);
     }
 
-    private Map<String, Object> getAllowExecuteApiPolicyForSubject(
+    private IamPolicyResponseV1 getAllowExecuteApiPolicyForSubject(
             String subject, String methodArn) {
-        var executeApiStatement =
-                Map.ofEntries(
-                        Map.entry("Action", "execute-api:Invoke"),
-                        Map.entry("Effect", "Allow"),
-                        Map.entry("Resource", methodArn));
-        return Map.ofEntries(
-                Map.entry("principalId", subject),
-                Map.entry(
-                        "policyDocument",
-                        Map.ofEntries(
-                                Map.entry("Version", "2012-10-17"),
-                                Map.entry("Statement", List.of(executeApiStatement)))));
+        var statement = IamPolicyResponseV1.allowStatement(methodArn);
+
+        var policyDocument =
+                IamPolicyResponseV1.PolicyDocument.builder()
+                        .withStatement(List.of(statement))
+                        .withVersion(IamPolicyResponseV1.VERSION_2012_10_17)
+                        .build();
+
+        return IamPolicyResponseV1.builder()
+                .withPolicyDocument(policyDocument)
+                .withPrincipalId(subject)
+                .build();
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -155,6 +155,14 @@ public class AuthorizeHandler
             LOG.warn("Access Token audience is invalid");
             return Result.failure(new UnauthorizedException());
         }
+        if (claimsSet.getNotBeforeTime() == null) {
+            LOG.warn("Access Token is missing nbf claim");
+            return Result.failure(new UnauthorizedException());
+        }
+        if (DateUtils.isAfter(claimsSet.getNotBeforeTime(), NowHelper.now(), 0)) {
+            LOG.warn("Access Token is not yet valid (nbf: {})", claimsSet.getNotBeforeTime());
+            return Result.failure(new UnauthorizedException());
+        }
         return Result.success(claimsSet);
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -32,6 +32,7 @@ import java.util.Map;
 public class AuthorizeHandler
         implements RequestHandler<APIGatewayCustomAuthorizerEvent, IamPolicyResponseV1> {
     private static final Logger LOG = LogManager.getLogger(AuthorizeHandler.class);
+    private final ConfigurationService configurationService;
     private RemoteJwksService jwksService;
 
     public AuthorizeHandler() {
@@ -39,6 +40,7 @@ public class AuthorizeHandler
     }
 
     public AuthorizeHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         try {
             this.jwksService = new RemoteJwksService(configurationService.getAccountDataJwksUrl());
         } catch (MalformedURLException e) {
@@ -48,6 +50,13 @@ public class AuthorizeHandler
     }
 
     public AuthorizeHandler(RemoteJwksService jwksService) {
+        this.configurationService = ConfigurationService.getInstance();
+        this.jwksService = jwksService;
+    }
+
+    public AuthorizeHandler(
+            ConfigurationService configurationService, RemoteJwksService jwksService) {
+        this.configurationService = configurationService;
         this.jwksService = jwksService;
     }
 
@@ -134,6 +143,11 @@ public class AuthorizeHandler
     private Result<UnauthorizedException, JWTClaimsSet> validateClaimsSet(JWTClaimsSet claimsSet) {
         if (claimsSet.getSubject() == null || claimsSet.getSubject().isEmpty()) {
             LOG.warn("Access Token subject is missing");
+            return Result.failure(new UnauthorizedException());
+        }
+        var expectedIssuer = configurationService.getAuthIssuerClaim();
+        if (!expectedIssuer.equals(claimsSet.getIssuer())) {
+            LOG.warn("Access Token issuer is invalid");
             return Result.failure(new UnauthorizedException());
         }
         return Result.success(claimsSet);

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -26,6 +27,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.net.MalformedURLException;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class AuthorizeHandler
         implements RequestHandler<APIGatewayCustomAuthorizerEvent, IamPolicyResponseV1> {
@@ -63,14 +65,20 @@ public class AuthorizeHandler
                             .flatMap(success -> verifySignature(signedAccessToken))
                             .flatMap(success -> validateClaimsSet(claimsSet));
 
-            if (validatedClaimsResult.isFailure()) {
-                throw validatedClaimsResult.getFailure();
+            var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
+
+            var result =
+                    validatedClaimsResult
+                            .flatMap(this::validateScope)
+                            .map(JWTClaimsSet::getSubject);
+
+            if (result.isFailure()) {
+                throw result.getFailure();
             }
 
-            var subject = validatedClaimsResult.getSuccess().getSubject();
-            var methodArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
+            var scope = (String) claimsSet.getClaim("scope");
             LOG.info("Request validated, returning access policy");
-            return getAllowExecuteApiPolicyForSubject(subject, methodArn);
+            return getAllowExecuteApiPolicyForSubject(result.getSuccess(), methodArn, scope);
         } catch (ParseException | java.text.ParseException e) {
             LOG.warn("Unable to parse Access Token {}", e.getMessage());
             throw new UnauthorizedException();
@@ -132,7 +140,7 @@ public class AuthorizeHandler
     }
 
     private IamPolicyResponseV1 getAllowExecuteApiPolicyForSubject(
-            String subject, String methodArn) {
+            String subject, String methodArn, String scope) {
         var statement = IamPolicyResponseV1.allowStatement(methodArn);
 
         var policyDocument =
@@ -144,6 +152,19 @@ public class AuthorizeHandler
         return IamPolicyResponseV1.builder()
                 .withPolicyDocument(policyDocument)
                 .withPrincipalId(subject)
+                .withContext(Map.of("scope", scope))
                 .build();
+    }
+
+    private Result<UnauthorizedException, JWTClaimsSet> validateScope(JWTClaimsSet claimsSet) {
+        var scopeValue = (String) claimsSet.getClaim("scope");
+        var scope = AccountDataScope.fromValue(scopeValue);
+
+        if (scope.isEmpty()) {
+            LOG.warn("Invalid or missing scope: {}", scopeValue);
+            return Result.failure(new UnauthorizedException());
+        }
+
+        return Result.success(claimsSet);
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -163,6 +163,13 @@ public class AuthorizeHandler
             LOG.warn("Access Token is not yet valid (nbf: {})", claimsSet.getNotBeforeTime());
             return Result.failure(new UnauthorizedException());
         }
+        var amcClientId = configurationService.getAMCClientId();
+        var homeClientId = configurationService.getHomeClientId();
+        var clientId = (String) claimsSet.getClaim("client_id");
+        if (!amcClientId.equals(clientId) && !homeClientId.equals(clientId)) {
+            LOG.warn("Access Token client_id is invalid");
+            return Result.failure(new UnauthorizedException());
+        }
         return Result.success(claimsSet);
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -150,6 +150,11 @@ public class AuthorizeHandler
             LOG.warn("Access Token issuer is invalid");
             return Result.failure(new UnauthorizedException());
         }
+        var expectedAudience = configurationService.getAuthToAccountDataApiAudience();
+        if (!claimsSet.getAudience().contains(expectedAudience)) {
+            LOG.warn("Access Token audience is invalid");
+            return Result.failure(new UnauthorizedException());
+        }
         return Result.success(claimsSet);
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysCreateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -21,6 +22,7 @@ import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.MISSING_SUBJECT_ID;
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.UNAUTHORIZED_REQUEST;
 import static uk.gov.di.authentication.accountdata.helpers.PasskeysHelper.isAaguidValid;
+import static uk.gov.di.authentication.accountdata.helpers.ScopeAuthorizerHelper.isScopeAuthorized;
 import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -65,6 +67,7 @@ public class PasskeysCreateHandler
 
         return parseRequest(input)
                 .flatMap(createContext -> validateAuthorizedSubjectId(createContext, input))
+                .flatMap(createContext -> validateScope(createContext, input))
                 .flatMap(this::validateRequest)
                 .flatMap(this::createPasskey)
                 .fold(
@@ -113,6 +116,15 @@ public class PasskeysCreateHandler
             return Result.success(context);
         } else {
             LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
+            return Result.failure(UNAUTHORIZED_REQUEST);
+        }
+    }
+
+    private Result<PasskeysCreateFailureReason, PasskeysCreateContext> validateScope(
+            PasskeysCreateContext context, APIGatewayProxyRequestEvent input) {
+        if (isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, input.getRequestContext())) {
+            return Result.success(context);
+        } else {
             return Result.failure(UNAUTHORIZED_REQUEST);
         }
     }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -9,12 +9,14 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Objects;
 
+import static uk.gov.di.authentication.accountdata.helpers.ScopeAuthorizerHelper.isScopeAuthorized;
 import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
@@ -77,6 +79,10 @@ public class PasskeysDeleteHandler
 
         if (!isSubjectIdAuthorized(
                 input.getPathParameters().get("publicSubjectId"), input.getRequestContext())) {
+            return Result.failure(PasskeysDeleteFailureReason.UNAUTHORIZED_REQUEST);
+        }
+
+        if (!isScopeAuthorized(AccountDataScope.PASSKEY_DELETE, input.getRequestContext())) {
             return Result.failure(PasskeysDeleteFailureReason.UNAUTHORIZED_REQUEST);
         }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -19,6 +20,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.util.List;
 
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons.UNAUTHORIZED_REQUEST;
+import static uk.gov.di.authentication.accountdata.helpers.ScopeAuthorizerHelper.isScopeAuthorized;
 import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -64,6 +66,7 @@ public class PasskeysRetrieveHandler
                 .flatMap(
                         publicSubjectIdFromPath ->
                                 validateAuthorizedSubjectId(publicSubjectIdFromPath, input))
+                .flatMap(publicSubjectId -> validateScope(publicSubjectId, input))
                 .flatMap(passkeysService::retrievePasskeys)
                 .flatMap(this::mapPasskeysListToResponse)
                 .flatMap(this::generateApiResponse)
@@ -98,6 +101,15 @@ public class PasskeysRetrieveHandler
             return Result.success(publicSubjectId);
         } else {
             LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
+            return Result.failure(UNAUTHORIZED_REQUEST);
+        }
+    }
+
+    private Result<PasskeysRetrieveFailureReasons, String> validateScope(
+            String publicSubjectId, APIGatewayProxyRequestEvent input) {
+        if (isScopeAuthorized(AccountDataScope.PASSKEY_RETRIEVE, input.getRequestContext())) {
+            return Result.success(publicSubjectId);
+        } else {
             return Result.failure(UNAUTHORIZED_REQUEST);
         }
     }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandler.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysUpdateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -20,6 +21,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason.UNAUTHORIZED_REQUEST;
+import static uk.gov.di.authentication.accountdata.helpers.ScopeAuthorizerHelper.isScopeAuthorized;
 import static uk.gov.di.authentication.accountdata.helpers.SubjectIdAuthorizerHelper.isSubjectIdAuthorized;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -68,6 +70,7 @@ public class PasskeysUpdateHandler
 
         return parseUpdateRequest(input)
                 .flatMap(updateContext -> validateAuthorizedSubjectId(updateContext, input))
+                .flatMap(updateContext -> validateScope(updateContext, input))
                 .flatMap(
                         requestContext ->
                                 passkeysService.updatePasskey(
@@ -118,6 +121,15 @@ public class PasskeysUpdateHandler
             return Result.success(passkeysUpdateContext);
         } else {
             LOG.warn("SubjectId in path parameter does not match Authorizer principalId");
+            return Result.failure(UNAUTHORIZED_REQUEST);
+        }
+    }
+
+    private Result<PasskeysUpdateFailureReason, PasskeysUpdateContext> validateScope(
+            PasskeysUpdateContext passkeysUpdateContext, APIGatewayProxyRequestEvent input) {
+        if (isScopeAuthorized(AccountDataScope.PASSKEY_UPDATE, input.getRequestContext())) {
+            return Result.success(passkeysUpdateContext);
+        } else {
             return Result.failure(UNAUTHORIZED_REQUEST);
         }
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelperTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelperTest.java
@@ -1,0 +1,45 @@
+package uk.gov.di.authentication.accountdata.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.accountdata.helpers.ScopeAuthorizerHelper.isScopeAuthorized;
+
+class ScopeAuthorizerHelperTest {
+
+    @Test
+    void shouldReturnTrueWhenScopeMatches() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(Map.of("scope", "passkey-create"));
+
+        assertTrue(isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, requestContext));
+    }
+
+    @Test
+    void shouldReturnFalseWhenScopeDoesNotMatch() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(Map.of("scope", "passkey-retrieve"));
+
+        assertFalse(isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, requestContext));
+    }
+
+    @Test
+    void shouldReturnFalseWhenAuthorizerIsNull() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+
+        assertFalse(isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, requestContext));
+    }
+
+    @Test
+    void shouldReturnFalseWhenScopeFieldIsMissing() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(Map.of("principalId", "some-subject"));
+
+        assertFalse(isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, requestContext));
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
@@ -20,6 +20,7 @@ public class TokenGeneratorHelper {
                 .audience("https://account-data.example.com")
                 .expirationTime(expiryDate)
                 .issueTime(NowHelper.now())
+                .notBeforeTime(NowHelper.now())
                 .claim("client_id", "some-client-id")
                 .jwtID(UUID.randomUUID().toString());
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
@@ -10,13 +10,12 @@ import com.nimbusds.jwt.SignedJWT;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 
 public class TokenGeneratorHelper {
     public static JWTClaimsSet.Builder claimsSetBuilderWithoutSubject(Date expiryDate) {
         return new JWTClaimsSet.Builder()
-                .claim("scope", List.of("some-scopes"))
+                .claim("scope", "passkey-retrieve")
                 .issuer("https://example.com")
                 .expirationTime(expiryDate)
                 .issueTime(NowHelper.now())

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/TokenGeneratorHelper.java
@@ -17,6 +17,7 @@ public class TokenGeneratorHelper {
         return new JWTClaimsSet.Builder()
                 .claim("scope", "passkey-retrieve")
                 .issuer("https://example.com")
+                .audience("https://account-data.example.com")
                 .expirationTime(expiryDate)
                 .issueTime(NowHelper.now())
                 .claim("client_id", "some-client-id")

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -89,11 +89,11 @@ class AuthorizeHandlerTest {
                             {
                                 "principalId": "%s",
                                 "policyDocument": {
-                                    "Version": "2012-10-17",
-                                    "Statement": [{
-                                        "Action": "execute-api:Invoke",
-                                        "Effect": "Allow",
-                                        "Resource": "%s"
+                                    "version": "2012-10-17",
+                                    "statement": [{
+                                        "action": "execute-api:Invoke",
+                                        "effect": "Allow",
+                                        "resource": ["%s"]
                                     }]
                                 }
                             }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -57,6 +57,8 @@ class AuthorizeHandlerTest {
     private static final String SUBJECT = "some-subject";
     private static final String ISSUER = "https://example.com";
     private static final String AUDIENCE = "https://account-data.example.com";
+    private static final String CLIENT_ID = "some-client-id";
+    private static final String HOME_CLIENT_ID = "home-client-id";
 
     private static ECKey ecSigningKey;
     private APIGatewayCustomAuthorizerEvent event;
@@ -74,6 +76,8 @@ class AuthorizeHandlerTest {
                 .thenReturn(Result.success(ecSigningKey.toPublicJWK()));
         when(configurationService.getAuthIssuerClaim()).thenReturn(ISSUER);
         when(configurationService.getAuthToAccountDataApiAudience()).thenReturn(AUDIENCE);
+        when(configurationService.getAMCClientId()).thenReturn(CLIENT_ID);
+        when(configurationService.getHomeClientId()).thenReturn(HOME_CLIENT_ID);
     }
 
     @AfterEach
@@ -100,7 +104,7 @@ class AuthorizeHandlerTest {
 
             var bearerAccessToken =
                     createBearerAccessTokenWithExpiry(
-                            expiryDateFiveMinutesFromNow, ecSigningKey, scope);
+                            expiryDateFiveMinutesFromNow, ecSigningKey, scope, HOME_CLIENT_ID);
 
             event.setMethodArn(METHOD_ARN);
             event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
@@ -383,6 +387,27 @@ class AuthorizeHandlerTest {
         }
 
         @Test
+        void authorizeHandlerShouldRejectInvalidClientId() throws JOSEException {
+            when(configurationService.getAMCClientId()).thenReturn("expected-client-id");
+            when(configurationService.getHomeClientId()).thenReturn("expected-home-client-id");
+
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
+        @Test
         void authorizeHandlerShouldRejectTokenWithMissingNbf() throws JOSEException {
             var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
@@ -424,6 +449,16 @@ class AuthorizeHandlerTest {
     private static BearerAccessToken createBearerAccessTokenWithExpiry(
             Date expiryDate, ECKey ecSigningKey, String scope) throws JOSEException {
         var claimsBuilder = claimsSetBuilder(SUBJECT, expiryDate).claim("scope", scope);
+        return createBearerAccessToken(ecSigningKey, claimsBuilder);
+    }
+
+    private static BearerAccessToken createBearerAccessTokenWithExpiry(
+            Date expiryDate, ECKey ecSigningKey, String scope, String clientId)
+            throws JOSEException {
+        var claimsBuilder =
+                claimsSetBuilder(SUBJECT, expiryDate)
+                        .claim("scope", scope)
+                        .claim("client_id", clientId);
         return createBearerAccessToken(ecSigningKey, claimsBuilder);
     }
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -49,11 +49,13 @@ class AuthorizeHandlerTest {
     private static final String KEY_ID = "14342354354353";
     private final Context context = mock(Context.class);
     private final RemoteJwksService remoteJwksService = mock(RemoteJwksService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private static final Date expiryDateFiveMinutesFromNow =
             Date.from(Instant.now().plus(5, ChronoUnit.MINUTES));
     private static final String METHOD_ARN =
             "arn:aws:execute-api:eu-west-2:123456789:abc123/dev/GET/accounts";
     private static final String SUBJECT = "some-subject";
+    private static final String ISSUER = "https://example.com";
 
     private static ECKey ecSigningKey;
     private APIGatewayCustomAuthorizerEvent event;
@@ -69,6 +71,7 @@ class AuthorizeHandlerTest {
         event.setMethodArn(METHOD_ARN);
         when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
                 .thenReturn(Result.success(ecSigningKey.toPublicJWK()));
+        when(configurationService.getAuthIssuerClaim()).thenReturn(ISSUER);
     }
 
     @AfterEach
@@ -91,7 +94,7 @@ class AuthorizeHandlerTest {
         @MethodSource("validScopes")
         void authorizeHandlerShouldAllowNonExpiredTokenWithValidScope(String scope)
                 throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var bearerAccessToken =
                     createBearerAccessTokenWithExpiry(
@@ -130,7 +133,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectInvalidScope() throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var bearerAccessToken =
                     createBearerAccessTokenWithExpiry(
@@ -149,7 +152,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectIfScopeIsNotPresent() throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var bearerAccessToken =
                     createBearerAccessTokenWithExpiry(
@@ -168,7 +171,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectMissingToken() {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             event.setAuthorizationToken("");
 
@@ -183,7 +186,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectExpiredToken() throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var yesterdayInstant = Instant.now().minus(1, ChronoUnit.DAYS);
             var bearerAccessToken =
@@ -206,7 +209,7 @@ class AuthorizeHandlerTest {
             when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
                     .thenReturn(Result.success(differentKeyPair.toPublicJWK()));
 
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var bearerAccessToken =
                     createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
@@ -227,7 +230,7 @@ class AuthorizeHandlerTest {
             when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
                     .thenReturn(Result.failure("Failed to retrieve jwks key"));
 
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var bearerAccessToken =
                     createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
@@ -245,7 +248,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectUnparseableToken() {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             event.setAuthorizationToken("Bearer not-a-valid-jwt");
 
@@ -260,7 +263,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectAnUnsupportedAlgorithm() throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
             JWSSigner signer = new RSASSASigner(rsaKey);
@@ -282,7 +285,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectMissingSubjectId() throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var claimsWithoutSubject = claimsSetBuilderWithoutSubject(expiryDateFiveMinutesFromNow);
             var signedToken = createBearerAccessToken(ecSigningKey, claimsWithoutSubject);
@@ -299,7 +302,7 @@ class AuthorizeHandlerTest {
 
         @Test
         void authorizeHandlerShouldRejectEmptySubjectId() throws JOSEException {
-            var handler = new AuthorizeHandler(remoteJwksService);
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 
             var claimsWithEmptySubject = claimsSetBuilder("", expiryDateFiveMinutesFromNow);
             var signedToken = createBearerAccessToken(ecSigningKey, claimsWithEmptySubject);
@@ -315,15 +318,36 @@ class AuthorizeHandlerTest {
         }
 
         @Test
+        void authorizeHandlerShouldRejectInvalidIssuer() throws JOSEException {
+            when(configurationService.getAuthIssuerClaim())
+                    .thenReturn("https://expected-issuer.com");
+
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
+        @Test
         void authorizeHandlerFailsToInitialiseWhenAccountDataJwksUrlMalformed()
                 throws MalformedURLException {
-            var configurationService = mock(ConfigurationService.class);
-            when(configurationService.getAccountDataJwksUrl())
+            var malformedConfig = mock(ConfigurationService.class);
+            when(malformedConfig.getAccountDataJwksUrl())
                     .thenThrow(new MalformedURLException("uh oh"));
 
             assertThrows(
                     AuthorizeException.class,
-                    () -> new AuthorizeHandler(configurationService),
+                    () -> new AuthorizeHandler(malformedConfig),
                     "Expected to throw exception");
         }
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -56,6 +56,7 @@ class AuthorizeHandlerTest {
             "arn:aws:execute-api:eu-west-2:123456789:abc123/dev/GET/accounts";
     private static final String SUBJECT = "some-subject";
     private static final String ISSUER = "https://example.com";
+    private static final String AUDIENCE = "https://account-data.example.com";
 
     private static ECKey ecSigningKey;
     private APIGatewayCustomAuthorizerEvent event;
@@ -72,6 +73,7 @@ class AuthorizeHandlerTest {
         when(remoteJwksService.retrieveJwkFromURLWithKeyId(KEY_ID))
                 .thenReturn(Result.success(ecSigningKey.toPublicJWK()));
         when(configurationService.getAuthIssuerClaim()).thenReturn(ISSUER);
+        when(configurationService.getAuthToAccountDataApiAudience()).thenReturn(AUDIENCE);
     }
 
     @AfterEach
@@ -321,6 +323,27 @@ class AuthorizeHandlerTest {
         void authorizeHandlerShouldRejectInvalidIssuer() throws JOSEException {
             when(configurationService.getAuthIssuerClaim())
                     .thenReturn("https://expected-issuer.com");
+
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
+        @Test
+        void authorizeHandlerShouldRejectInvalidAudience() throws JOSEException {
+            when(configurationService.getAuthToAccountDataApiAudience())
+                    .thenReturn("https://wrong-audience.com");
 
             var handler = new AuthorizeHandler(configurationService, remoteJwksService);
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -20,9 +20,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
+import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -30,6 +34,7 @@ import java.net.MalformedURLException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -73,13 +78,26 @@ class AuthorizeHandlerTest {
 
     @Nested
     class Success {
-        @Test
-        void authorizeHandlerShouldAllowNonExpiredToken() throws JOSEException {
+
+        static Stream<Arguments> validScopes() {
+            return Stream.of(
+                    Arguments.of(AccountDataScope.PASSKEY_CREATE.getValue()),
+                    Arguments.of(AccountDataScope.PASSKEY_RETRIEVE.getValue()),
+                    Arguments.of(AccountDataScope.PASSKEY_UPDATE.getValue()),
+                    Arguments.of(AccountDataScope.PASSKEY_DELETE.getValue()));
+        }
+
+        @ParameterizedTest
+        @MethodSource("validScopes")
+        void authorizeHandlerShouldAllowNonExpiredTokenWithValidScope(String scope)
+                throws JOSEException {
             var handler = new AuthorizeHandler(remoteJwksService);
 
             var bearerAccessToken =
-                    createBearerAccessTokenWithExpiry(expiryDateFiveMinutesFromNow, ecSigningKey);
+                    createBearerAccessTokenWithExpiry(
+                            expiryDateFiveMinutesFromNow, ecSigningKey, scope);
 
+            event.setMethodArn(METHOD_ARN);
             event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
 
             var result = handler.handleRequest(event, context);
@@ -88,6 +106,7 @@ class AuthorizeHandlerTest {
                     """
                             {
                                 "principalId": "%s",
+                                "context": {"scope": "%s"},
                                 "policyDocument": {
                                     "version": "2012-10-17",
                                     "statement": [{
@@ -98,7 +117,7 @@ class AuthorizeHandlerTest {
                                 }
                             }
                             """
-                            .formatted(SUBJECT, METHOD_ARN);
+                            .formatted(SUBJECT, scope, METHOD_ARN);
 
             assertEquals(
                     JsonParser.parseString(expectedPolicyDocument),
@@ -108,6 +127,45 @@ class AuthorizeHandlerTest {
 
     @Nested
     class Failure {
+
+        @Test
+        void authorizeHandlerShouldRejectInvalidScope() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(
+                            expiryDateFiveMinutesFromNow, ecSigningKey, "invalid-scope");
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
+        @Test
+        void authorizeHandlerShouldRejectIfScopeIsNotPresent() throws JOSEException {
+            var handler = new AuthorizeHandler(remoteJwksService);
+
+            var bearerAccessToken =
+                    createBearerAccessTokenWithExpiry(
+                            expiryDateFiveMinutesFromNow, ecSigningKey, "");
+
+            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
         @Test
         void authorizeHandlerShouldRejectMissingToken() {
             var handler = new AuthorizeHandler(remoteJwksService);
@@ -273,6 +331,12 @@ class AuthorizeHandlerTest {
     private static BearerAccessToken createBearerAccessTokenWithExpiry(
             Date expiryDate, ECKey ecSigningKey) throws JOSEException {
         var claimsBuilder = claimsSetBuilder(SUBJECT, expiryDate);
+        return createBearerAccessToken(ecSigningKey, claimsBuilder);
+    }
+
+    private static BearerAccessToken createBearerAccessTokenWithExpiry(
+            Date expiryDate, ECKey ecSigningKey, String scope) throws JOSEException {
+        var claimsBuilder = claimsSetBuilder(SUBJECT, expiryDate).claim("scope", scope);
         return createBearerAccessToken(ecSigningKey, claimsBuilder);
     }
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -362,6 +362,46 @@ class AuthorizeHandlerTest {
         }
 
         @Test
+        void authorizeHandlerShouldRejectTokenNotYetValid() throws JOSEException {
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var futureNbf = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+            var claimsBuilder =
+                    claimsSetBuilder(SUBJECT, expiryDateFiveMinutesFromNow)
+                            .notBeforeTime(futureNbf);
+            var signedToken = createBearerAccessToken(ecSigningKey, claimsBuilder);
+
+            event.setAuthorizationToken(signedToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
+        @Test
+        void authorizeHandlerShouldRejectTokenWithMissingNbf() throws JOSEException {
+            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
+
+            var claimsBuilder =
+                    claimsSetBuilder(SUBJECT, expiryDateFiveMinutesFromNow).notBeforeTime(null);
+            var signedToken = createBearerAccessToken(ecSigningKey, claimsBuilder);
+
+            event.setAuthorizationToken(signedToken.toAuthorizationHeader());
+
+            RuntimeException exception =
+                    assertThrows(
+                            UnauthorizedException.class,
+                            () -> handler.handleRequest(event, context),
+                            "Expected to throw exception");
+
+            assertEquals("Unauthorized", exception.getMessage());
+        }
+
+        @Test
         void authorizeHandlerFailsToInitialiseWhenAccountDataJwksUrlMalformed()
                 throws MalformedURLException {
             var malformedConfig = mock(ConfigurationService.class);

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -38,7 +38,7 @@ class PasskeysCreateHandlerTest {
     private final PasskeysService passkeysService = mock(PasskeysService.class);
     private final Json objectMapper = SerializationService.getInstance();
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-create");
 
     private PasskeysCreateHandler handler;
 
@@ -261,7 +261,38 @@ class PasskeysCreateHandlerTest {
                         false,
                         false,
                         false);
-        var authorizerParams = Map.<String, Object>of("principalId", "different-subject-id");
+        var authorizerParams =
+                Map.<String, Object>of(
+                        "principalId", "different-subject-id", "scope", "passkey-create");
+        var request =
+                passkeysCreateRequest(passkeysCreateRequestBody, pathParams, authorizerParams);
+
+        // When
+        var result = handler.handleRequest(request, context);
+
+        // Then
+        assertThat(result, hasStatus(401));
+        assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+    }
+
+    @Test
+    void shouldReturn401WhenScopeDoesNotMatchEndpoint() throws Json.JsonException {
+        // Given
+        var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+        var passkeysCreateRequestBody =
+                buildPasskeysCreateRequestBody(
+                        CREDENTIAL,
+                        PRIMARY_PASSKEY_ID,
+                        TEST_AAGUID,
+                        false,
+                        0,
+                        PASSKEY_TRANSPORTS,
+                        false,
+                        false,
+                        false);
+        var authorizerParams =
+                Map.<String, Object>of(
+                        "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-retrieve");
         var request =
                 passkeysCreateRequest(passkeysCreateRequestBody, pathParams, authorizerParams);
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandlerTest.java
@@ -45,7 +45,9 @@ class PasskeysDeleteHandlerTest {
             // Given
             var pathParams =
                     Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
-            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");
             when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
                     .thenReturn(Result.success(null));
 
@@ -66,7 +68,9 @@ class PasskeysDeleteHandlerTest {
             // Given
             var pathParams =
                     Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
-            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");
             when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
                     .thenReturn(Result.failure(PasskeysDeleteFailureReason.PASSKEY_NOT_FOUND));
 
@@ -85,7 +89,9 @@ class PasskeysDeleteHandlerTest {
             // Given
             var pathParams =
                     Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
-            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");
             when(passkeysService.deletePasskey(PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID))
                     .thenReturn(
                             Result.failure(PasskeysDeleteFailureReason.FAILED_TO_DELETE_PASSKEY));
@@ -122,7 +128,9 @@ class PasskeysDeleteHandlerTest {
                 Map<String, String> pathParamsWithMissingFields,
                 ErrorResponse expectedErrorResponse) {
             // Given
-            var authorizerParams = Map.<String, Object>of("principalId", PUBLIC_SUBJECT_ID);
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");
 
             // When
             var result =
@@ -140,7 +148,27 @@ class PasskeysDeleteHandlerTest {
             // Given
             var pathParams =
                     Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
-            var authorizerParams = Map.<String, Object>of("principalId", "another-subject-id");
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", "another-subject-id", "scope", "passkey-delete");
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysDeleteRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(401));
+        }
+
+        @Test
+        void shouldReturn401WhenScopeDoesNotMatchEndpoint() {
+            // Given
+            var pathParams =
+                    Map.of("publicSubjectId", PUBLIC_SUBJECT_ID, "passkeyId", PRIMARY_PASSKEY_ID);
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-create");
 
             // When
             var result =

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandlerTest.java
@@ -32,7 +32,7 @@ class PasskeysRetrieveHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeysService passkeysService = mock(PasskeysService.class);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-retrieve");
 
     private PasskeysRetrieveHandler handler;
 
@@ -93,7 +93,29 @@ class PasskeysRetrieveHandlerTest {
             // Given
             var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
             var authorizerParams =
-                    Map.<String, Object>of("principalId", "a-different-public-subject-id");
+                    Map.<String, Object>of(
+                            "principalId",
+                            "a-different-public-subject-id",
+                            "scope",
+                            "passkey-retrieve");
+
+            // When
+            var result =
+                    handler.handleRequest(
+                            passkeysRetrieveRequest(pathParams, authorizerParams), context);
+
+            // Then
+            assertThat(result, hasStatus(401));
+            assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+        }
+
+        @Test
+        void shouldReturn401WhenScopeDoesNotMatchEndpoint() {
+            // Given
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var authorizerParams =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-create");
 
             // When
             var result =

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
@@ -39,7 +39,7 @@ class PasskeysUpdateHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeysService passkeysService = mock(PasskeysService.class);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
-            Map.of("principalId", PUBLIC_SUBJECT_ID);
+            Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-update");
 
     private PasskeysUpdateHandler handler;
 
@@ -168,9 +168,39 @@ class PasskeysUpdateHandlerTest {
         void shouldReturn401WhenPublicSubjectIdDoesNotMatchTheOneInAuthorizerParams() {
             // Given
             var authorizerParamsWithDifferentPublicSubjectId =
-                    Map.<String, Object>of("principalId", "a-different-public-subject-id");
+                    Map.<String, Object>of(
+                            "principalId",
+                            "a-different-public-subject-id",
+                            "scope",
+                            "passkey-update");
             var request =
                     baseApiProxyRequest(authorizerParamsWithDifferentPublicSubjectId)
+                            .withPathParameters(
+                                    Map.of(
+                                            "publicSubjectId",
+                                            PUBLIC_SUBJECT_ID,
+                                            "passkeyId",
+                                            PRIMARY_PASSKEY_ID))
+                            .withBody(
+                                    "{\"signCount\":%d, \"lastUsedAt\":\"%s\"}"
+                                            .formatted(SIGN_COUNT, LAST_USED_AT));
+
+            // When
+            var result = handler.handleRequest(request, context);
+
+            // Then
+            assertThat(result, hasStatus(401));
+            assertThat(result, hasJsonBody(ErrorResponse.UNAUTHORIZED_REQUEST));
+        }
+
+        @Test
+        void shouldReturn401WhenScopeDoesNotMatchEndpoint() {
+            // Given
+            var authorizerParamsWithWrongScope =
+                    Map.<String, Object>of(
+                            "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");
+            var request =
+                    baseApiProxyRequest(authorizerParamsWithWrongScope)
                             .withPathParameters(
                                     Map.of(
                                             "publicSubjectId",

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -34,6 +34,13 @@ Resources:
               - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
               - !Sub "https://account.${Environment}.account.gov.uk"
             - "https://account.account.gov.uk"
+          AMC_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              amcClientId,
+            ]
+          HOME_CLIENT_ID: "home"
       LoggingConfig:
         LogGroup: !Ref AuthorizerFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -21,6 +21,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               accountDataJwksUrl,
             ]
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
       LoggingConfig:
         LogGroup: !Ref AuthorizerFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-data/function/authorizer.yaml
+++ b/ci/cloudformation/account-data/function/authorizer.yaml
@@ -27,6 +27,13 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               frontendBaseUrl,
             ]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
       LoggingConfig:
         LogGroup: !Ref AuthorizerFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -68,6 +68,12 @@ Conditions:
               - !Ref SubEnvironment
               - none
 
+  IsNotProduction:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref Environment
+          - production
+
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -114,16 +114,19 @@ Mappings:
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d41a1b95-0291-4477-93f7-f1428ceef646
       accountDataJwksUrl: https://5fgwu5kpd2.execute-api.eu-west-2.amazonaws.com/authdev1/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev1.dev.account.gov.uk
+      amcClientId: auth
     authdev2:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
       accountDataJwksUrl: https://nw0dah7bxk.execute-api.eu-west-2.amazonaws.com/authdev2/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev2.dev.account.gov.uk
+      amcClientId: auth
     authdev3:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
       accountDataJwksUrl: https://y3s69ubaz5.execute-api.eu-west-2.amazonaws.com/authdev3/.well-known/amc-jwks.json
       frontendBaseUrl: https://signin.authdev3.dev.account.gov.uk
+      amcClientId: auth
     dev:
       cloudwatchLogRetentionInDays: 1
       IsSplunkEnabled: "No"
@@ -133,6 +136,7 @@ Mappings:
       dataStoreAccountId: 653994557586
       accountDataJwksUrl: https://tze402cnbk.execute-api.eu-west-2.amazonaws.com/dev/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.dev.account.gov.uk
+      amcClientId: auth
     build:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -142,6 +146,7 @@ Mappings:
       dataStoreAccountId: 761723964695
       accountDataJwksUrl: https://7ecg8e1o73.execute-api.eu-west-2.amazonaws.com/build/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.build.account.gov.uk
+      amcClientId: auth
     staging:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -152,6 +157,7 @@ Mappings:
       accountComponentsVpcEndpointId: vpce-04ae8d53b32b38278
       accountDataJwksUrl: https://z02rnzbqw8.execute-api.eu-west-2.amazonaws.com/staging/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.staging.account.gov.uk
+      amcClientId: auth
     integration:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -162,6 +168,7 @@ Mappings:
       accountComponentsVpcEndpointId: vpce-0553cfc8fc1aeb970
       accountDataJwksUrl: https://db10ia9pr6.execute-api.eu-west-2.amazonaws.com/integration/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.integration.account.gov.uk
+      amcClientId: auth
     production:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -172,6 +179,7 @@ Mappings:
       accountComponentsVpcEndpointId: vpce-0d6fa47d5c9ae876d
       accountDataJwksUrl: https://86n9innl95.execute-api.eu-west-2.amazonaws.com/production/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.account.gov.uk
+      amcClientId: auth
   LambdaConfiguration:
     passkeys-create:
       RunbookLink: "https://govukverify.atlassian.net/wiki/x/HIHpRQE"

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -107,14 +107,17 @@ Mappings:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d41a1b95-0291-4477-93f7-f1428ceef646
       accountDataJwksUrl: https://5fgwu5kpd2.execute-api.eu-west-2.amazonaws.com/authdev1/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.authdev1.dev.account.gov.uk
     authdev2:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
       accountDataJwksUrl: https://nw0dah7bxk.execute-api.eu-west-2.amazonaws.com/authdev2/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.authdev2.dev.account.gov.uk
     authdev3:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
       accountDataJwksUrl: https://y3s69ubaz5.execute-api.eu-west-2.amazonaws.com/authdev3/.well-known/amc-jwks.json
+      frontendBaseUrl: https://signin.authdev3.dev.account.gov.uk
     dev:
       cloudwatchLogRetentionInDays: 1
       IsSplunkEnabled: "No"
@@ -123,6 +126,7 @@ Mappings:
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c6a2fb5e-c92b-4129-bc0c-d75b2b72bae8
       dataStoreAccountId: 653994557586
       accountDataJwksUrl: https://tze402cnbk.execute-api.eu-west-2.amazonaws.com/dev/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.dev.account.gov.uk
     build:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -131,6 +135,7 @@ Mappings:
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3c2113fe-9f53-4bed-a46f-c53f02f6c117
       dataStoreAccountId: 761723964695
       accountDataJwksUrl: https://7ecg8e1o73.execute-api.eu-west-2.amazonaws.com/build/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.build.account.gov.uk
     staging:
       cloudwatchLogRetentionInDays: 7
       IsSplunkEnabled: "Yes"
@@ -140,6 +145,7 @@ Mappings:
       dataStoreAccountId: 758531536632
       accountComponentsVpcEndpointId: vpce-04ae8d53b32b38278
       accountDataJwksUrl: https://z02rnzbqw8.execute-api.eu-west-2.amazonaws.com/staging/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.staging.account.gov.uk
     integration:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -149,6 +155,7 @@ Mappings:
       dataStoreAccountId: 761723964695
       accountComponentsVpcEndpointId: vpce-0553cfc8fc1aeb970
       accountDataJwksUrl: https://db10ia9pr6.execute-api.eu-west-2.amazonaws.com/integration/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.integration.account.gov.uk
     production:
       cloudwatchLogRetentionInDays: 30
       IsSplunkEnabled: "Yes"
@@ -158,6 +165,7 @@ Mappings:
       dataStoreAccountId: 172348255554
       accountComponentsVpcEndpointId: vpce-0d6fa47d5c9ae876d
       accountDataJwksUrl: https://86n9innl95.execute-api.eu-west-2.amazonaws.com/production/.well-known/ad-jwks.json
+      frontendBaseUrl: https://signin.account.gov.uk
   LambdaConfiguration:
     passkeys-create:
       RunbookLink: "https://govukverify.atlassian.net/wiki/x/HIHpRQE"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccountDataScope.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccountDataScope.java
@@ -1,8 +1,13 @@
 package uk.gov.di.authentication.shared.entity;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 public enum AccountDataScope implements AccessTokenScope {
     PASSKEY_CREATE("passkey-create"),
-    PASSKEY_RETRIEVE("passkey-retrieve");
+    PASSKEY_RETRIEVE("passkey-retrieve"),
+    PASSKEY_UPDATE("passkey-update"),
+    PASSKEY_DELETE("passkey-delete");
 
     private final String value;
 
@@ -12,5 +17,9 @@ public enum AccountDataScope implements AccessTokenScope {
 
     public String getValue() {
         return value;
+    }
+
+    public static Optional<AccountDataScope> fromValue(String value) {
+        return Arrays.stream(values()).filter(s -> s.value.equals(value)).findFirst();
     }
 }


### PR DESCRIPTION
## What

- Extends the account-data-api authorizer to validate all JWT claims: 
   - issuer 
   - audience 
   - not-before time 
   - client_id (AMC + Home allow list) 
   - scope-to-HTTP-method mapping (AMC client restricted to create/retrieve only) 

## How to review

1. Code Review commit-by-commit
2. Test in dev

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
