### PR TITLE
AUT-5450: Redis failover notifications

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -38,7 +38,7 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   parameter_group_name        = "default.redis6.x"
   port                        = local.redis_port_number
   maintenance_window          = "tue:22:00-tue:23:00"
-  notification_topic_arn      = local.slack_event_sns_topic_arn
+  notification_topic_arn      = local.elasticache_alerts_sns_topic_arn
 
   multi_az_enabled = true
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -9,21 +9,5 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  lambda_code_signing_configuration_arn           = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
-  account_modifiers_encryption_policy_arn         = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
-  common_passwords_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
-  client_registry_encryption_policy_arn           = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
-  user_profile_encryption_policy_arn              = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
-  user_credentials_kms_key_arn                    = data.terraform_remote_state.shared.outputs.user_credentials_kms_key_arn
-  pending_email_check_queue_id                    = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
-  pending_email_check_queue_access_policy_arn     = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
-  client_registry_encryption_key_arn              = data.terraform_remote_state.shared.outputs.client_registry_encryption_key_arn
-  user_profile_kms_key_arn                        = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
-  email_check_results_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
-  test_client_allow_list_secret_access_policy_arn = var.test_clients_enabled ? data.terraform_remote_state.shared.outputs.test_client_allow_list_secret_access_policy_arn : null
-
-
-  slack_event_sns_topic_arn        = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
   elasticache_alerts_sns_topic_arn = data.terraform_remote_state.shared.outputs.elasticache_alerts_sns_topic_arn
-  aws_account_alias                = data.terraform_remote_state.shared.outputs.aws_account_alias
 }

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -9,5 +9,21 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  slack_event_sns_topic_arn = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
+  lambda_code_signing_configuration_arn           = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  account_modifiers_encryption_policy_arn         = data.terraform_remote_state.shared.outputs.account_modifiers_encryption_policy_arn
+  common_passwords_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
+  client_registry_encryption_policy_arn           = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
+  user_profile_encryption_policy_arn              = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
+  user_credentials_kms_key_arn                    = data.terraform_remote_state.shared.outputs.user_credentials_kms_key_arn
+  pending_email_check_queue_id                    = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
+  pending_email_check_queue_access_policy_arn     = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
+  client_registry_encryption_key_arn              = data.terraform_remote_state.shared.outputs.client_registry_encryption_key_arn
+  user_profile_kms_key_arn                        = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
+  email_check_results_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
+  test_client_allow_list_secret_access_policy_arn = var.test_clients_enabled ? data.terraform_remote_state.shared.outputs.test_client_allow_list_secret_access_policy_arn : null
+
+
+  slack_event_sns_topic_arn        = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
+  elasticache_alerts_sns_topic_arn = data.terraform_remote_state.shared.outputs.elasticache_alerts_sns_topic_arn
+  aws_account_alias                = data.terraform_remote_state.shared.outputs.aws_account_alias
 }

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -31,7 +31,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   port                        = local.redis_port_number
   multi_az_enabled            = true
   maintenance_window          = "wed:22:00-wed:23:00"
-  notification_topic_arn      = aws_sns_topic.slack_events.arn
+  notification_topic_arn      = aws_sns_topic.elasticache_alerts.arn
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
@@ -50,13 +50,10 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   }
 
   depends_on = [
-    aws_sns_topic.slack_events,
+    aws_sns_topic.elasticache_alerts,
   ]
 }
 
-data "aws_sns_topic" "slack_events" {
-  name = "${var.environment}-slack-events"
-}
 
 resource "random_password" "frontend_redis_password" {
   length = 32
@@ -86,7 +83,7 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
   parameter_group_name        = "default.redis6.x"
   port                        = local.redis_port_number
   maintenance_window          = "sun:22:00-sun:23:00"
-  notification_topic_arn      = data.aws_sns_topic.slack_events.arn
+  notification_topic_arn      = aws_sns_topic.elasticache_alerts.arn
 
   multi_az_enabled = true
 

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -8,36 +8,17 @@ resource "aws_sns_topic" "elasticache_alerts" {
   name = "${var.environment}-elasticache-alerts"
 }
 
-resource "aws_sns_topic_policy" "elasticache_alerts_policy" {
-  arn    = aws_sns_topic.elasticache_alerts.arn
-  policy = data.aws_iam_policy_document.elasticache_alerts_topic_policy.json
-}
-
-data "aws_iam_policy_document" "elasticache_alerts_topic_policy" {
-  statement {
-    sid    = "AllowCrossAccountSubscription"
-    effect = "Allow"
-    actions = [
-      "SNS:Subscribe",
-      "SNS:Receive",
-    ]
-    resources = [aws_sns_topic.elasticache_alerts.arn]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.auth_new_account_id}:root"]
-    }
-  }
+resource "aws_sns_topic_subscription" "elasticache_alerts_lambda" {
+  topic_arn                       = aws_sns_topic.elasticache_alerts.arn
+  protocol                        = "lambda"
+  endpoint                        = "arn:aws:lambda:eu-west-2:${var.auth_new_account_id}:function:${var.environment}-alerts"
+  endpoint_auto_confirms          = true
+  confirmation_timeout_in_minutes = 5
 }
 
 output "slack_event_sns_topic_arn" {
   description = "The ARN of the SNS topic for Slack events"
   value       = aws_sns_topic.slack_events.arn
-}
-
-output "elasticache_alerts_sns_topic_arn" {
-  description = "The ARN of the unencrypted SNS topic for ElastiCache notifications"
-  value       = aws_sns_topic.elasticache_alerts.arn
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -4,9 +4,40 @@ resource "aws_sns_topic" "slack_events" {
   kms_master_key_id                = "alias/aws/sns"
 }
 
+resource "aws_sns_topic" "elasticache_alerts" {
+  name = "${var.environment}-elasticache-alerts"
+}
+
+resource "aws_sns_topic_policy" "elasticache_alerts_policy" {
+  arn    = aws_sns_topic.elasticache_alerts.arn
+  policy = data.aws_iam_policy_document.elasticache_alerts_topic_policy.json
+}
+
+data "aws_iam_policy_document" "elasticache_alerts_topic_policy" {
+  statement {
+    sid    = "AllowCrossAccountSubscription"
+    effect = "Allow"
+    actions = [
+      "SNS:Subscribe",
+      "SNS:Receive",
+    ]
+    resources = [aws_sns_topic.elasticache_alerts.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.auth_new_account_id}:root"]
+    }
+  }
+}
+
 output "slack_event_sns_topic_arn" {
   description = "The ARN of the SNS topic for Slack events"
   value       = aws_sns_topic.slack_events.arn
+}
+
+output "elasticache_alerts_sns_topic_arn" {
+  description = "The ARN of the unencrypted SNS topic for ElastiCache notifications"
+  value       = aws_sns_topic.elasticache_alerts.arn
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -9,6 +9,7 @@ resource "aws_sns_topic" "elasticache_alerts" {
 }
 
 resource "aws_sns_topic_subscription" "elasticache_alerts_lambda" {
+  count                           = contains(["integration", "production"], var.environment) ? 1 : 0
   topic_arn                       = aws_sns_topic.elasticache_alerts.arn
   protocol                        = "lambda"
   endpoint                        = "arn:aws:lambda:eu-west-2:${var.auth_new_account_id}:function:${var.environment}-alerts"

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -17,6 +17,11 @@ resource "aws_sns_topic_subscription" "elasticache_alerts_lambda" {
   confirmation_timeout_in_minutes = 5
 }
 
+output "elasticache_alerts_sns_topic_arn" {
+  description = "The ARN of the unencrypted SNS topic for ElastiCache notifications"
+  value       = aws_sns_topic.elasticache_alerts.arn
+}
+
 output "slack_event_sns_topic_arn" {
   description = "The ARN of the SNS topic for Slack events"
   value       = aws_sns_topic.slack_events.arn


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

## How to review

1. Code Review
2. Deploy in Authdevs ./deploy-authdevs.sh -s -a -p 

Verify the the changes to Elastic cache notification ARN  group changes




## Related PRs
  - PR is dependent ,Below PR need to be merged first 

https://github.com/govuk-one-login/authentication-smoke-tests/pull/1287




