### PR TITLE
AUT-5449: Add logging configuration to the ticf cri stub

### DIFF
--- a/ticf-cri-stub/src/main/resources/LambdaJsonLayout.json
+++ b/ticf-cri-stub/src/main/resources/LambdaJsonLayout.json
@@ -1,0 +1,91 @@
+{
+  "instant": {
+    "epochSecond": {
+      "$resolver": "timestamp",
+      "epoch": {
+        "unit": "secs",
+        "rounded": true
+      }
+    },
+    "nanoOfSecond": {
+      "$resolver": "timestamp",
+      "epoch": {
+        "unit": "secs.nanos"
+      }
+    }
+  },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "loggerName": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "message": {
+    "$resolver": "message"
+  },
+  "thrown": {
+    "message": {
+      "$resolver": "exception",
+      "field": "message"
+    },
+    "name": {
+      "$resolver": "exception",
+      "field": "className"
+    },
+    "extendedStackTrace": {
+      "$resolver": "exception",
+      "field": "stackTrace"
+    }
+  },
+  "contextStack": {
+    "$resolver": "ndc"
+  },
+  "source": {
+    "class": {
+      "$resolver": "source",
+      "field": "className"
+    },
+    "method": {
+      "$resolver": "source",
+      "field": "methodName"
+    },
+    "file": {
+      "$resolver": "source",
+      "field": "fileName"
+    },
+    "line": {
+      "$resolver": "source",
+      "field": "lineNumber"
+    }
+  },
+  "session-id": {
+    "$resolver": "mdc",
+    "key": "sessionId"
+  },
+  "persistent-session-id": {
+    "$resolver": "mdc",
+    "key": "persistentSessionId"
+  },
+  "client-session-id": {
+    "$resolver": "mdc",
+    "key": "clientSessionId"
+  },
+  "govuk_signin_journey_id": {
+    "$resolver": "mdc",
+    "key": "govukSigninJourneyId"
+  },
+  "client-id": {
+    "$resolver": "mdc",
+    "key": "clientId"
+  },
+  "aws-request-id": {
+    "$resolver": "mdc",
+    "key": "awsRequestId"
+  },
+  "trace-id": {
+    "$resolver": "mdc",
+    "key": "traceId"
+  }
+}

--- a/ticf-cri-stub/src/main/resources/log4j2.xml
+++ b/ticf-cri-stub/src/main/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN" />
+        <Logger name="software.amazon.awssdk.request" level="DEBUG" />
+    </Loggers>
+</Configuration>


### PR DESCRIPTION


## What

Add logging configuration to the ticf cri stub.

Nothing is currently being logged.  Logging is useful to undertand what gets sent to the TICF CRI in each scenario.

https://github.com/govuk-one-login/authentication-api/blob/1afec1d34c26c9a86263164d8ae999856641c405/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java#L29

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)


