### PR TITLE
BAU: Constrain opentelemetry-api to >=1.62.0 to fix CVE-2026-45292

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,11 @@ subprojects {
                     because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
                 }
 
+                // OpenTelemetry constraints
+                classpath('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+                    because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
+                }
+
                 // Other constraints
                 classpath('com.google.protobuf:protobuf-java:[3.25.5,)') {
                     because 'CVE-2024-7254 is fixed in 3.25.5 and above'
@@ -187,6 +192,11 @@ subprojects {
 
                     add(conf.name, 'commons-io:commons-io:[2.21.0,)') {
                         because 'CVE-2021-29425 is fixed in commons-io:commons-io:2.21.0 and higher'
+                    }
+
+                    // OpenTelemetry constraints
+                    add(conf.name, 'io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+                        because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
                     }
 
                     // Other constraints


### PR DESCRIPTION
## What

- CVE-2026-45292: OpenTelemetry Java SDK has unbounded memory allocation in W3C Baggage propagation. Constraining io.opentelemetry:opentelemetry-api to >=1.62.0 in both buildscript and main dependency blocks.

## How to review

1. Code Review