### PR TITLE
BAU: Constrain netty-handler-proxy to >=4.1.133.Final to fix CVE-2026-42578

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ subprojects {
                     because 'CVE-2025-24970 is fixed in io.netty:netty-handler:4.1.118.Final and higher'
                 }
 
+                classpath('io.netty:netty-handler-proxy:[4.1.133.Final,4.2.0)') {
+                    because 'CVE-2026-42578 is fixed in io.netty:netty-handler-proxy:4.1.133.Final and higher'
+                }
+
                 classpath('io.netty:netty-codec-http2:[4.1.133.Final,4.2.0)') {
                     because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.1.133.Final and higher'
                 }
@@ -140,6 +144,10 @@ subprojects {
 
                     add(conf.name, 'io.netty:netty-handler:[4.1.118.Final,)') {
                         because 'CVE-2025-24970 is fixed in io.netty:netty-handler:4.1.118.Final and higher'
+                    }
+
+                    add(conf.name, 'io.netty:netty-handler-proxy:[4.1.133.Final,4.2.0)') {
+                        because 'CVE-2026-42578 is fixed in io.netty:netty-handler-proxy:4.1.133.Final and higher'
                     }
 
                     add(conf.name, 'io.netty:netty-codec-http2:[4.1.133.Final,4.2.0)') {


### PR DESCRIPTION
## What

- CVE-2026-42578: Netty has HTTP Header Injection via HttpProxyHandler disabled validation (incomplete fix for CVE-2025-67735). Constraining io.netty:netty-handler-proxy to >=4.1.133.Final in both buildscript and main dependency blocks.

## How to review

1. Code Review