### PR TITLE
ATO-2537: add feature flag to stop publishing old external token key …

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -64,11 +64,14 @@ public class JwksHandler
 
             List<JWK> signingKeys = new ArrayList<>();
 
-            signingKeys.add(jwksService.getPublicTokenJwkWithOpaqueId());
             signingKeys.add(jwksService.getPublicDocAppSigningJwkWithOpaqueId());
 
-            if (configurationService.isRsaSigningAvailable()) {
-                signingKeys.add(jwksService.getPublicTokenRsaJwkWithOpaqueId());
+            if (configurationService.isPublishOldExternalTokenSigningKeysEnabled()) {
+                signingKeys.add(jwksService.getPublicTokenJwkWithOpaqueId());
+
+                if (configurationService.isRsaSigningAvailable()) {
+                    signingKeys.add(jwksService.getPublicTokenRsaJwkWithOpaqueId());
+                }
             }
 
             if (configurationService.isPublishNextExternalTokenSigningKeysEnabledV2()) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
@@ -38,6 +38,7 @@ class JwksHandlerTest {
 
     @Test
     void shouldReturnTwoJwksWhenRsaSigningIsDisabled() throws JOSEException {
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
         var tokenSigningKey = generateECKey();
         var docAppSigningKey = generateECKey();
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
@@ -46,7 +47,7 @@ class JwksHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         var result = handler.handleRequest(event, context);
 
-        var expectedJWKSet = new JWKSet(List.of(tokenSigningKey, docAppSigningKey));
+        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey, tokenSigningKey));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));
@@ -55,6 +56,7 @@ class JwksHandlerTest {
     @Test
     void shouldReturnThreeJwksWhenRsaSigningIsEnabled() throws JOSEException {
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
         var tokenSigningKey = generateECKey();
         var docAppSigningKey = generateECKey();
         var rsaTokenSigningKey =
@@ -67,7 +69,7 @@ class JwksHandlerTest {
         var result = handler.handleRequest(event, context);
 
         var expectedJWKSet =
-                new JWKSet(List.of(tokenSigningKey, docAppSigningKey, rsaTokenSigningKey));
+                new JWKSet(List.of(docAppSigningKey, tokenSigningKey, rsaTokenSigningKey));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));
@@ -75,6 +77,7 @@ class JwksHandlerTest {
 
     @Test
     void shouldReturn200WhenRequestIsSuccessful() throws JOSEException {
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
         var opaqueSigningKey = generateECKey();
         var docAppSigningKey = generateECKey();
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
@@ -83,7 +86,7 @@ class JwksHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         var result = handler.handleRequest(event, context);
 
-        var expectedJWKSet = new JWKSet(List.of(opaqueSigningKey, docAppSigningKey));
+        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey, opaqueSigningKey));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));
@@ -91,6 +94,7 @@ class JwksHandlerTest {
 
     @Test
     void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(null);
 
         var event = new APIGatewayProxyRequestEvent();
@@ -102,6 +106,7 @@ class JwksHandlerTest {
 
     @Test
     void shouldSetACacheHeaderOfOneDayOnSuccess() throws JOSEException {
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
         var opaqueSigningKey = generateECKey();
         var docAppSigningKey = generateECKey();
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
@@ -116,6 +121,7 @@ class JwksHandlerTest {
         when(configurationService.isRsaSigningAvailable()).thenReturn(false);
         when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
                 .thenReturn(true);
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
 
         var tokenSigningKey = generateECKey();
         var docAppSigningKey = generateECKey();
@@ -129,7 +135,26 @@ class JwksHandlerTest {
         var result = handler.handleRequest(event, context);
 
         var expectedJWKSet =
-                new JWKSet(List.of(tokenSigningKey, docAppSigningKey, newTokenSigningKeyV2));
+                new JWKSet(List.of(docAppSigningKey, tokenSigningKey, newTokenSigningKeyV2));
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
+    }
+
+    @Test
+    void shouldNotPublishOldEcKeyWhenOldPublishDisabled() throws JOSEException {
+        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(false);
+
+        var tokenSigningKey = generateECKey();
+        var docAppSigningKey = generateECKey();
+
+        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
+        when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -306,5 +306,10 @@ public class IntegrationTest {
         public Optional<String> getIPVCapacity() {
             return Optional.of("1");
         }
+
+        @Override
+        public boolean isPublishOldExternalTokenSigningKeysEnabled() {
+            return true;
+        }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -385,6 +385,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2");
     }
 
+    public boolean isPublishOldExternalTokenSigningKeysEnabled() {
+        return getFlagOrFalse("PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS");
+    }
+
     public boolean isRsaSigningAvailable() {
         return List.of("dev", "build", "staging", "integration", "production")
                 .contains(getEnvironment());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
@@ -132,8 +132,8 @@ public class TokenValidationService {
     }
 
     private boolean validateWithOldECPublicKey(SignedJWT jwt) throws JOSEException {
-        var oldPublicKey = jwksService.getPublicTokenJwkWithOpaqueId();
-        if (configuration.isUseStoredOldIdTokenPublicKeysEnabled()) {
+        if (configuration.isUseStoredOldIdTokenPublicKeysEnabled()
+                || !configuration.isPublishOldExternalTokenSigningKeysEnabled()) {
             var oldStoredPublicKeys = jwksService.getStoredOldPublicTokenJwksWithOpaqueId();
             Optional<ECKey> optionalPublicKey =
                     oldStoredPublicKeys.stream()
@@ -145,6 +145,7 @@ public class TokenValidationService {
             return optionalPublicKey.isPresent()
                     && jwt.verify(new ECDSAVerifier(optionalPublicKey.get()));
         } else {
+            var oldPublicKey = jwksService.getPublicTokenJwkWithOpaqueId();
             return jwt.verify(new ECDSAVerifier(oldPublicKey.toECKey()));
         }
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
@@ -199,19 +199,29 @@ class TokenValidationServiceTest {
         @Test
         void shouldSuccessfullyValidateReauthIDToken() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+
+            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
+                    .thenReturn(true);
+
             SignedJWT signedIdToken = createSignedIdToken(expiryDate);
-            assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
+            assertTrue(
+                    tokenValidationService.isReauthTokenSignatureValid(signedIdToken.serialize()));
         }
 
         @Test
         void shouldNotFailSignatureValidationIfReauthIDTokenHasExpired() {
             Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
+
+            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
+                    .thenReturn(true);
+
             SignedJWT signedIdToken = createSignedIdToken(expiryDate);
-            assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
+            assertTrue(
+                    tokenValidationService.isReauthTokenSignatureValid(signedIdToken.serialize()));
         }
 
         @Test
-        void shouldSuccessfullyValidateNewECKeyV2ReauthIDToken() throws JOSEException {
+        void shouldSuccessfullyValidateNewECKeyV2ReauthIDToken() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
 
@@ -221,27 +231,30 @@ class TokenValidationServiceTest {
 
             SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, newECKey);
             assertTrue(
-                    tokenValidationService.isTokenSignatureValid(
+                    tokenValidationService.isReauthTokenSignatureValid(
                             new BearerAccessToken(signedIdToken.serialize()).getValue()));
         }
 
         @Test
-        void shouldSuccessfullyValidateReauthIDTokenWithOldKeyWhenKeyIdMatches() {
+        void
+                shouldSuccessfullyValidateReauthIDTokenWithOldKeyWhenKeyIdMatchesAndOldKeyIsPublished() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
 
             when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
             when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
                     .thenReturn(true);
+            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
+                    .thenReturn(true);
 
             SignedJWT signedIdToken = createSignedIdToken(expiryDate);
             assertTrue(
-                    tokenValidationService.isTokenSignatureValid(
+                    tokenValidationService.isReauthTokenSignatureValid(
                             new BearerAccessToken(signedIdToken.serialize()).getValue()));
         }
 
         @Test
-        void shouldFailToValidateECKeyReauthIDTokenIfKeyIdInvalid() throws JOSEException {
+        void shouldFailToValidateECKeyReauthIDTokenIfKeyIdInvalid() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
             var failedECKey = generateCustomECKeyPair(FAILED_KEY_ID);
@@ -252,12 +265,13 @@ class TokenValidationServiceTest {
 
             SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, failedECKey);
             assertFalse(
-                    tokenValidationService.isTokenSignatureValid(
+                    tokenValidationService.isReauthTokenSignatureValid(
                             new BearerAccessToken(signedIdToken.serialize()).getValue()));
         }
 
         @Test
-        void shouldSuccessfullyValidateOldStoredECKeyReauthIDToken() throws JOSEException {
+        void
+                shouldSuccessfullyValidateOldStoredECKeyReauthIDTokenWhenKeyIdMatchesAndStoredKeyEnabled() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
 
@@ -272,8 +286,25 @@ class TokenValidationServiceTest {
         }
 
         @Test
-        void shouldFailToValidateECKeyReauthIDTokenIfOldStoredPublicKeyIdInvalid()
-                throws JOSEException {
+        void
+                shouldSuccessfullyValidateOldStoredECKeyReauthIDTokenWhenKeyIdMatchesAndStoredKeyDisabledAndOldKeyIsNotPublished() {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
+
+            when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
+                    .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
+            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(false);
+            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
+                    .thenReturn(false);
+
+            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, oldStoredECKey);
+            assertTrue(
+                    tokenValidationService.isReauthTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
+
+        @Test
+        void shouldFailToValidateECKeyReauthIDTokenIfOldStoredPublicKeyIdInvalid() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
             var failedECKey = generateCustomECKeyPair(FAILED_KEY_ID);

--- a/template.yaml
+++ b/template.yaml
@@ -149,6 +149,12 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
+  PublishOldExternalTokenSigningKeys:
+    !Or [
+      !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
+      !Equals [production, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -3455,6 +3461,10 @@ Resources:
             - PublishNextExternalTokenSigningKeysV2
             - !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
             - !Ref AWS::NoValue
+          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: !If
+            - PublishOldExternalTokenSigningKeys
+            - true
+            - false
           DOC_APP_SIGNING_KEY_ALIAS: !Ref OrchDocAppSigningKmsKeyAlias
       Policies:
         - !Ref IdTokenKmsAccessPolicy
@@ -3967,6 +3977,10 @@ Resources:
             ]
           USE_STORED_OLD_ID_TOKEN_PUBLIC_KEYS: !If
             - UseStoredOldIdTokenPublicKeys
+            - true
+            - false
+          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: !If
+            - PublishOldExternalTokenSigningKeys
             - true
             - false
           IDENTITY_ENABLED: true


### PR DESCRIPTION
…(while still supporting the old key for reauth using the stored public key)

### Wider context of change

To decommission the old keys, we first want to stop publishing them to the jwks endpoint.

### What’s changed

Adds a feature flag to publish the old keys to the jwks endpoint. Note: I did add a funky thing where if using the stored public key isn't enabled, we do publish the key anyway. I'm not sure if that's the way round we want but wanted to ensure reauth doesn't get accidentally broken.

### Manual testing

- Stored old public key enabled and publishing enabled - keys show at endpoint
- Stored old public key enabled and publishing disabled - keys don't show at endpoint
- Stored old public key disabled and publishing enabled - keys show at endpoint
- Stored old public key disabled and publishing disabled - keys show at endpoint
Also checked a reauth journey still works
Also also tested rollback plan works

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**