### PR TITLE
BAU: Constrain netty-handler-proxy to 4.1.133.Final to fix CVE-2026-42578

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,10 @@ subprojects {
                     because 'CVE-2025-58057 is fixed in io.netty:netty-codec:4.1.125.Final and higher'
                 }
 
+                classpath('io.netty:netty-handler-proxy:[4.1.133.Final,4.2.0)') {
+                    because 'CVE-2026-42578 is fixed in io.netty:netty-handler-proxy:4.1.133.Final and higher'
+                }
+
                 // Apache Commons constraints
                 classpath('commons-beanutils:commons-beanutils:[1.11.0,)') {
                     because 'CVE-2025-48734 is fixed in commons-beanutils:commons-beanutils:1.11.0 and higher'
@@ -152,6 +156,10 @@ subprojects {
 
                     add(conf.name, 'io.netty:netty-transport-native-epoll:[4.2.13.Final,5.0)') {
                         because 'CVE-2026-42577 is fixed in io.netty:netty-transport-native-epoll:4.2.13.Final and higher'
+                    }
+
+                    add(conf.name, 'io.netty:netty-handler-proxy:[4.1.133.Final,4.2.0)') {
+                        because 'CVE-2026-42578 is fixed in io.netty:netty-handler-proxy:4.1.133.Final and higher'
                     }
 
                     // Jetty constraints


### PR DESCRIPTION
## What

- Constrains io.netty:netty-handler-proxy to >=4.1.133.Final to fix CVE-2026-42578 (SOCKS/HTTP proxy handler vulnerability). This is a transitive dependency.

## How to review

1. Code Review