### PR TITLE
AUT-5449: TICFCRIStub should marshall to ExternalTICFCRIRequest

### DIFF
--- a/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
+++ b/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
@@ -6,7 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.entity.InternalTICFCRIRequest;
+import uk.gov.di.authentication.entity.ExternalTICFCRIRequest;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.ticf.cri.stub.lambda.entity.TICFCRIStubResponse;
@@ -25,17 +25,18 @@ public class TICFCRIStubHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
-            var request = objectMapper.readValue(input.getBody(), InternalTICFCRIRequest.class);
+            var request = objectMapper.readValue(input.getBody(), ExternalTICFCRIRequest.class);
             LOG.info(
-                    "TICF Request - govukSigninJourneyId: {}, vtr: {}, authenticated: {}, accountState: {}, resetPasswordState: {}, resetMfaState: {}, mfaMethodType: {}",
+                    "TICF Request - govuk_signin_journey_id: {}, vtr: {}, authenticated: {}, initial_registration: {}, password_reset: {}, 2fa_reset: {}, 2fa_method: {}",
                     request.govukSigninJourneyId(),
                     request.vtr(),
                     request.authenticated(),
-                    request.accountState(),
-                    request.resetPasswordState(),
-                    request.resetMfaState(),
-                    request.mfaMethodType());
+                    request.initialRegistration(),
+                    request.passwordReset(),
+                    request.mfaReset(),
+                    request.mfaMethod());
         } catch (Json.JsonException e) {
+            LOG.error("Invalid ExternalTICFCRIRequest", e.getMessage());
             throw new RuntimeException(e);
         }
         String testInternalPairwiseId = "urn:fdc:gov.uk:2022:test";

--- a/ticf-cri-stub/src/test/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandlerTest.java
+++ b/ticf-cri-stub/src/test/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandlerTest.java
@@ -25,16 +25,26 @@ class TICFCRIStubHandlerTest {
         TICFCRIStubHandler handler = new TICFCRIStubHandler();
         var event = new APIGatewayProxyRequestEvent();
         event.setBody(
-                "{\"sub\":\"urn:fdc:gov.uk:2022:test\","
-                        + "\"vtr\":[\"Cl.Cm\"],"
-                        + "\"govuk_signin_journey_id\":\"44444444-4444-4444-4444-444444444444\","
-                        + "\"authenticated\":\"Y\"}\n");
+                """
+                        {
+                            "sub":"urn:fdc:gov.uk:2022:test",
+                            "vtr":["Cl.Cm"],
+                            "govuk_signin_journey_id":"44444444-4444-4444-4444-444444444444",
+                            "authenticated":"Y",
+                            "initial_registration":"NEW",
+                            "password_reset":"NONE",
+                            "2fa_reset":"NONE"
+                        }
+                """);
         var result = handler.handleRequest(event, context);
         String expectedResponse =
-                "{\"intervention\":{\"interventionCode\":\"01\",\"interventionReason\":\"01\"},"
-                        + "\"sub\":\"urn:fdc:gov.uk:2022:test\","
-                        + "\"govuk_signin_journey_id\":\"44444444-4444-4444-4444-444444444444\","
-                        + "\"ci\":[\"D03\",\"F01\"]}";
+                """
+                        {\
+                        "intervention":{"interventionCode":"01","interventionReason":"01"},\
+                        "sub":"urn:fdc:gov.uk:2022:test",\
+                        "govuk_signin_journey_id":"44444444-4444-4444-4444-444444444444",\
+                        "ci":["D03","F01"]}\
+                        """;
         assertEquals(result.getBody(), expectedResponse);
         assertEquals(200, result.getStatusCode());
     }
@@ -44,23 +54,34 @@ class TICFCRIStubHandlerTest {
         TICFCRIStubHandler handler = new TICFCRIStubHandler();
         var event = new APIGatewayProxyRequestEvent();
         event.setBody(
-                "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:test\","
-                        + "\"vtr\":[\"Cl.Cm\"],"
-                        + "\"govukSigninJourneyId\":\"44444444-4444-4444-4444-444444444444\","
-                        + "\"authenticated\":true,"
-                        + "\"accountState\":\"EXISTING\","
-                        + "\"resetPasswordState\":\"NONE\","
-                        + "\"resetMfaState\":\"NONE\"}");
+                """
+                        {
+                            "sub":"urn:fdc:gov.uk:2022:test",
+                            "vtr":["Cl.Cm"],
+                            "govuk_signin_journey_id":"44444444-4444-4444-4444-444444444444",
+                            "authenticated":"Y",
+                            "initial_registration":"EXISTING",
+                            "password_reset":"NONE",
+                            "2fa_reset":"NONE",
+                            "2fa_method":["SMS"]
+                        }
+                """);
+
         handler.handleRequest(event, context);
 
         assertThat(logging.events(), hasItem(withMessageContaining("TICF Request")));
-        assertThat(logging.events(), hasItem(withMessageContaining("govukSigninJourneyId:")));
-        assertThat(logging.events(), hasItem(withMessageContaining("vtr:")));
-        assertThat(logging.events(), hasItem(withMessageContaining("authenticated:")));
-        assertThat(logging.events(), hasItem(withMessageContaining("accountState:")));
-        assertThat(logging.events(), hasItem(withMessageContaining("resetPasswordState:")));
-        assertThat(logging.events(), hasItem(withMessageContaining("resetMfaState:")));
-        assertThat(logging.events(), hasItem(withMessageContaining("mfaMethodType:")));
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "govuk_signin_journey_id: 44444444-4444-4444-4444-444444444444")));
+        assertThat(logging.events(), hasItem(withMessageContaining("vtr: [Cl.Cm]")));
+        assertThat(logging.events(), hasItem(withMessageContaining("authenticated: Y")));
+        assertThat(
+                logging.events(), hasItem(withMessageContaining("initial_registration: EXISTING")));
+        assertThat(logging.events(), hasItem(withMessageContaining("password_reset: NONE")));
+        assertThat(logging.events(), hasItem(withMessageContaining("2fa_reset: NONE")));
+        assertThat(logging.events(), hasItem(withMessageContaining("2fa_method:")));
         assertThat(
                 logging.events(), not(hasItem(withMessageContaining("urn:fdc:gov.uk:2022:test"))));
     }


### PR DESCRIPTION


## What

TICFCRIStub should marshall to ExternalTICFCRIRequest

- The stub was trying to marshall the incoming message to InternalTICFCRIRequest rather than ExternalTICFCRIRequest, whereas the message is in ExternalTICFCRIRequest format.
- Logging field names and tests updated to reflect structure and field names

Fixes an issue where values sent to the stub were not being received and [logged](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?q=search%20index%3D%22gds_di_development%22%20%22TICF%20Request%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&earliest=1779098400&latest=1779115500&sid=1779115434.8442_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF) correctly:

`TICF Request - govukSigninJourneyId: F1_HKcV_PWO5I1i-8N1ZCOl9BME, vtr: [Cl.Cm], authenticated: false, accountState: null, resetPasswordState: null, resetMfaState: null, mfaMethodType: null`



## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

#8341 