### PR TITLE
ATO-2538: stop publishing old token key in staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -151,7 +151,6 @@ Conditions:
     ]
   PublishOldExternalTokenSigningKeys:
     !Or [
-      !Equals [staging, !Ref Environment],
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]


### PR DESCRIPTION
### Wider context of change

To decommission the old keys, we first want to stop publishing them to the jwks endpoint.

### What’s changed

Stop publishing in staging.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**

### Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8346
https://github.com/govuk-one-login/authentication-api/pull/8351
