### PR TITLE
BAU: Run spotless without --no-daemon and with --parallel

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run Spotless
         if: needs.check-changed-files.outputs.java_changed == 'true'
-        run: ./gradlew --no-daemon spotlessCheck
+        run: ./gradlew --parallel spotlessCheck
 
   run-unit-tests:
     runs-on: ubuntu-24.04-arm

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -36,7 +36,7 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     private static final int VERIFICATION_CODE_LENGTH = 6;
 
     private final NotificationHandler handler = new NotificationHandler(configurationService);
-    public final String CODE = format("%06d", new SecureRandom().nextInt(999999));
+    public static final String CODE = format("%06d", new SecureRandom().nextInt(999999));
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "known-client-session-id";
 


### PR DESCRIPTION
Spotless is taking > 30 mins to run in github actions.  Recommendation is to remove --no-daemon as the daemon will cache the Eclipse download used for formatting.

## What

Run spotless without --no-daemon and with --parallel

Spotless is taking > 30 mins to run in github actions.  Recommendation is to remove --no-daemon as the daemon will cache the Eclipse download used for formatting.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

