### PR TITLE
BAU: Adjust auth journey completion rate alarm

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -9234,17 +9234,17 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref OrchProdSlackEvents
-      AlarmDescription: !Sub "Auth journey completion rate has dropped below 50% in ${Environment}.ACCOUNT: di-orchestration-${Environment}."
+      AlarmDescription: !Sub "Auth journey completion rate has dropped below 30% in ${Environment}.ACCOUNT: di-orchestration-${Environment}."
       AlarmName: !Sub ${Environment}-auth-journey-completion-rate-alarm
       ComparisonOperator: LessThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 5
-      Threshold: 50
+      Threshold: 30
       TreatMissingData: notBreaching
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: "IF(m2 >= 160, m1/m2*100)"
+          Expression: "IF(m2 >= 250, m1/m2*100)"
           Label: Journey Completion Rate
         - Id: m1
           ReturnData: false


### PR DESCRIPTION
### Wider context of change

The auth journey rate alarm has been going off a bit too much recently. We should adjust it so its not as sensitive.

### What’s changed

This PR reduces the journey completion rate % threshold from 50% to 30%, and increases the minimum amount of traffic from 160 to 250. 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
