### PR TITLE
BAU: Add missing isResidentKey to PasskeysRetrieveResponse

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
@@ -198,8 +198,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
             boolean isResidentKey)
             throws Json.JsonException {
         Map<String, Object> requestBody = new HashMap<>();
-        requestBody.put("credential", credential);
         requestBody.put("id", id);
+        requestBody.put("credential", credential);
         requestBody.put("aaguid", aaguid);
         requestBody.put("isAttested", String.valueOf(isAttested));
         requestBody.put("signCount", String.valueOf(signCount));

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysCreateRequest.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysCreateRequest.java
@@ -7,8 +7,8 @@ import uk.gov.di.authentication.shared.validation.Required;
 import java.util.List;
 
 public record PasskeysCreateRequest(
-        @SerializedName("credential") @Expose @Required String credential,
         @SerializedName("id") @Expose @Required String passkeyId,
+        @SerializedName("credential") @Expose @Required String credential,
         @SerializedName("aaguid") @Expose @Required String aaguid,
         @SerializedName("isAttested") @Expose @Required boolean isAttested,
         @SerializedName("signCount") @Expose @Required int signCount,

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
@@ -18,6 +18,7 @@ public record PasskeysRetrieveResponse(
             @SerializedName("transports") @Expose @Required List<String> transports,
             @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,
+            @SerializedName("isResidentKey") @Expose @Required boolean isResidentKey,
             @SerializedName("createdAt") @Expose String createdAt,
             @SerializedName("lastUsedAt") @Expose String lastUsedAt) {}
 
@@ -31,6 +32,7 @@ public record PasskeysRetrieveResponse(
                 passkey.getPasskeyTransports(),
                 passkey.getPasskeyBackupEligible(),
                 passkey.getPasskeyBackedUp(),
+                passkey.getPasskeyIsResidentKey(),
                 passkey.getCreated(),
                 passkey.getLastUsed());
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -316,8 +316,8 @@ class PasskeysCreateHandlerTest {
             boolean isResidentKey)
             throws Json.JsonException {
         Map<String, Object> requestBody = new HashMap<>();
-        requestBody.put("credential", credential);
         requestBody.put("id", id);
+        requestBody.put("credential", credential);
         requestBody.put("aaguid", aaguid);
         requestBody.put("isAttested", String.valueOf(isAttested));
         requestBody.put("signCount", String.valueOf(signCount));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeysRetrieveResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeysRetrieveResponse.java
@@ -18,6 +18,7 @@ public record PasskeysRetrieveResponse(
             @SerializedName("transports") @Expose @Required List<String> transports,
             @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,
+            @SerializedName("isResidentKey") @Expose @Required boolean isResidentKey,
             @SerializedName("createdAt") @Expose String createdAt,
             @SerializedName("lastUsedAt") @Expose String lastUsedAt) {}
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
@@ -234,6 +234,7 @@ class AccountDataCredentialRepositoryTest {
                 List.of(),
                 true,
                 true,
+                true,
                 "some-timestamp",
                 "another-timestamp");
     }


### PR DESCRIPTION
## What

The `isResidentKey` field was missing from the `PasskeysRetrieveResponse` object. This PR adds it to match the OpenAPI Spec for the Account Data API.

## How to review

1. Code Review