### PR TITLE
ATO-2559: Add feature flag for defaulting tokenAuthMethod

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -137,7 +137,8 @@ public class TokenHandler
         this.tokenClientAuthValidatorFactory =
                 new TokenClientAuthValidatorFactory(
                         new DynamoClientService(configurationService),
-                        new ClientSignatureValidationService(configurationService));
+                        new ClientSignatureValidationService(configurationService),
+                        configurationService);
         this.metrics = new Metrics(configurationService);
         this.auditService = new AuditService(configurationService);
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.orchestration.shared.utils.ClientUtils.getTokenAuthMethodOrDefault;
+
 public abstract class BaseAuthorizeValidator {
 
     protected static final String VTR_PARAM = "vtr";
@@ -210,8 +212,9 @@ public abstract class BaseAuthorizeValidator {
     protected Optional<ErrorObject>
             errorForIdentityJourneyRequestWithInsufficientlySecureTokenAuthMethod(
                     List<VectorOfTrust> vtrList, ClientRegistry client) {
-        if (requestContainsIdentityLoC(vtrList)
-                && ("client_secret_post".equals(client.getTokenAuthMethod()))) {
+        String tokenAuthMethod = getTokenAuthMethodOrDefault(client, configurationService);
+
+        if (requestContainsIdentityLoC(vtrList) && ("client_secret_post".equals(tokenAuthMethod))) {
             logErrorInProdElseWarn(
                     "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible.");
             return Optional.of(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -470,6 +470,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("SYNC_WAIT_FOR_SPOT_TIMEOUT", "5000"));
     }
 
+    public boolean isUseDefaultTokenAuthMethod() {
+        return getFlagOrFalse("USE_DEFAULT_TOKEN_AUTH_METHOD");
+    }
+
     public String getNotifyTemplateId(String templateName) {
         return System.getenv(templateName);
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientUtils.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/utils/ClientUtils.java
@@ -1,0 +1,20 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import java.util.Objects;
+
+public class ClientUtils {
+    private ClientUtils() {}
+
+    public static String getTokenAuthMethodOrDefault(
+            ClientRegistry clientRegistry, ConfigurationService configurationService) {
+        var tokenAuthMethod = clientRegistry.getTokenAuthMethod();
+        if (Objects.isNull(tokenAuthMethod) && configurationService.isUseDefaultTokenAuthMethod()) {
+            tokenAuthMethod = ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue();
+        }
+        return tokenAuthMethod;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/ClientSecretPostClientAuthValidator.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/ClientSecretPostClientAuthValidator.java
@@ -9,6 +9,7 @@ import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.Argon2MatcherHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.util.Map;
@@ -17,11 +18,16 @@ import java.util.Objects;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.addAnnotation;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.utils.ClientUtils.getTokenAuthMethodOrDefault;
 
 public class ClientSecretPostClientAuthValidator extends TokenClientAuthValidator {
 
-    public ClientSecretPostClientAuthValidator(DynamoClientService dynamoClientService) {
+    private final ConfigurationService configurationService;
+
+    public ClientSecretPostClientAuthValidator(
+            DynamoClientService dynamoClientService, ConfigurationService configurationService) {
         super(dynamoClientService);
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -56,10 +62,10 @@ public class ClientSecretPostClientAuthValidator extends TokenClientAuthValidato
 
     private void validateTokenAuthMethod(ClientRegistry clientRegistry)
             throws TokenAuthInvalidException {
-        if (Objects.isNull(clientRegistry.getTokenAuthMethod())
-                || !clientRegistry
-                        .getTokenAuthMethod()
-                        .equals(ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue())) {
+        var tokenAuthMethod = getTokenAuthMethodOrDefault(clientRegistry, configurationService);
+        if (Objects.isNull(tokenAuthMethod)
+                || !tokenAuthMethod.equals(
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue())) {
             LOG.warn("Client is not registered to use client_secret_post");
             throw generateExceptionWithInvalidClientCode(
                     "Client is not registered to use client_secret_post",

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidator.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidator.java
@@ -15,6 +15,7 @@ import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.util.Date;
@@ -24,17 +25,21 @@ import java.util.Objects;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.addAnnotation;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.orchestration.shared.utils.ClientUtils.getTokenAuthMethodOrDefault;
 
 public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
 
     private final ClientSignatureValidationService clientSignatureValidationService;
+    private final ConfigurationService configurationService;
     private static final String UNKNOWN_CLIENT_ID = "unknown";
 
     public PrivateKeyJwtClientAuthValidator(
             DynamoClientService dynamoClientService,
-            ClientSignatureValidationService clientSignatureValidationService) {
+            ClientSignatureValidationService clientSignatureValidationService,
+            ConfigurationService configurationService) {
         super(dynamoClientService);
         this.clientSignatureValidationService = clientSignatureValidationService;
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -51,10 +56,10 @@ public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
             var clientRegistry = getClientRegistryFromTokenAuth(privateKeyJWT.getClientID());
             attachLogFieldToLogs(CLIENT_ID, clientRegistry.getClientID());
             addAnnotation("client_id", clientRegistry.getClientID());
-            if (Objects.nonNull(clientRegistry.getTokenAuthMethod())
-                    && !clientRegistry
-                            .getTokenAuthMethod()
-                            .equals(ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue())) {
+            var tokenAuthMethod = getTokenAuthMethodOrDefault(clientRegistry, configurationService);
+            if (Objects.nonNull(tokenAuthMethod)
+                    && !tokenAuthMethod.equals(
+                            ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue())) {
                 LOG.warn("Client is not registered to use private_key_jwt");
                 throw new TokenAuthInvalidException(
                         new ErrorObject(

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactory.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactory.java
@@ -35,7 +35,9 @@ public class TokenClientAuthValidatorFactory {
             checkAssertionType(requestBody);
             return Optional.of(
                     new PrivateKeyJwtClientAuthValidator(
-                            dynamoClientService, clientSignatureValidationService));
+                            dynamoClientService,
+                            clientSignatureValidationService,
+                            configurationService));
         }
 
         if (requestBody.containsKey("client_secret") && requestBody.containsKey("client_id")) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactory.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactory.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.shared.validation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.util.Map;
@@ -12,13 +13,16 @@ import java.util.Optional;
 public class TokenClientAuthValidatorFactory {
     private final DynamoClientService dynamoClientService;
     private final ClientSignatureValidationService clientSignatureValidationService;
+    private final ConfigurationService configurationService;
     private static final Logger LOG = LogManager.getLogger(TokenClientAuthValidatorFactory.class);
 
     public TokenClientAuthValidatorFactory(
             DynamoClientService dynamoClientService,
-            ClientSignatureValidationService clientSignatureValidationService) {
+            ClientSignatureValidationService clientSignatureValidationService,
+            ConfigurationService configurationService) {
         this.clientSignatureValidationService = clientSignatureValidationService;
         this.dynamoClientService = dynamoClientService;
+        this.configurationService = configurationService;
     }
 
     public Optional<TokenClientAuthValidator> getTokenAuthenticationValidator(
@@ -36,7 +40,9 @@ public class TokenClientAuthValidatorFactory {
 
         if (requestBody.containsKey("client_secret") && requestBody.containsKey("client_id")) {
             LOG.info("Client auth method is: client_secret_post");
-            return Optional.of(new ClientSecretPostClientAuthValidator(dynamoClientService));
+            return Optional.of(
+                    new ClientSecretPostClientAuthValidator(
+                            dynamoClientService, configurationService));
         }
         return Optional.empty();
     }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/ClientUtilsTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/utils/ClientUtilsTest.java
@@ -1,0 +1,60 @@
+package uk.gov.di.orchestration.shared.utils;
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ClientUtilsTest {
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    @BeforeEach
+    public void setup() {
+        when(configurationService.isUseDefaultTokenAuthMethod()).thenReturn(false);
+    }
+
+    @Test
+    void shouldDefaultToPrivateKeyJwtIfFeatureFlagIsEnabledAndTokenAuthMethodIsNull() {
+        when(configurationService.isUseDefaultTokenAuthMethod()).thenReturn(true);
+        var client = clientWithTokenAuthMethod(null);
+
+        var actualTokenAuthMethod =
+                ClientUtils.getTokenAuthMethodOrDefault(client, configurationService);
+        assertEquals(actualTokenAuthMethod, ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+    }
+
+    @Test
+    void shouldNotDefaultToPrivateKeyJwtIfFeatureFlagDisabled() {
+        when(configurationService.isUseDefaultTokenAuthMethod()).thenReturn(false);
+        var client = clientWithTokenAuthMethod(null);
+
+        var actualTokenAuthMethod =
+                ClientUtils.getTokenAuthMethodOrDefault(client, configurationService);
+        assertNull(actualTokenAuthMethod);
+    }
+
+    @Test
+    void shouldNotDefaultToPrivateKeyJwtIfFeatureFlagIsEnabledAndTokenAuthMethodIsAlreadySet() {
+        when(configurationService.isUseDefaultTokenAuthMethod()).thenReturn(true);
+        var client =
+                clientWithTokenAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue());
+
+        var actualTokenAuthMethod =
+                ClientUtils.getTokenAuthMethodOrDefault(client, configurationService);
+        assertEquals(
+                actualTokenAuthMethod, ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue());
+    }
+
+    private ClientRegistry clientWithTokenAuthMethod(String tokenAuthMethod) {
+        return new ClientRegistry()
+                .withClientID("client-id")
+                .withClientName("client-one")
+                .withTokenAuthMethod(tokenAuthMethod);
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/ClientSecretPostClientAuthValidatorTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/ClientSecretPostClientAuthValidatorTest.java
@@ -9,9 +9,12 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.util.Objects;
@@ -30,6 +33,7 @@ import static org.mockito.Mockito.when;
 class ClientSecretPostClientAuthValidatorTest {
 
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private ClientSecretPostClientAuthValidator clientSecretPostClientAuthValidator;
 
     private static final ClientID CLIENT_ID = new ClientID();
@@ -38,7 +42,7 @@ class ClientSecretPostClientAuthValidatorTest {
     @BeforeEach
     void setUp() {
         clientSecretPostClientAuthValidator =
-                new ClientSecretPostClientAuthValidator(dynamoClientService);
+                new ClientSecretPostClientAuthValidator(dynamoClientService, configurationService);
     }
 
     @Test
@@ -80,13 +84,17 @@ class ClientSecretPostClientAuthValidatorTest {
         assertThat(tokenAuthInvalidException.getErrorObject(), equalTo(OAuth2Error.INVALID_CLIENT));
     }
 
-    @Test
-    void shouldThrowIfClientRegistryDoesNotSupportClientSecretPost() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldThrowIfClientRegistryDoesNotSupportClientSecretPost(
+            boolean useDefaultTokenAuthMethod) {
         var expectedClientRegistry =
                 generateClientRegistry(
                         null, Argon2EncoderHelper.argon2Hash(CLIENT_SECRET.getValue()));
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
                 .thenReturn(Optional.of(expectedClientRegistry));
+        when(configurationService.isUseDefaultTokenAuthMethod())
+                .thenReturn(useDefaultTokenAuthMethod);
         var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
         var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.exceptions.TokenAuthInvalidException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
 import java.net.URI;
@@ -46,6 +47,7 @@ class PrivateKeyJwtClientAuthValidatorTest {
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final ClientSignatureValidationService clientSignatureValidationService =
             mock(ClientSignatureValidationService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private OidcAPI oidcAPI = mock(OidcAPI.class);
     private static final URI OIDC_TOKEN_URL = URI.create("https://example.com/token");
     private static final ClientID CLIENT_ID = new ClientID();
@@ -57,7 +59,9 @@ class PrivateKeyJwtClientAuthValidatorTest {
         when(oidcAPI.tokenURI()).thenReturn(OIDC_TOKEN_URL);
         privateKeyJwtClientAuthValidator =
                 new PrivateKeyJwtClientAuthValidator(
-                        dynamoClientService, clientSignatureValidationService);
+                        dynamoClientService,
+                        clientSignatureValidationService,
+                        configurationService);
     }
 
     private static Stream<JWSAlgorithm> supportedAlgorithms() {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/validation/TokenClientAuthValidatorFactoryTest.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils;
 
@@ -23,11 +24,12 @@ class TokenClientAuthValidatorFactoryTest {
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final ClientSignatureValidationService clientSignatureValidationService =
             mock(ClientSignatureValidationService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private static final ClientID CLIENT_ID = new ClientID();
     private static final Secret CLIENT_SECRET = new Secret();
     private final TokenClientAuthValidatorFactory tokenClientAuthValidatorFactory =
             new TokenClientAuthValidatorFactory(
-                    dynamoClientService, clientSignatureValidationService);
+                    dynamoClientService, clientSignatureValidationService, configurationService);
 
     @Test
     void shouldReturnPrivateKeyJwtClientAuthValidator() throws JOSEException {

--- a/template.yaml
+++ b/template.yaml
@@ -154,6 +154,12 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
+  UseDefaultTokenAuthMethod:
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -2393,6 +2399,10 @@ Resources:
                   !Ref Environment,
                   authEnvironment,
                 ]
+          USE_DEFAULT_TOKEN_AUTH_METHOD: !If
+            - UseDefaultTokenAuthMethod
+            - true
+            - false
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
@@ -4027,6 +4037,10 @@ Resources:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           TXMA_AUDIT_ENCODED_ENABLED: true
           JWK_CACHE_EXPIRATION_IN_SECONDS: 300
+          USE_DEFAULT_TOKEN_AUTH_METHOD: !If
+            - UseDefaultTokenAuthMethod
+            - true
+            - false
 
       Policies:
         - !Ref ClientRegistryTableReadAccessPolicy


### PR DESCRIPTION
### Wider context of change

We previously allowed for tokenAuthMethod to be null, and treated `private_key_jwt` as the default in the `PrivateKeyJwtClientAuthValidator`. To make it a bit clearer it would be nice to move this defaulting into the client registry getter.

### What’s changed

This PR adds a feature flag (enabled in dev, build, and staging) to default the tokenAuthMethod to `private_key_jwt` if it is null. This is done in a utility class and the method is used in all places where we access the tokenAuthMethod. I also added some tests for the utility class.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
