### PR TITLE
ATO-2555: bump stack versions

### DIFF
--- a/ci/stack-orchestration/deploy-build.sh
+++ b/ci/stack-orchestration/deploy-build.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
-VPC_STACK_VERSION="v2.10.0"
-SECURE_PIPELINE_STACK_VERSION="v2.90.0"
+VPC_STACK_VERSION="v2.14.3"
+SECURE_PIPELINE_STACK_VERSION="v2.105.0"
 GITHUB_IDENTITY_STACK_VERSION="v1.1.1"
 SIGNER_STACK_VERSION="v1.0.7"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"

--- a/ci/stack-orchestration/deploy-build.sh
+++ b/ci/stack-orchestration/deploy-build.sh
@@ -143,8 +143,7 @@ function provision_vpc_stack() {
 
   echo "Provisioning VPC stack"
 
-  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/build-notifications/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" build-notifications build-notifications "${BUILD_NOTIFICATION_STACK_VERSION}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
-
+  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/vpc/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
   echo "Provisioned VPC stack"
 }
 

--- a/ci/stack-orchestration/deploy-dev.sh
+++ b/ci/stack-orchestration/deploy-dev.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
-VPC_STACK_VERSION="v2.10.0"
-SECURE_PIPELINE_STACK_VERSION="v2.95.0"
+VPC_STACK_VERSION="v2.14.3"
+SECURE_PIPELINE_STACK_VERSION="v2.105.0"
 GITHUB_IDENTITY_STACK_VERSION="v1.1.1"
 SIGNER_STACK_VERSION="v1.0.8"
 CLOUDWATCH_ALARM_STACK_VERSION="v0.0.10"

--- a/ci/stack-orchestration/deploy-integration.sh
+++ b/ci/stack-orchestration/deploy-integration.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
-VPC_STACK_VERSION="v2.10.0"
-SECURE_PIPELINE_STACK_VERSION="v2.90.0"
+VPC_STACK_VERSION="v2.14.3"
+SECURE_PIPELINE_STACK_VERSION="v2.105.0"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"
 BUILD_NOTIFICATION_STACK_VERSION="v2.7.0"
 

--- a/ci/stack-orchestration/deploy-integration.sh
+++ b/ci/stack-orchestration/deploy-integration.sh
@@ -128,8 +128,7 @@ function provision_vpc_stack() {
 
   echo "Provisioning VPC stack"
 
-  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/build-notifications/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" build-notifications build-notifications "${BUILD_NOTIFICATION_STACK_VERSION}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
-
+  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/vpc/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
   echo "Provisioned VPC stack"
 }
 

--- a/ci/stack-orchestration/deploy-production.sh
+++ b/ci/stack-orchestration/deploy-production.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
-VPC_STACK_VERSION="v2.10.0"
-SECURE_PIPELINE_STACK_VERSION="v2.90.0"
+VPC_STACK_VERSION="v2.14.3"
+SECURE_PIPELINE_STACK_VERSION="v2.105.0"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"
 BUILD_NOTIFICATION_STACK_VERSION="v2.7.0"
 

--- a/ci/stack-orchestration/deploy-production.sh
+++ b/ci/stack-orchestration/deploy-production.sh
@@ -128,8 +128,7 @@ function provision_vpc_stack() {
 
   echo "Provisioning VPC stack"
 
-  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/build-notifications/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" build-notifications build-notifications "${BUILD_NOTIFICATION_STACK_VERSION}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
-
+  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/vpc/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
   echo "Provisioned VPC stack"
 }
 

--- a/ci/stack-orchestration/deploy-staging.sh
+++ b/ci/stack-orchestration/deploy-staging.sh
@@ -136,8 +136,7 @@ function provision_vpc_stack() {
 
   echo "Provisioning VPC stack"
 
-  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/build-notifications/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" build-notifications build-notifications "${BUILD_NOTIFICATION_STACK_VERSION}" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
-
+  PARAMETERS_FILE="$(pwd)/configuration/${ENVIRONMENT}/vpc/parameters.json" ${PROVISION_COMMAND} "${ENVIRONMENT}" "vpc" "vpc" "${VPC_STACK_VERSION}"
   echo "Provisioned VPC stack"
 }
 

--- a/ci/stack-orchestration/deploy-staging.sh
+++ b/ci/stack-orchestration/deploy-staging.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
 
 # To update a stack bump the version here and run the deployment command which contains that stack
-VPC_STACK_VERSION="v2.10.0"
-SECURE_PIPELINE_STACK_VERSION="v2.90.0"
+VPC_STACK_VERSION="v2.14.3"
+SECURE_PIPELINE_STACK_VERSION="v2.105.0"
 API_GATEWAY_LOGGING_STACK_VERSION="v1.0.9"
 BUILD_NOTIFICATION_STACK_VERSION="v2.7.0"
 CLOUDWATCH_ALARM_STACK_VERSION="v0.0.10"


### PR DESCRIPTION
### Wider context of change

We deploy some dev platform infrastructure which need to be updated semi-frequently as new versions and features are released. 

### What’s changed:
- Bumps VPC stack to the latest version: 2.14.3
- Bumps secure pipeline stack to latest version: 2.105.0

### Manual testing:
- Deployed to dev - integration > 1 day ago
- Left some time for changes to _soak_ to highlight any issues 
- Will deploy to prod after merge to main

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
