### PR TITLE
BAU: Script to peek at audit events in dev env queues and extract to a csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ specs-and-prompts/
 
 # Detect secrets
 .secrets.baseline
+
+# audit event extracts
+audit-events*.csv

--- a/scripts/peek-audit-to-csv.sh
+++ b/scripts/peek-audit-to-csv.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Peek at messages on an SQS queue and extract to CSV.
+# Messages are returned to the queue after the visibility timeout (not deleted).
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat << EOF
+Usage: $(basename "$0") [MAX_MESSAGES] [OUTPUT_FILE]
+
+Peek at audit events from SQS queues and extract to CSV.
+Messages are returned to the queue after the visibility timeout (not deleted).
+
+Arguments:
+  MAX_MESSAGES  Maximum messages to fetch per queue (default: 50)
+  OUTPUT_FILE   Output CSV file path (default: audit-events.csv)
+
+Options:
+  -h, --help    Show this help message
+EOF
+  exit 0
+}
+
+[[ ${1:-} == "-h" || ${1:-} == "--help" ]] && usage
+
+MAX_MESSAGES="${1:-50}"
+OUTPUT_FILE="${2:-audit-events.csv}"
+
+environments=("authdev1" "authdev2" "authdev3" "dev")
+
+echo "Select environment:"
+select env in "${environments[@]}"; do
+  if [[ -n ${env} ]]; then
+    ENVIRONMENT="${env}"
+    break
+  fi
+  echo "Invalid selection. Please try again."
+done
+
+QUEUE_NAMES=(
+  "${ENVIRONMENT}-auth-internal-api-txma-audit-queue"
+  "${ENVIRONMENT}-auth-external-api-txma-audit-queue"
+)
+export AWS_PROFILE="di-authentication-development-AdministratorAccessPermission"
+
+# shellcheck source=/dev/null
+source "${DIR}/export_aws_creds.sh"
+
+VISIBILITY_TIMEOUT=30
+BATCH_SIZE=10
+first=true
+total_received=0
+
+echo "Output: ${OUTPUT_FILE}"
+
+for QUEUE_NAME in "${QUEUE_NAMES[@]}"; do
+  QUEUE_URL=$(aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --query 'QueueUrl' --output text 2> /dev/null) || {
+    echo "Skipping ${QUEUE_NAME} (not found)"
+    continue
+  }
+  echo "Peeking at up to ${MAX_MESSAGES} messages from: ${QUEUE_NAME}"
+
+  received=0
+  while [ "${received}" -lt "${MAX_MESSAGES}" ]; do
+    remaining=$((MAX_MESSAGES - received))
+    fetch=$((remaining < BATCH_SIZE ? remaining : BATCH_SIZE))
+
+    response=$(aws sqs receive-message \
+      --queue-url "${QUEUE_URL}" \
+      --max-number-of-messages "${fetch}" \
+      --visibility-timeout "${VISIBILITY_TIMEOUT}" \
+      --message-attribute-names All \
+      --attribute-names All 2> /dev/null)
+
+    messages=$(echo "${response}" | jq -r '.Messages // [] | length')
+    [ "${messages}" -eq 0 ] && break
+
+    if [ "${first}" = true ]; then
+      REST_COLS=$(echo "${response}" | jq -c '
+        .Messages[0].Body | fromjson | walk(if type == "object" then del(.device_information, .timestamp) else . end)
+        | [keys_unsorted[] | select(. != "event_name" and . != "event_timestamp_ms")]
+      ')
+      echo "${response}" | jq -r --argjson rest "${REST_COLS}" '
+        ["event_name", "govuk_signin_journey_id", "event_timestamp_ms", "event_timestamp_readable"] + $rest | @csv
+      ' > "${OUTPUT_FILE}"
+      first=false
+    fi
+
+    echo "${response}" | jq -r --argjson rest "${REST_COLS}" '
+      .Messages[].Body | fromjson | walk(if type == "object" then del(.device_information, .timestamp) else . end)
+      | (first(.. | .govuk_signin_journey_id? // empty) // "") as $journey_id
+      | ((.event_timestamp_ms // 0) | "\(. / 1000 | floor | strftime("%Y-%m-%d %H:%M:%S")).\(. % 1000)") as $readable_ts
+      | . as $msg
+      | [.event_name, $journey_id, .event_timestamp_ms, $readable_ts] + [$rest[] as $k | $msg[$k] // null | if type == "object" or type == "array" then tojson else . end]
+      | @csv
+    ' >> "${OUTPUT_FILE}"
+
+    received=$((received + messages))
+  done
+
+  echo "  Got ${received} messages from ${QUEUE_NAME}"
+  total_received=$((total_received + received))
+done
+
+echo "Extracted ${total_received} total messages to ${OUTPUT_FILE}"


### PR DESCRIPTION

## What

Script to peek at audit events in dev env queues and extract to a csv

For usage:

`
./scripts/peek-audit-to-csv.sh -h
`

Message retention is currently set to 14d in all evironments so purge the event queues before testing.

## How to review

1. Code Review
1. Run the script to review results

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

