### PR TITLE
BAU: Support multiple scopes in ADAPI token

### DIFF
--- a/account-data-api/README.md
+++ b/account-data-api/README.md
@@ -34,11 +34,13 @@ export AMC_CLIENT_ID="auth"
 
 ```bash
 python3 ./account-data-api/scripts/generate_account_data_token.py <public-subject-id> \
-  --scope passkey-retrieve \
+  --scope "passkey-create passkey-retrieve" \
   --profile di-authentication-development-AdministratorAccessPermission
 ```
 
 Available scopes: `passkey-create`, `passkey-retrieve`, `passkey-update`, `passkey-delete`
+
+Multiple scopes can be passed as a space-separated string (e.g. `"passkey-create passkey-retrieve"`).
 
 Options: `--ttl <minutes>` (default 5), `--region <region>` (default eu-west-2)
 
@@ -95,6 +97,8 @@ A valid token returns an Allow policy with the scope in context. An invalid toke
 When invoking Lambda directly you must supply `pathParameters` and `requestContext.authorizer.principalId` explicitly — API Gateway is not involved so these are not populated automatically.
 
 The `principalId` must match the `publicSubjectId` path parameter, otherwise the handler returns 401.
+
+The `scope` field should be a space-separated string of the scopes the token was issued with (e.g. `"passkey-create passkey-retrieve"`). Each handler checks that its required scope is present in this list.
 
 #### Retrieve passkeys
 

--- a/account-data-api/scripts/generate_account_data_token.py
+++ b/account-data-api/scripts/generate_account_data_token.py
@@ -120,7 +120,9 @@ def main():
         help="Session ID (sid claim); random UUID if omitted",
     )
     parser.add_argument(
-        "--scope", default="passkeys.read", help="Token scope (default: passkeys.read)"
+        "--scope",
+        default="passkey-retrieve",
+        help="Token scope - space-separated for multiple (default: passkey-retrieve)",
     )
     parser.add_argument(
         "--ttl", type=int, default=5, help="Token TTL in minutes (default: 5)"

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelper.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelper.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 
+import java.util.Arrays;
+
 public class ScopeAuthorizerHelper {
     private static final Logger LOG = LogManager.getLogger(ScopeAuthorizerHelper.class);
     private static final String SCOPE_FIELD = "scope";
@@ -20,7 +22,7 @@ public class ScopeAuthorizerHelper {
             return false;
         }
         var scope = requestContext.getAuthorizer().get(SCOPE_FIELD).toString();
-        var matches = expectedScope.getValue().equals(scope);
+        var matches = Arrays.asList(scope.split(" ")).contains(expectedScope.getValue());
         if (!matches) {
             LOG.warn("Scope {} does not match expected scope {}", scope, expectedScope.getValue());
         }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
-import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -142,30 +141,35 @@ public class AuthorizeHandler
             LOG.warn("Access Token subject is missing");
             return Result.failure(new UnauthorizedException());
         }
+
         var scopeValue = (String) claimsSet.getClaim(SCOPE_CLAIM);
-        var scope = AccountDataScope.fromValue(scopeValue);
-        if (scope.isEmpty()) {
+        if (scopeValue == null || scopeValue.isBlank()) {
             LOG.warn("Invalid or missing scope: {}", scopeValue);
             return Result.failure(new UnauthorizedException());
         }
+
         var expectedIssuer = configurationService.getAuthIssuerClaim();
         if (!expectedIssuer.equals(claimsSet.getIssuer())) {
             LOG.warn("Access Token issuer is invalid");
             return Result.failure(new UnauthorizedException());
         }
+
         var expectedAudience = configurationService.getAuthToAccountDataApiAudience();
         if (!claimsSet.getAudience().contains(expectedAudience)) {
             LOG.warn("Access Token audience is invalid");
             return Result.failure(new UnauthorizedException());
         }
+
         if (claimsSet.getNotBeforeTime() == null) {
             LOG.warn("Access Token is missing nbf claim");
             return Result.failure(new UnauthorizedException());
         }
+
         if (DateUtils.isAfter(claimsSet.getNotBeforeTime(), NowHelper.now(), 0)) {
             LOG.warn("Access Token is not yet valid (nbf: {})", claimsSet.getNotBeforeTime());
             return Result.failure(new UnauthorizedException());
         }
+
         var amcClientId = configurationService.getAMCClientId();
         var homeClientId = configurationService.getHomeClientId();
         var clientId = (String) claimsSet.getClaim(CLIENT_ID_CLAIM);

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelperTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/helpers/ScopeAuthorizerHelperTest.java
@@ -21,6 +21,16 @@ class ScopeAuthorizerHelperTest {
     }
 
     @Test
+    void shouldReturnTrueWhenExpectedScopeIsInSpaceSeparatedList() {
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(Map.of("scope", "passkey-create passkey-retrieve"));
+
+        assertTrue(isScopeAuthorized(AccountDataScope.PASSKEY_CREATE, requestContext));
+        assertTrue(isScopeAuthorized(AccountDataScope.PASSKEY_RETRIEVE, requestContext));
+        assertFalse(isScopeAuthorized(AccountDataScope.PASSKEY_DELETE, requestContext));
+    }
+
+    @Test
     void shouldReturnFalseWhenScopeDoesNotMatch() {
         var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
         requestContext.setAuthorizer(Map.of("scope", "passkey-retrieve"));

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -93,7 +93,8 @@ class AuthorizeHandlerTest {
                     Arguments.of(AccountDataScope.PASSKEY_CREATE.getValue()),
                     Arguments.of(AccountDataScope.PASSKEY_RETRIEVE.getValue()),
                     Arguments.of(AccountDataScope.PASSKEY_UPDATE.getValue()),
-                    Arguments.of(AccountDataScope.PASSKEY_DELETE.getValue()));
+                    Arguments.of(AccountDataScope.PASSKEY_DELETE.getValue()),
+                    Arguments.of("passkey-create passkey-retrieve"));
         }
 
         @ParameterizedTest
@@ -136,25 +137,6 @@ class AuthorizeHandlerTest {
 
     @Nested
     class Failure {
-
-        @Test
-        void authorizeHandlerShouldRejectInvalidScope() throws JOSEException {
-            var handler = new AuthorizeHandler(configurationService, remoteJwksService);
-
-            var bearerAccessToken =
-                    createBearerAccessTokenWithExpiry(
-                            expiryDateFiveMinutesFromNow, ecSigningKey, "invalid-scope");
-
-            event.setAuthorizationToken(bearerAccessToken.toAuthorizationHeader());
-
-            RuntimeException exception =
-                    assertThrows(
-                            RuntimeException.class,
-                            () -> handler.handleRequest(event, context),
-                            "Expected to throw exception");
-
-            assertEquals("Unauthorized", exception.getMessage());
-        }
 
         @Test
         void authorizeHandlerShouldRejectIfScopeIsNotPresent() throws JOSEException {

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import java.nio.ByteBuffer;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.List;
 import java.util.Objects;
 
 public class UserInfoService {
@@ -120,7 +121,7 @@ public class UserInfoService {
             var result =
                     accessTokenConstructorService.createSignedAccessToken(
                             userProfile.getPublicSubjectID(),
-                            AccountDataScope.PASSKEY_CREATE,
+                            List.of(AccountDataScope.PASSKEY_CREATE),
                             authSession.getSessionId(),
                             NowHelper.now(),
                             NowHelper.nowPlus(2, ChronoUnit.HOURS),

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -121,7 +121,11 @@ public class UserInfoService {
             var result =
                     accessTokenConstructorService.createSignedAccessToken(
                             userProfile.getPublicSubjectID(),
-                            List.of(AccountDataScope.PASSKEY_CREATE),
+                            List.of(
+                                    AccountDataScope.PASSKEY_CREATE,
+                                    AccountDataScope.PASSKEY_RETRIEVE,
+                                    AccountDataScope.PASSKEY_UPDATE,
+                                    AccountDataScope.PASSKEY_DELETE),
                             authSession.getSessionId(),
                             NowHelper.now(),
                             NowHelper.nowPlus(2, ChronoUnit.HOURS),

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -137,7 +137,12 @@ public class UserInfoServiceTest {
                                 List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
         when(accessTokenConstructorService.createSignedAccessToken(
                         eq(TEST_PUBLIC_SUBJECT_ID),
-                        eq(List.of(AccountDataScope.PASSKEY_CREATE)),
+                        eq(
+                                List.of(
+                                        AccountDataScope.PASSKEY_CREATE,
+                                        AccountDataScope.PASSKEY_RETRIEVE,
+                                        AccountDataScope.PASSKEY_UPDATE,
+                                        AccountDataScope.PASSKEY_DELETE)),
                         any(),
                         any(),
                         any(),
@@ -316,7 +321,12 @@ public class UserInfoServiceTest {
                                 List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
         when(accessTokenConstructorService.createSignedAccessToken(
                         eq(TEST_PUBLIC_SUBJECT_ID),
-                        eq(List.of(AccountDataScope.PASSKEY_CREATE)),
+                        eq(
+                                List.of(
+                                        AccountDataScope.PASSKEY_CREATE,
+                                        AccountDataScope.PASSKEY_RETRIEVE,
+                                        AccountDataScope.PASSKEY_UPDATE,
+                                        AccountDataScope.PASSKEY_DELETE)),
                         any(),
                         any(),
                         any(),

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/UserInfoServiceTest.java
@@ -137,7 +137,7 @@ public class UserInfoServiceTest {
                                 List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
         when(accessTokenConstructorService.createSignedAccessToken(
                         eq(TEST_PUBLIC_SUBJECT_ID),
-                        eq(AccountDataScope.PASSKEY_CREATE),
+                        eq(List.of(AccountDataScope.PASSKEY_CREATE)),
                         any(),
                         any(),
                         any(),
@@ -316,7 +316,7 @@ public class UserInfoServiceTest {
                                 List.of(generatePhoneNumberMFAMethod(PriorityIdentifier.DEFAULT))));
         when(accessTokenConstructorService.createSignedAccessToken(
                         eq(TEST_PUBLIC_SUBJECT_ID),
-                        eq(AccountDataScope.PASSKEY_CREATE),
+                        eq(List.of(AccountDataScope.PASSKEY_CREATE)),
                         any(),
                         any(),
                         any(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AMCJourneyType.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AMCJourneyType.java
@@ -14,13 +14,13 @@ public enum AMCJourneyType {
             case SFAD -> List.of(
                     new AccessTokenConfig(
                             "account_management_api_access_token",
-                            AccountManagementScope.ACCOUNT_DELETE,
+                            List.of(AccountManagementScope.ACCOUNT_DELETE),
                             config.getAuthToAMApiAudience(),
                             config.getAuthToAccountManagementSigningKey()));
             case PASSKEY_CREATE -> List.of(
                     new AccessTokenConfig(
                             "account_data_api_access_token",
-                            AccountDataScope.PASSKEY_CREATE,
+                            List.of(AccountDataScope.PASSKEY_CREATE),
                             config.getAuthToAccountDataApiAudience(),
                             config.getAuthToAccountDataSigningKey()));
         };

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AMCJourneyType.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AMCJourneyType.java
@@ -20,7 +20,9 @@ public enum AMCJourneyType {
             case PASSKEY_CREATE -> List.of(
                     new AccessTokenConfig(
                             "account_data_api_access_token",
-                            List.of(AccountDataScope.PASSKEY_CREATE),
+                            List.of(
+                                    AccountDataScope.PASSKEY_CREATE,
+                                    AccountDataScope.PASSKEY_RETRIEVE),
                             config.getAuthToAccountDataApiAudience(),
                             config.getAuthToAccountDataSigningKey()));
         };

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenConfig.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenConfig.java
@@ -2,5 +2,10 @@ package uk.gov.di.authentication.frontendapi.entity.amc;
 
 import uk.gov.di.authentication.shared.entity.AccessTokenScope;
 
+import java.util.List;
+
 public record AccessTokenConfig(
-        String accessTokenName, AccessTokenScope scope, String audience, String signingKey) {}
+        String accessTokenName,
+        List<AccessTokenScope> scopes,
+        String audience,
+        String signingKey) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -219,7 +219,7 @@ public class AMCService {
                     accessTokenConstructorService
                             .createSignedAccessToken(
                                     publicSubjectId,
-                                    config.scope(),
+                                    config.scopes(),
                                     sessionId,
                                     issueTime,
                                     expiryDate,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeysRetrieveResponse;
+import uk.gov.di.authentication.shared.entity.AccessTokenScope;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.HttpClientHelper;
@@ -61,7 +62,8 @@ public class PasskeysService {
             String publicSubjectId, String sessionId) {
 
         var accountDataApiAccessTokenResult =
-                createAccountDataApiAccessToken(publicSubjectId, sessionId);
+                createAccountDataApiAccessToken(
+                        publicSubjectId, sessionId, List.of(AccountDataScope.PASSKEY_RETRIEVE));
         if (accountDataApiAccessTokenResult.isFailure()) {
             return Result.failure(accountDataApiAccessTokenResult.getFailure());
         }
@@ -124,11 +126,11 @@ public class PasskeysService {
     }
 
     private Result<PasskeyRetrieveError, BearerAccessToken> createAccountDataApiAccessToken(
-            String publicSubjectId, String sessionId) {
+            String publicSubjectId, String sessionId, List<AccessTokenScope> scopes) {
         return accessTokenConstructorService
                 .createSignedAccessToken(
                         publicSubjectId,
-                        List.of(AccountDataScope.PASSKEY_RETRIEVE),
+                        scopes,
                         sessionId,
                         nowClock.now(),
                         nowClock.nowPlus(ADAPI_ACCESS_TOKEN_LIFETIME, ChronoUnit.MINUTES),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -21,6 +21,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
@@ -127,7 +128,7 @@ public class PasskeysService {
         return accessTokenConstructorService
                 .createSignedAccessToken(
                         publicSubjectId,
-                        AccountDataScope.PASSKEY_RETRIEVE,
+                        List.of(AccountDataScope.PASSKEY_RETRIEVE),
                         sessionId,
                         nowClock.now(),
                         nowClock.nowPlus(ADAPI_ACCESS_TOKEN_LIFETIME, ChronoUnit.MINUTES),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -122,7 +122,7 @@ class AMCServiceTest {
             List.of(
                     new AccessTokenConfig(
                             "account_management_api_access_token",
-                            AccountManagementScope.ACCOUNT_DELETE,
+                            List.of(AccountManagementScope.ACCOUNT_DELETE),
                             ACCESS_TOKEN_AUDIENCE,
                             ACCESS_TOKEN_KEY_ALIAS));
     private final JWKSource<SecurityContext> jwkSource = mock(JWKSource.class);
@@ -189,19 +189,19 @@ class AMCServiceTest {
                             List.of(
                                     new AccessTokenConfig(
                                             "account_management_api_access_token",
-                                            AccountManagementScope.ACCOUNT_DELETE,
+                                            List.of(AccountManagementScope.ACCOUNT_DELETE),
                                             ACCESS_TOKEN_AUDIENCE,
                                             ACCESS_TOKEN_KEY_ALIAS))),
                     Arguments.of(
                             List.of(
                                     new AccessTokenConfig(
                                             "account_management_api_access_token",
-                                            AccountManagementScope.ACCOUNT_DELETE,
+                                            List.of(AccountManagementScope.ACCOUNT_DELETE),
                                             ACCESS_TOKEN_AUDIENCE,
                                             OTHER_ACCESS_TOKEN_KEY_ALIAS),
                                     new AccessTokenConfig(
                                             "account_data_api_access_token",
-                                            AccountDataScope.PASSKEY_CREATE,
+                                            List.of(AccountDataScope.PASSKEY_CREATE),
                                             SECOND_ACCESS_TOKEN_AUDIENCE,
                                             ACCESS_TOKEN_KEY_ALIAS))));
         }
@@ -258,7 +258,9 @@ class AMCServiceTest {
 
                 JWTClaimsSet accessTokenClaims = accessTokenJWT.getJWTClaimsSet();
                 assertAccessTokenClaims(
-                        accessTokenConfig.scope(), accessTokenConfig.audience(), accessTokenClaims);
+                        accessTokenConfig.scopes(),
+                        accessTokenConfig.audience(),
+                        accessTokenClaims);
             }
         }
 
@@ -415,17 +417,19 @@ class AMCServiceTest {
         }
 
         private void assertAccessTokenClaims(
-                AccessTokenScope expectedScope,
+                List<AccessTokenScope> expectedScopes,
                 String expectedAudience,
                 JWTClaimsSet accessTokenClaims) {
+            var expectedScopeValue =
+                    expectedScopes.stream()
+                            .map(AccessTokenScope::getValue)
+                            .collect(java.util.stream.Collectors.joining(" "));
             assertAll(
                     "Access Token Claims",
                     () -> assertEquals(AUTH_ISSUER_CLAIM, accessTokenClaims.getIssuer()),
                     () -> assertEquals(PUBLIC_SUBJECT, accessTokenClaims.getSubject()),
                     () -> assertEquals(List.of(expectedAudience), accessTokenClaims.getAudience()),
-                    () ->
-                            assertEquals(
-                                    expectedScope.getValue(), accessTokenClaims.getClaim("scope")),
+                    () -> assertEquals(expectedScopeValue, accessTokenClaims.getClaim("scope")),
                     () -> assertEquals(AMC_CLIENT_ID, accessTokenClaims.getClaim("client_id")),
                     () -> assertEquals(SESSION_ID, accessTokenClaims.getClaim("sid")),
                     () ->
@@ -634,7 +638,7 @@ class AMCServiceTest {
                 .thenAnswer(
                         invocation -> {
                             String publicSubjectId = invocation.getArgument(0);
-                            AccessTokenScope scope = invocation.getArgument(1);
+                            List<AccessTokenScope> scopes = invocation.getArgument(1);
                             String sessionId = invocation.getArgument(2);
                             Date issueTime = invocation.getArgument(3);
                             Date expiryDate = invocation.getArgument(4);
@@ -642,6 +646,11 @@ class AMCServiceTest {
                             String issuer = invocation.getArgument(6);
                             String clientId = invocation.getArgument(7);
                             String signingKeyAlias = invocation.getArgument(8);
+
+                            var scopeValue =
+                                    scopes.stream()
+                                            .map(AccessTokenScope::getValue)
+                                            .collect(java.util.stream.Collectors.joining(" "));
 
                             ECKey key =
                                     Map.of(
@@ -652,7 +661,7 @@ class AMCServiceTest {
 
                             var claims =
                                     new JWTClaimsSet.Builder()
-                                            .claim("scope", scope.getValue())
+                                            .claim("scope", scopeValue)
                                             .issuer(issuer)
                                             .audience(audience)
                                             .expirationTime(expiryDate)
@@ -675,9 +684,7 @@ class AMCServiceTest {
 
                             return Result.success(
                                     new BearerAccessToken(
-                                            signedJWT.serialize(),
-                                            3600L,
-                                            new Scope(scope.getValue())));
+                                            signedJWT.serialize(), 3600L, new Scope(scopeValue)));
                         });
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -117,7 +117,7 @@ class PasskeysServiceTest {
             verify(accessTokenConstructorService)
                     .createSignedAccessToken(
                             eq(PUBLIC_SUBJECT_ID),
-                            eq(AccountDataScope.PASSKEY_RETRIEVE),
+                            eq(List.of(AccountDataScope.PASSKEY_RETRIEVE)),
                             eq(SESSION_ID),
                             any(),
                             any(),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorService.java
@@ -9,7 +9,9 @@ import uk.gov.di.authentication.shared.entity.JwtFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class AccessTokenConstructorService {
 
@@ -29,7 +31,7 @@ public class AccessTokenConstructorService {
 
     public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
             String publicSubjectId,
-            AccessTokenScope scope,
+            List<AccessTokenScope> scopes,
             String sessionId,
             Date issueTime,
             Date expiryDate,
@@ -37,9 +39,12 @@ public class AccessTokenConstructorService {
             String issuer,
             String clientId,
             String signingKey) {
+        var scopeValue =
+                scopes.stream().map(AccessTokenScope::getValue).collect(Collectors.joining(" "));
+
         var claims =
                 new JWTClaimsSet.Builder()
-                        .claim("scope", scope.getValue())
+                        .claim("scope", scopeValue)
                         .issuer(issuer)
                         .audience(audience)
                         .expirationTime(expiryDate)
@@ -53,13 +58,13 @@ public class AccessTokenConstructorService {
 
         return jwtService
                 .signJWT(claims, signingKey)
-                .map(signedJWT -> signedJwtToAccessToken(signedJWT, scope));
+                .map(signedJWT -> signedJwtToAccessToken(signedJWT, scopeValue));
     }
 
-    private BearerAccessToken signedJwtToAccessToken(SignedJWT signedJWT, AccessTokenScope scope) {
+    private BearerAccessToken signedJwtToAccessToken(SignedJWT signedJWT, String scopeValue) {
         return new BearerAccessToken(
                 signedJWT.serialize(),
                 configurationService.getSessionExpiry(),
-                new Scope(scope.getValue()));
+                new Scope(scopeValue));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccessTokenConstructorServiceTest.java
@@ -25,6 +25,7 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,21 +66,24 @@ class AccessTokenConstructorServiceTest {
 
     private static Stream<Arguments> validScopes() {
         return Stream.of(
-                Arguments.of(AccountDataScope.PASSKEY_CREATE, "passkey-create"),
-                Arguments.of(AccountDataScope.PASSKEY_RETRIEVE, "passkey-retrieve"));
+                Arguments.of(List.of(AccountDataScope.PASSKEY_CREATE), "passkey-create"),
+                Arguments.of(List.of(AccountDataScope.PASSKEY_RETRIEVE), "passkey-retrieve"),
+                Arguments.of(
+                        List.of(AccountDataScope.PASSKEY_CREATE, AccountDataScope.PASSKEY_RETRIEVE),
+                        "passkey-create passkey-retrieve"));
     }
 
     @ParameterizedTest
     @MethodSource("validScopes")
     void shouldCreateAndSignAccessTokenWithValidScope(
-            AccessTokenScope accessTokenScope, String expectedScope)
+            List<AccessTokenScope> scopes, String expectedScope)
             throws ParseException, JOSEException {
         // Arrange
         // Act
         var result =
                 accessTokenConstructorService.createSignedAccessToken(
                         PUBLIC_SUBJECT_ID,
-                        accessTokenScope,
+                        scopes,
                         SESSION_ID,
                         NOW,
                         EXPIRY,
@@ -116,7 +120,7 @@ class AccessTokenConstructorServiceTest {
         var result =
                 accessTokenConstructorService.createSignedAccessToken(
                         PUBLIC_SUBJECT_ID,
-                        AccountDataScope.PASSKEY_CREATE,
+                        List.of(AccountDataScope.PASSKEY_CREATE),
                         SESSION_ID,
                         NOW,
                         EXPIRY,


### PR DESCRIPTION
## What

In some cases, we need to generate ADAPI tokens with multiple scopes (e.g. a token might need the ability to read and write passkeys). Previously, our token generation helper method only allowed you to set one - now it allows multiple. The scopes are passed around as a `List` until the point when they're written to the token body as a space-separated `String`.

This commits can be roughly grouped like this:
* 8374ac071a6098a0544bbf812fc4e83e3c95c93a
  * Supporting generation with multiple scopes
* 701b71d1435133109a39c46ce7a5f26c19fb7643, 9203d7dcf7c672ea14e5c492e7f60af053e1b71f, 611902dd72f17dc6213cdc25dc688adb7585b4fb
  * Updating places where we generate tokens to make sure they're generated with the correct scopes
* b1abcc63a3317eba1a92880987adb1992faa20de, d1b69bb6a9d9c2a6e04cd238773b3713d7fced42
  * Validating the scopes correctly in the ADAPI
* e077a34b70a643a853620fb9182ca53db519a69d
  * Updating the ADAPI token generator script

## How to review

1. Code Review
2. Test end-to-end journeys with AMC/Home once it reaches Staging