### PR TITLE
BAU: Update the local running to support ADAPI

### DIFF
--- a/local-running/Dockerfile
+++ b/local-running/Dockerfile
@@ -17,6 +17,7 @@ COPY user-permissions ./user-permissions
 COPY auth-external-api ./auth-external-api
 COPY frontend-api ./frontend-api
 COPY audit-events ./audit-events
+COPY account-data-api ./account-data-api
 
 RUN --mount=type=cache,target=/root/.gradle ./gradlew :local-running:build --no-daemon
 RUN mkdir untarred && tar -xvf local-running/build/distributions/local-running.tar -C ./untarred

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -22,7 +22,8 @@ dependencies {
             libs.awsSecretsManager,
             project(":shared"),
             project(":auth-external-api"),
-            project(":frontend-api")
+            project(":frontend-api"),
+            project(":account-data-api")
 }
 
 java {

--- a/local-running/src/main/java/uk/gov/di/authentication/local/LocalAuthApi.java
+++ b/local-running/src/main/java/uk/gov/di/authentication/local/LocalAuthApi.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.local;
 
 import io.javalin.Javalin;
+import uk.gov.di.authentication.accountdata.lambda.PasskeysRetrieveHandler;
 import uk.gov.di.authentication.external.lambda.TokenHandler;
 import uk.gov.di.authentication.external.lambda.UserInfoHandler;
 import uk.gov.di.authentication.frontendapi.lambda.AMCAuthorizeHandler;
@@ -99,6 +100,11 @@ public class LocalAuthApi {
                             // External API
                             config.routes.post("/token", handlerFor(new TokenHandler()));
                             config.routes.get("/userinfo", handlerFor(new UserInfoHandler()));
+
+                            // Account Data API
+                            config.routes.post(
+                                    "/accounts/{publicSubjectId}/authenticators/passkeys",
+                                    handlerFor(new PasskeysRetrieveHandler()));
                         });
 
         // Start app


### PR DESCRIPTION
## What

- In order to test passkeys locally, we first need to be able to manually add a passkey to the local-authenticator table in the docker dynamo container. These changes expose the PasskeysRetrieveHandler to local-running which initialises a local-authenticator table we can add items to.
- Note we don't need to introduce the other ADAPI endpoints because the frontend-api only interacts with the passkey-retrieve endpoint (in the AccountDataCredentialRepository)

## How to review

1. Code review
2. Check local running the frontend + backend still works using `./startup.sh -L` in the frontend repo

