### PR TITLE
ATO-2575: remove new v2 key feature flags

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -74,12 +74,10 @@ public class JwksHandler
                 }
             }
 
-            if (configurationService.isPublishNextExternalTokenSigningKeysEnabledV2()) {
-                signingKeys.add(jwksService.getNextPublicTokenJwkWithOpaqueIdV2());
+            signingKeys.add(jwksService.getNextPublicTokenJwkWithOpaqueIdV2());
 
-                if (configurationService.isRsaSigningAvailable()) {
-                    signingKeys.add(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2());
-                }
+            if (configurationService.isRsaSigningAvailable()) {
+                signingKeys.add(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2());
             }
 
             JWKSet jwkSet = new JWKSet(signingKeys);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
@@ -38,16 +38,15 @@ class JwksHandlerTest {
 
     @Test
     void shouldReturnTwoJwksWhenRsaSigningIsDisabled() throws JOSEException {
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
-        var tokenSigningKey = generateECKey();
+        var newTokenSigningKeyV2 = generateECKey();
         var docAppSigningKey = generateECKey();
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
+        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newTokenSigningKeyV2);
         when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
 
         var event = new APIGatewayProxyRequestEvent();
         var result = handler.handleRequest(event, context);
 
-        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey, tokenSigningKey));
+        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey, newTokenSigningKeyV2));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));
@@ -56,37 +55,21 @@ class JwksHandlerTest {
     @Test
     void shouldReturnThreeJwksWhenRsaSigningIsEnabled() throws JOSEException {
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
-        var tokenSigningKey = generateECKey();
+        var newTokenSigningKeyV2 = generateECKey();
         var docAppSigningKey = generateECKey();
-        var rsaTokenSigningKey =
+        var newRSATokenSigningKeyV2 =
                 new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
-        when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaTokenSigningKey);
+        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newTokenSigningKeyV2);
+        when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2())
+                .thenReturn(newRSATokenSigningKeyV2);
         when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
 
         var event = new APIGatewayProxyRequestEvent();
         var result = handler.handleRequest(event, context);
 
         var expectedJWKSet =
-                new JWKSet(List.of(docAppSigningKey, tokenSigningKey, rsaTokenSigningKey));
-
-        assertThat(result, hasStatus(200));
-        assertThat(result, hasBody(expectedJWKSet.toString(true)));
-    }
-
-    @Test
-    void shouldReturn200WhenRequestIsSuccessful() throws JOSEException {
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
-        var opaqueSigningKey = generateECKey();
-        var docAppSigningKey = generateECKey();
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
-        when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
-
-        var event = new APIGatewayProxyRequestEvent();
-        var result = handler.handleRequest(event, context);
-
-        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey, opaqueSigningKey));
+                new JWKSet(
+                        List.of(docAppSigningKey, newTokenSigningKeyV2, newRSATokenSigningKeyV2));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));
@@ -94,8 +77,7 @@ class JwksHandlerTest {
 
     @Test
     void shouldReturn500WhenSigningKeyIsNotPresent() {
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(null);
+        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(null);
 
         var event = new APIGatewayProxyRequestEvent();
         var result = handler.handleRequest(event, context);
@@ -106,10 +88,9 @@ class JwksHandlerTest {
 
     @Test
     void shouldSetACacheHeaderOfOneDayOnSuccess() throws JOSEException {
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
-        var opaqueSigningKey = generateECKey();
+        var newTokenSigningKeyV2 = generateECKey();
         var docAppSigningKey = generateECKey();
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
+        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newTokenSigningKeyV2);
         when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
 
         var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
@@ -117,10 +98,7 @@ class JwksHandlerTest {
     }
 
     @Test
-    void shouldPublishNewEcKeyWhenNewPublishIsEnabledButRsaNotEnabled() throws JOSEException {
-        when(configurationService.isRsaSigningAvailable()).thenReturn(false);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
+    void shouldPublishOldEcKeyWhenOldPublishEnabled() throws JOSEException {
         when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
 
         var tokenSigningKey = generateECKey();
@@ -136,25 +114,6 @@ class JwksHandlerTest {
 
         var expectedJWKSet =
                 new JWKSet(List.of(docAppSigningKey, tokenSigningKey, newTokenSigningKeyV2));
-
-        assertThat(result, hasStatus(200));
-        assertThat(result, hasBody(expectedJWKSet.toString(true)));
-    }
-
-    @Test
-    void shouldNotPublishOldEcKeyWhenOldPublishDisabled() throws JOSEException {
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(false);
-
-        var tokenSigningKey = generateECKey();
-        var docAppSigningKey = generateECKey();
-
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
-        when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
-
-        var event = new APIGatewayProxyRequestEvent();
-        var result = handler.handleRequest(event, context);
-
-        var expectedJWKSet = new JWKSet(List.of(docAppSigningKey));
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -306,10 +306,5 @@ public class IntegrationTest {
         public Optional<String> getIPVCapacity() {
             return Optional.of("1");
         }
-
-        @Override
-        public boolean isPublishOldExternalTokenSigningKeysEnabled() {
-            return true;
-        }
     }
 }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/TokenSigningExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/TokenSigningExtension.java
@@ -54,7 +54,7 @@ public class TokenSigningExtension extends KmsKeyExtension {
             SignRequest signRequest =
                     SignRequest.builder()
                             .message(SdkBytes.fromByteBuffer(messageToSign))
-                            .keyId(getKeyAlias())
+                            .keyId(getNewKeyAliasV2())
                             .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
                             .build();
             var signResult = kmsConnectionService.sign(signRequest);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -394,10 +394,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .contains(getEnvironment());
     }
 
-    public boolean isUseNewV2TokenSigningKeysEnabled() {
-        return getFlagOrFalse("USE_NEW_V2_TOKEN_SIGNING_KEYS");
-    }
-
     public boolean isUseStoredOldIdTokenPublicKeysEnabled() {
         return getFlagOrFalse("USE_STORED_OLD_ID_TOKEN_PUBLIC_KEYS");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -381,10 +381,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("STORED_OLD_ID_TOKEN_EC_PUBLIC_KEYS");
     }
 
-    public boolean isPublishNextExternalTokenSigningKeysEnabledV2() {
-        return getFlagOrFalse("PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2");
-    }
-
     public boolean isPublishOldExternalTokenSigningKeysEnabled() {
         return getFlagOrFalse("PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -385,18 +385,10 @@ public class TokenService {
 
     public SignedJWT generateSignedJwtUsingExternalKey(
             JWTClaimsSet claimsSet, Optional<String> type, JWSAlgorithm algorithm) {
-        String alias;
-        if (configService.isUseNewV2TokenSigningKeysEnabled()) {
-            alias =
-                    algorithm == JWSAlgorithm.ES256
-                            ? configService.getNextExternalTokenSigningKeyAliasV2()
-                            : configService.getNextExternalTokenSigningKeyRsaAliasV2();
-        } else {
-            alias =
-                    algorithm == JWSAlgorithm.ES256
-                            ? configService.getExternalTokenSigningKeyAlias()
-                            : configService.getExternalTokenSigningKeyRsaAlias();
-        }
+        String alias =
+                algorithm == JWSAlgorithm.ES256
+                        ? configService.getNextExternalTokenSigningKeyAliasV2()
+                        : configService.getNextExternalTokenSigningKeyRsaAliasV2();
         return generateSignedJWT(claimsSet, type, algorithm, alias);
     }
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
@@ -62,23 +62,11 @@ public class TokenValidationService {
 
             if (JWSAlgorithm.RS256 == jwt.getHeader().getAlgorithm()
                     && configuration.isRsaSigningAvailable()) {
-                if (configuration.isPublishNextExternalTokenSigningKeysEnabledV2()) {
-                    var newV2PublicKey = jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2();
-                    return jwt.verify(new RSASSAVerifier(newV2PublicKey.toRSAKey()));
-                } else {
-                    return jwt.verify(
-                            new RSASSAVerifier(
-                                    jwksService.getPublicTokenRsaJwkWithOpaqueId().toRSAKey()));
-                }
+                var newV2PublicKey = jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2();
+                return jwt.verify(new RSASSAVerifier(newV2PublicKey.toRSAKey()));
             } else {
-                if (configuration.isPublishNextExternalTokenSigningKeysEnabledV2()) {
-                    var newV2PublicKey = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
-                    return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
-                } else {
-                    return jwt.verify(
-                            new ECDSAVerifier(
-                                    jwksService.getPublicTokenJwkWithOpaqueId().toECKey()));
-                }
+                var newV2PublicKey = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
+                return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
             }
 
         } catch (JOSEException | java.text.ParseException e) {
@@ -91,13 +79,9 @@ public class TokenValidationService {
         try {
             var jwt = SignedJWT.parse(tokenValue);
 
-            if (configuration.isPublishNextExternalTokenSigningKeysEnabledV2()) {
-                var newV2PublicKey = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
-                if (Objects.equals(jwt.getHeader().getKeyID(), newV2PublicKey.getKeyID())) {
-                    return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
-                } else {
-                    return validateWithOldECPublicKey(jwt);
-                }
+            var newV2PublicKey = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
+            if (Objects.equals(jwt.getHeader().getKeyID(), newV2PublicKey.getKeyID())) {
+                return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
             } else {
                 return validateWithOldECPublicKey(jwt);
             }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
@@ -63,13 +63,8 @@ public class TokenValidationService {
             if (JWSAlgorithm.RS256 == jwt.getHeader().getAlgorithm()
                     && configuration.isRsaSigningAvailable()) {
                 if (configuration.isPublishNextExternalTokenSigningKeysEnabledV2()) {
-                    var oldPublicKey = jwksService.getPublicTokenRsaJwkWithOpaqueId();
                     var newV2PublicKey = jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2();
-                    if (Objects.equals(jwt.getHeader().getKeyID(), newV2PublicKey.getKeyID())) {
-                        return jwt.verify(new RSASSAVerifier(newV2PublicKey.toRSAKey()));
-                    } else {
-                        return jwt.verify(new RSASSAVerifier(oldPublicKey.toRSAKey()));
-                    }
+                    return jwt.verify(new RSASSAVerifier(newV2PublicKey.toRSAKey()));
                 } else {
                     return jwt.verify(
                             new RSASSAVerifier(
@@ -77,13 +72,8 @@ public class TokenValidationService {
                 }
             } else {
                 if (configuration.isPublishNextExternalTokenSigningKeysEnabledV2()) {
-                    var oldPublicKey = jwksService.getPublicTokenJwkWithOpaqueId();
                     var newV2PublicKey = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
-                    if (Objects.equals(jwt.getHeader().getKeyID(), newV2PublicKey.getKeyID())) {
-                        return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
-                    } else {
-                        return jwt.verify(new ECDSAVerifier(oldPublicKey.toECKey()));
-                    }
+                    return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
                 } else {
                     return jwt.verify(
                             new ECDSAVerifier(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -616,7 +616,6 @@ class TokenServiceTest {
 
         @Test
         void itShouldUseTheNewV2KeyToCreateATokenWhenFeatureFlagEnabled() {
-            when(configurationService.isUseNewV2TokenSigningKeysEnabled()).thenReturn(true);
             when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(mockSignResponseEc);
 
             var testClaimsSet =
@@ -637,7 +636,6 @@ class TokenServiceTest {
 
         @Test
         void itShouldUseTheNewV2RsaKeyToCreateATokenWhenFeatureFlagEnabled() {
-            when(configurationService.isUseNewV2TokenSigningKeysEnabled()).thenReturn(true);
             when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(mockSignResponseRsa);
 
             var testClaimsSet =
@@ -655,51 +653,6 @@ class TokenServiceTest {
             assertThat(signedToken.getHeader().getAlgorithm(), equalTo(JWSAlgorithm.RS256));
             assertThat(
                     signedToken.getHeader().getKeyID(), equalTo(EXPECTED_OPAQUE_NEW_V2_RSA_KEY_ID));
-        }
-
-        @Test
-        void itShouldContinueToUseOldKeyWhenFeatureFlagIsDisabled() {
-            when(configurationService.isUseNewV2TokenSigningKeysEnabled()).thenReturn(false);
-            when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(mockSignResponseEc);
-
-            var testClaimsSet =
-                    new JWTClaimsSet.Builder()
-                            .claim("sub", FIXED_INTERNAL_PAIRWISE_SUBJECT)
-                            .build();
-
-            var signedToken =
-                    tokenService.generateSignedJwtUsingExternalKey(
-                            testClaimsSet, Optional.empty(), JWSAlgorithm.ES256);
-
-            verify(kmsConnectionService)
-                    .getPublicKey(GetPublicKeyRequest.builder().keyId(PREVIOUS_KEY_ALIAS).build());
-            assertThat(signedToken.getHeader().getAlgorithm(), equalTo(JWSAlgorithm.ES256));
-            assertThat(
-                    signedToken.getHeader().getKeyID(),
-                    equalTo(EXPECTED_OPAQUE_PREVIOUS_EC_KEY_ID));
-        }
-
-        @Test
-        void itShouldContinueToUseOldRsaKeyWhenFeatureFlagIsDisabled() {
-            when(configurationService.isUseNewV2TokenSigningKeysEnabled()).thenReturn(false);
-            when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(mockSignResponseRsa);
-
-            var testClaimsSet =
-                    new JWTClaimsSet.Builder()
-                            .claim("sub", FIXED_INTERNAL_PAIRWISE_SUBJECT)
-                            .build();
-
-            var signedToken =
-                    tokenService.generateSignedJwtUsingExternalKey(
-                            testClaimsSet, Optional.empty(), JWSAlgorithm.RS256);
-
-            verify(kmsConnectionService)
-                    .getPublicKey(
-                            GetPublicKeyRequest.builder().keyId(PREVIOUS_KEY_ALIAS_RSA).build());
-            assertThat(signedToken.getHeader().getAlgorithm(), equalTo(JWSAlgorithm.RS256));
-            assertThat(
-                    signedToken.getHeader().getKeyID(),
-                    equalTo(EXPECTED_OPAQUE_PREVIOUS_RSA_KEY_ID));
         }
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -531,19 +531,6 @@ class TokenServiceTest {
         private final String NEW_V2_KEY_ALIAS = "alias/new-signing-key-v2";
         private final String NEW_V2_KEY_ALIAS_RSA = "alias/new-signing-key-rsa-v2";
 
-        private final String PREVIOUS_KEY_ALIAS = "alias/old-signing-key";
-        private final String PREVIOUS_KEY_ALIAS_RSA = "alias/old-signing-key-rsa";
-
-        private final String MOCK_PREVIOUS_EC_KEY_ID =
-                "nF2rpzCc-UZavTfpb9V7TTBG4uphYul9u-Op-cLqf_4";
-        private final String MOCK_PREVIOUS_RSA_KEY_ID =
-                "A67fuGRkM96UF0YRCObJMeRLfL38jAP07zAAv79uYRk";
-
-        private final String EXPECTED_OPAQUE_PREVIOUS_EC_KEY_ID =
-                hashSha256String(MOCK_PREVIOUS_EC_KEY_ID);
-        private final String EXPECTED_OPAQUE_PREVIOUS_RSA_KEY_ID =
-                hashSha256String(MOCK_PREVIOUS_RSA_KEY_ID);
-
         private final String MOCK_NEW_V2_EC_KEY_ID = "i4rwnl-SLuhPjdtP1GJyKXZRDG00znaRld8s-h6Fn2i";
         private final String MOCK_NEW_V2_RSA_KEY_ID = "LA9hmMyeZ2h4oOZcoWpReQKHGp0PwfyzuKCc08cdjYh";
 
@@ -560,21 +547,6 @@ class TokenServiceTest {
 
         @BeforeEach
         void setup() throws JOSEException {
-
-            when(configurationService.getExternalTokenSigningKeyAlias())
-                    .thenReturn(PREVIOUS_KEY_ALIAS);
-            when(configurationService.getExternalTokenSigningKeyRsaAlias())
-                    .thenReturn(PREVIOUS_KEY_ALIAS_RSA);
-
-            when(kmsConnectionService.getPublicKey(
-                            GetPublicKeyRequest.builder().keyId(PREVIOUS_KEY_ALIAS).build()))
-                    .thenReturn(
-                            GetPublicKeyResponse.builder().keyId(MOCK_PREVIOUS_EC_KEY_ID).build());
-            when(kmsConnectionService.getPublicKey(
-                            GetPublicKeyRequest.builder().keyId(PREVIOUS_KEY_ALIAS_RSA).build()))
-                    .thenReturn(
-                            GetPublicKeyResponse.builder().keyId(MOCK_PREVIOUS_RSA_KEY_ID).build());
-
             when(configurationService.getNextExternalTokenSigningKeyAliasV2())
                     .thenReturn(NEW_V2_KEY_ALIAS);
             when(configurationService.getNextExternalTokenSigningKeyRsaAliasV2())

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
@@ -45,64 +45,37 @@ class TokenValidationServiceTest {
     private static final String NEW_V2_KEY_ID = "14342334554354";
     private static final String OLD_STORED_KEY_ID = "14442634554354";
     private static final String FAILED_KEY_ID = "14342354354355";
-    private JWSSigner signer;
     private ECKey ecJWK;
+    private JWSSigner newV2Signer;
+    private ECKey newV2ECJWK;
 
     @BeforeEach
     void setUp() throws JOSEException {
         ecJWK = generateECKeyPair();
-        signer = new ECDSASigner(ecJWK);
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(ecJWK.toPublicJWK());
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(false);
+
+        newV2ECJWK = generateCustomECKeyPair(NEW_V2_KEY_ID);
+        newV2Signer = new ECDSASigner(newV2ECJWK);
+        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newV2ECJWK);
     }
 
     @Test
     void shouldSuccessfullyValidateIDToken() {
         Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-        SignedJWT signedIdToken = createSignedIdToken(expiryDate);
+        SignedJWT signedIdToken = createSignedIdTokenWithV2Key(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
     }
 
     @Test
     void shouldNotFailSignatureValidationIfIdTokenHasExpired() {
         Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
-        SignedJWT signedIdToken = createSignedIdToken(expiryDate);
+        SignedJWT signedIdToken = createSignedIdTokenWithV2Key(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
     }
 
     @Test
-    void shouldSuccessfullyValidateAccessToken() {
-        SignedJWT signedAccessToken = createSignedAccessToken(signer);
-        assertTrue(
-                tokenValidationService.isTokenSignatureValid(
-                        new BearerAccessToken(signedAccessToken.serialize()).getValue()));
-    }
-
-    @Test
-    void shouldSuccessfullyValidateNewECKeyV2AccessToken() throws JOSEException {
-        var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
-        var ecSigner = new ECDSASigner(newECKey);
-
-        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
-
-        SignedJWT signedAccessToken = createCustomSignedAccessToken(ecSigner, NEW_V2_KEY_ID);
-        assertTrue(
-                tokenValidationService.isTokenSignatureValid(
-                        new BearerAccessToken(signedAccessToken.serialize()).getValue()));
-    }
-
-    @Test
-    void shouldSuccessfullyValidateAccessTokenWithOldKeyWhenKeyIdMatches() {
-        var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
-
-        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
-
-        SignedJWT signedAccessToken = createSignedAccessToken(signer);
+    void shouldSuccessfullyValidateNewECKeyV2AccessToken() {
+        SignedJWT signedAccessToken = createSignedAccessTokenWithV2Signer();
         assertTrue(
                 tokenValidationService.isTokenSignatureValid(
                         new BearerAccessToken(signedAccessToken.serialize()).getValue()));
@@ -110,30 +83,11 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldFailToValidateECKeyAccessTokenIfKeyIdInvalid() throws JOSEException {
-        var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
         var failedECKey = generateCustomECKeyPair(FAILED_KEY_ID);
         var ecSigner = new ECDSASigner(failedECKey);
 
-        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
-
         SignedJWT signedAccessToken = createCustomSignedAccessToken(ecSigner, FAILED_KEY_ID);
         assertFalse(
-                tokenValidationService.isTokenSignatureValid(
-                        new BearerAccessToken(signedAccessToken.serialize()).getValue()));
-    }
-
-    @Test
-    void shouldSuccessfullyValidateRsaSignedAccessToken() throws JOSEException {
-        var rsaKey = generateCustomRsaKeyPair(KEY_ID);
-        var rsaSigner = new RSASSASigner(rsaKey);
-
-        when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
-
-        SignedJWT signedAccessToken = createSignedAccessToken(rsaSigner);
-        assertTrue(
                 tokenValidationService.isTokenSignatureValid(
                         new BearerAccessToken(signedAccessToken.serialize()).getValue()));
     }
@@ -145,31 +99,10 @@ class TokenValidationServiceTest {
         var newRSASigner = new RSASSASigner(newRSAKey);
 
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
         when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
         when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2()).thenReturn(newRSAKey);
 
         SignedJWT signedAccessToken = createCustomSignedAccessToken(newRSASigner, NEW_V2_KEY_ID);
-        assertTrue(
-                tokenValidationService.isTokenSignatureValid(
-                        new BearerAccessToken(signedAccessToken.serialize()).getValue()));
-    }
-
-    @Test
-    void shouldSuccessfullyValidateRsaSignedAccessTokenWithOldKeyWhenKeyIdMatches()
-            throws JOSEException {
-        var rsaKey = generateCustomRsaKeyPair(KEY_ID);
-        var newRSAKey = generateCustomRsaKeyPair(NEW_V2_KEY_ID);
-        var rsaSigner = new RSASSASigner(rsaKey);
-
-        when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
-        when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
-        when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2()).thenReturn(newRSAKey);
-
-        SignedJWT signedAccessToken = createCustomSignedAccessToken(rsaSigner, KEY_ID);
         assertTrue(
                 tokenValidationService.isTokenSignatureValid(
                         new BearerAccessToken(signedAccessToken.serialize()).getValue()));
@@ -183,8 +116,6 @@ class TokenValidationServiceTest {
         var rsaSigner = new RSASSASigner(wrongRSAKey);
 
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                .thenReturn(true);
         when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
         when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2()).thenReturn(newRSAKey);
 
@@ -223,13 +154,8 @@ class TokenValidationServiceTest {
         @Test
         void shouldSuccessfullyValidateNewECKeyV2ReauthIDToken() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-            var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
 
-            when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
-            when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                    .thenReturn(true);
-
-            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, newECKey);
+            SignedJWT signedIdToken = createSignedIdTokenWithV2Key(expiryDate);
             assertTrue(
                     tokenValidationService.isReauthTokenSignatureValid(
                             new BearerAccessToken(signedIdToken.serialize()).getValue()));
@@ -239,11 +165,7 @@ class TokenValidationServiceTest {
         void
                 shouldSuccessfullyValidateReauthIDTokenWithOldKeyWhenKeyIdMatchesAndOldKeyIsPublished() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-            var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
 
-            when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
-            when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                    .thenReturn(true);
             when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
                     .thenReturn(true);
 
@@ -256,12 +178,7 @@ class TokenValidationServiceTest {
         @Test
         void shouldFailToValidateECKeyReauthIDTokenIfKeyIdInvalid() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-            var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
             var failedECKey = generateCustomECKeyPair(FAILED_KEY_ID);
-
-            when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
-            when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
-                    .thenReturn(true);
 
             SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, failedECKey);
             assertFalse(
@@ -337,7 +254,7 @@ class TokenValidationServiceTest {
     void shouldSuccessfullyValidateRefreshToken() {
         Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
 
-        SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(signer, expiryDate);
+        SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(expiryDate);
         assertTrue(
                 tokenValidationService.validateRefreshTokenSignatureAndExpiry(
                         new RefreshToken(signedAccessToken.serialize())));
@@ -347,7 +264,7 @@ class TokenValidationServiceTest {
     void shouldFailToValidateRefreshTokenIfExpired() {
         Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
 
-        SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(signer, expiryDate);
+        SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(expiryDate);
         assertFalse(
                 tokenValidationService.validateRefreshTokenSignatureAndExpiry(
                         new RefreshToken(signedAccessToken.serialize())));
@@ -398,9 +315,18 @@ class TokenValidationServiceTest {
                 CLIENT_ID, SUBJECT, BASE_URL, ecJWK, expiryDate);
     }
 
+    private SignedJWT createSignedIdTokenWithV2Key(Date expiryDate) {
+        return TokenGeneratorHelper.generateIDToken(
+                CLIENT_ID, SUBJECT, BASE_URL, newV2ECJWK, expiryDate);
+    }
+
     private SignedJWT createCustomSignedIdToken(Date expiryDate, ECKey ecKey) {
         return TokenGeneratorHelper.generateIDToken(
                 CLIENT_ID, SUBJECT, BASE_URL, ecKey, expiryDate);
+    }
+
+    private SignedJWT createSignedAccessTokenWithV2Signer() {
+        return createCustomSignedAccessToken(newV2Signer, NEW_V2_KEY_ID);
     }
 
     private SignedJWT createCustomSignedAccessToken(JWSSigner signer, String keyId) {
@@ -408,12 +334,14 @@ class TokenValidationServiceTest {
                 CLIENT_ID, BASE_URL, SCOPES, signer, SUBJECT, keyId);
     }
 
-    private SignedJWT createSignedAccessToken(JWSSigner signer) {
-        return createCustomSignedAccessToken(signer, KEY_ID);
-    }
-
-    private SignedJWT createSignedRefreshTokenWithExpiry(JWSSigner signer, Date expiryDate) {
+    private SignedJWT createSignedRefreshTokenWithExpiry(Date expiryDate) {
         return TokenGeneratorHelper.generateSignedToken(
-                CLIENT_ID, BASE_URL, REFRESH_SCOPES, signer, SUBJECT, KEY_ID, expiryDate);
+                CLIENT_ID,
+                BASE_URL,
+                REFRESH_SCOPES,
+                newV2Signer,
+                SUBJECT,
+                NEW_V2_KEY_ID,
+                expiryDate);
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -109,25 +109,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  ProvisionNewExternalTokenSigningKeysV2:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
-  PublishNextExternalTokenSigningKeysV2:
-    !And [
-      !Condition ProvisionNewExternalTokenSigningKeysV2,
-      !Or [
-        !Equals [dev, !Ref Environment],
-        !Equals [build, !Ref Environment],
-        !Equals [staging, !Ref Environment],
-        !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
-      ],
-    ]
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]
   UseCloudfront: !Equals [dev, !Ref Environment]
   ProvisionNewApiClientRegistryApiKey:
@@ -1924,14 +1905,7 @@ Resources:
                   !Ref Environment,
                   serviceDomain,
                 ]
-          PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - true
-            - false
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
       Policies:
         - !Ref IdTokenKmsAccessPolicy
         - !Ref BackChannelLogoutQueueConsumePolicy
@@ -2330,18 +2304,8 @@ Resources:
               !Ref Environment,
               idTokenKeyRsaArn,
             ]
-          PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - true
-            - false
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -2549,18 +2513,8 @@ Resources:
               !Ref Environment,
               idTokenKeyRsaArn,
             ]
-          PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - true
-            - false
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -3420,18 +3374,8 @@ Resources:
               !Ref Environment,
               idTokenKeyRsaArn,
             ]
-          PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - true
-            - false
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: !If
             - PublishOldExternalTokenSigningKeys
             - true
@@ -3932,14 +3876,7 @@ Resources:
               !Ref Environment,
               idTokenKeyArn,
             ]
-          PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - true
-            - false
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           STORED_OLD_ID_TOKEN_EC_PUBLIC_KEYS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -4189,18 +4126,8 @@ Resources:
               !Ref Environment,
               idTokenKeyRsaArn,
             ]
-          PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - true
-            - false
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
-          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !If
-            - PublishNextExternalTokenSigningKeysV2
-            - !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
-            - !Ref AWS::NoValue
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
+          NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -6751,16 +6678,13 @@ Resources:
                   !Ref Environment,
                   idTokenKeyArn,
                 ]
-          - Fn::If:
-              - ProvisionNewExternalTokenSigningKeysV2
-              - Sid: AllowNewIdTokenSigningKmsV2
-                Effect: Allow
-                Action:
-                  - kms:Sign
-                  - kms:GetPublicKey
-                Resource:
-                  - !GetAtt OrchExternalTokenEcSigningKmsKeyV2.Arn
-              - !Ref AWS::NoValue
+          - Sid: AllowNewIdTokenSigningKmsV2
+            Effect: Allow
+            Action:
+              - kms:Sign
+              - kms:GetPublicKey
+            Resource:
+              - !GetAtt OrchExternalTokenEcSigningKmsKeyV2.Arn
 
   IdTokenKmsRsaAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -6779,16 +6703,13 @@ Resources:
                   !Ref Environment,
                   idTokenKeyRsaArn,
                 ]
-          - Fn::If:
-              - ProvisionNewExternalTokenSigningKeysV2
-              - Sid: AllowNewIdTokenSigningKmsV2
-                Effect: Allow
-                Action:
-                  - kms:Sign
-                  - kms:GetPublicKey
-                Resource:
-                  - !GetAtt OrchExternalTokenRsaSigningKmsKeyV2.Arn
-              - !Ref AWS::NoValue
+          - Sid: AllowNewIdTokenSigningKmsV2
+            Effect: Allow
+            Action:
+              - kms:Sign
+              - kms:GetPublicKey
+            Resource:
+              - !GetAtt OrchExternalTokenRsaSigningKmsKeyV2.Arn
 
   DocAppSigningKmsAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -8224,7 +8145,6 @@ Resources:
   #region External Token signing keys
 
   OrchExternalTokenEcSigningKmsKeyV2:
-    Condition: ProvisionNewExternalTokenSigningKeysV2
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -8244,14 +8164,12 @@ Resources:
             Resource: "*"
 
   OrchExternalTokenEcSigningKmsKeyAliasV2:
-    Condition: ProvisionNewExternalTokenSigningKeysV2
     Type: AWS::KMS::Alias
     Properties:
       AliasName: !Sub "alias/${Environment}-orch-external-token-ec-signing-kms-key-alias-v2"
       TargetKeyId: !Ref OrchExternalTokenEcSigningKmsKeyV2
 
   OrchExternalTokenRsaSigningKmsKeyV2:
-    Condition: ProvisionNewExternalTokenSigningKeysV2
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -8271,7 +8189,6 @@ Resources:
             Resource: "*"
 
   OrchExternalTokenRsaSigningKmsKeyAliasV2:
-    Condition: ProvisionNewExternalTokenSigningKeysV2
     Type: AWS::KMS::Alias
     Properties:
       AliasName: !Sub "alias/${Environment}-orch-external-token-rsa-signing-kms-key-alias-v2"

--- a/template.yaml
+++ b/template.yaml
@@ -128,17 +128,6 @@ Conditions:
         !Equals [production, !Ref Environment],
       ],
     ]
-  UseNewV2SigningKeys:
-    !And [
-      !Condition PublishNextExternalTokenSigningKeysV2,
-      !Or [
-        !Equals [dev, !Ref Environment],
-        !Equals [build, !Ref Environment],
-        !Equals [staging, !Ref Environment],
-        !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
-      ],
-    ]
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]
   UseCloudfront: !Equals [dev, !Ref Environment]
   ProvisionNewApiClientRegistryApiKey:
@@ -1943,10 +1932,6 @@ Resources:
             - PublishNextExternalTokenSigningKeysV2
             - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
             - !Ref AWS::NoValue
-          USE_NEW_V2_TOKEN_SIGNING_KEYS: !If
-            - UseNewV2SigningKeys
-            - true
-            - false
       Policies:
         - !Ref IdTokenKmsAccessPolicy
         - !Ref BackChannelLogoutQueueConsumePolicy
@@ -2357,10 +2342,6 @@ Resources:
             - PublishNextExternalTokenSigningKeysV2
             - !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
             - !Ref AWS::NoValue
-          USE_NEW_V2_TOKEN_SIGNING_KEYS: !If
-            - UseNewV2SigningKeys
-            - true
-            - false
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:


### PR DESCRIPTION
### Wider context of change

As part of the key rotation, the new V2 keys have been successfully rotated and no longer need to be behind a feature flag.

### What’s changed

Remove UseV2Key, PublishV2Key, and ProvisionV2Key feature flags, as well as tidy up fetching the old public key for non-reauth journeys.

### Manual testing

Tested in dev

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**