### PR TITLE
ATO-2539: enable using the stored old public key for reauth validation in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -148,6 +148,7 @@ Conditions:
       !Equals [dev, !Ref Environment],
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
     ]
   PublishOldExternalTokenSigningKeys:
     !Or [


### PR DESCRIPTION
### Wider context of change

We want to remove the old public keys from auth's account, but we still need to support them for reauth journeys for a while. To do this, we've stored the old public keys in code and are going to start using them instead directly using the key from AWS.

### What’s changed

Turned a feature flag on in integration.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**