### PR TITLE
ATO-2539: stop publishing old token signing key in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -113,11 +113,7 @@ Conditions:
       !Equals [staging, !Ref Environment],
       !Equals [integration, !Ref Environment],
     ]
-  PublishOldExternalTokenSigningKeys:
-    !Or [
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
+  PublishOldExternalTokenSigningKeys: !Equals [production, !Ref Environment]
   UseDefaultTokenAuthMethod:
     !Or [
       !Equals [dev, !Ref Environment],


### PR DESCRIPTION
### Wider context of change

As part of the key rotation we need to stop publishing the old key. This stops publishing it in integration.

### What’s changed

Turns on feature flag.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**
