### PR TITLE
BAU: Make lastUsedAt nullable in the ADAPI API spec

### DIFF
--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
@@ -19,7 +19,7 @@ public record PasskeysRetrieveResponse(
             @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,
             @SerializedName("isResidentKey") @Expose @Required boolean isResidentKey,
-            @SerializedName("createdAt") @Expose String createdAt,
+            @SerializedName("createdAt") @Expose @Required String createdAt,
             @SerializedName("lastUsedAt") @Expose String lastUsedAt) {}
 
     public static PasskeyResponse from(Passkey passkey) {

--- a/ci/openAPI/AccountDataApi.yaml
+++ b/ci/openAPI/AccountDataApi.yaml
@@ -323,6 +323,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/PasskeyAuthenticatorCreate"
         - type: object
+          required:
+            - createdAt
           properties:
             createdAt:
               type: string
@@ -330,6 +332,7 @@ components:
               description: The timestamp the passkey was created
             lastUsedAt:
               type: string
+              nullable: true
               format: date-time
               description: The timestamp for when the passkey was last used
 


### PR DESCRIPTION
## What

It's possible that a `null` value will be returned if the user has never used their passkey to sign in. Usually, we return these nulls in our JSON (except in the case of TICF where we need to remove them).

Also made createdAt a required field in the passkey retrieve response as it will always exist and should never be null.

## How to review

1. Code Review