### PR TITLE
ATO-2438: run unit test pre-upload

### DIFF
--- a/.github/workflows/deploy-orch-build-and-promote.yml
+++ b/.github/workflows/deploy-orch-build-and-promote.yml
@@ -30,6 +30,8 @@ on:
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-orch.yml
+    with:
+      run_unit_tests: true
     secrets:
       ORCH_GH_ACTIONS_ROLE_ARN: ${{ secrets.ORCH_GH_ACTIONS_ROLE_ARN }}
       ORCH_ARTIFACT_BUCKET_NAME: ${{ secrets.ORCH_ARTIFACT_BUCKET_NAME }}

--- a/.github/workflows/deploy-orch.yml
+++ b/.github/workflows/deploy-orch.yml
@@ -12,10 +12,104 @@ on:
         required: true
       ORCH_SIGNING_PROFILE_NAME:
         required: true
+    inputs:
+      run_unit_tests:
+        description: "Boolean to run unit tests before deploying"
+        type: boolean
+        default: false
 
 jobs:
+  build:
+    if: ${{ inputs.run_unit_tests == true }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: gradle
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+      - name: Build Cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ github.event.pull_request.base.sha }}
+            ${{ runner.os }}-build-
+      - name: Run Build
+        run: ./gradlew --parallel build -x test -x spotlessApply -x spotlessCheck
+
+  run-unit-tests:
+    if: ${{ inputs.run_unit_tests == true }}
+    runs-on: ubuntu-24.04-arm
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: gradle
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Restore Build Cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ github.event.pull_request.base.sha }}
+            ${{ runner.os }}-build-
+      - name: Run Unit Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew client-registry-api:test doc-checking-app-api:test ipv-api:test oidc-api:test orchestration-shared:test jacocoTestReport
+
+  run-alerting-tests:
+    if: ${{ inputs.run_unit_tests == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+        working-directory: ./orchestration-alerting
+      - name: Run Unit Tests
+        run: npm test
+        working-directory: ./orchestration-alerting
+
   deploy:
     runs-on: ubuntu-latest
+    needs:
+      - run-unit-tests
+      - run-alerting-tests
+    if: |
+      always() &&
+      (needs.run-unit-tests.result == 'success' || needs.run-unit-tests.result == 'skipped') &&
+      (needs.run-alerting-tests.result == 'success' || needs.run-alerting-tests.result == 'skipped')
     timeout-minutes: 60
     permissions:
       id-token: write

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -334,6 +334,24 @@
             "file": ".github/workflows/sonar-analysis-on-merge.yml",
             "path": "jobs.run-code-analysis"
           }
+        },
+        {
+          "check-types": ["unit"],
+          "provider": "GitHub",
+          "phase": "pre-upload",
+          "config": {
+            "file": ".github/workflows/deploy-orch.yml",
+            "path": "jobs.run-unit-tests"
+          }
+        },
+        {
+          "check-types": ["unit"],
+          "provider": "GitHub",
+          "phase": "pre-upload",
+          "config": {
+            "file": ".github/workflows/deploy-orch.yml",
+            "path": "jobs.run-orchestration-alerting-tests"
+          }
         }
       ]
     }


### PR DESCRIPTION
### Wider context of change

To meet quality gates Bronze standards, we need to run unit tests before deploy/uploading the code.

### What’s changed

Add gradle command to run orchestration unit tests

### Manual testing

Ran gradle locally, will try deploying to dev to test this as GHA are only applied to main.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [ ] Successfully deployed to authdev or not required. **Can only do post-merge**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**