### PR TITLE
ATO-2512: Check refresh tokens are bound to the client

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -338,18 +338,32 @@ public class TokenHandler
         Subject rpPairwiseSubject;
         List<String> scopes;
         String jwtId;
+        String refreshTokenClientId;
         try {
             SignedJWT signedJwt = SignedJWT.parse(currentRefreshToken.getValue());
-            rpPairwiseSubject = new Subject(signedJwt.getJWTClaimsSet().getSubject());
-            scopes = (List<String>) signedJwt.getJWTClaimsSet().getClaim("scope");
-            jwtId = signedJwt.getJWTClaimsSet().getJWTID();
+            var jwtClaimSet = signedJwt.getJWTClaimsSet();
+            rpPairwiseSubject = new Subject(jwtClaimSet.getSubject());
+            scopes = (List<String>) jwtClaimSet.getClaim("scope");
+            jwtId = jwtClaimSet.getJWTID();
+            refreshTokenClientId = jwtClaimSet.getStringClaim("client_id");
         } catch (java.text.ParseException e) {
             LOG.warn("Unable to parse RefreshToken");
             return ApiResponse.badRequest(
                     new ErrorObject(INVALID_GRANT_CODE, "Invalid Refresh token"));
         }
+
+        if (!clientId.equals(refreshTokenClientId)) {
+            LOG.warn(
+                    "Refresh Token Client ID does not match authenticated client ID. Authenticated Client ID: {}, Client ID from token: {}",
+                    clientId,
+                    refreshTokenClientId);
+            return ApiResponse.badRequest(
+                    new ErrorObject(INVALID_GRANT_CODE, "Invalid Refresh token"));
+        }
+
         boolean areScopesValid =
                 tokenValidationService.validateRefreshTokenScopes(clientScopes, scopes);
+
         if (!areScopesValid) {
             return ApiResponse.badRequest(OAuth2Error.INVALID_SCOPE);
         }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -1149,6 +1149,30 @@ public class TokenHandlerTest {
             verifyNoMetricsOrAuditEvents();
         }
 
+        @Test
+        void shouldReturnInvalidGrantIfRefreshTokenFromDifferentClient()
+                throws JOSEException, TokenAuthInvalidException {
+            KeyPair keyPair = generateRsaKeyPair();
+            PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
+            ClientRegistry clientRegistry = generateClientRegistry(keyPair, CLIENT_ID);
+            setupTokenServiceValidationMocks(clientRegistry);
+
+            SignedJWT signedRefreshToken = createSignedRefreshToken("a-non-matching-client-id");
+            RefreshToken refreshTokenInRequest = new RefreshToken(signedRefreshToken.serialize());
+            when(tokenValidationService.validateRefreshTokenSignatureAndExpiry(
+                            refreshTokenInRequest))
+                    .thenReturn(true);
+
+            APIGatewayProxyResponseEvent result =
+                    generateApiGatewayRefreshRequest(
+                            privateKeyJWT, refreshTokenInRequest.getValue(), CLIENT_ID);
+
+            assertThat(result, hasStatus(400));
+            assertTrue(result.getBody().contains("invalid_grant"));
+            assertTrue(result.getBody().contains("Invalid Refresh token"));
+            verifyNoMetricsOrAuditEvents();
+        }
+
         @ParameterizedTest
         @NullSource
         @ValueSource(strings = {CLIENT_ID})
@@ -1318,6 +1342,10 @@ public class TokenHandlerTest {
     }
 
     private SignedJWT createSignedRefreshToken() throws JOSEException {
+        return createSignedRefreshToken(CLIENT_ID);
+    }
+
+    private SignedJWT createSignedRefreshToken(String clientId) throws JOSEException {
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256)
                         .keyID("KEY_ID")
@@ -1325,7 +1353,7 @@ public class TokenHandlerTest {
                         .generate();
         ECDSASigner signer = new ECDSASigner(ecSigningKey);
         return TokenGeneratorHelper.generateSignedToken(
-                CLIENT_ID, BASE_URI, SCOPES.toStringList(), signer, RP_PAIRWISE_SUBJECT, "KEY_ID");
+                clientId, BASE_URI, SCOPES.toStringList(), signer, RP_PAIRWISE_SUBJECT, "KEY_ID");
     }
 
     private SignedJWT createSignedRsaRefreshToken() throws JOSEException {


### PR DESCRIPTION
### Wider context of change

When we generate a refresh token, we put the `client_id` inside the token as a claim. We should validate that this matches the currently authenticated client making the request - ensuring these are bound to the client they are issued to

### What’s changed

- Adds a check that the client_id in the refresh tokens matches the client_id of the authenticated client

### Manual testing
-  Deployed to dev:
- Ran through refresh token journey
- Made a token request and acquired a new refresh token
- Run OIDC conformance test against these changes?

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
