### PR TITLE
ATO-2559: Enable feature flag in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -159,6 +159,7 @@ Conditions:
       !Equals [dev, !Ref Environment],
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
     ]
 
 Mappings:


### PR DESCRIPTION
### Wider context of change

We would like to default the tokenAuthMethod earlier instead of having the defaulting logic hidden inside the `PrivateKeyJwtClientAuthValidator`. We have a feature flag which changes the getter for tokenAuthMethod to a custom one in ClientUtils which returns `private_key_jwt` if the tokenAuthMethod is null. This feature flag is enabled up to staging at the moment.

### What’s changed

This PR enables this feature flag in integration

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

