### PR TITLE
ATO-2597: Add isDeprecated field for clients

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -26,6 +26,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.orchestration.shared.entity.ServiceType.MANDATORY;
@@ -106,6 +107,7 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
         assertTrue(clientStore.clientExists(clientResponse.getClientId()));
         assertTrue(client.isPresent());
         assertTrue(client.get().isActive());
+        assertFalse(client.get().isDeprecated());
         assertEquals(2000, client.get().getRateLimit());
         assertThat(clientResponse.getClaims(), equalTo(claims));
         assertThat(clientResponse.getBackChannelLogoutUri(), equalTo(backChannelLogoutUri));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -351,6 +351,17 @@ public class AuthorisationHandler
                     user);
         }
 
+        if (client.isDeprecated()) {
+            LOG.error("Client configured as deprecated in Client Registry");
+            return generateErrorResponse(
+                    authRequest.getRedirectionURI(),
+                    authRequest.getState(),
+                    authRequest.getResponseMode(),
+                    new ErrorObject(UNAUTHORIZED_CLIENT_CODE, "client deprecated"),
+                    authRequest.getClientID().getValue(),
+                    user);
+        }
+
         var rateLimitDecision =
                 rateLimitService.getClientRateLimitDecision(
                         ClientRateLimitConfig.fromClientRegistry(client));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -2075,6 +2075,36 @@ class AuthorisationHandlerTest {
         }
 
         @Test
+        void shouldReturn302WithErrorQueryParamsWhenClientIsDeprecated() {
+            when(clientService.getClient(CLIENT_ID.toString()))
+                    .thenReturn(Optional.of(generateClientRegistry().withDeprecated(true)));
+
+            var event =
+                    withRequestEvent(
+                            Map.of(
+                                    "client_id",
+                                    CLIENT_ID.getValue(),
+                                    "scope",
+                                    SCOPE,
+                                    "redirect_uri",
+                                    REDIRECT_URI,
+                                    "response_type",
+                                    "code"));
+
+            var response = makeHandlerRequest(event);
+
+            assertThat(response, hasStatus(302));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessage("Client configured as deprecated in Client Registry")));
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.LOCATION),
+                    equalTo(
+                            REDIRECT_URI
+                                    + "?error=unauthorized_client&error_description=client+deprecated"));
+        }
+
+        @Test
         void
                 shouldRedirectToProvidedRedirectUriWhenJARIsRequiredButRequestObjectIsMissingAndRedirectUriIsInClientRegistry() {
             when(orchestrationAuthorizationService.isJarValidationRequired(any())).thenReturn(true);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/ClientRegistry.java
@@ -28,6 +28,7 @@ public class ClientRegistry {
     private String sectorIdentifierUri;
     private String subjectType;
     private boolean isActive = true;
+    private boolean isDeprecated = false;
     private boolean cookieConsentShared = false;
     private boolean jarValidationRequired = false;
     private boolean testClient = false;
@@ -249,6 +250,20 @@ public class ClientRegistry {
 
     public ClientRegistry withActive(boolean isActive) {
         this.isActive = isActive;
+        return this;
+    }
+
+    @DynamoDbAttribute("IsDeprecated")
+    public boolean isDeprecated() {
+        return isDeprecated;
+    }
+
+    public void setDeprecated(boolean isDeprecated) {
+        this.isDeprecated = isDeprecated;
+    }
+
+    public ClientRegistry withDeprecated(boolean isDeprecated) {
+        this.isDeprecated = isDeprecated;
         return this;
     }
 


### PR DESCRIPTION
### Wider context of change

We currently have some clients that are no longer being used. We are currently using the isActive field to mark them as deprecated, but this isActive field is intended to be a short-term toggle for clients. We would like to add a new field to the client registry that represents a client that has been deprecated, and reject requests in a similar way to how we reject them if a client is marked as not active.

### What’s changed

This PR adds the `isDeprecated` field to the client registry, defaulting to false. This PR also rejects requests if a client has isDeprecated = true. 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

