### PR TITLE
AUT-5450: Redis failover notifications

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -38,7 +38,7 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   parameter_group_name        = "default.redis6.x"
   port                        = local.redis_port_number
   maintenance_window          = "tue:22:00-tue:23:00"
-  notification_topic_arn      = local.slack_event_sns_topic_arn
+  notification_topic_arn      = local.elasticache_alerts_sns_topic_arn
 
   multi_az_enabled = true
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -9,5 +9,5 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  slack_event_sns_topic_arn = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
+  elasticache_alerts_sns_topic_arn = data.terraform_remote_state.shared.outputs.elasticache_alerts_sns_topic_arn
 }

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -31,7 +31,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   port                        = local.redis_port_number
   multi_az_enabled            = true
   maintenance_window          = "wed:22:00-wed:23:00"
-  notification_topic_arn      = aws_sns_topic.slack_events.arn
+  notification_topic_arn      = aws_sns_topic.elasticache_alerts.arn
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
@@ -50,13 +50,10 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   }
 
   depends_on = [
-    aws_sns_topic.slack_events,
+    aws_sns_topic.elasticache_alerts,
   ]
 }
 
-data "aws_sns_topic" "slack_events" {
-  name = "${var.environment}-slack-events"
-}
 
 resource "random_password" "frontend_redis_password" {
   length = 32
@@ -86,7 +83,7 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
   parameter_group_name        = "default.redis6.x"
   port                        = local.redis_port_number
   maintenance_window          = "sun:22:00-sun:23:00"
-  notification_topic_arn      = data.aws_sns_topic.slack_events.arn
+  notification_topic_arn      = aws_sns_topic.elasticache_alerts.arn
 
   multi_az_enabled = true
 

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -4,6 +4,24 @@ resource "aws_sns_topic" "slack_events" {
   kms_master_key_id                = "alias/aws/sns"
 }
 
+resource "aws_sns_topic" "elasticache_alerts" {
+  name = "${var.environment}-elasticache-alerts"
+}
+
+resource "aws_sns_topic_subscription" "elasticache_alerts_lambda" {
+  count                           = contains(["integration", "production"], var.environment) ? 1 : 0
+  topic_arn                       = aws_sns_topic.elasticache_alerts.arn
+  protocol                        = "lambda"
+  endpoint                        = "arn:aws:lambda:eu-west-2:${var.auth_new_account_id}:function:${var.environment}-alerts"
+  endpoint_auto_confirms          = true
+  confirmation_timeout_in_minutes = 5
+}
+
+output "elasticache_alerts_sns_topic_arn" {
+  description = "The ARN of the unencrypted SNS topic for ElastiCache notifications"
+  value       = aws_sns_topic.elasticache_alerts.arn
+}
+
 output "slack_event_sns_topic_arn" {
   description = "The ARN of the SNS topic for Slack events"
   value       = aws_sns_topic.slack_events.arn


### PR DESCRIPTION


## What

Redis failover notifications

Create a separate unencrypted sns topic to publish Redis failover notifications.  (Encrypted topics do not work with Elasticache)

## How to review

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).


## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

PR is dependent ,Below PR need to be merged first
https://github.com/govuk-one-login/authentication-smoke-tests/pull/1287
