### PR TITLE
AUT-5002: Successful passkey authentication

### DIFF
--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -69,6 +69,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               relyingPartyId,
             ]
+          PASSKEY_ALLOWED_ORIGIN:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
       LoggingConfig:
         LogGroup: !Ref FinishPasskeyAssertionFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -69,6 +69,7 @@ Resources:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoAuthSessionStoreReadWriteAccessPolicy
+        - !Ref AuthToAccountDataSigningKeyPolicy
       SnapStart:
         ApplyOn: PublishedVersions
       VpcConfig:

--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -63,6 +63,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               amcClientId,
             ]
+          WEBAUTHN_RELYING_PARTY_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              relyingPartyId,
+            ]
       LoggingConfig:
         LogGroup: !Ref FinishPasskeyAssertionFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -26,6 +26,43 @@ Resources:
               - !Sub "https://identity.${SubEnvironment}.${Environment}.account.gov.uk"
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
+          AUTH_TO_ACCOUNT_DATA_API_AUDIENCE: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://account.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://account.${Environment}.account.gov.uk"
+            - "https://account.account.gov.uk"
+          AUTH_TO_ACCOUNT_DATA_SIGNING_KEY: !Sub
+            - arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${env}-auth-to-account-data-signing-key
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          AUTH_ISSUER_CLAIM:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
+          AMC_CLIENT_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              amcClientId,
+            ]
       LoggingConfig:
         LogGroup: !Ref FinishPasskeyAssertionFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/function/start-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/start-passkey-assertion.yaml
@@ -69,6 +69,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               relyingPartyId,
             ]
+          PASSKEY_ALLOWED_ORIGIN:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              frontendBaseUrl,
+            ]
       LoggingConfig:
         LogGroup: !Ref StartPasskeyAssertionFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/function/start-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/start-passkey-assertion.yaml
@@ -63,6 +63,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               amcClientId,
             ]
+          WEBAUTHN_RELYING_PARTY_ID:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              relyingPartyId,
+            ]
       LoggingConfig:
         LogGroup: !Ref StartPasskeyAssertionFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -262,6 +262,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: authdev1.dev.account.gov.uk
     authdev2:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ff8d97e6-69d6-4ea1-81c0-0de8d8bcac85
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/a99e39a4-0a63-4816-b222-6e7c6c318b32
@@ -318,6 +319,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: authdev2.dev.account.gov.uk
     authdev3:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/8a67ba56-4eb2-4bfb-8254-5cc1c92a5db5
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ce9680d3-953a-4b6a-9098-a0380d0afc70
@@ -378,6 +380,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: authdev3.dev.account.gov.uk
     dev:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f5e5d059-1581-4c5c-8d60-e168fd8a9a84
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4b475855-e71a-43a5-a836-c6cb37e9cb22
@@ -443,6 +446,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: dev.account.gov.uk
     build:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/e8fdebb6-2d33-4d0c-825c-2b5c874522d8
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/4932c4d3-bf86-4f39-a32c-b82faf9a2574
@@ -513,6 +517,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: build.account.gov.uk
     staging:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/01f3d1a6-e66f-4eb7-a3d7-412437c8f01d
@@ -585,6 +590,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: staging.account.gov.uk
     integration:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
@@ -657,6 +663,7 @@ Mappings:
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: integration.account.gov.uk
     production:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/730472f0-c7ba-4bda-a411-08cdaa65fe8a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/075774c2-b836-452f-9684-dcd742146f81
@@ -729,6 +736,7 @@ Mappings:
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      relyingPartyId: account.gov.uk
   LambdaConfiguration:
     account-recovery:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -19,6 +19,8 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
+import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -28,6 +30,7 @@ public class FinishPasskeyAssertionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private static final Logger LOG = LogManager.getLogger(FinishPasskeyAssertionHandler.class);
     private final PasskeyAssertionService passkeyAssertionService;
+    private final UserActionsManager userActionsManager;
 
     public FinishPasskeyAssertionHandler() {
         this(ConfigurationService.getInstance());
@@ -37,13 +40,15 @@ public class FinishPasskeyAssertionHandler
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
             AuthSessionService authSessionService,
-            PasskeyAssertionService passkeyAssertionService) {
+            PasskeyAssertionService passkeyAssertionService,
+            UserActionsManager userActionsManager) {
         super(
                 FinishPasskeyAssertionRequest.class,
                 configurationService,
                 authenticationService,
                 authSessionService);
         this.passkeyAssertionService = passkeyAssertionService;
+        this.userActionsManager = userActionsManager;
     }
 
     public FinishPasskeyAssertionHandler(ConfigurationService configurationService) {
@@ -52,6 +57,7 @@ public class FinishPasskeyAssertionHandler
                 new PasskeyAssertionService(
                         RelyingPartyProvider.provide(configurationService),
                         new DefaultPasskeyJsonParser());
+        this.userActionsManager = new UserActionsManager(configurationService);
     }
 
     @Override
@@ -69,22 +75,53 @@ public class FinishPasskeyAssertionHandler
 
         LOG.info("FinishPasskeyAssertionHandler called");
 
-        Result<FinishPasskeyAssertionFailureReason, AssertionResult> result =
-                passkeyAssertionService.finishAssertion(
-                        userContext.getAuthSession().getPasskeyAssertionRequest(), request.pkc());
-
-        return result.fold(
-                failure ->
-                        switch (failure) {
-                            case PARSING_ASSERTION_REQUEST_ERROR -> generateApiGatewayProxyErrorResponse(
-                                    500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
-                            case PARSING_PKC_ERROR -> generateApiGatewayProxyErrorResponse(
-                                    400, ErrorResponse.PASSKEY_ASSERTION_INVALID_PKC);
-                            case ASSERTION_FAILED_ERROR -> generateApiGatewayProxyErrorResponse(
-                                    401, ErrorResponse.PASSKEY_ASSERTION_FAILED);
+        return verifyPasskeyAssertion(userContext, request)
+                .flatMap(this::updatePasskeyRecord)
+                .map(success -> reportCorrectPasskeyReceived(userContext))
+                .fold(
+                        failure -> {
+                            reportIncorrectPasskeyReceived(userContext);
+                            return switch (failure) {
+                                case PARSING_ASSERTION_REQUEST_ERROR -> generateApiGatewayProxyErrorResponse(
+                                        500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
+                                case PARSING_PKC_ERROR -> generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.PASSKEY_ASSERTION_INVALID_PKC);
+                                case ASSERTION_FAILED_ERROR -> generateApiGatewayProxyErrorResponse(
+                                        401, ErrorResponse.PASSKEY_ASSERTION_FAILED);
+                            };
                         },
-                assertionResult -> generateApiGatewayProxyResponse(200, ""));
+                        success -> generateApiGatewayProxyResponse(200, ""));
+    }
 
+    private Result<FinishPasskeyAssertionFailureReason, AssertionResult> verifyPasskeyAssertion(
+            UserContext userContext, FinishPasskeyAssertionRequest request) {
+        return passkeyAssertionService.finishAssertion(
+                userContext.getAuthSession().getPasskeyAssertionRequest(), request.pkc());
+    }
+
+    private Result<FinishPasskeyAssertionFailureReason, Void> updatePasskeyRecord(
+            AssertionResult assertionResult) {
         // TODO - AUT-4938 - Update database with latest passkey values
+        return Result.success(null);
+    }
+
+    private Void reportCorrectPasskeyReceived(UserContext userContext) {
+        PermissionContext permissionContext =
+                PermissionContext.builder()
+                        .withAuthSessionItem(userContext.getAuthSession())
+                        .build();
+        userActionsManager.correctPasskeyReceived(null, permissionContext);
+
+        return null;
+    }
+
+    private Void reportIncorrectPasskeyReceived(UserContext userContext) {
+        PermissionContext permissionContext =
+                PermissionContext.builder()
+                        .withAuthSessionItem(userContext.getAuthSession())
+                        .build();
+        userActionsManager.incorrectPasskeyReceived(null, permissionContext);
+
+        return null;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -211,9 +211,10 @@ public class StartHandler
 
             if (reauthenticate) {
                 LOG.info(
-                        "Reauthentication - Setting hasVerifiedPassword & hasVerifiedMfa to false");
+                        "Reauthentication - Setting hasVerifiedPassword, hasVerifiedMfa & hasVerifiedPasskey to false");
                 authSession.setHasVerifiedPassword(false);
                 authSession.setHasVerifiedMfa(false);
+                authSession.setHasVerifiedPasskey(false);
             }
 
             Optional<String> maybeInternalSubject =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -10,6 +10,8 @@ import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
 import com.yubico.webauthn.data.PublicKeyCredential;
 import com.yubico.webauthn.exception.AssertionFailedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
 
@@ -19,6 +21,7 @@ import java.util.Optional;
 public class PasskeyAssertionService {
     private final RelyingParty relyingParty;
     private final PasskeyJsonParser jsonParser;
+    private static final Logger LOG = LogManager.getLogger(PasskeyAssertionService.class);
 
     public PasskeyAssertionService(RelyingParty relyingParty, PasskeyJsonParser jsonParser) {
         this.relyingParty = relyingParty;
@@ -59,10 +62,12 @@ public class PasskeyAssertionService {
                                     .response(credential)
                                     .build());
         } catch (AssertionFailedException e) {
+            LOG.error("Passkey assertion unexpectedly failed with error: {}", e.getMessage());
             return Result.failure(FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR);
         }
 
         if (!assertionResult.isSuccess()) {
+            LOG.warn("Passkey assertion unsuccessful");
             return Result.failure(FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR);
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProvider.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProvider.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,6 +42,9 @@ public class RelyingPartyProvider {
                     return RelyingParty.builder()
                             .identity(rpIdentity)
                             .credentialRepository(credentialRepository)
+                            .origins(
+                                    Collections.singleton(
+                                            configurationService.getPasskeyAllowedOrigin()))
                             .build();
                 });
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -14,12 +14,15 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.userpermissions.UserActionsManager;
 
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
@@ -35,6 +38,7 @@ class FinishPasskeyAssertionHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeyAssertionService passkeyAssertionService =
             mock(PasskeyAssertionService.class);
+    private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
     private FinishPasskeyAssertionHandler handler;
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
 
@@ -49,7 +53,8 @@ class FinishPasskeyAssertionHandlerTest {
                         configurationService,
                         authenticationService,
                         authSessionService,
-                        passkeyAssertionService);
+                        passkeyAssertionService,
+                        userActionsManager);
     }
 
     @Nested
@@ -66,6 +71,21 @@ class FinishPasskeyAssertionHandlerTest {
 
             // Then
             assertThat(response, hasStatus(200));
+        }
+
+        @Test
+        void shouldReportCorrectPasskeyReceivedWhenAssertionSuccessful() {
+            // Given
+            AssertionResult mockAssertionResult = mock(AssertionResult.class);
+            when(passkeyAssertionService.finishAssertion(any(), any()))
+                    .thenReturn(Result.success(mockAssertionResult));
+
+            // When
+            handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+            // Then
+            verify(userActionsManager, times(1)).correctPasskeyReceived(any(), any());
+            verify(userActionsManager, times(0)).incorrectPasskeyReceived(any(), any());
         }
     }
 
@@ -87,6 +107,22 @@ class FinishPasskeyAssertionHandlerTest {
 
     @Nested
     class Error {
+        @Test
+        void shouldReportIncorrectPasskeyReceivedWhenAssertionUnsuccessful() {
+            // Given
+            when(passkeyAssertionService.finishAssertion(any(), any()))
+                    .thenReturn(
+                            Result.failure(
+                                    FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR));
+
+            // When
+            handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+            // Then
+            verify(userActionsManager, times(1)).incorrectPasskeyReceived(any(), any());
+            verify(userActionsManager, times(0)).correctPasskeyReceived(any(), any());
+        }
+
         @Test
         void shouldReturn500WhenAssertionRequestDeserializationFails() {
             // Given

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -896,8 +896,7 @@ class StartHandlerTest {
     }
 
     @Test
-    void shouldResetHasVerifiedPasswordAndHasVerifiedMfaOnReauthJourney()
-            throws Json.JsonException {
+    void shouldResetHasVerifiedOnReauthJourney() throws Json.JsonException {
         // Arrange
         var authSession =
                 new AuthSessionItem()
@@ -905,7 +904,8 @@ class StartHandlerTest {
                         .withClientId(CLIENT_ID)
                         .withInternalCommonSubjectId(TEST_SUBJECT_ID)
                         .withHasVerifiedPassword(true)
-                        .withHasVerifiedMfa(true);
+                        .withHasVerifiedMfa(true)
+                        .withHasVerifiedPasskey(true);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
                 .thenReturn(authSession);
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
@@ -920,5 +920,6 @@ class StartHandlerTest {
         assertThat(result, hasStatus(200));
         assertFalse(authSession.getHasVerifiedPassword());
         assertFalse(authSession.getHasVerifiedMfa());
+        assertFalse(authSession.getHasVerifiedPasskey());
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProviderTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/RelyingPartyProviderTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ class RelyingPartyProviderTest {
 
     private static final String RELYING_PARTY_ID_A = "test.example.com";
     private static final String RELYING_PARTY_NAME_A = "Test Service";
+    private static final String ALLOWED_ORIGIN = "https://subdomain.test.example.com";
     private static final String RELYING_PARTY_ID_B = "other.example.com";
     private static final String RELYING_PARTY_NAME_B = "Other Service";
 
@@ -35,6 +37,7 @@ class RelyingPartyProviderTest {
         MockitoAnnotations.openMocks(this);
         when(configurationService.getWebAuthnRelyingPartyId()).thenReturn(RELYING_PARTY_ID_A);
         when(configurationService.getWebAuthnRelyingPartyName()).thenReturn(RELYING_PARTY_NAME_A);
+        when(configurationService.getPasskeyAllowedOrigin()).thenReturn(ALLOWED_ORIGIN);
     }
 
     @Nested
@@ -48,6 +51,8 @@ class RelyingPartyProviderTest {
             assertThat(result, is(notNullValue()));
             assertThat(result.getIdentity().getId(), equalTo(RELYING_PARTY_ID_A));
             assertThat(result.getIdentity().getName(), equalTo(RELYING_PARTY_NAME_A));
+            assertThat(result.getOrigins().size(), equalTo(1));
+            assertTrue(result.getOrigins().contains(ALLOWED_ORIGIN));
         }
 
         @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.entity.AuthCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -147,6 +148,13 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         var sessionId = IdGenerator.generate();
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
+        authSessionExtension.addRequestedCredentialStrengthToSession(
+                sessionId, CredentialTrustLevel.LOW_LEVEL);
+        authSessionExtension.addAchievedCredentialTrustToSession(
+                sessionId, CredentialTrustLevel.LOW_LEVEL);
+        var session = authSessionExtension.getSession(sessionId).orElseThrow();
+        session.setHasVerifiedPassword(true);
+        authSessionExtension.updateSession(session);
         return sessionId;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -46,6 +46,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_PASSKEY_ASSERTION_REQUEST = "PasskeyAssertionRequest";
     public static final String ATTRIBUTE_HAS_VERIFIED_PASSWORD = "HasVerifiedPassword";
     public static final String ATTRIBUTE_HAS_VERIFIED_MFA = "HasVerifiedMfa";
+    public static final String ATTRIBUTE_HAS_VERIFIED_PASSKEY = "HasVerifiedPasskey";
 
     public enum AccountState {
         NEW,
@@ -91,6 +92,7 @@ public class AuthSessionItem {
     private String passkeyAssertionRequest;
     private boolean hasVerifiedPassword;
     private boolean hasVerifiedMfa;
+    private boolean hasVerifiedPasskey;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -524,6 +526,20 @@ public class AuthSessionItem {
         return this;
     }
 
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_PASSKEY)
+    public boolean getHasVerifiedPasskey() {
+        return hasVerifiedPasskey;
+    }
+
+    public void setHasVerifiedPasskey(boolean hasVerifiedPasskey) {
+        this.hasVerifiedPasskey = hasVerifiedPasskey;
+    }
+
+    public AuthSessionItem withHasVerifiedPasskey(boolean hasVerifiedPasskey) {
+        this.hasVerifiedPasskey = hasVerifiedPasskey;
+        return this;
+    }
+
     /**
      * Return a string representation of the instance that is safe to record in logs (e.g. does not
      * contain PII)
@@ -549,6 +565,8 @@ public class AuthSessionItem {
                 + hasVerifiedPassword
                 + "', hasVerifiedMfa = '"
                 + hasVerifiedMfa
+                + "', hasVerifiedPasskey = '"
+                + hasVerifiedPasskey
                 + "'}}";
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -657,6 +657,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("WEBAUTHN_RELYING_PARTY_NAME", "GOV.UK One Login");
     }
 
+    public String getPasskeyAllowedOrigin() {
+        return System.getenv().getOrDefault("PASSKEY_ALLOWED_ORIGIN", "");
+    }
+
     public String getAuthToAMApiAudience() {
         return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_MANAGEMENT_API_AUDIENCE", "");
     }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -385,26 +385,61 @@ public class PermissionDecisionManager implements PermissionDecisions {
 
     @Override
     public boolean canIssueAuthCode(AuthSessionItem authSession) {
-        if (!authSession.getHasVerifiedPassword()) {
-            LOG.info("Auth code failed to issue due to session not having a verified password");
+        var achievedCredentialStrength = authSession.getAchievedCredentialStrength();
+        var requestedCredentialStrength = authSession.getRequestedCredentialStrength();
+        var hasVerifiedPasskey = authSession.getHasVerifiedPasskey();
+        var hasVerifiedPassword = authSession.getHasVerifiedPassword();
+        var hasVerifiedMfa = authSession.getHasVerifiedMfa();
+
+        LOG.info(
+                "Checking if auth code is blocked - "
+                        + "achievedCredentialStrength='{}', "
+                        + "requestedCredentialStrength='{}', "
+                        + "hasVerifiedPasskey='{}', "
+                        + "hasVerifiedPassword='{}', "
+                        + "hasVerifiedMfa='{}'",
+                achievedCredentialStrength == null ? null : achievedCredentialStrength.getValue(),
+                requestedCredentialStrength == null ? null : requestedCredentialStrength.getValue(),
+                hasVerifiedPasskey,
+                hasVerifiedPassword,
+                hasVerifiedMfa);
+
+        if (achievedCredentialStrength == null) {
+            LOG.info("Auth code blocked: no credential strength achieved");
             return false;
         }
 
-        if (authSession.getRequestedCredentialStrength() == CredentialTrustLevel.MEDIUM_LEVEL) {
-            if (!authSession.getHasVerifiedMfa()) {
-                LOG.info("Auth code failed to issue due to session not having a verified MFA");
+        if (requestedCredentialStrength == null) {
+            LOG.info("Auth code blocked: no required credential strength provided");
+            return false;
+        }
+
+        if (achievedCredentialStrength.isLowerThan(requestedCredentialStrength)) {
+            LOG.info(
+                    "Auth code blocked: achieved credential strength does not meet required credential strength");
+            return false;
+        }
+
+        if (hasVerifiedPasskey) {
+            LOG.info("Auth code permitted");
+            return true;
+        }
+
+        LOG.info("Passkey not verified");
+
+        if (!hasVerifiedPassword) {
+            LOG.info("Auth code blocked: password not verified");
+            return false;
+        }
+
+        if (requestedCredentialStrength == CredentialTrustLevel.MEDIUM_LEVEL) {
+            if (!hasVerifiedMfa) {
+                LOG.info("Auth code blocked: mfa not verified");
                 return false;
             }
         }
 
-        if (authSession
-                .getAchievedCredentialStrength()
-                .isLowerThan(authSession.getRequestedCredentialStrength())) {
-            LOG.info(
-                    "Auth code failed to issue due to session not having an achieved credential strength");
-            return false;
-        }
-
+        LOG.info("Auth code permitted");
         return true;
     }
 

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActions.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActions.java
@@ -158,4 +158,24 @@ public interface UserActions {
      */
     Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext);
+
+    /**
+     * Records that a user successfully authenticated with a passkey.
+     *
+     * @param journeyType The type of authentication journey
+     * @param permissionContext The user's permission context
+     * @return A Result indicating success or failure of the tracking operation
+     */
+    Result<TrackingError, Void> correctPasskeyReceived(
+            JourneyType journeyType, PermissionContext permissionContext);
+
+    /**
+     * Records that a user failed to authenticate with a passkey.
+     *
+     * @param journeyType The type of authentication journey
+     * @param permissionContext The user's permission context
+     * @return A Result indicating success or failure of the tracking operation
+     */
+    Result<TrackingError, Void> incorrectPasskeyReceived(
+            JourneyType journeyType, PermissionContext permissionContext);
 }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CodeRequestType.SupportedCodeType;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -290,6 +291,26 @@ public class UserActionsManager implements UserActions {
     public Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
         var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        getAuthSessionService().updateSession(updatedSession);
+        return Result.success(null);
+    }
+
+    @Override
+    public Result<TrackingError, Void> correctPasskeyReceived(
+            JourneyType journeyType, PermissionContext permissionContext) {
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedPasskey(true)
+                        .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
+        getAuthSessionService().updateSession(updatedSession);
+        return Result.success(null);
+    }
+
+    @Override
+    public Result<TrackingError, Void> incorrectPasskeyReceived(
+            JourneyType journeyType, PermissionContext permissionContext) {
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPasskey(false);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
@@ -1234,63 +1235,81 @@ class PermissionDecisionManagerTest {
 
     @Nested
     class CanIssueAuthCode {
-        AuthSessionItem mockSession;
-
-        @BeforeEach
-        void setUp() {
-            mockSession = mock(AuthSessionItem.class);
-            when(mockSession.getHasVerifiedPassword()).thenReturn(true);
-            when(mockSession.getHasVerifiedMfa()).thenReturn(true);
+        @ParameterizedTest
+        @CsvSource({
+            // Achieved    Required      Passkey  Password  MFA    Issue?
+            "LOW_LEVEL,    LOW_LEVEL,    false,   false,    false, false",
+            "LOW_LEVEL,    LOW_LEVEL,    true,    false,    false, true",
+            "LOW_LEVEL,    LOW_LEVEL,    false,   true,     false, true",
+            "LOW_LEVEL,    LOW_LEVEL,    false,   false,    true,  false",
+            "LOW_LEVEL,    LOW_LEVEL,    false,   true,     true,  true",
+            "MEDIUM_LEVEL, LOW_LEVEL,    false,   false,    false, false",
+            "MEDIUM_LEVEL, LOW_LEVEL,    true,    false,    false, true",
+            "MEDIUM_LEVEL, LOW_LEVEL,    false,   true,     false, true",
+            "MEDIUM_LEVEL, LOW_LEVEL,    false,   false,    true,  false",
+            "MEDIUM_LEVEL, LOW_LEVEL,    false,   true,     true,  true",
+            "LOW_LEVEL,    MEDIUM_LEVEL, false,   false,    false, false",
+            "LOW_LEVEL,    MEDIUM_LEVEL, true,    false,    false, false",
+            "LOW_LEVEL,    MEDIUM_LEVEL, false,   true,     false, false",
+            "LOW_LEVEL,    MEDIUM_LEVEL, false,   false,    true,  false",
+            "LOW_LEVEL,    MEDIUM_LEVEL, false,   true,     true,  false",
+            "MEDIUM_LEVEL, MEDIUM_LEVEL, false,   false,    false, false",
+            "MEDIUM_LEVEL, MEDIUM_LEVEL, true,    false,    false, true",
+            "MEDIUM_LEVEL, MEDIUM_LEVEL, false,   true,     false, false",
+            "MEDIUM_LEVEL, MEDIUM_LEVEL, false,   false,    true,  false",
+            "MEDIUM_LEVEL, MEDIUM_LEVEL, false,   true,     true,  true"
+        })
+        void shouldReturnCorrectAssessmentForDifferentSessions(
+                CredentialTrustLevel achievedCredentialTrustLevel,
+                CredentialTrustLevel requiredCredentialTrustLevel,
+                boolean hasVerifiedPasskey,
+                boolean hasVerifiedPassword,
+                boolean hasVerifiedMfa,
+                boolean shouldIssueAuthCode) {
+            // Arrange
+            var mockSession = mock(AuthSessionItem.class);
             when(mockSession.getAchievedCredentialStrength())
-                    .thenReturn(CredentialTrustLevel.MEDIUM_LEVEL);
+                    .thenReturn(achievedCredentialTrustLevel);
             when(mockSession.getRequestedCredentialStrength())
-                    .thenReturn(CredentialTrustLevel.MEDIUM_LEVEL);
-        }
-
-        @Test
-        void shouldReturnTrueWhenAllRequirementsMet() {
-            // Act
-            var result = permissionDecisionManager.canIssueAuthCode(mockSession);
-
-            // Assert
-            assertTrue(result);
-        }
-
-        @Test
-        void shouldReturnFalseIfHasNotVerifiedPassword() {
-            // Arrange
-            when(mockSession.getHasVerifiedPassword()).thenReturn(false);
+                    .thenReturn(requiredCredentialTrustLevel);
+            when(mockSession.getHasVerifiedPasskey()).thenReturn(hasVerifiedPasskey);
+            when(mockSession.getHasVerifiedPassword()).thenReturn(hasVerifiedPassword);
+            when(mockSession.getHasVerifiedMfa()).thenReturn(hasVerifiedMfa);
 
             // Act
             var result = permissionDecisionManager.canIssueAuthCode(mockSession);
 
             // Assert
-            assertFalse(result);
+            assertEquals(shouldIssueAuthCode, result);
         }
 
         @Test
-        void shouldReturnFalseIfHasNotVerifiedMfa() {
-            // Arrange
-            when(mockSession.getHasVerifiedMfa()).thenReturn(false);
-
-            // Act
-            var result = permissionDecisionManager.canIssueAuthCode(mockSession);
-
-            // Assert
-            assertFalse(result);
-        }
-
-        @Test
-        void shouldReturnFalseIfNotAchievedRequiredCredentialStrength() {
-            // Arrange
-            when(mockSession.getAchievedCredentialStrength())
+        void shouldReturnFalseWhenAchievedCredentialStrengthIsNull() {
+            var mockSession = mock(AuthSessionItem.class);
+            when(mockSession.getAchievedCredentialStrength()).thenReturn(null);
+            when(mockSession.getRequestedCredentialStrength())
                     .thenReturn(CredentialTrustLevel.LOW_LEVEL);
 
-            // Act
-            var result = permissionDecisionManager.canIssueAuthCode(mockSession);
+            assertFalse(permissionDecisionManager.canIssueAuthCode(mockSession));
+        }
 
-            // Assert
-            assertFalse(result);
+        @Test
+        void shouldReturnFalseWhenRequestedCredentialStrengthIsNull() {
+            var mockSession = mock(AuthSessionItem.class);
+            when(mockSession.getAchievedCredentialStrength())
+                    .thenReturn(CredentialTrustLevel.LOW_LEVEL);
+            when(mockSession.getRequestedCredentialStrength()).thenReturn(null);
+
+            assertFalse(permissionDecisionManager.canIssueAuthCode(mockSession));
+        }
+
+        @Test
+        void shouldReturnFalseWhenBothCredentialStrengthsAreNull() {
+            var mockSession = mock(AuthSessionItem.class);
+            when(mockSession.getAchievedCredentialStrength()).thenReturn(null);
+            when(mockSession.getRequestedCredentialStrength()).thenReturn(null);
+
+            assertFalse(permissionDecisionManager.canIssueAuthCode(mockSession));
         }
     }
 

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CodeRequestType.SupportedCodeType;
 import uk.gov.di.authentication.shared.entity.CountType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
@@ -24,6 +25,7 @@ import uk.gov.di.authentication.userpermissions.entity.TrackingError;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -583,6 +585,46 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(result.isSuccess());
+        }
+    }
+
+    @Nested
+    class CorrectPasskeyReceived {
+        @Test
+        void
+                correctPasskeyReceivedShouldSetHasVerifiedPasskeyToTrueAndCredentialStrengthToMedium() {
+            // Arrange
+            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
+
+            // Act
+            var result = userActionsManager.correctPasskeyReceived(null, permissionContext);
+
+            // Assert
+            verify(authSessionService).updateSession(captor.capture());
+            AuthSessionItem capturedSession = captor.getValue();
+            assertTrue(capturedSession.getHasVerifiedPasskey());
+            assertEquals(
+                    CredentialTrustLevel.MEDIUM_LEVEL,
+                    capturedSession.getAchievedCredentialStrength());
+            assertTrue(result.isSuccess());
+        }
+    }
+
+    @Nested
+    class IncorrectPasskeyReceived {
+        @Test
+        void incorrectPasskeyReceivedShouldSetHasVerifiedPasskeyToFalse() {
+            // Arrange
+            ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
+
+            // Act
+            var result = userActionsManager.incorrectPasskeyReceived(null, permissionContext);
+
+            // Assert
+            verify(authSessionService).updateSession(captor.capture());
+            AuthSessionItem capturedSession = captor.getValue();
+            assertFalse(capturedSession.getHasVerifiedPasskey());
             assertTrue(result.isSuccess());
         }
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsTest.java
@@ -114,5 +114,17 @@ class UserActionsTest {
                 JourneyType journeyType, PermissionContext permissionContext) {
             return Result.success(null);
         }
+
+        @Override
+        public Result<TrackingError, Void> correctPasskeyReceived(
+                JourneyType journeyType, PermissionContext permissionContext) {
+            return Result.success(null);
+        }
+
+        @Override
+        public Result<TrackingError, Void> incorrectPasskeyReceived(
+                JourneyType journeyType, PermissionContext permissionContext) {
+            return Result.success(null);
+        }
     }
 }


### PR DESCRIPTION
## What

Makes some changes required to verify a passkey assertion in the FinishPasskeyAssertionHandler.

- e96d2c20, 61f24437, 49dd174a, 14cffce6, ed8b5fab
  - Updated the enhanced auth code protection rules to report and allow a successful passkey assertion as a means to obtain an auth code
- 792d17ea
  - Was debugging and needed some extra logs, but think these will be useful to keep
- 52967579
  - Added policy to allow ADAPI token signing
- e5ebe234
  - Added missing env vars

## How to review

1. Code Review
1. Deploy to a dev environment (along with the frontend change) and test a sign in working correctly. You'll need to configure a test passkey against your account. Everything should already be deployed to `authdev1`.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3414