### PR TITLE
AUT-5458: Add has active passkey extension to audit event

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -48,6 +48,7 @@ import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.getLastDigitsOfPhoneNumber;
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADetail;
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.hasInternationalPhoneNumber;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
@@ -175,6 +176,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
             AuditableEvent auditableEvent;
             var rpPairwiseId = AuditService.UNKNOWN;
+            var metadataPairs = new ArrayList<AuditService.MetadataPair>();
             var userMfaDetail = UserMfaDetail.noMfa();
             Optional<Boolean> hasActivePasskey = Optional.empty();
             var needsForcedMFAResetAfterMFACheck = false;
@@ -208,13 +210,23 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                         authSession, userCredentials, userProfile.get());
                 hasActivePasskey =
                         hasActivePasskey(userProfile.get().getPublicSubjectID(), authSession);
+                metadataPairs.add(
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY,
+                                hasActivePasskey
+                                        .map(Object::toString)
+                                        .orElse(AuditService.UNKNOWN)));
             } else {
                 authSession.setInternalCommonSubjectId(null);
                 auditableEvent = FrontendAuditableEvent.AUTH_CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
             }
 
+            metadataPairs.add(pair("rpPairwiseId", rpPairwiseId));
+
             auditService.submitAuditEvent(
-                    auditableEvent, auditContext, pair("rpPairwiseId", rpPairwiseId));
+                    auditableEvent,
+                    auditContext,
+                    metadataPairs.toArray(AuditService.MetadataPair[]::new));
 
             var lockoutInformationResult = determineLockoutInformation(permissionContext);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -74,6 +74,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_ACCOUNT_TEMPORARILY_LOCKED;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.ENCODED_DEVICE_DETAILS;
@@ -168,11 +169,13 @@ class CheckUserExistsHandlerTest {
 
     @Nested
     class WhenUserExists {
+        private UserProfile userProfile;
+
         @BeforeEach
         void setup() {
             authSessionExists();
             when(configurationService.isForcedMFAResetAfterMFACheckEnabled()).thenReturn(false);
-            var userProfile =
+            userProfile =
                     generateUserProfile().withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER);
             setupUserProfileAndClient(Optional.of(userProfile));
         }
@@ -271,6 +274,7 @@ class CheckUserExistsHandlerTest {
         void shouldSubmitTheRelevantAuditEvent() {
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+
             var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
 
             assertThat(result, hasStatus(200));
@@ -278,8 +282,29 @@ class CheckUserExistsHandlerTest {
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_CHECK_USER_KNOWN_EMAIL,
                             AUDIT_CONTEXT.withSubjectId(getExpectedInternalPairwiseId()),
-                            AuditService.MetadataPair.pair(
-                                    "rpPairwiseId", getExpectedRpPairwiseId()));
+                            pair("has_active_passkey", AuditService.UNKNOWN),
+                            pair("rpPairwiseId", getExpectedRpPairwiseId()));
+        }
+
+        @ValueSource(booleans = {true, false})
+        @ParameterizedTest
+        void shouldIncludeWhetherTheUserHasAnActivePasskeyOnAuthCheckUserKnownEmail(
+                Boolean hasActivePasskey) {
+            when(configurationService.supportPasskeys()).thenReturn(true);
+            when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID))
+                    .thenReturn(Result.success((hasActivePasskey)));
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+
+            assertThat(result, hasStatus(200));
+            verify(auditService)
+                    .submitAuditEvent(
+                            FrontendAuditableEvent.AUTH_CHECK_USER_KNOWN_EMAIL,
+                            AUDIT_CONTEXT.withSubjectId(getExpectedInternalPairwiseId()),
+                            pair("has_active_passkey", hasActivePasskey.toString()),
+                            pair("rpPairwiseId", getExpectedRpPairwiseId()));
         }
 
         @Test
@@ -298,8 +323,8 @@ class CheckUserExistsHandlerTest {
                             AUDIT_CONTEXT
                                     .withSubjectId(getExpectedInternalPairwiseId())
                                     .withTxmaAuditEncoded(Optional.empty()),
-                            AuditService.MetadataPair.pair(
-                                    "rpPairwiseId", getExpectedRpPairwiseId()));
+                            pair("has_active_passkey", AuditService.UNKNOWN),
+                            pair("rpPairwiseId", getExpectedRpPairwiseId()));
         }
 
         @Test
@@ -683,8 +708,7 @@ class CheckUserExistsHandlerTest {
                     .submitAuditEvent(
                             AUTH_ACCOUNT_TEMPORARILY_LOCKED,
                             AUDIT_CONTEXT.withSubjectId(getExpectedInternalPairwiseId()),
-                            AuditService.MetadataPair.pair(
-                                    "number_of_attempts_user_allowed_to_login", 5));
+                            pair("number_of_attempts_user_allowed_to_login", 5));
         }
     }
 
@@ -708,7 +732,7 @@ class CheckUserExistsHandlerTest {
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
                         AUDIT_CONTEXT,
-                        AuditService.MetadataPair.pair("rpPairwiseId", AuditService.UNKNOWN));
+                        pair("rpPairwiseId", AuditService.UNKNOWN));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -237,8 +237,8 @@ class CheckUserExistsHandlerTest {
                 MFAMethod mfaMethod,
                 MFAMethodType expectedMfaMethodType,
                 String expectedPhoneNumberLastThree) {
-            var userProfile = generateUserProfile().withMfaMethodsMigrated(true);
-            setupUserProfileAndClient(Optional.of(userProfile));
+            var userProfilWithMigratedMethods = generateUserProfile().withMfaMethodsMigrated(true);
+            setupUserProfileAndClient(Optional.of(userProfilWithMigratedMethods));
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
 
@@ -646,8 +646,6 @@ class CheckUserExistsHandlerTest {
         void shouldReturnResultOfHasActivePasskeysWhenFeatureFlagIsOn(boolean hasActivePasskey)
                 throws Json.JsonException {
             when(configurationService.supportPasskeys()).thenReturn(true);
-            var userProfile = generateUserProfile();
-            setupUserProfileAndClient(Optional.of(userProfile));
 
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
@@ -667,8 +665,6 @@ class CheckUserExistsHandlerTest {
         void shouldReturnNullForHasActivePasskeyIfPasskeysServiceReturnsFailure()
                 throws Json.JsonException {
             when(configurationService.supportPasskeys()).thenReturn(true);
-            var userProfile = generateUserProfile();
-            setupUserProfileAndClient(Optional.of(userProfile));
 
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -12,6 +12,7 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE = "notification-type";
     String AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED = "MFACodeEntered";
     String AUDIT_EVENT_EXTENSIONS_MFA_RESET_TYPE = "mfaResetType";
+    String AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY = "has_active_passkey";
 
     AuditableEvent parseFromName(String name);
 }


### PR DESCRIPTION
Adds the has_active_passkey extension to the AUTH_CHECK_USER_KNOWN_EMAIL audit event. If we do not know whether a user has an active passkey or not (either because the feature flag is off or the call to the account data api failed) we still emit this pair but with an unknown value (empty string).
