### PR TITLE
ATO-2509: Enable SnapStart for AuthorisationHandler

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -58,13 +58,6 @@ Conditions:
       !Equals [production, !Ref Environment],
     ]
   UseSpotStub: !Not [!Condition IpvExists]
-  EnableProvisionedConcurrency:
-    !Or [
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   IsDevOrBuild:
     !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
   IsStagingIntOrProd:
@@ -187,7 +180,6 @@ Mappings:
       clientRegistryTableKeyArn: arn:aws:kms:eu-west-2:653994557586:key/258b15a8-6157-439e-8018-24c59b91c8c5
       txmaEventEncryptionKeyArn: arn:aws:kms:eu-west-2:816047645251:key/d74787b0-8d11-4dd9-8691-7c0e26856225
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:653994557586:key/8a74d461-33b1-455e-9539-3d8ad2916deb
-      defaultProvisionedConcurrency: 0
       aisUriSecretId: bfd50b92-6ea2-40c7-9125-f7e27ca9b896
       authStubEnabled: false
       syncWaitForSpotTimeout: 20000
@@ -224,7 +216,6 @@ Mappings:
       clientRegistryTableKeyArn: arn:aws:kms:eu-west-2:761723964695:key/147435a7-f01d-4ed3-9485-ebe7f72808dd
       txmaEventEncryptionKeyArn: arn:aws:kms:eu-west-2:767397776536:key/4d851d1e-acd1-4c73-a754-617ffd380b3d
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:761723964695:key/fd8afa13-ccee-4199-9a01-d85483f3431d
-      defaultProvisionedConcurrency: 1
       aisUriSecretId: 79692761-0248-4f13-8f1a-39b91596b24f
       authStubEnabled: false
       syncWaitForSpotTimeout: 20000
@@ -260,7 +251,6 @@ Mappings:
       clientRegistryTableKeyArn: arn:aws:kms:eu-west-2:758531536632:key/32415ead-d88f-4724-aedf-5fe3ce8ed48e
       txmaEventEncryptionKeyArn: arn:aws:kms:eu-west-2:590183975515:key/c653db36-52fa-475c-8866-e167e3e85761
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:758531536632:key/3afafd1f-59f2-4ceb-806c-f67c0c120968
-      defaultProvisionedConcurrency: 3
       aisUriSecretId: 2b9a3315-50e9-4970-87e6-b354cc4a2484
       globalLogoutQueueArn: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-orchGlobalLogout
       globalLogoutQueueKmsKeyArn: arn:aws:kms:eu-west-2:178023842775:key/7cf407f9-958e-4039-a095-c46ba0a08d82
@@ -298,7 +288,6 @@ Mappings:
       clientRegistryTableKeyArn: arn:aws:kms:eu-west-2:761723964695:key/f8897cf9-760f-463e-bb27-a86cc9e629de
       txmaEventEncryptionKeyArn: arn:aws:kms:eu-west-2:058264132019:key/d1aefc2a-038d-460f-b6fd-d0ee749d3ad5
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:761723964695:key/2c2b295b-4ec7-41dd-b399-a2e98b7b39f9
-      defaultProvisionedConcurrency: 1
       aisUriSecretId: ""
       authStubEnabled: false
       syncWaitForSpotTimeout: 5000
@@ -334,7 +323,6 @@ Mappings:
       clientRegistryTableKeyArn: arn:aws:kms:eu-west-2:172348255554:key/afefa38f-5797-4722-9969-c7ad5ec6d6fe
       txmaEventEncryptionKeyArn: arn:aws:kms:eu-west-2:533266965190:key/4bc0dac2-f40f-4c3e-9f9e-30549dd8769d
       spotRequestQueueKmsArn: arn:aws:kms:eu-west-2:172348255554:key/4a4d1b21-d38d-4ce3-bf7f-6778423b297b
-      defaultProvisionedConcurrency: 3
       aisUriSecretId: ""
       authStubEnabled: false
       syncWaitForSpotTimeout: 5000
@@ -3874,17 +3862,8 @@ Resources:
       DeploymentPreference:
         Alarms:
           - Ref: AuthorisationFunctionErrorAnomalyAlarm
-      ProvisionedConcurrencyConfig:
-        !If [
-          EnableProvisionedConcurrency,
-          ProvisionedConcurrentExecutions:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              defaultProvisionedConcurrency,
-            ],
-          !Ref AWS::NoValue,
-        ]
+      SnapStart:
+        ApplyOn: PublishedVersions
       VpcConfig:
         SecurityGroupIds:
           - !Ref LambdaSecurityGroup


### PR DESCRIPTION
### What’s changed

This PR enables SnapStart for the AuthorisationHandler lambda. It also cleans up some now unused variables and conditions related to provisioned concurrency.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

