### PR TITLE
BAU: Add required field 'algorithm' to the PasskeyAuthenticatorCreate request body

### DIFF
--- a/ci/openAPI/AccountDataApi.yaml
+++ b/ci/openAPI/AccountDataApi.yaml
@@ -277,6 +277,7 @@ components:
         - isBackUpEligible
         - isBackedUp
         - isResidentKey
+        - algorithm
       properties:
         id:
           type: string
@@ -307,6 +308,9 @@ components:
         isResidentKey:
           type: boolean
           description: Is the passkey a resident key (stored on the device)
+        algorithm:
+          type: number
+          description: The COSE Algorithm ID of the key pair, as specified in [section 5.8.5 of the W3C WebAuthn specification](https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier)
 
     PasskeyAuthenticatorUpdate:
       type: object


### PR DESCRIPTION
## What

We want to record the algorithm used when client authenticators generate their passkey. In the future, this information may be used to highlight at-risk credentials that use weaker/broken algorithms.

We get the algorithm at passkey registration (e.g. -7 for ES256), so the Create Passkey endpoint needs to capture this information.

This PR just describes the upcoming change in the OpenAPI spec.

## How to review

1. Code Review