### PR TITLE
AUT-5370: Fix TICF partially created account state

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -188,7 +188,9 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                         userContext,
                         internalPairwiseId,
                         request.authenticated(),
-                        authSession.getIsNewAccount(),
+                        authSession.getIsPartiallyCreatedAccount()
+                                ? AuthSessionItem.AccountState.NEW
+                                : authSession.getIsNewAccount(),
                         authSession.getResetPasswordState(),
                         authSession.getResetMfaState(),
                         authSession.getVerifiedMfaMethodType());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -349,7 +349,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         authSessionService.updateSession(
                 authSessionItem
                         .withAccountState(AuthSessionItem.AccountState.EXISTING)
-                        .withInternalCommonSubjectId(internalCommonSubjectIdentifier));
+                        .withInternalCommonSubjectId(internalCommonSubjectIdentifier)
+                        .withIsPartiallyCreatedAccount(!userMfaDetail.mfaMethodVerified()));
 
         String redactedPhoneNumber =
                 userMfaDetail.phoneNumber() != null && userMfaDetail.mfaMethodVerified()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -402,6 +402,38 @@ class AccountInterventionsHandlerTest {
         return Stream.of(Boolean.TRUE, Boolean.FALSE, null);
     }
 
+    @Test
+    void checkInvokesTICFLambdaWithNewAccountStateWhenPartiallyCreatedAccount()
+            throws UnsuccessfulAccountInterventionsResponseException {
+        when(configurationService.accountInterventionsServiceActionEnabled()).thenReturn(false);
+        when(authenticationService.getUserProfileByEmailMaybe(anyString()))
+                .thenReturn(Optional.of(generateUserProfile()));
+        when(accountInterventionsService.sendAccountInterventionsOutboundRequest(any()))
+                .thenReturn(generateAccountInterventionResponse(true, true, true, true));
+        when(configurationService.isInvokeTicfCRILambdaEnabled()).thenReturn(true);
+        var authSessionWithChanges =
+                authSession
+                        .withAccountState(AccountState.EXISTING)
+                        .withIsPartiallyCreatedAccount(true)
+                        .withVerifiedMfaMethodType(MFAMethodType.NONE);
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(authSessionWithChanges));
+
+        var result =
+                handler.handleRequestWithUserContext(
+                        apiRequestEventForTICF(true),
+                        context,
+                        new AccountInterventionsRequest("test", true),
+                        userContext);
+
+        assertThat(result, hasStatus(200));
+        verify(mockLambdaInvokerService, times(1))
+                .invokeAsyncWithPayload(
+                        eq(
+                                "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        any());
+    }
+
     @ParameterizedTest
     @MethodSource("authenticatedUserSource")
     void checkDoesNotInvokesTICFLambdaForUsersWithUnknownAuthenticationStatus(Boolean authenticated)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -1486,4 +1486,39 @@ class LoginHandlerTest {
                 .updateSession(
                         argThat(s -> s.getIsNewAccount() == AuthSessionItem.AccountState.EXISTING));
     }
+
+    @Test
+    void shouldSetIsPartiallyCreatedAccountTrueWhenMfaMethodNotVerified() {
+        var userProfile =
+                generateUserProfile(null).withPhoneNumberVerified(false).withPhoneNumber(null);
+        var userCredentialsNoMfa =
+                new UserCredentials().withEmail(EMAIL).withPassword(CommonTestVariables.PASSWORD);
+        when(authenticationService.login(userCredentialsNoMfa, CommonTestVariables.PASSWORD))
+                .thenReturn(true);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(authenticationService.getUserCredentialsFromEmail(EMAIL))
+                .thenReturn(userCredentialsNoMfa);
+        when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of()));
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        handler.handleRequest(event, context);
+
+        verify(authSessionService).updateSession(argThat(s -> s.getIsPartiallyCreatedAccount()));
+    }
+
+    @Test
+    void shouldSetIsPartiallyCreatedAccountFalseWhenMfaMethodVerified() {
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        usingApplicableUserCredentialsWithLogin(SMS, true);
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        handler.handleRequest(event, context);
+
+        verify(authSessionService).updateSession(argThat(s -> !s.getIsPartiallyCreatedAccount()));
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -47,6 +47,7 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_HAS_VERIFIED_PASSWORD = "HasVerifiedPassword";
     public static final String ATTRIBUTE_HAS_VERIFIED_MFA = "HasVerifiedMfa";
     public static final String ATTRIBUTE_HAS_VERIFIED_PASSKEY = "HasVerifiedPasskey";
+    public static final String ATTRIBUTE_IS_PARTIALLY_CREATED_ACCOUNT = "IsPartiallyCreatedAccount";
 
     public enum AccountState {
         NEW,
@@ -93,6 +94,7 @@ public class AuthSessionItem {
     private boolean hasVerifiedPassword;
     private boolean hasVerifiedMfa;
     private boolean hasVerifiedPasskey;
+    private boolean isPartiallyCreatedAccount;
 
     public AuthSessionItem() {
         this.codeRequestCountMap = new HashMap<>();
@@ -537,6 +539,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withHasVerifiedPasskey(boolean hasVerifiedPasskey) {
         this.hasVerifiedPasskey = hasVerifiedPasskey;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_IS_PARTIALLY_CREATED_ACCOUNT)
+    public boolean getIsPartiallyCreatedAccount() {
+        return isPartiallyCreatedAccount;
+    }
+
+    public void setIsPartiallyCreatedAccount(boolean isPartiallyCreatedAccount) {
+        this.isPartiallyCreatedAccount = isPartiallyCreatedAccount;
+    }
+
+    public AuthSessionItem withIsPartiallyCreatedAccount(boolean isPartiallyCreatedAccount) {
+        this.isPartiallyCreatedAccount = isPartiallyCreatedAccount;
         return this;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthSessionServiceTest.java
@@ -56,6 +56,7 @@ class AuthSessionServiceTest {
         var session = authSessionService.generateNewAuthSession(SESSION_ID);
         assertEquals(SESSION_ID, session.getSessionId());
         assertEquals(AuthSessionItem.AccountState.UNKNOWN, session.getIsNewAccount());
+        assertEquals(false, session.getIsPartiallyCreatedAccount());
         assertTrue(session.getTimeToLive() > Instant.now().getEpochSecond());
 
         for (CodeRequestType requestType : CodeRequestType.values()) {
@@ -204,6 +205,18 @@ class AuthSessionServiceTest {
         assertThrows(
                 AuthSessionException.class,
                 () -> authSessionService.getSessionFromRequestHeaders(headerMap));
+    }
+
+    @Test
+    void shouldSetAndGetIsPartiallyCreatedAccount() {
+        var session = new AuthSessionItem();
+        assertThat(session.getIsPartiallyCreatedAccount(), is(false));
+
+        session.setIsPartiallyCreatedAccount(true);
+        assertThat(session.getIsPartiallyCreatedAccount(), is(true));
+
+        var builtSession = new AuthSessionItem().withIsPartiallyCreatedAccount(true);
+        assertThat(builtSession.getIsPartiallyCreatedAccount(), is(true));
     }
 
     private AuthSessionItem withValidSession() {


### PR DESCRIPTION
## What

- Added an `isPartiallyCreatedAccount` attribute to `AuthSessionItem` to track users resuming incomplete registration journeys.
- Updated `LoginHandler` to flag sessions as partially created when a user logs in but their `mfaMethodVerified` status is false.
- Modified `AccountInterventionsHandler` to send `AccountState.NEW` to the TICF CRI for partially created accounts, resolving the issue where they were incorrectly recorded as `EXISTING`.

## How to review

1. Code review.

## Checklist

- [ ] Deployment of this PR will not break active user journeys **- Should be ok: the new `isPartiallyCreatedAccount` session attribute defaults to false and does not invalidate existing session data**
- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A**