### PR TITLE
Bau: Stop setting metadata on audit context in Mfa Methods Put Handler

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -98,4 +98,21 @@ public class AuditHelper {
 
         return Result.success(null);
     }
+
+    public static Result<ErrorResponse, Void> sendAuditEvent(
+            AccountManagementAuditableEvent auditEvent,
+            AuditContext auditContext,
+            AuditService auditService,
+            Logger logger,
+            AuditService.MetadataPair[] metadataPairs) {
+        try {
+            auditService.submitAuditEvent(
+                    auditEvent, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME, metadataPairs);
+        } catch (Exception e) {
+            logger.error("Error submitting audit event", e);
+            return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
+        }
+
+        return Result.success(null);
+    }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -49,7 +49,7 @@ public class AuditHelper {
         }
     }
 
-    public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
+    public static Result<ErrorResponse, AuditContext> accountManagementAuditContextWithJourneyType(
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
             APIGatewayProxyRequestEvent input,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -34,6 +34,8 @@ public class AuditHelper {
     private static final Logger LOG = LogManager.getLogger(AuditHelper.class);
     public static final String TXMA_ENCODED_HEADER_NAME = "txma-audit-encoded";
     public static final String ERROR_BUILDING_AUDIT_CONTEXT = "Error building audit context";
+    public static final AuditService.MetadataPair ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR =
+            pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.getValue());
 
     private AuditHelper() {}
 
@@ -49,7 +51,7 @@ public class AuditHelper {
         }
     }
 
-    public static Result<ErrorResponse, AuditContext> accountManagementAuditContextWithJourneyType(
+    public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
             APIGatewayProxyRequestEvent input,
@@ -74,14 +76,24 @@ public class AuditHelper {
                             null,
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                             getTxmaAuditEncoded(input.getHeaders()),
-                            List.of(
-                                    pair(
-                                            AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                            ACCOUNT_MANAGEMENT.getValue()))));
+                            List.of()));
         } catch (Exception e) {
             LOG.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);
         }
+    }
+
+    public static Result<ErrorResponse, AuditContext> accountManagementAuditContextWithJourneyType(
+            ConfigurationService configurationService,
+            AuthenticationService authenticationService,
+            APIGatewayProxyRequestEvent input,
+            UserProfile userProfile) {
+        return accountManagementAuditContext(
+                        configurationService, authenticationService, input, userProfile)
+                .map(
+                        auditContext ->
+                                auditContext.withMetadataItem(
+                                        ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR));
     }
 
     public static Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -47,7 +47,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContextWithJourneyType;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
@@ -437,7 +437,7 @@ public class MFAMethodsCreateHandler
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
         var auditContextResult =
-                accountManagementAuditContext(
+                accountManagementAuditContextWithJourneyType(
                         configurationService, dynamoService, input, userProfile);
         if (auditContextResult.isFailure()) {
             LOG.error(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_DELETE_COMPLETED;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContextWithJourneyType;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -199,7 +199,7 @@ public class MFAMethodsDeleteHandler
                         ? mfaMethod.getDestination()
                         : AuditService.UNKNOWN;
         var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
-        return accountManagementAuditContext(
+        return accountManagementAuditContextWithJourneyType(
                         configurationService, dynamoService, input, userProfile)
                 .map(
                         baseContext ->

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -194,6 +195,17 @@ public class MFAMethodsPutHandler
 
         var mfaMethodResult = maybeMfaMethodResult.getSuccess();
 
+        var auditContextResult =
+                accountManagementAuditContext(
+                        configurationService, authenticationService, input, putRequest.userProfile);
+        if (auditContextResult.isFailure()) {
+            LOG.error(
+                    "Unable to build audit context for update MFA method request: {}",
+                    auditContextResult.getFailure());
+            return generateApiGatewayProxyErrorResponse(500, auditContextResult.getFailure());
+        }
+        var auditContext = auditContextResult.getSuccess();
+
         if (isDefaultMethod
                 && putRequest.request.mfaMethod().method()
                         instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
@@ -206,9 +218,9 @@ public class MFAMethodsPutHandler
                 var maybeAuditEventStatus =
                         sendAuditEvent(
                                 AUTH_INVALID_CODE_SENT,
-                                input,
                                 putRequest,
-                                mfaMethodResult.mfaMethod());
+                                mfaMethodResult.mfaMethod(),
+                                auditContext);
                 if (maybeAuditEventStatus.isFailure()) {
                     return maybeAuditEventStatus.getFailure();
                 }
@@ -223,7 +235,10 @@ public class MFAMethodsPutHandler
         if (!isSwitch) {
             var maybeAuditEventStatus =
                     sendAuditEvent(
-                            AUTH_CODE_VERIFIED, input, putRequest, mfaMethodResult.mfaMethod());
+                            AUTH_CODE_VERIFIED,
+                            putRequest,
+                            mfaMethodResult.mfaMethod(),
+                            auditContext);
             if (maybeAuditEventStatus.isFailure()) {
                 return maybeAuditEventStatus.getFailure();
             }
@@ -237,10 +252,11 @@ public class MFAMethodsPutHandler
                         putRequest.request);
 
         if (maybeUpdateResult.isFailure()) {
-            return handleUpdateMfaFailureReason(maybeUpdateResult.getFailure(), input, putRequest);
+            return handleUpdateMfaFailureReason(
+                    maybeUpdateResult.getFailure(), auditContext, putRequest);
         }
 
-        var auditResult = emitAuditEventForAuthAppUpdate(putRequest, input);
+        var auditResult = emitAuditEventForAuthAppUpdate(putRequest, auditContext);
 
         if (auditResult.isFailure()) {
             return auditResult.getFailure();
@@ -269,7 +285,10 @@ public class MFAMethodsPutHandler
 
             var maybeAuditEventsStatus =
                     sendSuccessAuditEvents(
-                            updateTypeIdentifier, input, putRequest, successfulUpdateMethods);
+                            updateTypeIdentifier,
+                            putRequest,
+                            successfulUpdateMethods,
+                            auditContext);
 
             if (maybeAuditEventsStatus.isFailure()) {
                 return maybeAuditEventsStatus.getFailure();
@@ -288,9 +307,7 @@ public class MFAMethodsPutHandler
     }
 
     private APIGatewayProxyResponseEvent handleUpdateMfaFailureReason(
-            MfaUpdateFailure failure,
-            APIGatewayProxyRequestEvent input,
-            ValidPutRequest putRequest) {
+            MfaUpdateFailure failure, AuditContext auditContext, ValidPutRequest putRequest) {
         var failureReason = failure.failureReason();
         var updateType = failure.updateTypeIdentifier();
         var mfaMethodToBeUpdated = failure.mfaMethodToUpdate();
@@ -308,9 +325,9 @@ public class MFAMethodsPutHandler
                                         MFAMethodUpdateIdentifier.SWITCHED_MFA_METHODS)) {
                             sendAuditEvent(
                                     AUTH_MFA_METHOD_SWITCH_FAILED,
-                                    input,
                                     putRequest,
-                                    mfaMethodToBeUpdated);
+                                    mfaMethodToBeUpdated,
+                                    auditContext);
                         }
                         yield generateApiGatewayProxyErrorResponse(
                                 500, ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR);
@@ -507,9 +524,9 @@ public class MFAMethodsPutHandler
 
     private Result<APIGatewayProxyResponseEvent, Void> sendSuccessAuditEvents(
             MFAMethodUpdateIdentifier updateTypeIdentifier,
-            APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
-            List<MFAMethod> updatedMfaMethods) {
+            List<MFAMethod> updatedMfaMethods,
+            AuditContext auditContext) {
         var postUpdateDefaultMfaMethod =
                 updatedMfaMethods.stream()
                         .filter(mfaMethod -> DEFAULT.name().equals(mfaMethod.getPriority()))
@@ -518,9 +535,9 @@ public class MFAMethodsPutHandler
 
         return switch (updateTypeIdentifier) {
             case SWITCHED_MFA_METHODS -> handleSwitchedMfaMethodsAuditEvents(
-                    input, putRequest, updatedMfaMethods);
+                    auditContext, putRequest, updatedMfaMethods);
             case CHANGED_SMS -> sendAuditEvent(
-                    AUTH_UPDATE_PHONE_NUMBER, input, putRequest, postUpdateDefaultMfaMethod);
+                    AUTH_UPDATE_PHONE_NUMBER, putRequest, postUpdateDefaultMfaMethod, auditContext);
             case CHANGED_DEFAULT_MFA -> {
                 var isDefaultMfaMethodSMS =
                         postUpdateDefaultMfaMethod
@@ -529,9 +546,9 @@ public class MFAMethodsPutHandler
                 if (isDefaultMfaMethodSMS) {
                     yield sendAuditEvent(
                             AUTH_UPDATE_PHONE_NUMBER,
-                            input,
                             putRequest,
-                            postUpdateDefaultMfaMethod);
+                            postUpdateDefaultMfaMethod,
+                            auditContext);
                 }
 
                 yield Result.success(null);
@@ -541,7 +558,7 @@ public class MFAMethodsPutHandler
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> handleSwitchedMfaMethodsAuditEvents(
-            APIGatewayProxyRequestEvent input,
+            AuditContext auditContext,
             ValidPutRequest putRequest,
             List<MFAMethod> updatedMfaMethods) {
         var postUpdateDefaultMfaMethod =
@@ -553,9 +570,9 @@ public class MFAMethodsPutHandler
         var maybeCompletedAuditEvent =
                 sendAuditEvent(
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
-                        input,
                         putRequest,
-                        postUpdateDefaultMfaMethod);
+                        postUpdateDefaultMfaMethod,
+                        auditContext);
 
         if (maybeCompletedAuditEvent.isFailure()) {
             return maybeCompletedAuditEvent;
@@ -566,26 +583,20 @@ public class MFAMethodsPutHandler
 
     private Result<APIGatewayProxyResponseEvent, Void> sendAuditEvent(
             AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
-            MFAMethod mfaMethod) {
-        return accountManagementAuditContext(
-                        configurationService, authenticationService, input, putRequest.userProfile)
+            MFAMethod mfaMethod,
+            AuditContext auditContext) {
+        var phoneNumber =
+                mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
+                        ? mfaMethod.getDestination()
+                        : AuditService.UNKNOWN;
+        var contextWithPhoneNumber = auditContext.withPhoneNumber(phoneNumber);
+
+        var pairs = metadataPairsForEvent(auditEvent, putRequest, mfaMethod);
+
+        return AuditHelper.sendAuditEvent(
+                        auditEvent, contextWithPhoneNumber, auditService, LOG, pairs)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
-                .map(context -> {
-                    var phoneNumber =
-                            mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
-                                    ? mfaMethod.getDestination()
-                                    : AuditService.UNKNOWN;
-                    return context.withPhoneNumber(phoneNumber);
-                })
-                .flatMap(
-                        context -> {
-                            var pairs = metadataPairsForEvent(auditEvent, putRequest, mfaMethod);
-                            return AuditHelper.sendAuditEvent(
-                                            auditEvent, context, auditService, LOG, pairs)
-                                    .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f));
-                        })
                 .map(
                         success -> {
                             LOG.info("Successfully submitted audit event: {}", auditEvent.name());
@@ -594,21 +605,10 @@ public class MFAMethodsPutHandler
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> emitAuditEventForAuthAppUpdate(
-            ValidPutRequest putRequest, APIGatewayProxyRequestEvent input) {
+            ValidPutRequest putRequest, AuditContext auditContext) {
         if (!(putRequest.request.mfaMethod().method() instanceof RequestAuthAppMfaDetail)) {
             return Result.success(null);
         }
-
-        var maybeAuditContext =
-                accountManagementAuditContext(
-                        configurationService, dynamoService, input, putRequest.userProfile);
-
-        if (maybeAuditContext.isFailure()) {
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(401, maybeAuditContext.getFailure()));
-        }
-
-        var auditContext = maybeAuditContext.getSuccess();
 
         var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.getValue());
         var priority = putRequest.request.mfaMethod().priorityIdentifier().toString().toLowerCase();
@@ -671,5 +671,4 @@ public class MFAMethodsPutHandler
 
         return pairs.toArray(AuditService.MetadataPair[]::new);
     }
-
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -633,12 +633,12 @@ public class MFAMethodsPutHandler
             case AUTH_UPDATE_PHONE_NUMBER -> new AuditService.MetadataPair[] {priorityPair};
             case AUTH_MFA_METHOD_SWITCH_FAILED, AUTH_INVALID_CODE_SENT -> new AuditService
                             .MetadataPair[] {mfaTypePair, priorityPair};
+            case AUTH_CODE_VERIFIED -> pairsForAuthCodeVerified(putRequest);
             default -> new AuditService.MetadataPair[] {};
         };
     }
 
-    private AuditService.MetadataPair[] pairsForAuthCodeVerified(
-            ValidPutRequest putRequest, MFAMethod retrievedMfaMethod) {
+    private AuditService.MetadataPair[] pairsForAuthCodeVerified(ValidPutRequest putRequest) {
         var pairs = new ArrayList<AuditService.MetadataPair>();
 
         var requestedMethod = putRequest.request.mfaMethod();
@@ -667,40 +667,6 @@ public class MFAMethodsPutHandler
                 retrievedMfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
                         ? retrievedMfaMethod.getDestination()
                         : AuditService.UNKNOWN;
-        var context = baseContext.withPhoneNumber(phoneNumber);
-
-        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)
-                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
-                || auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
-                || auditEvent.equals(AUTH_INVALID_CODE_SENT)
-                || auditEvent.equals(AUTH_UPDATE_PROFILE_AUTH_APP)) {
-            return context;
-        }
-
-        if (!(auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
-                || auditEvent.equals(AUTH_CODE_VERIFIED))) {
-            var mfaTypePair =
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, retrievedMfaMethod.getMfaMethodType());
-            context = context.withMetadataItem(mfaTypePair);
-        }
-
-        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
-                || auditEvent.equals(AUTH_INVALID_CODE_SENT)
-                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
-            var priorityPair =
-                    pair(
-                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                            retrievedMfaMethod.getPriority().toLowerCase());
-            context = context.withMetadataItem(priorityPair);
-        }
-
-        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-            var metadataPairs = pairsForAuthCodeVerified(putRequest, retrievedMfaMethod);
-            for (var pair : metadataPairs) {
-                context = context.withMetadataItem(pair);
-            }
-        }
-
-        return context;
+        return baseContext.withPhoneNumber(phoneNumber);
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -601,18 +601,18 @@ public class MFAMethodsPutHandler
                     generateApiGatewayProxyErrorResponse(401, maybeAuditContext.getFailure()));
         }
 
+        var auditContext = maybeAuditContext.getSuccess();
+
         var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.AUTH_APP.getValue());
         var priority = putRequest.request.mfaMethod().priorityIdentifier().toString().toLowerCase();
         var priorityPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority);
 
-        var auditContext =
-                maybeAuditContext
-                        .getSuccess()
-                        .withMetadataItem(mfaTypePair)
-                        .withMetadataItem(priorityPair);
-
         auditService.submitAuditEvent(
-                AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);
+                AUTH_UPDATE_PROFILE_AUTH_APP,
+                auditContext,
+                AUDIT_EVENT_COMPONENT_ID_HOME,
+                mfaTypePair,
+                priorityPair);
 
         return Result.success(null);
     }
@@ -650,7 +650,8 @@ public class MFAMethodsPutHandler
         if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
                 || auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
-                || auditEvent.equals(AUTH_INVALID_CODE_SENT)) {
+                || auditEvent.equals(AUTH_INVALID_CODE_SENT)
+                || auditEvent.equals(AUTH_UPDATE_PROFILE_AUTH_APP)) {
             return context;
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -15,7 +15,6 @@ import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
-import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -573,7 +572,13 @@ public class MFAMethodsPutHandler
         return accountManagementAuditContext(
                         configurationService, authenticationService, input, putRequest.userProfile)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
-                .map(context -> addPhoneNumberToContext(mfaMethod, context))
+                .map(context -> {
+                    var phoneNumber =
+                            mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
+                                    ? mfaMethod.getDestination()
+                                    : AuditService.UNKNOWN;
+                    return context.withPhoneNumber(phoneNumber);
+                })
                 .flatMap(
                         context -> {
                             var pairs = metadataPairsForEvent(auditEvent, putRequest, mfaMethod);
@@ -667,12 +672,4 @@ public class MFAMethodsPutHandler
         return pairs.toArray(AuditService.MetadataPair[]::new);
     }
 
-    private AuditContext addPhoneNumberToContext(
-            MFAMethod retrievedMfaMethod, AuditContext baseContext) {
-        var phoneNumber =
-                retrievedMfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
-                        ? retrievedMfaMethod.getDestination()
-                        : AuditService.UNKNOWN;
-        return baseContext.withPhoneNumber(phoneNumber);
-    }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -630,9 +630,8 @@ public class MFAMethodsPutHandler
         return switch (auditableEvent) {
             case AUTH_MFA_METHOD_SWITCH_COMPLETED -> new AuditService.MetadataPair[] {mfaTypePair};
             case AUTH_UPDATE_PHONE_NUMBER -> new AuditService.MetadataPair[] {priorityPair};
-            case AUTH_MFA_METHOD_SWITCH_FAILED -> new AuditService.MetadataPair[] {
-                mfaTypePair, priorityPair
-            };
+            case AUTH_MFA_METHOD_SWITCH_FAILED, AUTH_INVALID_CODE_SENT -> new AuditService
+                            .MetadataPair[] {mfaTypePair, priorityPair};
             default -> new AuditService.MetadataPair[] {};
         };
     }
@@ -650,7 +649,8 @@ public class MFAMethodsPutHandler
 
         if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
-                || auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)) {
+                || auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)
+                || auditEvent.equals(AUTH_INVALID_CODE_SENT)) {
             return context;
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -39,6 +39,7 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailure;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -636,6 +637,27 @@ public class MFAMethodsPutHandler
         };
     }
 
+    private AuditService.MetadataPair[] pairsForAuthCodeVerified(
+            ValidPutRequest putRequest, MFAMethod retrievedMfaMethod) {
+        var pairs = new ArrayList<AuditService.MetadataPair>();
+
+        var requestedMethod = putRequest.request.mfaMethod();
+
+        if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
+                && requestSmsMfaDetail.otp() != null) {
+            pairs.add(pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, requestSmsMfaDetail.otp()));
+            pairs.add(pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name()));
+        }
+
+        pairs.add(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"));
+        var priority = requestedMethod.priorityIdentifier().name().toLowerCase();
+        pairs.add(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority));
+        var mfaType = requestedMethod.method().mfaMethodType().toString();
+        pairs.add(pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType));
+
+        return pairs.toArray(AuditService.MetadataPair[]::new);
+    }
+
     private AuditContext buildAuditContext(
             AccountManagementAuditableEvent auditEvent,
             ValidPutRequest putRequest,
@@ -673,25 +695,10 @@ public class MFAMethodsPutHandler
         }
 
         if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-            MfaMethodUpdateRequest.MfaMethod requestedMethod = putRequest.request.mfaMethod();
-            if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
-                    && requestSmsMfaDetail.otp() != null) {
-                var codeEnteredPair =
-                        pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, requestSmsMfaDetail.otp());
-                var notificationTypePair =
-                        pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name());
-                context =
-                        context.withMetadataItem(codeEnteredPair)
-                                .withMetadataItem(notificationTypePair);
+            var metadataPairs = pairsForAuthCodeVerified(putRequest, retrievedMfaMethod);
+            for (var pair : metadataPairs) {
+                context = context.withMetadataItem(pair);
             }
-            var priority = requestedMethod.priorityIdentifier().name().toLowerCase();
-            var mfaType = requestedMethod.method().mfaMethodType().toString();
-            var priorityPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority);
-            var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType);
-            context =
-                    context.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false"))
-                            .withMetadataItem(priorityPair)
-                            .withMetadataItem(mfaTypePair);
         }
 
         return context;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -623,8 +623,13 @@ public class MFAMethodsPutHandler
             MFAMethod retrievedMfaMethod) {
         var mfaTypePair =
                 pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, retrievedMfaMethod.getMfaMethodType());
+        var priorityPair =
+                pair(
+                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                        retrievedMfaMethod.getPriority().toLowerCase());
         return switch (auditableEvent) {
             case AUTH_MFA_METHOD_SWITCH_COMPLETED -> new AuditService.MetadataPair[] {mfaTypePair};
+            case AUTH_UPDATE_PHONE_NUMBER -> new AuditService.MetadataPair[] {priorityPair};
             default -> new AuditService.MetadataPair[] {};
         };
     }
@@ -640,7 +645,8 @@ public class MFAMethodsPutHandler
                         : AuditService.UNKNOWN;
         var context = baseContext.withPhoneNumber(phoneNumber);
 
-        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)) {
+        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
             return context;
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -50,7 +50,8 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContextWithJourneyType;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
@@ -569,7 +570,7 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        return accountManagementAuditContextWithJourneyType(
+        return accountManagementAuditContext(
                         configurationService, authenticationService, input, putRequest.userProfile)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
                 .map(context -> addPhoneNumberToContext(mfaMethod, context))
@@ -594,7 +595,7 @@ public class MFAMethodsPutHandler
         }
 
         var maybeAuditContext =
-                accountManagementAuditContextWithJourneyType(
+                accountManagementAuditContext(
                         configurationService, dynamoService, input, putRequest.userProfile);
 
         if (maybeAuditContext.isFailure()) {
@@ -612,6 +613,7 @@ public class MFAMethodsPutHandler
                 AUTH_UPDATE_PROFILE_AUTH_APP,
                 auditContext,
                 AUDIT_EVENT_COMPONENT_ID_HOME,
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
                 mfaTypePair,
                 priorityPair);
 
@@ -629,10 +631,16 @@ public class MFAMethodsPutHandler
                         AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
                         retrievedMfaMethod.getPriority().toLowerCase());
         return switch (auditableEvent) {
-            case AUTH_MFA_METHOD_SWITCH_COMPLETED -> new AuditService.MetadataPair[] {mfaTypePair};
-            case AUTH_UPDATE_PHONE_NUMBER -> new AuditService.MetadataPair[] {priorityPair};
+            case AUTH_MFA_METHOD_SWITCH_COMPLETED -> new AuditService.MetadataPair[] {
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR, mfaTypePair
+            };
+            case AUTH_UPDATE_PHONE_NUMBER -> new AuditService.MetadataPair[] {
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR, priorityPair
+            };
             case AUTH_MFA_METHOD_SWITCH_FAILED, AUTH_INVALID_CODE_SENT -> new AuditService
-                            .MetadataPair[] {mfaTypePair, priorityPair};
+                            .MetadataPair[] {
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR, mfaTypePair, priorityPair
+            };
             case AUTH_CODE_VERIFIED -> pairsForAuthCodeVerified(putRequest);
             default -> new AuditService.MetadataPair[] {};
         };
@@ -640,6 +648,7 @@ public class MFAMethodsPutHandler
 
     private AuditService.MetadataPair[] pairsForAuthCodeVerified(ValidPutRequest putRequest) {
         var pairs = new ArrayList<AuditService.MetadataPair>();
+        pairs.add(ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR);
 
         var requestedMethod = putRequest.request.mfaMethod();
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -572,7 +572,7 @@ public class MFAMethodsPutHandler
         return accountManagementAuditContext(
                         configurationService, authenticationService, input, putRequest.userProfile)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
-                .map(context -> buildAuditContext(auditEvent, putRequest, mfaMethod, context))
+                .map(context -> addPhoneNumberToContext(mfaMethod, context))
                 .flatMap(
                         context -> {
                             var pairs = metadataPairsForEvent(auditEvent, putRequest, mfaMethod);
@@ -658,11 +658,8 @@ public class MFAMethodsPutHandler
         return pairs.toArray(AuditService.MetadataPair[]::new);
     }
 
-    private AuditContext buildAuditContext(
-            AccountManagementAuditableEvent auditEvent,
-            ValidPutRequest putRequest,
-            MFAMethod retrievedMfaMethod,
-            AuditContext baseContext) {
+    private AuditContext addPhoneNumberToContext(
+            MFAMethod retrievedMfaMethod, AuditContext baseContext) {
         var phoneNumber =
                 retrievedMfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.getValue())
                         ? retrievedMfaMethod.getDestination()

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -630,6 +630,9 @@ public class MFAMethodsPutHandler
         return switch (auditableEvent) {
             case AUTH_MFA_METHOD_SWITCH_COMPLETED -> new AuditService.MetadataPair[] {mfaTypePair};
             case AUTH_UPDATE_PHONE_NUMBER -> new AuditService.MetadataPair[] {priorityPair};
+            case AUTH_MFA_METHOD_SWITCH_FAILED -> new AuditService.MetadataPair[] {
+                mfaTypePair, priorityPair
+            };
             default -> new AuditService.MetadataPair[] {};
         };
     }
@@ -646,7 +649,8 @@ public class MFAMethodsPutHandler
         var context = baseContext.withPhoneNumber(phoneNumber);
 
         if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)
-                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
+                || auditEvent.equals(AUTH_MFA_METHOD_SWITCH_FAILED)) {
             return context;
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -50,7 +50,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContextWithJourneyType;
 import static uk.gov.di.accountmanagement.helpers.MfaMethodResponseConverterHelper.convertMfaMethodsToMfaMethodResponse;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
@@ -569,7 +569,7 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input,
             ValidPutRequest putRequest,
             MFAMethod mfaMethod) {
-        return accountManagementAuditContext(
+        return accountManagementAuditContextWithJourneyType(
                         configurationService, authenticationService, input, putRequest.userProfile)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
                 .map(context -> addPhoneNumberToContext(mfaMethod, context))
@@ -594,7 +594,7 @@ public class MFAMethodsPutHandler
         }
 
         var maybeAuditContext =
-                accountManagementAuditContext(
+                accountManagementAuditContextWithJourneyType(
                         configurationService, dynamoService, input, putRequest.userProfile);
 
         if (maybeAuditContext.isFailure()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -573,10 +573,12 @@ public class MFAMethodsPutHandler
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
                 .map(context -> buildAuditContext(auditEvent, putRequest, mfaMethod, context))
                 .flatMap(
-                        context ->
-                                AuditHelper.sendAuditEvent(auditEvent, context, auditService, LOG)
-                                        .mapFailure(
-                                                f -> generateApiGatewayProxyErrorResponse(500, f)))
+                        context -> {
+                            var pairs = metadataPairsForEvent(auditEvent, putRequest, mfaMethod);
+                            return AuditHelper.sendAuditEvent(
+                                            auditEvent, context, auditService, LOG, pairs)
+                                    .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f));
+                        })
                 .map(
                         success -> {
                             LOG.info("Successfully submitted audit event: {}", auditEvent.name());
@@ -615,6 +617,18 @@ public class MFAMethodsPutHandler
         return Result.success(null);
     }
 
+    private AuditService.MetadataPair[] metadataPairsForEvent(
+            AccountManagementAuditableEvent auditableEvent,
+            ValidPutRequest putRequest,
+            MFAMethod retrievedMfaMethod) {
+        var mfaTypePair =
+                pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, retrievedMfaMethod.getMfaMethodType());
+        return switch (auditableEvent) {
+            case AUTH_MFA_METHOD_SWITCH_COMPLETED -> new AuditService.MetadataPair[] {mfaTypePair};
+            default -> new AuditService.MetadataPair[] {};
+        };
+    }
+
     private AuditContext buildAuditContext(
             AccountManagementAuditableEvent auditEvent,
             ValidPutRequest putRequest,
@@ -625,6 +639,10 @@ public class MFAMethodsPutHandler
                         ? retrievedMfaMethod.getDestination()
                         : AuditService.UNKNOWN;
         var context = baseContext.withPhoneNumber(phoneNumber);
+
+        if (auditEvent.equals(AUTH_MFA_METHOD_SWITCH_COMPLETED)) {
+            return context;
+        }
 
         if (!(auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
                 || auditEvent.equals(AUTH_CODE_VERIFIED))) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
@@ -98,7 +98,7 @@ class AuditHelperTest {
             when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
 
             Result<ErrorResponse, AuditContext> result =
-                    AuditHelper.accountManagementAuditContext(
+                    AuditHelper.accountManagementAuditContextWithJourneyType(
                             configurationService, dynamoService, input, userProfile);
 
             assertTrue(result.isSuccess());
@@ -120,7 +120,7 @@ class AuditHelperTest {
             input = new APIGatewayProxyRequestEvent();
 
             Result<ErrorResponse, AuditContext> result =
-                    AuditHelper.accountManagementAuditContext(
+                    AuditHelper.accountManagementAuditContextWithJourneyType(
                             configurationService, dynamoService, input, userProfile);
 
             assertTrue(result.isFailure());

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -427,16 +427,12 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        var expectedAuditContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(UK_MOBILE_NUMBER)
-                        .withMetadataItem(pair("mfa-type", defaultMfaMethod.getMfaMethodType()));
-
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
-                        expectedAuditContext,
-                        AUDIT_EVENT_COMPONENT_ID_HOME);
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("mfa-type", defaultMfaMethod.getMfaMethodType()));
     }
 
     private static Stream<MFAMethodUpdateIdentifier> phoneNumberUpdateTypeIdentifiers() {
@@ -545,17 +541,12 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        var expectedAuditContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(existingBackupNumber)
-                        .withMetadataItem(
-                                pair("mfa-type", defaultMethodAfterSwitch.getMfaMethodType()));
-
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
-                        expectedAuditContext,
-                        AUDIT_EVENT_COMPONENT_ID_HOME);
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(existingBackupNumber),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("mfa-type", defaultMethodAfterSwitch.getMfaMethodType()));
 
         verify(auditService, never()).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any(), any());
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -618,19 +618,16 @@ class MFAMethodsPutHandlerTest {
 
         handler.handleRequest(eventWithUpdateRequest, context);
 
-        var expectedAuditContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(UK_MOBILE_NUMBER)
-                        .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
-                        .withMetadataItem(pair("notification-type", "MFA_SMS"))
-                        .withMetadataItem(pair("account-recovery", "false"))
-                        .withMetadataItem(
-                                pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()))
-                        .withMetadataItem(pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
-
         verify(auditService)
                 .submitAuditEvent(
-                        AUTH_CODE_VERIFIED, expectedAuditContext, AUDIT_EVENT_COMPONENT_ID_HOME);
+                        AUTH_CODE_VERIFIED,
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("MFACodeEntered", TEST_OTP),
+                        pair("notification-type", "MFA_SMS"),
+                        pair("account-recovery", "false"),
+                        pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()),
+                        pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -851,17 +851,13 @@ class MFAMethodsPutHandlerTest {
 
         handler.handleRequest(eventWithUpdateRequest, context);
 
-        var expectedAuditContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(UK_MOBILE_NUMBER)
-                        .withMetadataItem(pair("mfa-type", BACKUP_SMS_METHOD.getMfaMethodType()))
-                        .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_MFA_METHOD_SWITCH_FAILED,
-                        expectedAuditContext,
-                        AUDIT_EVENT_COMPONENT_ID_HOME);
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("mfa-type", BACKUP_SMS_METHOD.getMfaMethodType()),
+                        pair("mfa-method", BACKUP.name().toLowerCase()));
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -122,8 +122,7 @@ class MFAMethodsPutHandlerTest {
                     .withSubjectId(TEST_INTERNAL_SUBJECT)
                     .withIpAddress(IP_ADDRESS)
                     .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
-                    .withPersistentSessionId(PERSISTENT_ID)
-                    .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+                    .withPersistentSessionId(PERSISTENT_ID);
     private static final String NON_MIGRATED_EMAIL = "non-migrated-email@example.com";
     private static final UserProfile NON_MIGRATED_USER =
             new UserProfile()
@@ -432,6 +431,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("mfa-type", defaultMfaMethod.getMfaMethodType()));
     }
 
@@ -485,6 +485,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_UPDATE_PHONE_NUMBER,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("mfa-method", defaultMfaMethod.getPriority().toLowerCase()));
     }
 
@@ -541,6 +542,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_MFA_METHOD_SWITCH_COMPLETED,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(existingBackupNumber),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("mfa-type", defaultMethodAfterSwitch.getMfaMethodType()));
 
         verify(auditService, never()).submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any(), any());
@@ -623,6 +625,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_CODE_VERIFIED,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("MFACodeEntered", TEST_OTP),
                         pair("notification-type", "MFA_SMS"),
                         pair("account-recovery", "false"),
@@ -743,6 +746,7 @@ class MFAMethodsPutHandlerTest {
                             AUTH_UPDATE_PHONE_NUMBER,
                             expectedAuditContext,
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-method", DEFAULT.name().toLowerCase()));
         } else {
             verifyNoInteractions(auditService);
@@ -853,6 +857,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_MFA_METHOD_SWITCH_FAILED,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("mfa-type", BACKUP_SMS_METHOD.getMfaMethodType()),
                         pair("mfa-method", BACKUP.name().toLowerCase()));
     }
@@ -1257,6 +1262,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_INVALID_CODE_SENT,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(phoneNumber),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("mfa-type", "SMS"),
                         pair("mfa-method", DEFAULT.name().toLowerCase()));
 
@@ -1298,6 +1304,7 @@ class MFAMethodsPutHandlerTest {
                         AUTH_UPDATE_PROFILE_AUTH_APP,
                         BASE_AUDIT_CONTEXT.withPhoneNumber(null),
                         AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                         pair("mfa-type", "AUTH_APP"),
                         pair("mfa-method", DEFAULT.name().toLowerCase()));
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -1255,17 +1255,13 @@ class MFAMethodsPutHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.INVALID_OTP));
 
-        var expectedAuditContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(phoneNumber)
-                        .withMetadataItem(pair("mfa-type", "SMS"))
-                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
-
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_INVALID_CODE_SENT,
-                        expectedAuditContext,
-                        AUDIT_EVENT_COMPONENT_ID_HOME);
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(phoneNumber),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("mfa-type", "SMS"),
+                        pair("mfa-method", DEFAULT.name().toLowerCase()));
 
         verify(sqsClient, never()).send(any());
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -744,11 +744,16 @@ class MFAMethodsPutHandlerTest {
         }
 
         if (migrationFailureReason == MfaMigrationFailureReason.ALREADY_MIGRATED) {
+            var expectedAuditContext =
+                    BASE_AUDIT_CONTEXT
+                            .withEmail(NON_MIGRATED_EMAIL)
+                            .withPhoneNumber(phoneNumber)
+                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
             verify(auditService)
                     .submitAuditEvent(
-                            eq(AUTH_UPDATE_PHONE_NUMBER),
-                            any(AuditContext.class),
-                            eq(AUDIT_EVENT_COMPONENT_ID_HOME));
+                            AUTH_UPDATE_PHONE_NUMBER,
+                            expectedAuditContext,
+                            AUDIT_EVENT_COMPONENT_ID_HOME);
         } else {
             verifyNoInteractions(auditService);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -1296,17 +1296,13 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        var expectedContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(null)
-                        .withMetadataItem(pair("mfa-type", "AUTH_APP"))
-                        .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
-
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_AUTH_APP,
-                        expectedContext,
-                        AUDIT_EVENT_COMPONENT_ID_HOME);
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("mfa-type", "AUTH_APP"),
+                        pair("mfa-method", DEFAULT.name().toLowerCase()));
     }
 
     private static APIGatewayProxyRequestEvent baseRequestWithoutPathParams(String principal) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -480,17 +480,12 @@ class MFAMethodsPutHandlerTest {
 
         assertEquals(200, result.getStatusCode());
 
-        var expectedAuditContext =
-                BASE_AUDIT_CONTEXT
-                        .withPhoneNumber(UK_MOBILE_NUMBER)
-                        .withMetadataItem(
-                                pair("mfa-method", defaultMfaMethod.getPriority().toLowerCase()));
-
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PHONE_NUMBER,
-                        expectedAuditContext,
-                        AUDIT_EVENT_COMPONENT_ID_HOME);
+                        BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
+                        AUDIT_EVENT_COMPONENT_ID_HOME,
+                        pair("mfa-method", defaultMfaMethod.getPriority().toLowerCase()));
     }
 
     @Test
@@ -745,15 +740,13 @@ class MFAMethodsPutHandlerTest {
 
         if (migrationFailureReason == MfaMigrationFailureReason.ALREADY_MIGRATED) {
             var expectedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withEmail(NON_MIGRATED_EMAIL)
-                            .withPhoneNumber(phoneNumber)
-                            .withMetadataItem(pair("mfa-method", DEFAULT.name().toLowerCase()));
+                    BASE_AUDIT_CONTEXT.withEmail(NON_MIGRATED_EMAIL).withPhoneNumber(phoneNumber);
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_UPDATE_PHONE_NUMBER,
                             expectedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-method", DEFAULT.name().toLowerCase()));
         } else {
             verifyNoInteractions(auditService);
         }


### PR DESCRIPTION
## What

Switches all events emitted in the mfa methods put handler over to pass metadata items in as varargs rather than setting them on the audit context.

This is a step towards removing the metadata items entirely from the audit context - currently it is confusing as they can be set in either place, but the audit context is supposed to contain only data that is common to all events emitted by a handler (and can just be created once per handler) rather than any event-specific metadata. 

## How to review

1. Code Review commit by commit - I've done this refactor very incrementally so it should be easy to see what's going on when going through each commit individually.


