### PR TITLE
Aut 5462: Add AMC Authorisation Initiated Event

### DIFF
--- a/ci/cloudformation/auth/function/amc-authorize.yaml
+++ b/ci/cloudformation/auth/function/amc-authorize.yaml
@@ -103,6 +103,7 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               authSessionUseStronglyConsistentReads,
             ]
+          TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
       LoggingConfig:
         LogGroup: !Ref AMCAuthorizeFunctionLogGroup
       Policies:
@@ -110,6 +111,7 @@ Resources:
         - !Ref AuthToAMCSigningKeyPolicy
         - !Ref AuthToAccountManagementSigningKeyPolicy
         - !Ref AuthToAccountDataSigningKeyPolicy
+        - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
         - !Ref DynamoAuthSessionStoreReadAccessPolicy
         - !Ref DynamoClientRegistryReadAccessPolicy
         - !Ref DynamoUserReadAccessPolicy

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -60,7 +60,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     AUTH_REAUTH_FAILED,
     AUTH_REAUTH_SUCCESS,
     AUTH_EMAIL_FRAUD_CHECK_DECISION_USED,
-    AUTH_MFA_RESET_REQUESTED;
+    AUTH_MFA_RESET_REQUESTED,
+    AUTH_AMC_AUTHORISATION_REQUESTED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -25,8 +25,11 @@ import uk.gov.di.authentication.frontendapi.errormapper.AMCFailureHttpMapper;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
@@ -43,8 +46,13 @@ import java.net.MalformedURLException;
 import java.time.Clock;
 import java.util.List;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_AMC_AUTHORISATION_REQUESTED;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_AMC_SCOPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest> {
     private final AMCService amcService;
@@ -154,6 +162,8 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                                     }
                                 });
 
+        emitAuthorizationRequestedAuditEvent(userContext, input, request);
+
         return result.fold(
                 AMCFailureHttpMapper::toApiGatewayProxyErrorResponse,
                 success -> {
@@ -165,6 +175,25 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                                 500, ErrorResponse.SERIALIZATION_ERROR);
                     }
                 });
+    }
+
+    private void emitAuthorizationRequestedAuditEvent(
+            UserContext userContext,
+            APIGatewayProxyRequestEvent input,
+            AMCAuthorizeRequest request) {
+        var auditContext =
+                auditContextFromUserContext(
+                        userContext,
+                        userContext.getAuthSession().getInternalCommonSubjectId(),
+                        userContext.getAuthSession().getEmailAddress(),
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService
+                                .UNKNOWN, // the schema does not include phone number for this event
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+        var journeyTypePair = pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN);
+        var amcScopePair = pair(AUDIT_EVENT_EXTENSIONS_AMC_SCOPE, request.amcJourneyType());
+        auditService.submitAuditEvent(
+                AUTH_AMC_AUTHORISATION_REQUESTED, auditContext, journeyTypePair, amcScopePair);
     }
 
     private Result<AMCFailureReason, RSAKey> getAMCPublicEncryptionKey() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -30,6 +30,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -48,6 +49,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest> {
     private final AMCService amcService;
     private final JWKSource<SecurityContext> jwkSource;
+    private final AuditService auditService;
 
     private static final Logger LOG = LogManager.getLogger(AMCAuthorizeHandler.class);
     private final DynamoAmcStateService dynamoAmcStateService;
@@ -76,6 +78,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                         new JwtService(new KmsConnectionService(configurationService)),
                         new AccessTokenConstructorService(configurationService));
         this.dynamoAmcStateService = new DynamoAmcStateService(configurationService);
+        this.auditService = new AuditService(configurationService);
     }
 
     @SuppressWarnings("java:S1185")
@@ -91,7 +94,8 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
             AuthSessionService authSessionService,
             AMCService amcService,
             JWKSource<SecurityContext> jwkSource,
-            DynamoAmcStateService amcStateService) {
+            DynamoAmcStateService amcStateService,
+            AuditService auditService) {
         super(
                 AMCAuthorizeRequest.class,
                 configurationService,
@@ -100,6 +104,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
         this.amcService = amcService;
         this.jwkSource = jwkSource;
         this.dynamoAmcStateService = amcStateService;
+        this.auditService = auditService;
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -81,13 +81,6 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
         this.auditService = new AuditService(configurationService);
     }
 
-    @SuppressWarnings("java:S1185")
-    @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return super.handleRequest(input, context);
-    }
-
     public AMCAuthorizeHandler(
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
@@ -105,6 +98,13 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
         this.jwkSource = jwkSource;
         this.dynamoAmcStateService = amcStateService;
         this.auditService = auditService;
+    }
+
+    @SuppressWarnings("java:S1185")
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return super.handleRequest(input, context);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -190,8 +190,16 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                         AuditService
                                 .UNKNOWN, // the schema does not include phone number for this event
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+
+        var amcScopeForAuditEvent =
+                switch (request.amcJourneyType()) {
+                    case PASSKEY_CREATE -> "passkey-create";
+                    case SFAD -> "sfad"; // note we'll probably want to review this when we get to
+                        // implementing sfad fully
+                };
+
         var journeyTypePair = pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN);
-        var amcScopePair = pair(AUDIT_EVENT_EXTENSIONS_AMC_SCOPE, request.amcJourneyType());
+        var amcScopePair = pair(AUDIT_EVENT_EXTENSIONS_AMC_SCOPE, amcScopeForAuditEvent);
         auditService.submitAuditEvent(
                 AUTH_AMC_AUTHORISATION_REQUESTED, auditContext, journeyTypePair, amcScopePair);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -22,7 +23,6 @@ import uk.gov.di.authentication.frontendapi.entity.amc.AMCFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCJourneyType;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCScope;
 import uk.gov.di.authentication.frontendapi.errormapper.AMCFailureHttpMapper;
-import uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -53,6 +53,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
@@ -140,7 +141,7 @@ class AMCAuthorizeHandlerTest {
                                     new AMCAuthorizationUrlAndCookie(expectedUrl, AMC_COOKIE)));
 
             var event =
-                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
+                    apiRequestEventWithHeadersAndBody(
                             CommonTestVariables.VALID_HEADERS,
                             format("{\"journeyType\":\"%s\"}", amcJourneyType));
 
@@ -181,19 +182,25 @@ class AMCAuthorizeHandlerTest {
 
     @Nested
     class Failure {
+        private static final APIGatewayProxyRequestEvent VALID_EVENT =
+                apiRequestEventWithHeadersAndBody(
+                        CommonTestVariables.VALID_HEADERS,
+                        format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
+
+        @BeforeEach
+        void setupUserProfile() {
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(userProfile));
+        }
+
         @Test
         void shouldReturn400WhenUserProfileNotFound() {
             when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                     .thenReturn(Optional.empty());
 
-            var event =
-                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                            CommonTestVariables.VALID_HEADERS,
-                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
-
             APIGatewayProxyResponseEvent result =
                     handler.handleRequestWithUserContext(
-                            event,
+                            VALID_EVENT,
                             context,
                             new AMCAuthorizeRequest(AMCJourneyType.SFAD),
                             userContext);
@@ -207,19 +214,12 @@ class AMCAuthorizeHandlerTest {
         @Test
         void shouldReturnJwksRetrievalErrorWhenKeySourceExceptionThrown()
                 throws KeySourceException {
-            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                    .thenReturn(Optional.of(userProfile));
             when(jwkSource.get(any(), any()))
                     .thenThrow(new KeySourceException("JWKS endpoint unreachable"));
 
-            var event =
-                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                            CommonTestVariables.VALID_HEADERS,
-                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
-
             APIGatewayProxyResponseEvent result =
                     handler.handleRequestWithUserContext(
-                            event,
+                            VALID_EVENT,
                             context,
                             new AMCAuthorizeRequest(AMCJourneyType.SFAD),
                             userContext);
@@ -232,18 +232,11 @@ class AMCAuthorizeHandlerTest {
 
         @Test
         void shouldReturnJwksRetrievalErrorWhenNoRsaKeyFound() throws KeySourceException {
-            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                    .thenReturn(Optional.of(userProfile));
             when(jwkSource.get(any(), any())).thenReturn(List.of());
-
-            var event =
-                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                            CommonTestVariables.VALID_HEADERS,
-                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
 
             APIGatewayProxyResponseEvent result =
                     handler.handleRequestWithUserContext(
-                            event,
+                            VALID_EVENT,
                             context,
                             new AMCAuthorizeRequest(AMCJourneyType.SFAD),
                             userContext);
@@ -257,8 +250,6 @@ class AMCAuthorizeHandlerTest {
         @ParameterizedTest
         @EnumSource(AMCFailureReason.class)
         void shouldHandleAllFailureReasons(AMCFailureReason failureReason) {
-            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                    .thenReturn(Optional.of(userProfile));
             when(amcService.buildAuthorizationResult(
                             anyString(),
                             any(),
@@ -271,23 +262,17 @@ class AMCAuthorizeHandlerTest {
                             any()))
                     .thenReturn(Result.failure(failureReason));
 
-            var event =
-                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                            CommonTestVariables.VALID_HEADERS,
-                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
-
             APIGatewayProxyResponseEvent result =
                     handler.handleRequestWithUserContext(
-                            event,
+                            VALID_EVENT,
                             context,
                             new AMCAuthorizeRequest(AMCJourneyType.SFAD),
                             userContext);
 
-            var httpResponse = AMCFailureHttpMapper.toHttpResponse(failureReason);
-            int expectedStatusCode = httpResponse.statusCode();
-            ErrorResponse expectedError = httpResponse.errorResponse();
+            var expectedHttpResponse = AMCFailureHttpMapper.toHttpResponse(failureReason);
+            var expectedError = expectedHttpResponse.errorResponse();
 
-            assertEquals(expectedStatusCode, result.getStatusCode());
+            assertEquals(expectedHttpResponse.statusCode(), result.getStatusCode());
             assertTrue(result.getBody().contains(expectedError.getMessage()));
         }
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -8,6 +8,7 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.oauth2.sdk.id.State;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -115,154 +116,179 @@ class AMCAuthorizeHandlerTest {
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
     }
 
-    private static Stream<Arguments> amcJourneyTypeAndExpectedScope() {
-        return Stream.of(
-                Arguments.of(AMCJourneyType.SFAD, AMCScope.ACCOUNT_DELETE),
-                Arguments.of(AMCJourneyType.PASSKEY_CREATE, AMCScope.PASSKEY_CREATE));
+    @Nested
+    class Success {
+        @ParameterizedTest
+        @MethodSource("amcJourneyTypeAndExpectedScope")
+        void shouldReturnAuthorizationUrlAndAmcCookieOnSuccess(
+                AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
+            String expectedUrl = "https://example.com/authorize";
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(userProfile));
+            when(amcService.buildAuthorizationResult(
+                            eq(INTERNAL_COMMON_SUBJECT_ID),
+                            eq(expectedAmcScope),
+                            eq(authSession),
+                            eq(PUBLIC_SUBJECT_ID),
+                            anyString(),
+                            anyList(),
+                            any(RSAPublicKey.class),
+                            anyString(),
+                            any(State.class)))
+                    .thenReturn(
+                            Result.success(
+                                    new AMCAuthorizationUrlAndCookie(expectedUrl, AMC_COOKIE)));
+
+            var event =
+                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
+                            CommonTestVariables.VALID_HEADERS,
+                            format("{\"journeyType\":\"%s\"}", amcJourneyType));
+
+            var request = new AMCAuthorizeRequest(amcJourneyType);
+            APIGatewayProxyResponseEvent result =
+                    handler.handleRequestWithUserContext(event, context, request, userContext);
+
+            var expectedResponse = new AMCAuthorizeResponse(expectedUrl, AMC_COOKIE);
+            assertEquals(200, result.getStatusCode());
+            assertThat(result, hasJsonBody(expectedResponse));
+
+            var expectedRedirectUri =
+                    request.amcJourneyType()
+                            .getTransportJwtConfig(configurationService)
+                            .redirectUri();
+            var expectedAccessTokenConfigs =
+                    request.amcJourneyType().getAccessTokenConfigs(configurationService);
+            var stateCaptor = ArgumentCaptor.forClass(State.class);
+            verify(amcService)
+                    .buildAuthorizationResult(
+                            eq(INTERNAL_COMMON_SUBJECT_ID),
+                            eq(expectedAmcScope),
+                            eq(authSession),
+                            eq(PUBLIC_SUBJECT_ID),
+                            eq(expectedRedirectUri),
+                            eq(expectedAccessTokenConfigs),
+                            any(RSAPublicKey.class),
+                            anyString(),
+                            stateCaptor.capture());
+        }
+
+        private static Stream<Arguments> amcJourneyTypeAndExpectedScope() {
+            return Stream.of(
+                    Arguments.of(AMCJourneyType.SFAD, AMCScope.ACCOUNT_DELETE),
+                    Arguments.of(AMCJourneyType.PASSKEY_CREATE, AMCScope.PASSKEY_CREATE));
+        }
     }
 
-    @ParameterizedTest
-    @MethodSource("amcJourneyTypeAndExpectedScope")
-    void shouldReturnAuthorizationUrlAndAmcCookieOnSuccess(
-            AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
-        String expectedUrl = "https://example.com/authorize";
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(userProfile));
-        when(amcService.buildAuthorizationResult(
-                        eq(INTERNAL_COMMON_SUBJECT_ID),
-                        eq(expectedAmcScope),
-                        eq(authSession),
-                        eq(PUBLIC_SUBJECT_ID),
-                        anyString(),
-                        anyList(),
-                        any(RSAPublicKey.class),
-                        anyString(),
-                        any(State.class)))
-                .thenReturn(
-                        Result.success(new AMCAuthorizationUrlAndCookie(expectedUrl, AMC_COOKIE)));
+    @Nested
+    class Failure {
+        @Test
+        void shouldReturn400WhenUserProfileNotFound() {
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.empty());
 
-        var event =
-                ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                        CommonTestVariables.VALID_HEADERS,
-                        format("{\"journeyType\":\"%s\"}", amcJourneyType));
+            var event =
+                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
+                            CommonTestVariables.VALID_HEADERS,
+                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
 
-        var request = new AMCAuthorizeRequest(amcJourneyType);
-        APIGatewayProxyResponseEvent result =
-                handler.handleRequestWithUserContext(event, context, request, userContext);
+            APIGatewayProxyResponseEvent result =
+                    handler.handleRequestWithUserContext(
+                            event,
+                            context,
+                            new AMCAuthorizeRequest(AMCJourneyType.SFAD),
+                            userContext);
 
-        var expectedResponse = new AMCAuthorizeResponse(expectedUrl, AMC_COOKIE);
-        assertEquals(200, result.getStatusCode());
-        assertThat(result, hasJsonBody(expectedResponse));
+            assertEquals(400, result.getStatusCode());
+            assertTrue(
+                    result.getBody()
+                            .contains(ErrorResponse.EMAIL_HAS_NO_USER_PROFILE.getMessage()));
+        }
 
-        var expectedRedirectUri =
-                request.amcJourneyType().getTransportJwtConfig(configurationService).redirectUri();
-        var expectedAccessTokenConfigs =
-                request.amcJourneyType().getAccessTokenConfigs(configurationService);
-        var stateCaptor = ArgumentCaptor.forClass(State.class);
-        verify(amcService)
-                .buildAuthorizationResult(
-                        eq(INTERNAL_COMMON_SUBJECT_ID),
-                        eq(expectedAmcScope),
-                        eq(authSession),
-                        eq(PUBLIC_SUBJECT_ID),
-                        eq(expectedRedirectUri),
-                        eq(expectedAccessTokenConfigs),
-                        any(RSAPublicKey.class),
-                        anyString(),
-                        stateCaptor.capture());
-    }
+        @Test
+        void shouldReturnJwksRetrievalErrorWhenKeySourceExceptionThrown()
+                throws KeySourceException {
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(userProfile));
+            when(jwkSource.get(any(), any()))
+                    .thenThrow(new KeySourceException("JWKS endpoint unreachable"));
 
-    @Test
-    void shouldReturn400WhenUserProfileNotFound() {
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.empty());
+            var event =
+                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
+                            CommonTestVariables.VALID_HEADERS,
+                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
 
-        var event =
-                ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                        CommonTestVariables.VALID_HEADERS,
-                        format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
+            APIGatewayProxyResponseEvent result =
+                    handler.handleRequestWithUserContext(
+                            event,
+                            context,
+                            new AMCAuthorizeRequest(AMCJourneyType.SFAD),
+                            userContext);
 
-        APIGatewayProxyResponseEvent result =
-                handler.handleRequestWithUserContext(
-                        event, context, new AMCAuthorizeRequest(AMCJourneyType.SFAD), userContext);
+            var httpResponse =
+                    AMCFailureHttpMapper.toHttpResponse(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
+            assertEquals(httpResponse.statusCode(), result.getStatusCode());
+            assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
+        }
 
-        assertEquals(400, result.getStatusCode());
-        assertTrue(result.getBody().contains(ErrorResponse.EMAIL_HAS_NO_USER_PROFILE.getMessage()));
-    }
+        @Test
+        void shouldReturnJwksRetrievalErrorWhenNoRsaKeyFound() throws KeySourceException {
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(userProfile));
+            when(jwkSource.get(any(), any())).thenReturn(List.of());
 
-    @Test
-    void shouldReturnJwksRetrievalErrorWhenKeySourceExceptionThrown() throws KeySourceException {
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(userProfile));
-        when(jwkSource.get(any(), any()))
-                .thenThrow(new KeySourceException("JWKS endpoint unreachable"));
+            var event =
+                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
+                            CommonTestVariables.VALID_HEADERS,
+                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
 
-        var event =
-                ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                        CommonTestVariables.VALID_HEADERS,
-                        format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
+            APIGatewayProxyResponseEvent result =
+                    handler.handleRequestWithUserContext(
+                            event,
+                            context,
+                            new AMCAuthorizeRequest(AMCJourneyType.SFAD),
+                            userContext);
 
-        APIGatewayProxyResponseEvent result =
-                handler.handleRequestWithUserContext(
-                        event, context, new AMCAuthorizeRequest(AMCJourneyType.SFAD), userContext);
+            var httpResponse =
+                    AMCFailureHttpMapper.toHttpResponse(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
+            assertEquals(httpResponse.statusCode(), result.getStatusCode());
+            assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
+        }
 
-        var httpResponse =
-                AMCFailureHttpMapper.toHttpResponse(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
-        assertEquals(httpResponse.statusCode(), result.getStatusCode());
-        assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
-    }
+        @ParameterizedTest
+        @EnumSource(AMCFailureReason.class)
+        void shouldHandleAllFailureReasons(AMCFailureReason failureReason) {
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(userProfile));
+            when(amcService.buildAuthorizationResult(
+                            anyString(),
+                            any(),
+                            any(),
+                            anyString(),
+                            anyString(),
+                            anyList(),
+                            any(RSAPublicKey.class),
+                            anyString(),
+                            any()))
+                    .thenReturn(Result.failure(failureReason));
 
-    @Test
-    void shouldReturnJwksRetrievalErrorWhenNoRsaKeyFound() throws KeySourceException {
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(userProfile));
-        when(jwkSource.get(any(), any())).thenReturn(List.of());
+            var event =
+                    ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
+                            CommonTestVariables.VALID_HEADERS,
+                            format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
 
-        var event =
-                ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                        CommonTestVariables.VALID_HEADERS,
-                        format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
+            APIGatewayProxyResponseEvent result =
+                    handler.handleRequestWithUserContext(
+                            event,
+                            context,
+                            new AMCAuthorizeRequest(AMCJourneyType.SFAD),
+                            userContext);
 
-        APIGatewayProxyResponseEvent result =
-                handler.handleRequestWithUserContext(
-                        event, context, new AMCAuthorizeRequest(AMCJourneyType.SFAD), userContext);
+            var httpResponse = AMCFailureHttpMapper.toHttpResponse(failureReason);
+            int expectedStatusCode = httpResponse.statusCode();
+            ErrorResponse expectedError = httpResponse.errorResponse();
 
-        var httpResponse =
-                AMCFailureHttpMapper.toHttpResponse(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
-        assertEquals(httpResponse.statusCode(), result.getStatusCode());
-        assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
-    }
-
-    @ParameterizedTest
-    @EnumSource(AMCFailureReason.class)
-    void shouldHandleAllFailureReasons(AMCFailureReason failureReason) {
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(userProfile));
-        when(amcService.buildAuthorizationResult(
-                        anyString(),
-                        any(),
-                        any(),
-                        anyString(),
-                        anyString(),
-                        anyList(),
-                        any(RSAPublicKey.class),
-                        anyString(),
-                        any()))
-                .thenReturn(Result.failure(failureReason));
-
-        var event =
-                ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(
-                        CommonTestVariables.VALID_HEADERS,
-                        format("{\"journeyType\":\"%s\"}", AMCJourneyType.SFAD));
-
-        APIGatewayProxyResponseEvent result =
-                handler.handleRequestWithUserContext(
-                        event, context, new AMCAuthorizeRequest(AMCJourneyType.SFAD), userContext);
-
-        var httpResponse = AMCFailureHttpMapper.toHttpResponse(failureReason);
-        int expectedStatusCode = httpResponse.statusCode();
-        ErrorResponse expectedError = httpResponse.errorResponse();
-
-        assertEquals(expectedStatusCode, result.getStatusCode());
-        assertTrue(result.getBody().contains(expectedError.getMessage()));
+            assertEquals(expectedStatusCode, result.getStatusCode());
+            assertTrue(result.getBody().contains(expectedError.getMessage()));
+        }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -58,9 +58,12 @@ import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLI
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class AMCAuthorizeHandlerTest {
@@ -119,16 +122,24 @@ class AMCAuthorizeHandlerTest {
 
     @Nested
     class Success {
-        @ParameterizedTest
-        @MethodSource("amcJourneyTypeAndExpectedScope")
-        void shouldReturnAuthorizationUrlAndAmcCookieOnSuccess(
-                AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
-            String expectedUrl = "https://example.com/authorize";
+        private static final String REDIRECT_URL_RETURNED_FROM_AUTHORIZATION =
+                "https://example.com/authorize";
+        private static final APIGatewayProxyRequestEvent EVENT_WITH_VALID_HEADERS =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        @BeforeEach
+        void setup() {
             when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                     .thenReturn(Optional.of(userProfile));
+
+            var authorizationUrlAndCookie =
+                    new AMCAuthorizationUrlAndCookie(
+                            REDIRECT_URL_RETURNED_FROM_AUTHORIZATION, AMC_COOKIE);
             when(amcService.buildAuthorizationResult(
                             eq(INTERNAL_COMMON_SUBJECT_ID),
-                            eq(expectedAmcScope),
+                            any(),
                             eq(authSession),
                             eq(PUBLIC_SUBJECT_ID),
                             anyString(),
@@ -136,22 +147,34 @@ class AMCAuthorizeHandlerTest {
                             any(RSAPublicKey.class),
                             anyString(),
                             any(State.class)))
-                    .thenReturn(
-                            Result.success(
-                                    new AMCAuthorizationUrlAndCookie(expectedUrl, AMC_COOKIE)));
+                    .thenReturn(Result.success(authorizationUrlAndCookie));
+        }
 
-            var event =
-                    apiRequestEventWithHeadersAndBody(
-                            CommonTestVariables.VALID_HEADERS,
-                            format("{\"journeyType\":\"%s\"}", amcJourneyType));
-
+        @ParameterizedTest
+        @MethodSource("amcJourneyTypeAndExpectedScope")
+        void shouldReturnAuthorizationUrlAndAmcCookieOnSuccess(
+                AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
             var request = new AMCAuthorizeRequest(amcJourneyType);
-            APIGatewayProxyResponseEvent result =
-                    handler.handleRequestWithUserContext(event, context, request, userContext);
+            var result =
+                    handler.handleRequestWithUserContext(
+                            EVENT_WITH_VALID_HEADERS, context, request, userContext);
 
-            var expectedResponse = new AMCAuthorizeResponse(expectedUrl, AMC_COOKIE);
+            var expectedResponse =
+                    new AMCAuthorizeResponse(REDIRECT_URL_RETURNED_FROM_AUTHORIZATION, AMC_COOKIE);
             assertEquals(200, result.getStatusCode());
             assertThat(result, hasJsonBody(expectedResponse));
+        }
+
+        @ParameterizedTest
+        @MethodSource("amcJourneyTypeAndExpectedScope")
+        void shouldConstructTheAuthorizationResultWithTheCorrectTransportJwtAndTokenConfigs(
+                AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
+            var request = new AMCAuthorizeRequest(amcJourneyType);
+            var result =
+                    handler.handleRequestWithUserContext(
+                            EVENT_WITH_VALID_HEADERS, context, request, userContext);
+
+            assertEquals(200, result.getStatusCode());
 
             var expectedRedirectUri =
                     request.amcJourneyType()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -67,6 +68,7 @@ class AMCAuthorizeHandlerTest {
     private final JWKSource<SecurityContext> jwkSource = mock(JWKSource.class);
     private final AMCService amcService = mock(AMCService.class);
     private final DynamoAmcStateService dynamoAmcStateService = mock(DynamoAmcStateService.class);
+    private final AuditService auditService = mock(AuditService.class);
     private AMCAuthorizeHandler handler;
     private final Context context = mock(Context.class);
     private final AuthSessionItem authSession =
@@ -94,7 +96,8 @@ class AMCAuthorizeHandlerTest {
                         authSessionService,
                         amcService,
                         jwkSource,
-                        dynamoAmcStateService);
+                        dynamoAmcStateService,
+                        auditService);
         when(jwkSource.get(any(), any())).thenReturn(List.of(TEST_RSA_JWK));
         when(configurationService.getAMCSfadRedirectURI())
                 .thenReturn("https://example.com/callback");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizationUrlAndCookie;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeRequest;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeResponse;
@@ -51,11 +52,16 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_AMC_AUTHORISATION_REQUESTED;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
+import static uk.gov.di.authentication.shared.entity.JourneyType.SIGN_IN;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
@@ -196,6 +202,36 @@ class AMCAuthorizeHandlerTest {
                             stateCaptor.capture());
         }
 
+        @ParameterizedTest
+        @MethodSource("amcJourneyTypeAndExpectedScope")
+        void shouldEmitTheRelevantAuditEvent(
+                AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
+            var request = new AMCAuthorizeRequest(amcJourneyType);
+            var result =
+                    handler.handleRequestWithUserContext(
+                            EVENT_WITH_VALID_HEADERS, context, request, userContext);
+
+            assertEquals(200, result.getStatusCode());
+
+            var expectedAuditContext =
+                    AuditContext.emptyAuditContext()
+                            .withClientId(CLIENT_ID)
+                            .withClientSessionId(CLIENT_SESSION_ID)
+                            .withSessionId(SESSION_ID)
+                            .withSubjectId(INTERNAL_COMMON_SUBJECT_ID)
+                            .withEmail(EMAIL)
+                            .withIpAddress(IP_ADDRESS)
+                            .withPersistentSessionId(DI_PERSISTENT_SESSION_ID);
+            var expectedJourneyTypePair = pair("journey-type", SIGN_IN);
+            var expectedAmcScopePair = pair("amc_scope", amcJourneyType);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_AMC_AUTHORISATION_REQUESTED,
+                            expectedAuditContext,
+                            expectedJourneyTypePair,
+                            expectedAmcScopePair);
+        }
+
         private static Stream<Arguments> amcJourneyTypeAndExpectedScope() {
             return Stream.of(
                     Arguments.of(AMCJourneyType.SFAD, AMCScope.ACCOUNT_DELETE),
@@ -232,6 +268,8 @@ class AMCAuthorizeHandlerTest {
             assertTrue(
                     result.getBody()
                             .contains(ErrorResponse.EMAIL_HAS_NO_USER_PROFILE.getMessage()));
+            verify(auditService, never())
+                    .submitAuditEvent(eq(AUTH_AMC_AUTHORISATION_REQUESTED), any());
         }
 
         @Test
@@ -251,6 +289,8 @@ class AMCAuthorizeHandlerTest {
                     AMCFailureHttpMapper.toHttpResponse(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
             assertEquals(httpResponse.statusCode(), result.getStatusCode());
             assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
+            verify(auditService, never())
+                    .submitAuditEvent(eq(AUTH_AMC_AUTHORISATION_REQUESTED), any());
         }
 
         @Test
@@ -268,6 +308,8 @@ class AMCAuthorizeHandlerTest {
                     AMCFailureHttpMapper.toHttpResponse(AMCFailureReason.JWKS_RETRIEVAL_ERROR);
             assertEquals(httpResponse.statusCode(), result.getStatusCode());
             assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
+            verify(auditService, never())
+                    .submitAuditEvent(eq(AUTH_AMC_AUTHORISATION_REQUESTED), any());
         }
 
         @ParameterizedTest
@@ -297,6 +339,8 @@ class AMCAuthorizeHandlerTest {
 
             assertEquals(expectedHttpResponse.statusCode(), result.getStatusCode());
             assertTrue(result.getBody().contains(expectedError.getMessage()));
+            verify(auditService, never())
+                    .submitAuditEvent(eq(AUTH_AMC_AUTHORISATION_REQUESTED), any());
         }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -203,9 +203,9 @@ class AMCAuthorizeHandlerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("amcJourneyTypeAndExpectedScope")
+        @MethodSource("amcJourneyTypeAndExpectedScopeInAudtEvent")
         void shouldEmitTheRelevantAuditEvent(
-                AMCJourneyType amcJourneyType, AMCScope expectedAmcScope) {
+                AMCJourneyType amcJourneyType, String expectedAmcScopeInAuditEvent) {
             var request = new AMCAuthorizeRequest(amcJourneyType);
             var result =
                     handler.handleRequestWithUserContext(
@@ -223,7 +223,7 @@ class AMCAuthorizeHandlerTest {
                             .withIpAddress(IP_ADDRESS)
                             .withPersistentSessionId(DI_PERSISTENT_SESSION_ID);
             var expectedJourneyTypePair = pair("journey-type", SIGN_IN);
-            var expectedAmcScopePair = pair("amc_scope", amcJourneyType);
+            var expectedAmcScopePair = pair("amc_scope", expectedAmcScopeInAuditEvent);
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_AMC_AUTHORISATION_REQUESTED,
@@ -236,6 +236,12 @@ class AMCAuthorizeHandlerTest {
             return Stream.of(
                     Arguments.of(AMCJourneyType.SFAD, AMCScope.ACCOUNT_DELETE),
                     Arguments.of(AMCJourneyType.PASSKEY_CREATE, AMCScope.PASSKEY_CREATE));
+        }
+
+        private static Stream<Arguments> amcJourneyTypeAndExpectedScopeInAudtEvent() {
+            return Stream.of(
+                    Arguments.of(AMCJourneyType.SFAD, "sfad"),
+                    Arguments.of(AMCJourneyType.PASSKEY_CREATE, "passkey-create"));
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCJourneyType;
@@ -42,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -208,9 +211,16 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
         assertDoesNotThrow(() -> encryptedJWT.decrypt(decrypter));
     }
 
+    private static Stream<Arguments> journeyTypesToAmcScopesInAuditEvent() {
+        return Stream.of(
+                Arguments.of(AMCJourneyType.SFAD, "sfad"),
+                Arguments.of(AMCJourneyType.PASSKEY_CREATE, "passkey-create"));
+    }
+
     @ParameterizedTest
-    @EnumSource(AMCJourneyType.class)
-    void shouldEmitCorrectAuditEvent(AMCJourneyType amcJourneyType) {
+    @MethodSource("journeyTypesToAmcScopesInAuditEvent")
+    void shouldEmitCorrectAuditEvent(
+            AMCJourneyType amcJourneyType, String expectedAmcScopeInMetadata) {
         handler = new AMCAuthorizeHandler();
 
         var requestBody =
@@ -231,7 +241,7 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
         Map<String, Object> expectedMetadataPairs =
                 Map.ofEntries(
                         Map.entry(EXTENSIONS_JOURNEY_TYPE, "SIGN_IN"),
-                        Map.entry(EXTENSIONS_AMC_SCOPE, amcJourneyType.name()));
+                        Map.entry(EXTENSIONS_AMC_SCOPE, expectedAmcScopeInMetadata));
         verifyAuditEvents(Map.of(AUTH_AMC_AUTHORISATION_REQUESTED, expectedMetadataPairs));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
@@ -81,6 +81,7 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
         environment.set("AMC_CLIENT_ID", "test-amc-client");
         environment.set("AMC_AUTHORIZE_URI", "https://test-amc.account.gov.uk/authorize");
         environment.set("AMC_REDIRECT_URI", "https://test.account.gov.uk/amc/callback");
+        environment.set("TXMA_AUDIT_QUEUE_URL", txmaAuditQueue.getQueueUrl());
 
         KeyPair keyPair;
         try {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AMCAuthorizeHandlerIntegrationTest.java
@@ -18,14 +18,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCJourneyType;
 import uk.gov.di.authentication.frontendapi.lambda.AMCAuthorizeHandler;
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AMCStateExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditEventExpectation;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -50,7 +53,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_AMC_AUTHORISATION_REQUESTED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_AMC_SCOPE;
+import static uk.gov.di.authentication.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
 
 @ExtendWith(SystemStubsExtension.class)
 class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -103,6 +111,11 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
         environment.set(
                 "AMC_JWKS_URL",
                 "http://localhost:" + wireMockServer.port() + "/.well-known/jwks.json");
+    }
+
+    @BeforeEach
+    void setUp() {
+        txmaAuditQueue.clear();
     }
 
     @AfterAll
@@ -195,6 +208,33 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
         assertDoesNotThrow(() -> encryptedJWT.decrypt(decrypter));
     }
 
+    @ParameterizedTest
+    @EnumSource(AMCJourneyType.class)
+    void shouldEmitCorrectAuditEvent(AMCJourneyType amcJourneyType) {
+        handler = new AMCAuthorizeHandler();
+
+        var requestBody =
+                """
+                {
+                    "journeyType": "%s"
+                    }
+                """
+                        .formatted(amcJourneyType);
+        var response =
+                makeRequest(
+                        Optional.of(requestBody),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(200));
+
+        Map<String, Object> expectedMetadataPairs =
+                Map.ofEntries(
+                        Map.entry(EXTENSIONS_JOURNEY_TYPE, "SIGN_IN"),
+                        Map.entry(EXTENSIONS_AMC_SCOPE, amcJourneyType.name()));
+        verifyAuditEvents(Map.of(AUTH_AMC_AUTHORISATION_REQUESTED, expectedMetadataPairs));
+    }
+
     @Test
     void shouldReturn400WhenUserProfileDoesNotExist() {
         handler = new AMCAuthorizeHandler();
@@ -215,5 +255,23 @@ class AMCAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         Map.of());
 
         assertThat(response, hasStatus(400));
+    }
+
+    private void verifyAuditEvents(Map<AuditableEvent, Map<String, Object>> eventExpectations) {
+        var receivedEvents =
+                assertTxmaAuditEventsReceived(txmaAuditQueue, eventExpectations.keySet());
+
+        for (Map.Entry<AuditableEvent, Map<String, Object>> eventEntry :
+                eventExpectations.entrySet()) {
+            var eventName = eventEntry.getKey().toString();
+            var attributes = eventEntry.getValue();
+
+            var expectation =
+                    new AuditEventExpectation(
+                            FrontendAuditableEvent.valueOf(eventName), attributes);
+
+            expectation.assertPublished(receivedEvents);
+            assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/AuditTestConstants.java
@@ -21,6 +21,7 @@ public interface AuditTestConstants {
     String EXTENSIONS_NOTIFICATION_TYPE = "extensions.notification-type";
     String EXTENSIONS_MFA_CODE_ENTERED = "extensions.MFACodeEntered";
     String EXTENSIONS_MAX_SMS_COUNT = "extensions.MaxSmsCount";
+    String EXTENSIONS_AMC_SCOPE = "extensions.amc_scope";
     String USER_EMAIL_FIELD = "user.email";
     String EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE = "extensions.phone_number_country_code";
     String EXTENSIONS_MFA_RESET_TYPE = "extensions.mfaResetType";

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditEventExpectation.java
@@ -19,6 +19,11 @@ public class AuditEventExpectation {
         this.expectedAttributes = new HashMap<>();
     }
 
+    public AuditEventExpectation(AuditableEvent event, Map<String, Object> expectedAttributes) {
+        this.event = event;
+        this.expectedAttributes = expectedAttributes;
+    }
+
     public AuditEventExpectation(AuditEventExpectation expectation) {
         this.event = expectation.event;
         this.expectedAttributes = expectation.expectedAttributes;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -16,6 +16,7 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED = "MFACodeEntered";
     String AUDIT_EVENT_EXTENSIONS_MFA_RESET_TYPE = "mfaResetType";
     String AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY = "has_active_passkey";
+    String AUDIT_EVENT_EXTENSIONS_AMC_SCOPE = "amc_scope";
 
     AuditableEvent parseFromName(String name);
 }


### PR DESCRIPTION
## What

Emit a new audit event when we're about to hand off to amc for passkeys. This is emitted just before we return to the frontend with the amc redirect url. It won't be emitted in the case of any failures to construct the redirect url (signing failures, jwks retrieval errors etc).

## How to review

1. Code Review commit by commit
1. Deploy to a dev env, go through a sign in journey where you're prompted to set up a passkey, choose to set up a passkey and then see the audit events emitted in sqs (you can also use the new script in this repo)