### PR TITLE
BAU: Mfa methods delete and create handlers do not set metadata items on audit context

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -83,34 +83,6 @@ public class AuditHelper {
         }
     }
 
-    public static Result<ErrorResponse, AuditContext> accountManagementAuditContextWithJourneyType(
-            ConfigurationService configurationService,
-            AuthenticationService authenticationService,
-            APIGatewayProxyRequestEvent input,
-            UserProfile userProfile) {
-        return accountManagementAuditContext(
-                        configurationService, authenticationService, input, userProfile)
-                .map(
-                        auditContext ->
-                                auditContext.withMetadataItem(
-                                        ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR));
-    }
-
-    public static Result<ErrorResponse, Void> sendAuditEvent(
-            AccountManagementAuditableEvent auditEvent,
-            AuditContext auditContext,
-            AuditService auditService,
-            Logger logger) {
-        try {
-            auditService.submitAuditEvent(auditEvent, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);
-        } catch (Exception e) {
-            logger.error("Error submitting audit event", e);
-            return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
-        }
-
-        return Result.success(null);
-    }
-
     public static Result<ErrorResponse, Void> sendAuditEvent(
             AccountManagementAuditableEvent auditEvent,
             AuditContext auditContext,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -389,7 +389,8 @@ public class MFAMethodsCreateHandler
         return switch (auditableEvent) {
             case AUTH_MFA_METHOD_ADD_COMPLETED,
                     AUTH_UPDATE_PHONE_NUMBER,
-                    AUTH_MFA_METHOD_ADD_FAILED -> new AuditService.MetadataPair[] {
+                    AUTH_MFA_METHOD_ADD_FAILED,
+                    AUTH_INVALID_CODE_SENT -> new AuditService.MetadataPair[] {
                 mfaTypePair, mfaMethodPair
             };
             case AUTH_CODE_VERIFIED -> {
@@ -420,7 +421,8 @@ public class MFAMethodsCreateHandler
         if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
                 || auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)
-                || auditEvent.equals(AUTH_CODE_VERIFIED)) {
+                || auditEvent.equals(AUTH_CODE_VERIFIED)
+                || auditEvent.equals(AUTH_INVALID_CODE_SENT)) {
             if (mfaMethodCreateRequest.mfaMethod().method()
                     instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
                 return enrichWithSmsDetails(baseAuditContext, requestSmsMfaDetail);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -380,7 +380,8 @@ public class MFAMethodsCreateHandler
     private AuditService.MetadataPair[] metadataPairsForEvent(
             AccountManagementAuditableEvent auditableEvent, MfaMethodCreateRequest createRequest) {
         return switch (auditableEvent) {
-            case AUTH_MFA_METHOD_ADD_COMPLETED -> new AuditService.MetadataPair[] {
+            case AUTH_MFA_METHOD_ADD_COMPLETED, AUTH_UPDATE_PHONE_NUMBER -> new AuditService
+                            .MetadataPair[] {
                 pair(
                         AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
                         createRequest.mfaMethod().method().mfaMethodType().name()),
@@ -398,7 +399,8 @@ public class MFAMethodsCreateHandler
             AuditContext baseAuditContext) {
         // Add a temporary short circuit while we switch audit events over one by one to not set
         // metadata on context
-        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
+        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
             if (mfaMethodCreateRequest.mfaMethod().method()
                     instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
                 return enrichWithSmsDetails(baseAuditContext, auditEvent, requestSmsMfaDetail);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -377,10 +377,35 @@ public class MFAMethodsCreateHandler
         };
     }
 
+    private AuditService.MetadataPair[] metadataPairsForEvent(
+            AccountManagementAuditableEvent auditableEvent, MfaMethodCreateRequest createRequest) {
+        return switch (auditableEvent) {
+            case AUTH_MFA_METHOD_ADD_COMPLETED -> new AuditService.MetadataPair[] {
+                pair(
+                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
+                        createRequest.mfaMethod().method().mfaMethodType().name()),
+                pair(
+                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                        PriorityIdentifier.BACKUP.name().toLowerCase()),
+            };
+            default -> new AuditService.MetadataPair[] {};
+        };
+    }
+
     private AuditContext enrichAuditContextForEvent(
             AccountManagementAuditableEvent auditEvent,
             MfaMethodCreateRequest mfaMethodCreateRequest,
             AuditContext baseAuditContext) {
+        // Add a temporary short circuit while we switch audit events over one by one to not set
+        // metadata on context
+        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)) {
+            if (mfaMethodCreateRequest.mfaMethod().method()
+                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+                return enrichWithSmsDetails(baseAuditContext, auditEvent, requestSmsMfaDetail);
+            } else {
+                return baseAuditContext;
+            }
+        }
         var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
         var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
 
@@ -450,7 +475,9 @@ public class MFAMethodsCreateHandler
         var baseAuditContext = auditContextResult.getSuccess();
         var enrichedAuditContext =
                 enrichAuditContextForEvent(auditEvent, mfaMethodCreateRequest, baseAuditContext);
-        return AuditHelper.sendAuditEvent(auditEvent, enrichedAuditContext, auditService, LOG)
+        var metadataPairs = metadataPairsForEvent(auditEvent, mfaMethodCreateRequest);
+        return AuditHelper.sendAuditEvent(
+                        auditEvent, enrichedAuditContext, auditService, LOG, metadataPairs)
                 .map(
                         sucess -> {
                             LOG.info("Successfully submitted audit event: {}", auditEvent.name());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -416,22 +416,19 @@ public class MFAMethodsCreateHandler
             MfaMethodCreateRequest mfaMethodCreateRequest, AuditContext baseAuditContext) {
         if (mfaMethodCreateRequest.mfaMethod().method()
                 instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            return enrichWithSmsDetails(baseAuditContext, requestSmsMfaDetail);
+            String formattedPhoneNumber;
+            try {
+                formattedPhoneNumber =
+                        PhoneNumberHelper.formatPhoneNumber(requestSmsMfaDetail.phoneNumber());
+            } catch (RuntimeException e) {
+                LOG.warn("Couldn't format phone number, audit event using raw number from request");
+                formattedPhoneNumber = requestSmsMfaDetail.phoneNumber();
+            }
+
+            return baseAuditContext.withPhoneNumber(formattedPhoneNumber);
         } else {
             return baseAuditContext;
         }
-    }
-
-    private AuditContext enrichWithSmsDetails(AuditContext context, RequestSmsMfaDetail smsDetail) {
-        String formattedPhoneNumber;
-        try {
-            formattedPhoneNumber = PhoneNumberHelper.formatPhoneNumber(smsDetail.phoneNumber());
-        } catch (RuntimeException e) {
-            LOG.warn("Couldn't format phone number, audit event using raw number from request");
-            formattedPhoneNumber = smsDetail.phoneNumber();
-        }
-
-        return context.withPhoneNumber(formattedPhoneNumber);
     }
 
     private Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -412,39 +412,14 @@ public class MFAMethodsCreateHandler
         };
     }
 
-    private AuditContext enrichAuditContextForEvent(
-            AccountManagementAuditableEvent auditEvent,
-            MfaMethodCreateRequest mfaMethodCreateRequest,
-            AuditContext baseAuditContext) {
-        // Add a temporary short circuit while we switch audit events over one by one to not set
-        // metadata on context
-        if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)
-                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
-                || auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)
-                || auditEvent.equals(AUTH_CODE_VERIFIED)
-                || auditEvent.equals(AUTH_INVALID_CODE_SENT)) {
-            if (mfaMethodCreateRequest.mfaMethod().method()
-                    instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                return enrichWithSmsDetails(baseAuditContext, requestSmsMfaDetail);
-            } else {
-                return baseAuditContext;
-            }
-        }
-        var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
-        var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
-
-        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType);
-        var mfaMethodPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority);
-
-        var context =
-                baseAuditContext.withMetadataItem(mfaTypePair).withMetadataItem(mfaMethodPair);
-
+    private AuditContext addPhoneNumberToAuditContext(
+            MfaMethodCreateRequest mfaMethodCreateRequest, AuditContext baseAuditContext) {
         if (mfaMethodCreateRequest.mfaMethod().method()
                 instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            context = enrichWithSmsDetails(context, requestSmsMfaDetail);
+            return enrichWithSmsDetails(baseAuditContext, requestSmsMfaDetail);
+        } else {
+            return baseAuditContext;
         }
-
-        return context;
     }
 
     private AuditContext enrichWithSmsDetails(AuditContext context, RequestSmsMfaDetail smsDetail) {
@@ -477,7 +452,7 @@ public class MFAMethodsCreateHandler
 
         var baseAuditContext = auditContextResult.getSuccess();
         var enrichedAuditContext =
-                enrichAuditContextForEvent(auditEvent, mfaMethodCreateRequest, baseAuditContext);
+                addPhoneNumberToAuditContext(mfaMethodCreateRequest, baseAuditContext);
         var metadataPairs = metadataPairsForEvent(auditEvent, mfaMethodCreateRequest);
         return AuditHelper.sendAuditEvent(
                         auditEvent, enrichedAuditContext, auditService, LOG, metadataPairs)

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -47,7 +47,8 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContextWithJourneyType;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
@@ -391,11 +392,12 @@ public class MFAMethodsCreateHandler
                     AUTH_UPDATE_PHONE_NUMBER,
                     AUTH_MFA_METHOD_ADD_FAILED,
                     AUTH_INVALID_CODE_SENT -> new AuditService.MetadataPair[] {
-                mfaTypePair, mfaMethodPair
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR, mfaTypePair, mfaMethodPair
             };
             case AUTH_CODE_VERIFIED -> {
                 if (createRequest.mfaMethod().method() instanceof RequestSmsMfaDetail smsDetail) {
                     yield new AuditService.MetadataPair[] {
+                        ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
                         mfaTypePair,
                         mfaMethodPair,
                         accountRecoveryPair,
@@ -404,7 +406,10 @@ public class MFAMethodsCreateHandler
                     };
                 } else {
                     yield new AuditService.MetadataPair[] {
-                        mfaTypePair, mfaMethodPair, accountRecoveryPair
+                        ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
+                        mfaTypePair,
+                        mfaMethodPair,
+                        accountRecoveryPair
                     };
                 }
             }
@@ -437,7 +442,7 @@ public class MFAMethodsCreateHandler
             UserProfile userProfile,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
         var auditContextResult =
-                accountManagementAuditContextWithJourneyType(
+                accountManagementAuditContext(
                         configurationService, dynamoService, input, userProfile);
         if (auditContextResult.isFailure()) {
             LOG.error(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -380,8 +380,9 @@ public class MFAMethodsCreateHandler
     private AuditService.MetadataPair[] metadataPairsForEvent(
             AccountManagementAuditableEvent auditableEvent, MfaMethodCreateRequest createRequest) {
         return switch (auditableEvent) {
-            case AUTH_MFA_METHOD_ADD_COMPLETED, AUTH_UPDATE_PHONE_NUMBER -> new AuditService
-                            .MetadataPair[] {
+            case AUTH_MFA_METHOD_ADD_COMPLETED,
+                    AUTH_UPDATE_PHONE_NUMBER,
+                    AUTH_MFA_METHOD_ADD_FAILED -> new AuditService.MetadataPair[] {
                 pair(
                         AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
                         createRequest.mfaMethod().method().mfaMethodType().name()),
@@ -400,7 +401,8 @@ public class MFAMethodsCreateHandler
         // Add a temporary short circuit while we switch audit events over one by one to not set
         // metadata on context
         if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)
-                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)) {
+                || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
+                || auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
             if (mfaMethodCreateRequest.mfaMethod().method()
                     instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
                 return enrichWithSmsDetails(baseAuditContext, auditEvent, requestSmsMfaDetail);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -379,17 +379,34 @@ public class MFAMethodsCreateHandler
 
     private AuditService.MetadataPair[] metadataPairsForEvent(
             AccountManagementAuditableEvent auditableEvent, MfaMethodCreateRequest createRequest) {
+        var mfaType = createRequest.mfaMethod().method().mfaMethodType().toString();
+        var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
+
+        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType);
+        var mfaMethodPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority);
+        var accountRecoveryPair = pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
+
         return switch (auditableEvent) {
             case AUTH_MFA_METHOD_ADD_COMPLETED,
                     AUTH_UPDATE_PHONE_NUMBER,
                     AUTH_MFA_METHOD_ADD_FAILED -> new AuditService.MetadataPair[] {
-                pair(
-                        AUDIT_EVENT_EXTENSIONS_MFA_TYPE,
-                        createRequest.mfaMethod().method().mfaMethodType().name()),
-                pair(
-                        AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                        PriorityIdentifier.BACKUP.name().toLowerCase()),
+                mfaTypePair, mfaMethodPair
             };
+            case AUTH_CODE_VERIFIED -> {
+                if (createRequest.mfaMethod().method() instanceof RequestSmsMfaDetail smsDetail) {
+                    yield new AuditService.MetadataPair[] {
+                        mfaTypePair,
+                        mfaMethodPair,
+                        accountRecoveryPair,
+                        pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, smsDetail.otp()),
+                        pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name())
+                    };
+                } else {
+                    yield new AuditService.MetadataPair[] {
+                        mfaTypePair, mfaMethodPair, accountRecoveryPair
+                    };
+                }
+            }
             default -> new AuditService.MetadataPair[] {};
         };
     }
@@ -402,10 +419,11 @@ public class MFAMethodsCreateHandler
         // metadata on context
         if (auditEvent.equals(AUTH_MFA_METHOD_ADD_COMPLETED)
                 || auditEvent.equals(AUTH_UPDATE_PHONE_NUMBER)
-                || auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)) {
+                || auditEvent.equals(AUTH_MFA_METHOD_ADD_FAILED)
+                || auditEvent.equals(AUTH_CODE_VERIFIED)) {
             if (mfaMethodCreateRequest.mfaMethod().method()
                     instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-                return enrichWithSmsDetails(baseAuditContext, auditEvent, requestSmsMfaDetail);
+                return enrichWithSmsDetails(baseAuditContext, requestSmsMfaDetail);
             } else {
                 return baseAuditContext;
             }
@@ -415,27 +433,19 @@ public class MFAMethodsCreateHandler
 
         var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaType);
         var mfaMethodPair = pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, mfaPriority);
-        var accountRecoveryPair = pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, "false");
 
         var context =
                 baseAuditContext.withMetadataItem(mfaTypePair).withMetadataItem(mfaMethodPair);
 
-        if (auditEvent.equals(AUTH_CODE_VERIFIED)) {
-            context = context.withMetadataItem(accountRecoveryPair);
-        }
-
         if (mfaMethodCreateRequest.mfaMethod().method()
                 instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            context = enrichWithSmsDetails(context, auditEvent, requestSmsMfaDetail);
+            context = enrichWithSmsDetails(context, requestSmsMfaDetail);
         }
 
         return context;
     }
 
-    private AuditContext enrichWithSmsDetails(
-            AuditContext context,
-            AccountManagementAuditableEvent auditEvent,
-            RequestSmsMfaDetail smsDetail) {
+    private AuditContext enrichWithSmsDetails(AuditContext context, RequestSmsMfaDetail smsDetail) {
         String formattedPhoneNumber;
         try {
             formattedPhoneNumber = PhoneNumberHelper.formatPhoneNumber(smsDetail.phoneNumber());
@@ -444,20 +454,7 @@ public class MFAMethodsCreateHandler
             formattedPhoneNumber = smsDetail.phoneNumber();
         }
 
-        var updatedContext = context.withPhoneNumber(formattedPhoneNumber);
-
-        // Note: we do not need to explicitly add the phone number country code metadata pair as
-        // this is handled already by the audit service
-
-        if (auditEvent.equals(AUTH_CODE_VERIFIED) && smsDetail.otp() != null) {
-            return updatedContext
-                    .withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, smsDetail.otp()))
-                    .withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, MFA_SMS.name()));
-        }
-
-        return updatedContext;
+        return context.withPhoneNumber(formattedPhoneNumber);
     }
 
     private Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -176,7 +176,7 @@ public class MFAMethodsCreateHandler
     }
 
     private Result<ErrorResponse, MfaMethodCreateRequest> validateRequest(
-            APIGatewayProxyRequestEvent input, UserProfile userProfile) {
+            APIGatewayProxyRequestEvent input, UserProfile userProfile, AuditContext auditContext) {
         MfaMethodCreateRequest mfaMethodCreateRequest = null;
 
         try {
@@ -204,10 +204,7 @@ public class MFAMethodsCreateHandler
             if (invalidPhoneNumber.isPresent()) {
                 var auditEventStatus =
                         sendAuditEvent(
-                                AUTH_MFA_METHOD_ADD_FAILED,
-                                input,
-                                userProfile,
-                                mfaMethodCreateRequest);
+                                AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
                 if (auditEventStatus.isFailure()) {
                     LOG.error(auditEventStatus.getFailure());
                 }
@@ -223,7 +220,7 @@ public class MFAMethodsCreateHandler
                 LOG.info("Invalid OTP presented.");
                 var auditEventStatus =
                         sendAuditEvent(
-                                AUTH_INVALID_CODE_SENT, input, userProfile, mfaMethodCreateRequest);
+                                AUTH_INVALID_CODE_SENT, auditContext, mfaMethodCreateRequest);
                 if (auditEventStatus.isFailure()) {
                     LOG.error(auditEventStatus.getFailure());
                 }
@@ -249,7 +246,19 @@ public class MFAMethodsCreateHandler
 
         var userProfile = maybePassedGuardConditions.getSuccess();
 
-        var maybeValidRequest = validateRequest(input, userProfile);
+        var auditContextResult =
+                accountManagementAuditContext(
+                        configurationService, dynamoService, input, userProfile);
+        if (auditContextResult.isFailure()) {
+            LOG.error(
+                    "Error when building audit context for with error code {}. No events raised",
+                    auditContextResult.getFailure());
+            return generateApiGatewayProxyErrorResponse(
+                    500, ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
+        }
+        var auditContext = auditContextResult.getSuccess();
+
+        var maybeValidRequest = validateRequest(input, userProfile, auditContext);
 
         if (maybeValidRequest.isFailure()) {
             return generateApiGatewayProxyErrorResponse(400, maybeValidRequest.getFailure());
@@ -258,7 +267,7 @@ public class MFAMethodsCreateHandler
         MfaMethodCreateRequest mfaMethodCreateRequest = maybeValidRequest.getSuccess();
 
         var auditEventStatus =
-                sendAuditEvent(AUTH_CODE_VERIFIED, input, userProfile, mfaMethodCreateRequest);
+                sendAuditEvent(AUTH_CODE_VERIFIED, auditContext, mfaMethodCreateRequest);
         if (auditEventStatus.isFailure()) {
             LOG.error(auditEventStatus.getFailure());
             return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
@@ -279,7 +288,7 @@ public class MFAMethodsCreateHandler
         if (addBackupMfaResult.isFailure()) {
             auditEventStatus =
                     sendAuditEvent(
-                            AUTH_MFA_METHOD_ADD_FAILED, input, userProfile, mfaMethodCreateRequest);
+                            AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
             if (auditEventStatus.isFailure()) {
                 LOG.error(auditEventStatus.getFailure());
                 return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
@@ -294,7 +303,7 @@ public class MFAMethodsCreateHandler
             LOG.error(backupMfaMethodAsResponse.getFailure());
             auditEventStatus =
                     sendAuditEvent(
-                            AUTH_MFA_METHOD_ADD_FAILED, input, userProfile, mfaMethodCreateRequest);
+                            AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
             if (auditEventStatus.isFailure()) {
                 LOG.error(auditEventStatus.getFailure());
                 return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
@@ -303,8 +312,7 @@ public class MFAMethodsCreateHandler
         }
 
         var addCompletedResult =
-                sendAuditEvent(
-                        AUTH_MFA_METHOD_ADD_COMPLETED, input, userProfile, mfaMethodCreateRequest);
+                sendAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext, mfaMethodCreateRequest);
 
         if (addCompletedResult.isFailure()) {
             LOG.error(addCompletedResult.getFailure());
@@ -318,8 +326,7 @@ public class MFAMethodsCreateHandler
 
         if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
             var updatePhoneNumberResult =
-                    sendAuditEvent(
-                            AUTH_UPDATE_PHONE_NUMBER, input, userProfile, mfaMethodCreateRequest);
+                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, auditContext, mfaMethodCreateRequest);
 
             if (updatePhoneNumberResult.isFailure()) {
                 LOG.error(updatePhoneNumberResult.getFailure());
@@ -438,23 +445,10 @@ public class MFAMethodsCreateHandler
 
     private Result<ErrorResponse, Void> sendAuditEvent(
             AccountManagementAuditableEvent auditEvent,
-            APIGatewayProxyRequestEvent input,
-            UserProfile userProfile,
+            AuditContext auditContext,
             MfaMethodCreateRequest mfaMethodCreateRequest) {
-        var auditContextResult =
-                accountManagementAuditContext(
-                        configurationService, dynamoService, input, userProfile);
-        if (auditContextResult.isFailure()) {
-            LOG.error(
-                    "Error when building audit context for {} audit event with error code {}. No event raised",
-                    auditEvent,
-                    auditContextResult.getFailure());
-            return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
-        }
-
-        var baseAuditContext = auditContextResult.getSuccess();
         var enrichedAuditContext =
-                addPhoneNumberToAuditContext(mfaMethodCreateRequest, baseAuditContext);
+                addPhoneNumberToAuditContext(mfaMethodCreateRequest, auditContext);
         var metadataPairs = metadataPairsForEvent(auditEvent, mfaMethodCreateRequest);
         return AuditHelper.sendAuditEvent(
                         auditEvent, enrichedAuditContext, auditService, LOG, metadataPairs)

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -30,7 +30,8 @@ import java.util.Map;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_DELETE_COMPLETED;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContextWithJourneyType;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -152,10 +153,12 @@ public class MFAMethodsDeleteHandler
             };
         }
 
+        var deletedMfaMethod = deleteResult.getSuccess();
+
         LOG.info("MFA method deleted {}", mfaIdentifier);
 
         Result<ErrorResponse, AuditContext> auditContextResult =
-                buildAuditContext(input, userProfile, deleteResult.getSuccess());
+                buildAuditContext(input, userProfile, deletedMfaMethod);
 
         if (auditContextResult.isFailure()) {
             return generateApiGatewayProxyErrorResponse(401, auditContextResult.getFailure());
@@ -164,7 +167,9 @@ public class MFAMethodsDeleteHandler
         auditService.submitAuditEvent(
                 AUTH_MFA_METHOD_DELETE_COMPLETED,
                 auditContextResult.getSuccess(),
-                AUDIT_EVENT_COMPONENT_ID_HOME);
+                AUDIT_EVENT_COMPONENT_ID_HOME,
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
+                pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, deletedMfaMethod.getMfaMethodType()));
 
         LOG.info("Audit event emitted.");
 
@@ -198,13 +203,9 @@ public class MFAMethodsDeleteHandler
                 mfaMethod.getMfaMethodType().equals(MFAMethodType.SMS.name())
                         ? mfaMethod.getDestination()
                         : AuditService.UNKNOWN;
-        var mfaTypePair = pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.getMfaMethodType());
-        return accountManagementAuditContextWithJourneyType(
+
+        return accountManagementAuditContext(
                         configurationService, dynamoService, input, userProfile)
-                .map(
-                        baseContext ->
-                                baseContext
-                                        .withPhoneNumber(phoneNumber)
-                                        .withMetadataItem(mfaTypePair));
+                .map(baseContext -> baseContext.withPhoneNumber(phoneNumber));
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
@@ -7,14 +7,11 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
-import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
@@ -24,11 +21,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_HAD_PARTIAL;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MIGRATION_SUCCEEDED;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueOrElse;
@@ -113,21 +109,13 @@ public class MfaMethodsMigrationService {
                         .withPhoneNumber(userProfile.getPhoneNumber())
                         .withTxmaAuditEncoded(AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
 
-        auditContext =
-                auditContext.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_HAD_PARTIAL, hadPartial));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.mfaMethodType()));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.ACCOUNT_MANAGEMENT));
-        auditContext =
-                auditContext.withMetadataItem(
-                        pair(AUDIT_EVENT_EXTENSIONS_MIGRATION_SUCCEEDED, migrationSucceeded));
-
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
                 auditContext,
-                AUDIT_EVENT_COMPONENT_ID_HOME);
+                AUDIT_EVENT_COMPONENT_ID_HOME,
+                pair(AUDIT_EVENT_EXTENSIONS_HAD_PARTIAL, hadPartial),
+                pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, mfaMethod.mfaMethodType()),
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
+                pair(AUDIT_EVENT_EXTENSIONS_MIGRATION_SUCCEEDED, migrationSucceeded));
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
@@ -113,15 +113,6 @@ public class MfaMethodsMigrationService {
                         .withPhoneNumber(userProfile.getPhoneNumber())
                         .withTxmaAuditEncoded(AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
 
-        if (mfaMethod instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE,
-                                    PhoneNumberHelper.getCountry(
-                                            requestSmsMfaDetail.phoneNumber())));
-        }
-
         auditContext =
                 auditContext.withMetadataItem(pair(AUDIT_EVENT_EXTENSIONS_HAD_PARTIAL, hadPartial));
         auditContext =

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
@@ -98,7 +98,7 @@ class AuditHelperTest {
             when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
 
             Result<ErrorResponse, AuditContext> result =
-                    AuditHelper.accountManagementAuditContextWithJourneyType(
+                    AuditHelper.accountManagementAuditContext(
                             configurationService, dynamoService, input, userProfile);
 
             assertTrue(result.isSuccess());
@@ -120,7 +120,7 @@ class AuditHelperTest {
             input = new APIGatewayProxyRequestEvent();
 
             Result<ErrorResponse, AuditContext> result =
-                    AuditHelper.accountManagementAuditContextWithJourneyType(
+                    AuditHelper.accountManagementAuditContext(
                             configurationService, dynamoService, input, userProfile);
 
             assertTrue(result.isFailure());

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -133,8 +133,7 @@ class MFAMethodsCreateHandlerTest {
                     .withSubjectId(TEST_INTERNAL_SUBJECT)
                     .withIpAddress(IP_ADDRESS)
                     .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
-                    .withPersistentSessionId(PERSISTENT_ID)
-                    .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()));
+                    .withPersistentSessionId(PERSISTENT_ID);
 
     private MFAMethodsCreateHandler handler;
 
@@ -288,6 +287,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_CODE_VERIFIED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()),
                             pair("account-recovery", "false"),
@@ -299,6 +299,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_COMPLETED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
 
@@ -307,6 +308,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_UPDATE_PHONE_NUMBER,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -385,6 +387,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_CODE_VERIFIED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(null),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", AUTH_APP.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()),
                             pair("account-recovery", "false"));
@@ -394,6 +397,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_COMPLETED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(null),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", AUTH_APP.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -455,6 +459,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_CODE_VERIFIED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()),
                             pair("account-recovery", "false"),
@@ -543,6 +548,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(INTERNATIONAL_MOBILE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -643,6 +649,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -672,6 +679,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber("not a real phone number"),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -697,6 +705,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(invalidPhoneNumber),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
 
@@ -731,6 +740,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_INVALID_CODE_SENT,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
 
@@ -759,6 +769,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", requestDetail.mfaMethodType().toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -785,6 +796,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(null),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", AUTH_APP.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }
@@ -815,6 +827,7 @@ class MFAMethodsCreateHandlerTest {
                             AUTH_MFA_METHOD_ADD_FAILED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(null),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", AUTH_APP.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -298,17 +298,13 @@ class MFAMethodsCreateHandlerTest {
                             expectedAuthCodeVerifiedAuditContext,
                             AUDIT_EVENT_COMPONENT_ID_HOME);
 
-            var expectedAuthMfaMethodAddCompleteContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_COMPLETED,
-                            expectedAuthMfaMethodAddCompleteContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.name()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
 
             var expectedUpdatedPhoneNumberContext =
                     BASE_AUDIT_CONTEXT
@@ -401,17 +397,13 @@ class MFAMethodsCreateHandlerTest {
                             expectedAuthCodeVerifiedAuditContext,
                             AUDIT_EVENT_COMPONENT_ID_HOME);
 
-            var expectedAddCompletedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_COMPLETED,
-                            expectedAddCompletedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", AUTH_APP.name()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -726,17 +726,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_OTP));
 
-            var expectedInvalidCodeSentAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_INVALID_CODE_SENT,
-                            expectedInvalidCodeSentAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verifyNoInteractions(sqsClient);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -283,20 +283,16 @@ class MFAMethodsCreateHandlerTest {
                     JsonParser.parseString(expectedResponse).getAsJsonObject().toString();
             assertEquals(expectedResponseParsedToString, result.getBody());
 
-            var expectedAuthCodeVerifiedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
-                            .withMetadataItem(pair("notification-type", MFA_SMS.name()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_CODE_VERIFIED,
-                            expectedAuthCodeVerifiedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.name()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()),
+                            pair("account-recovery", "false"),
+                            pair("MFACodeEntered", TEST_OTP),
+                            pair("notification-type", MFA_SMS.name()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -384,18 +380,14 @@ class MFAMethodsCreateHandlerTest {
                             any(),
                             any(AuditService.MetadataPair[].class));
 
-            var expectedAuthCodeVerifiedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("account-recovery", "false"));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_CODE_VERIFIED,
-                            expectedAuthCodeVerifiedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", AUTH_APP.name()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()),
+                            pair("account-recovery", "false"));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -458,20 +450,16 @@ class MFAMethodsCreateHandlerTest {
 
             handler.handleRequest(event, context);
 
-            var expectedAuthCodeVerifiedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()))
-                            .withMetadataItem(pair("account-recovery", "false"))
-                            .withMetadataItem(pair("MFACodeEntered", TEST_OTP))
-                            .withMetadataItem(pair("notification-type", MFA_SMS.name()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_CODE_VERIFIED,
-                            expectedAuthCodeVerifiedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.name()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()),
+                            pair("account-recovery", "false"),
+                            pair("MFACodeEntered", TEST_OTP),
+                            pair("notification-type", MFA_SMS.name()));
         }
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -550,16 +550,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INTERNATIONAL_PHONE_NUMBER_NOT_SUPPORTED));
             verifyNoInteractions(sqsClient);
-            var expectedContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(INTERNATIONAL_MOBILE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(INTERNATIONAL_MOBILE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test
@@ -653,17 +650,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.MFA_METHOD_COUNT_LIMIT_REACHED));
 
-            var expectedMfaMethodAddFailedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedMfaMethodAddFailedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test
@@ -686,17 +679,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_NUMBER));
 
-            var expectedMfaMethodAddFailedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber("not a real phone number")
-                            .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedMfaMethodAddFailedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber("not a real phone number"),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test
@@ -715,17 +704,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PHONE_NUMBER));
 
-            var expectedMfaMethodAddFailedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(invalidPhoneNumber)
-                            .withMetadataItem(pair("mfa-type", SMS.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedMfaMethodAddFailedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(invalidPhoneNumber),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(mfaMethodsService, org.mockito.Mockito.never()).addBackupMfa(any(), any());
         }
@@ -785,18 +770,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.SMS_MFA_WITH_NUMBER_EXISTS));
 
-            var expectedMfaMethodAddFailedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(
-                                    pair("mfa-type", requestDetail.mfaMethodType().toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedMfaMethodAddFailedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", requestDetail.mfaMethodType().toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test
@@ -816,17 +796,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.AUTH_APP_EXISTS));
 
-            var expectedMfaMethodAddFailedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedMfaMethodAddFailedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", AUTH_APP.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test
@@ -850,17 +826,13 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasJsonBody(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR));
             verifyNoInteractions(sqsClient);
 
-            var expectedMfaMethodAddFailedAuditContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(null)
-                            .withMetadataItem(pair("mfa-type", AUTH_APP.toString()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED,
-                            expectedMfaMethodAddFailedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", AUTH_APP.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -306,17 +306,13 @@ class MFAMethodsCreateHandlerTest {
                             pair("mfa-type", SMS.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
 
-            var expectedUpdatedPhoneNumberContext =
-                    BASE_AUDIT_CONTEXT
-                            .withPhoneNumber(TEST_E164_PHONE_NUMBER)
-                            .withMetadataItem(pair("mfa-type", SMS.name()))
-                            .withMetadataItem(pair("mfa-method", BACKUP.name().toLowerCase()));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_UPDATE_PHONE_NUMBER,
-                            expectedUpdatedPhoneNumberContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("mfa-type", SMS.name()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test
@@ -382,7 +378,11 @@ class MFAMethodsCreateHandlerTest {
                                             LocaleHelper.SupportedLanguage.EN)));
 
             verify(auditService, never())
-                    .submitAuditEvent(eq(AUTH_UPDATE_PHONE_NUMBER), any(), any());
+                    .submitAuditEvent(
+                            eq(AUTH_UPDATE_PHONE_NUMBER),
+                            any(),
+                            any(),
+                            any(AuditService.MetadataPair[].class));
 
             var expectedAuthCodeVerifiedAuditContext =
                     BASE_AUDIT_CONTEXT

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
@@ -139,15 +139,15 @@ class MFAMethodsDeleteHandlerTest {
                             .withSubjectId(TEST_INTERNAL_SUBJECT)
                             .withIpAddress(IP_ADDRESS)
                             .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
-                            .withPersistentSessionId(PERSISTENT_ID)
-                            .withMetadataItem(pair("journey-type", ACCOUNT_MANAGEMENT.getValue()))
-                            .withMetadataItem(pair("mfa-type", SMS.getValue(), false));
+                            .withPersistentSessionId(PERSISTENT_ID);
 
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_DELETE_COMPLETED,
                             expectedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
+                            pair("mfa-type", SMS.getValue()));
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
@@ -237,21 +237,15 @@ class MfaMethodsMigrationServiceTest {
             service.migrateMfaCredentialsForUserIfRequired(userProfile, logger, input, mfaDetail);
 
             // Then
-            var expectedAuditContext =
-                    BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber());
-
-            expectedAuditContext =
-                    expectedAuditContext
-                            .withMetadataItem(pair("had-partial", true))
-                            .withMetadataItem(pair("mfa-type", expectedMfaMethodType))
-                            .withMetadataItem(pair("journey-type", JourneyType.ACCOUNT_MANAGEMENT))
-                            .withMetadataItem(pair("migration-succeeded", true));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
-                            expectedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber()),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("had-partial", true),
+                            pair("mfa-type", expectedMfaMethodType),
+                            pair("journey-type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
+                            pair("migration-succeeded", true));
         }
 
         @ParameterizedTest
@@ -268,21 +262,15 @@ class MfaMethodsMigrationServiceTest {
             service.migrateMfaCredentialsForUserIfRequired(userProfile, logger, input, mfaDetail);
 
             // Then
-            var expectedAuditContext =
-                    BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber());
-
-            expectedAuditContext =
-                    expectedAuditContext
-                            .withMetadataItem(pair("had-partial", false))
-                            .withMetadataItem(pair("mfa-type", expectedMfaMethodType))
-                            .withMetadataItem(pair("journey-type", JourneyType.ACCOUNT_MANAGEMENT))
-                            .withMetadataItem(pair("migration-succeeded", false));
-
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
-                            expectedAuditContext,
-                            AUDIT_EVENT_COMPONENT_ID_HOME);
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber()),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("had-partial", false),
+                            pair("mfa-type", expectedMfaMethodType),
+                            pair("journey-type", JourneyType.ACCOUNT_MANAGEMENT.getValue()),
+                            pair("migration-succeeded", false));
         }
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
@@ -240,12 +240,6 @@ class MfaMethodsMigrationServiceTest {
             var expectedAuditContext =
                     BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber());
 
-            if (expectedMfaMethodType.equals(MFAMethodType.SMS)) {
-                expectedAuditContext =
-                        expectedAuditContext.withMetadataItem(
-                                pair("phone_number_country_code", "44"));
-            }
-
             expectedAuditContext =
                     expectedAuditContext
                             .withMetadataItem(pair("had-partial", true))
@@ -276,12 +270,6 @@ class MfaMethodsMigrationServiceTest {
             // Then
             var expectedAuditContext =
                     BASE_AUDIT_CONTEXT.withPhoneNumber(userProfile.getPhoneNumber());
-
-            if (expectedMfaMethodType.equals(MFAMethodType.SMS)) {
-                expectedAuditContext =
-                        expectedAuditContext.withMetadataItem(
-                                pair("phone_number_country_code", "44"));
-            }
 
             expectedAuditContext =
                     expectedAuditContext


### PR DESCRIPTION
## What

Switches all events emitted in the mfa methods delete and create handlers, as well as the mfa methods migration service, to pass metadata items in as varargs rather than setting them on the audit context.

This is a step towards removing the metadata items entirely from the audit context - currently it is confusing as they can be set in either place, but the audit context is supposed to contain only data that is common to all events emitted by a handler (and can just be created once per handler) rather than any event-specific metadata.

## Related PRs

A similar thing was done for another handler in [this PR](https://github.com/govuk-one-login/authentication-api/pull/8404)