### PR TITLE
BAU: config service for account data api

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountdata.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.accountdata.extensions.AuthenticatorExtension;
 import uk.gov.di.authentication.accountdata.lambda.PasskeysCreateHandler;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,7 +31,7 @@ import static uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper.bu
 
 class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private final ConfigurationService configurationService = ConfigurationService.getInstance();
+    private final ConfigurationService configurationService = new ConfigurationService();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
             Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-create");

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysDeleteHandlerIntegrationTest.java
@@ -8,8 +8,8 @@ import uk.gov.di.accountdata.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.accountdata.extensions.AuthenticatorExtension;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.lambda.PasskeysDeleteHandler;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,7 +26,7 @@ import static uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper.bu
 
 class PasskeysDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private final ConfigurationService configurationService = ConfigurationService.getInstance();
+    private final ConfigurationService configurationService = new ConfigurationService();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
             Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-delete");

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysRetrieveHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysRetrieveHandlerIntegrationTest.java
@@ -10,9 +10,9 @@ import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper;
 import uk.gov.di.authentication.accountdata.lambda.PasskeysRetrieveHandler;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ import static uk.gov.di.authentication.accountdata.helpers.CommonTestVariables.S
 
 class PasskeysRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private final ConfigurationService configurationService = ConfigurationService.getInstance();
+    private final ConfigurationService configurationService = new ConfigurationService();
     DynamoPasskeyService dynamoPasskeyService = new DynamoPasskeyService(configurationService);
     private static final Map<String, Object> AUTHORIZER_PARAMS =
             Map.of("principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-retrieve");

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysUpdateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysUpdateHandlerIntegrationTest.java
@@ -8,8 +8,8 @@ import uk.gov.di.accountdata.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.accountdata.extensions.AuthenticatorExtension;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.lambda.PasskeysUpdateHandler;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -28,7 +28,7 @@ import static uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper.bu
 class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     DynamoPasskeyService dynamoPasskeyService =
-            new DynamoPasskeyService(ConfigurationService.getInstance());
+            new DynamoPasskeyService(new ConfigurationService());
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =
@@ -46,7 +46,7 @@ class PasskeysUpdateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     @BeforeEach
     void setUp() {
-        handler = new PasskeysUpdateHandler(ConfigurationService.getInstance());
+        handler = new PasskeysUpdateHandler(new ConfigurationService());
         dynamoPasskeyService.savePasskeyIfUnique(EXISTING_PASSKEY);
     }
 

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
@@ -8,9 +8,9 @@ import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.helpers.CommonTestVariables;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.LocalDateTime;
 
@@ -33,7 +33,7 @@ import static uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper.bu
 class DynamoPasskeyServiceIntegrationTest {
 
     DynamoPasskeyService dynamoPasskeyService =
-            new DynamoPasskeyService(ConfigurationService.getInstance());
+            new DynamoPasskeyService(new ConfigurationService());
 
     @RegisterExtension
     protected static final AuthenticatorExtension authenticatorExtension =

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandler.java
@@ -18,10 +18,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.MalformedURLException;
 import java.util.Date;
@@ -37,7 +37,7 @@ public class AuthorizeHandler
     private RemoteJwksService jwksService;
 
     public AuthorizeHandler() {
-        this(ConfigurationService.getInstance());
+        this(new ConfigurationService());
     }
 
     public AuthorizeHandler(ConfigurationService configurationService) {
@@ -51,7 +51,7 @@ public class AuthorizeHandler
     }
 
     public AuthorizeHandler(RemoteJwksService jwksService) {
-        this.configurationService = ConfigurationService.getInstance();
+        this.configurationService = new ConfigurationService();
         this.jwksService = jwksService;
     }
 

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandler.java
@@ -9,12 +9,12 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysCreateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import static uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason.INVALID_AAGUID;
@@ -37,7 +37,7 @@ public class PasskeysCreateHandler
     private final Json objectMapper = SerializationService.getInstance();
 
     public PasskeysCreateHandler() {
-        this(ConfigurationService.getInstance());
+        this(new ConfigurationService());
     }
 
     public PasskeysCreateHandler(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysDeleteHandler.java
@@ -8,11 +8,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Objects;
 
@@ -29,7 +29,7 @@ public class PasskeysDeleteHandler
     private final PasskeysService passkeysService;
 
     public PasskeysDeleteHandler() {
-        this(ConfigurationService.getInstance());
+        this(new ConfigurationService());
     }
 
     public PasskeysDeleteHandler(ConfigurationService configurationService) {

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandler.java
@@ -10,12 +10,12 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
 
@@ -34,7 +34,7 @@ public class PasskeysRetrieveHandler
     private final PasskeysService passkeysService;
 
     public PasskeysRetrieveHandler() {
-        this(ConfigurationService.getInstance());
+        this(new ConfigurationService());
     }
 
     public PasskeysRetrieveHandler(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandler.java
@@ -9,12 +9,12 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysUpdateRequest;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.time.DateTimeException;
@@ -36,7 +36,7 @@ public class PasskeysUpdateHandler
     private final PasskeysService passkeysService;
 
     public PasskeysUpdateHandler() {
-        this(ConfigurationService.getInstance());
+        this(new ConfigurationService());
     }
 
     public PasskeysUpdateHandler(

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/BaseDynamoService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/BaseDynamoService.java
@@ -1,0 +1,125 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+public class BaseDynamoService<T> {
+
+    protected final DynamoDbTable<T> dynamoTable;
+
+    public BaseDynamoService(
+            Class<T> objectClass, String table, ConfigurationService configurationService) {
+        var tableName = getFullTableName(table, configurationService);
+        DynamoDbClient client = createDynamoClient(configurationService);
+        var enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
+        dynamoTable = enhancedClient.table(tableName, TableSchema.fromBean(objectClass));
+
+        warmUp(dynamoTable);
+    }
+
+    public static DynamoDbClient createDynamoClient(ConfigurationService configurationService) {
+        var dynamoDbClientBuilder =
+                DynamoDbClient.builder()
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                        .region(Region.of(configurationService.getAwsRegion()));
+        configurationService
+                .getDynamoEndpointUri()
+                .ifPresent(
+                        endpoint -> dynamoDbClientBuilder.endpointOverride(URI.create(endpoint)));
+        return dynamoDbClientBuilder.build();
+    }
+
+    public static void warmUp(DynamoDbTable<?> table) {
+        try {
+            table.describeTable();
+        } catch (ResourceNotFoundException e) {
+            if ("local".equals(System.getenv("ENVIRONMENT"))) {
+                table.createTable();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private static String getFullTableName(
+            String tableName, ConfigurationService configurationService) {
+        Optional<String> authDynamoArnPrefix = configurationService.getDynamoArnPrefix();
+        if (authDynamoArnPrefix.isPresent()) {
+            return authDynamoArnPrefix.get()
+                    + configurationService.getEnvironment()
+                    + "-"
+                    + tableName;
+        }
+        return configurationService.getEnvironment() + "-" + tableName;
+    }
+
+    public void update(T item) {
+        dynamoTable.updateItem(item);
+    }
+
+    public boolean putIfUnique(T item, String key) {
+        try {
+            dynamoTable.putItem(
+                    builder ->
+                            builder.item(item)
+                                    .conditionExpression(
+                                            Expression.builder()
+                                                    .expression("attribute_not_exists(#key)")
+                                                    .putExpressionName("#key", key)
+                                                    .build()));
+            return true;
+        } catch (ConditionalCheckFailedException e) {
+            return false;
+        }
+    }
+
+    public Optional<T> get(String partition) {
+
+        return Optional.ofNullable(
+                dynamoTable.getItem(Key.builder().partitionValue(partition).build()));
+    }
+
+    public Optional<T> get(String partition, String sortKey) {
+        return Optional.ofNullable(
+                dynamoTable.getItem(
+                        Key.builder().partitionValue(partition).sortValue(sortKey).build()));
+    }
+
+    public Optional<T> get(GetItemEnhancedRequest getItemEnhancedRequest) {
+        return Optional.ofNullable(dynamoTable.getItem(getItemEnhancedRequest));
+    }
+
+    public List<T> getAllByPrefix(String partition, String sortKeyPrefix) {
+        QueryConditional queryConditional =
+                QueryConditional.sortBeginsWith(
+                        Key.builder().partitionValue(partition).sortValue(sortKeyPrefix).build());
+        return dynamoTable
+                .query(
+                        QueryEnhancedRequest.builder()
+                                .consistentRead(true)
+                                .queryConditional(queryConditional)
+                                .build())
+                .items()
+                .stream()
+                .toList();
+    }
+
+    public void delete(T item) {
+        dynamoTable.deleteItem(item);
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+
+public class ConfigurationService {
+    private static final Logger LOG =
+            LogManager.getLogger(
+                    uk.gov.di.authentication.shared.services.ConfigurationService.class);
+
+    public String getAwsRegion() {
+        return System.getenv("AWS_REGION");
+    }
+
+    public String getEnvironment() {
+        return System.getenv().getOrDefault("ENVIRONMENT", "test");
+    }
+
+    public Optional<String> getDynamoArnPrefix() {
+        return Optional.ofNullable(System.getenv("DYNAMO_ARN_PREFIX"));
+    }
+
+    public Optional<String> getDynamoEndpointUri() {
+        return Optional.ofNullable(System.getenv("DYNAMO_ENDPOINT"));
+    }
+
+    public URL getAccountDataJwksUrl() throws MalformedURLException {
+        try {
+            return new URL(System.getenv().get("ACCOUNT_DATA_JWKS_URL"));
+        } catch (MalformedURLException e) {
+            LOG.error("Invalid JWKS URL: {}", e.getMessage());
+            throw new MalformedURLException(e.getMessage());
+        }
+    }
+
+    public String getAuthIssuerClaim() {
+        return System.getenv().getOrDefault("AUTH_ISSUER_CLAIM", "");
+    }
+
+    public String getAMCClientId() {
+        return System.getenv().getOrDefault("AMC_CLIENT_ID", "");
+    }
+
+    public String getHomeClientId() {
+        return System.getenv().getOrDefault("HOME_CLIENT_ID", "");
+    }
+
+    public String getAuthToAccountDataApiAudience() {
+        return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "");
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/DynamoPasskeyService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/DynamoPasskeyService.java
@@ -7,8 +7,6 @@ import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.Passke
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysDeleteFailureReason;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.BaseDynamoService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
 import java.util.Optional;

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.Passke
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AuthorizeHandlerTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.accountdata.entity.AuthorizeException;
 import uk.gov.di.authentication.accountdata.entity.UnauthorizedException;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.RemoteJwksService;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.MalformedURLException;
 import java.time.Instant;

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysCreateFailureReason;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysRetrieveHandlerTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.accountdata.entity.passkey.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysRetrieveFailureReasons;
 import uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
 import java.util.Map;

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.accountdata.entity.passkey.Passkey;
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.accountdata.services.PasskeysService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/ConfigurationServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/ConfigurationServiceTest.java
@@ -1,0 +1,59 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConfigurationServiceTest {
+
+    private static final ConfigurationService configurationService = new ConfigurationService();
+
+    @Test
+    void getAwsRegionShouldNotDefault() {
+        assertEquals(null, configurationService.getAwsRegion());
+    }
+
+    @Test
+    void getEnvironmentShouldDefaultToTest() {
+        assertEquals("test", configurationService.getEnvironment());
+    }
+
+    @Test
+    void getDynamoArnPrefixShouldReturnEmptyOptionalByDefault() {
+        assertFalse(configurationService.getDynamoArnPrefix().isPresent());
+    }
+
+    @Test
+    void getDynamoEndpointUriShouldReturnEmptyOptionalByDefault() {
+        assertFalse(configurationService.getDynamoEndpointUri().isPresent());
+    }
+
+    @Test
+    void getAccountDataJwksUrlShouldThrowMalformedUrlExceptionWhenUrlIsNull() {
+        assertThrows(MalformedURLException.class, configurationService::getAccountDataJwksUrl);
+    }
+
+    @Test
+    void getAuthIssuerClaimShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getAuthIssuerClaim());
+    }
+
+    @Test
+    void getAMCClientIdShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getAMCClientId());
+    }
+
+    @Test
+    void getHomeClientIdShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getHomeClientId());
+    }
+
+    @Test
+    void getAuthToAccountDataApiAudienceShouldDefaultToEmptyString() {
+        assertEquals("", configurationService.getAuthToAccountDataApiAudience());
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/PasskeysServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/PasskeysServiceTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.Passke
 import uk.gov.di.authentication.accountdata.helpers.CommonTestVariables;
 import uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -359,11 +359,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
         }
 
         @Override
-        public String getTokenSigningKeyAlias() {
-            return tokenSigningKey.getKeyAlias();
-        }
-
-        @Override
         public String getFrontendBaseUrl() {
             return "http://localhost:3000/reset-password?code=";
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -2,21 +2,16 @@ package uk.gov.di.authentication.shared.services;
 
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
-import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 
-import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
@@ -50,22 +45,6 @@ public class BaseDynamoService<T> {
         dynamoTable.putItem(item);
     }
 
-    public boolean putIfUnique(T item, String key) {
-        try {
-            dynamoTable.putItem(
-                    builder ->
-                            builder.item(item)
-                                    .conditionExpression(
-                                            Expression.builder()
-                                                    .expression("attribute_not_exists(#key)")
-                                                    .putExpressionName("#key", key)
-                                                    .build()));
-            return true;
-        } catch (ConditionalCheckFailedException e) {
-            return false;
-        }
-    }
-
     public Optional<T> get(String partition) {
 
         return Optional.ofNullable(
@@ -80,21 +59,6 @@ public class BaseDynamoService<T> {
 
     public Optional<T> get(GetItemEnhancedRequest getItemEnhancedRequest) {
         return Optional.ofNullable(dynamoTable.getItem(getItemEnhancedRequest));
-    }
-
-    public List<T> getAllByPrefix(String partition, String sortKeyPrefix) {
-        QueryConditional queryConditional =
-                QueryConditional.sortBeginsWith(
-                        Key.builder().partitionValue(partition).sortValue(sortKeyPrefix).build());
-        return dynamoTable
-                .query(
-                        QueryEnhancedRequest.builder()
-                                .consistentRead(true)
-                                .queryConditional(queryConditional)
-                                .build())
-                .items()
-                .stream()
-                .toList();
     }
 
     public void delete(String partition) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -433,10 +433,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SYNTHETICS_USERS", "");
     }
 
-    public String getTokenSigningKeyAlias() {
-        return System.getenv("TOKEN_SIGNING_KEY_ALIAS");
-    }
-
     public URL getAccessTokenJwksUrl() {
         try {
             return new URL(System.getenv().getOrDefault("ACCESS_TOKEN_JWKS_URL", ""));
@@ -444,10 +440,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
             LOG.error("Invalid JWKS URL: {}", e.getMessage());
             throw new RuntimeException(e);
         }
-    }
-
-    public String getTokenSigningKeyRsaAlias() {
-        return System.getenv("TOKEN_SIGNING_KEY_RSA_ALIAS");
     }
 
     public String getTestTokenSigningKeyAlias() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -446,10 +446,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
-    public URL getAccountDataJwksUrl() throws MalformedURLException {
-        return new URL(System.getenv().getOrDefault("ACCOUNT_DATA_JWKS_URL", ""));
-    }
-
     public String getTokenSigningKeyRsaAlias() {
         return System.getenv("TOKEN_SIGNING_KEY_RSA_ALIAS");
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -437,16 +437,6 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void getTokenSigningKeyAliasShouldNotDefault() {
-        assertNull(configurationService.getTokenSigningKeyAlias());
-    }
-
-    @Test
-    void getTokenSigningKeyRsaAliasShouldNotDefault() {
-        assertNull(configurationService.getTokenSigningKeyRsaAlias());
-    }
-
-    @Test
     void isRsaSigningAvailableShouldNotDefault() {
         assertFalse(configurationService.isRsaSigningAvailable());
     }


### PR DESCRIPTION
## What

Adds a ConfigurationService for the account data api, and removes any dependency on the shared configuration service in the account data api.

This is useful as:
* a step towards fully breaking the dependency of the account data api on shared, in order to eventually move it to its own repo
* a way of simplifying the configuration service and making it clear which environment variables are used in the account data api.

## How to review



1. Code Review
