### PR TITLE
ATO-2559: Enable tokenAuthMethod defaulting in production

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -120,6 +120,7 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
       !Equals [integration, !Ref Environment],
+      !Equals [production, !Ref Environment],
     ]
 
 Mappings:


### PR DESCRIPTION
### Wider context of change

We would like to make private_key_jwt the default token auth method if it is null for a client. Previously this was done inside the token validators and was quite hard to see. This is already being done in integration and below with the use of a feature flag. We would now like to enable this in production.

### What’s changed

This PR enables the feature flag for defaulting the tokenAuthMethod in production.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

