### PR TITLE
Bau: Remove final cases of metadata pairs on audit context

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -179,12 +179,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             AuditService.UNKNOWN,
                             persistentSessionId);
 
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, journeyType));
-            auditContext =
-                    auditContext.withMetadataItem(pair("mfa-type", MFAMethodType.SMS.getValue()));
-
             CodeRequestType.SupportedCodeType supportedCodeType =
                     CodeRequestType.SupportedCodeType.getFromMfaMethodType(
                             NotificationType.MFA_SMS.getMfaMethodType());
@@ -196,9 +190,13 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                 return generateApiGatewayProxyErrorResponse(400, INVALID_NOTIFICATION_TYPE);
             }
 
+            var journeyTypePair = pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, journeyType);
+            var mfaTypePair = pair("mfa-type", MFAMethodType.SMS.getValue());
+
             if (!userContext.getAuthSession().validateSession(email)) {
                 LOG.warn("Email does not match Email in Request");
-                auditService.submitAuditEvent(AUTH_MFA_MISMATCHED_EMAIL, auditContext);
+                auditService.submitAuditEvent(
+                        AUTH_MFA_MISMATCHED_EMAIL, auditContext, journeyTypePair, mfaTypePair);
 
                 return generateApiGatewayProxyErrorResponse(400, SESSION_ID_MISSING);
             }
@@ -233,7 +231,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             retrievedMfaMethods, request.getMfaMethodId(), MFAMethodType.SMS);
 
             if (maybeRequestedSmsMfaMethod.isEmpty()) {
-                auditService.submitAuditEvent(AUTH_MFA_MISSING_PHONE_NUMBER, auditContext);
+                auditService.submitAuditEvent(
+                        AUTH_MFA_MISSING_PHONE_NUMBER, auditContext, journeyTypePair, mfaTypePair);
                 return generateApiGatewayProxyErrorResponse(400, PHONE_NUMBER_NOT_REGISTERED);
             }
 
@@ -265,7 +264,9 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             permissionContext,
                             auditContext,
                             lockoutStateHolder,
-                            false);
+                            false,
+                            journeyTypePair,
+                            mfaTypePair);
             if (maybeResponseIfNotPermitted.isPresent()) {
                 return maybeResponseIfNotPermitted.get();
             }
@@ -277,7 +278,13 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
             maybeResponseIfNotPermitted =
                     getResponseIfNotPermitted(
-                            journeyType, permissionContext, auditContext, lockoutStateHolder, true);
+                            journeyType,
+                            permissionContext,
+                            auditContext,
+                            lockoutStateHolder,
+                            true,
+                            journeyTypePair,
+                            mfaTypePair);
             if (maybeResponseIfNotPermitted.isPresent()) {
                 return maybeResponseIfNotPermitted.get();
             }
@@ -290,12 +297,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                             .getOtpCode(codeIdentifier, notificationType)
                             .orElseGet(
                                     () -> generateAndSaveNewCode(codeIdentifier, notificationType));
-
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    requestSmsMfaMethod.getPriority().toLowerCase()));
 
             AuditableEvent auditableEvent;
             if (testUserHelper.isTestJourney(userContext)) {
@@ -321,7 +322,14 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                 auditableEvent = FrontendAuditableEvent.AUTH_MFA_CODE_SENT;
             }
 
-            auditService.submitAuditEvent(auditableEvent, auditContext);
+            auditService.submitAuditEvent(
+                    auditableEvent,
+                    auditContext,
+                    journeyTypePair,
+                    mfaTypePair,
+                    pair(
+                            AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                            requestSmsMfaMethod.getPriority().toLowerCase()));
             LOG.info("Successfully processed request");
 
             return generateEmptySuccessApiGatewayResponse();
@@ -346,7 +354,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             PermissionContext permissionContext,
             AuditContext auditContext,
             InMemoryLockoutStateHolder lockoutStateHolder,
-            boolean afterActionRecorded) {
+            boolean afterActionRecorded,
+            AuditService.MetadataPair... metadataPairs) {
         var canSendSmsResult =
                 permissionDecisionManager.canSendSmsOtpNotification(
                         journeyType, permissionContext, lockoutStateHolder);
@@ -362,7 +371,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         }
         if (canSendSmsResult.getSuccess() instanceof Decision.ReauthLockedOut
                 || canSendSmsResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
-            auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
+            auditService.submitAuditEvent(
+                    AUTH_MFA_INVALID_CODE_REQUEST, auditContext, metadataPairs);
             var errorResponse =
                     afterActionRecorded ? TOO_MANY_MFA_OTPS_SENT : BLOCKED_FOR_SENDING_MFA_OTPS;
             return Optional.of(generateApiGatewayProxyErrorResponse(400, errorResponse));
@@ -383,7 +393,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR));
         }
         if (canVerifyResult.getSuccess() instanceof Decision.TemporarilyLockedOut) {
-            auditService.submitAuditEvent(AUTH_MFA_INVALID_CODE_REQUEST, auditContext);
+            auditService.submitAuditEvent(
+                    AUTH_MFA_INVALID_CODE_REQUEST, auditContext, metadataPairs);
             return Optional.of(
                     generateApiGatewayProxyErrorResponse(400, TOO_MANY_INVALID_MFA_OTPS_ENTERED));
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -509,16 +509,14 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         String emailAddress = authSession.getEmailAddress();
         String otpCodeIdentifier = emailAddress;
         MFAMethod smsMfaMethod = null;
+        List<AuditService.MetadataPair> initialMetadataPairs = List.of();
         if (notificationType.isForPhoneNumber()) {
             smsMfaMethod = maybeRequestedSmsMfaMethod.orElseThrow();
             String formattedPhoneNumber =
                     PhoneNumberHelper.formatPhoneNumber(smsMfaMethod.getDestination());
             otpCodeIdentifier = emailAddress.concat(formattedPhoneNumber);
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    smsMfaMethod.getPriority().toLowerCase()));
+            var priority = smsMfaMethod.getPriority().toLowerCase();
+            initialMetadataPairs = List.of(pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority));
         }
 
         if (notificationType.equals(MFA_SMS)) {
@@ -544,7 +542,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     authSession
                             .withVerifiedMfaMethodType(MFAMethodType.SMS)
                             .withAchievedCredentialStrength(MEDIUM_LEVEL));
-            clearAccountRecoveryBlockIfPresent(authSession, auditContext);
+            clearAccountRecoveryBlockIfPresent(
+                    authSession, auditContext, initialMetadataPairs.stream().toList());
             cloudwatchMetricsService.incrementAuthenticationSuccessWithMfa(
                     authSession.getIsNewAccount(),
                     clientId,
@@ -572,7 +571,13 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         codeStorageService.deleteOtpCode(otpCodeIdentifier, notificationType);
 
         var metadataPairArray =
-                metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, false);
+                metadataPairs(
+                        notificationType,
+                        journeyType,
+                        codeRequest,
+                        loginFailureCount,
+                        false,
+                        initialMetadataPairs);
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
     }
@@ -610,20 +615,21 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             JourneyType journeyType,
             VerifyCodeRequest codeRequest,
             Integer loginFailureCount,
-            boolean isBlockedRequest) {
-        var metadataPairs = new ArrayList<AuditService.MetadataPair>();
-        metadataPairs.add(pair("notification-type", notificationType.name()));
-        metadataPairs.add(pair("account-recovery", journeyType == JourneyType.ACCOUNT_RECOVERY));
-        metadataPairs.add(pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, String.valueOf(journeyType)));
+            boolean isBlockedRequest,
+            List<AuditService.MetadataPair> initialPairs) {
+        var pairs = new ArrayList<>(initialPairs);
+        pairs.add(pair("notification-type", notificationType.name()));
+        pairs.add(pair("account-recovery", journeyType == JourneyType.ACCOUNT_RECOVERY));
+        pairs.add(pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, String.valueOf(journeyType)));
         if (notificationType == MFA_SMS) {
-            metadataPairs.add(pair("mfa-type", MFAMethodType.SMS.getValue()));
-            metadataPairs.add(pair("loginFailureCount", loginFailureCount));
-            metadataPairs.add(pair("MFACodeEntered", codeRequest.code()));
+            pairs.add(pair("mfa-type", MFAMethodType.SMS.getValue()));
+            pairs.add(pair("loginFailureCount", loginFailureCount));
+            pairs.add(pair("MFACodeEntered", codeRequest.code()));
         }
         if (notificationType == MFA_SMS && isBlockedRequest) {
-            metadataPairs.add(pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
+            pairs.add(pair("MaxSmsCount", configurationService.getCodeMaxRetries()));
         }
-        return metadataPairs.toArray(AuditService.MetadataPair[]::new);
+        return pairs.toArray(AuditService.MetadataPair[]::new);
     }
 
     private void processBlockedCodeSession(
@@ -656,17 +662,27 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 auditableEvent = FrontendAuditableEvent.AUTH_INVALID_CODE_SENT;
                 break;
         }
-        if (maybeRequestedSmsMfaMethod.isPresent()) {
-            auditContext =
-                    auditContext.withMetadataItem(
-                            pair(
-                                    AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                    maybeRequestedSmsMfaMethod.get().getPriority().toLowerCase()));
-        }
         var loginFailureCount =
                 codeStorageService.getIncorrectMfaCodeAttemptsCount(authSession.getEmailAddress());
+        var initialMetadataPairs =
+                maybeRequestedSmsMfaMethod
+                        .map(
+                                mfaMethod -> {
+                                    var priority = mfaMethod.getPriority().toLowerCase();
+                                    return List.of(
+                                            pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, priority));
+                                })
+                        .orElseGet(List::of);
+
         var metadataPairArray =
-                metadataPairs(notificationType, journeyType, codeRequest, loginFailureCount, true);
+                metadataPairs(
+                        notificationType,
+                        journeyType,
+                        codeRequest,
+                        loginFailureCount,
+                        true,
+                        initialMetadataPairs);
+
         auditService.submitAuditEvent(auditableEvent, auditContext, metadataPairArray);
     }
 
@@ -686,7 +702,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     }
 
     private void clearAccountRecoveryBlockIfPresent(
-            AuthSessionItem authSession, AuditContext auditContext) {
+            AuthSessionItem authSession,
+            AuditContext auditContext,
+            List<AuditService.MetadataPair> initialMetadataPairs) {
+        var pairs = new ArrayList<>(initialMetadataPairs);
         var accountRecoveryBlockPresent =
                 accountModifiersService.isAccountRecoveryBlockPresent(
                         authSession.getInternalCommonSubjectId());
@@ -694,10 +713,11 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             LOG.info("AccountRecovery block is present. Removing block");
             accountModifiersService.removeAccountRecoveryBlockIfPresent(
                     authSession.getInternalCommonSubjectId());
+            pairs.add(pair("mfa-type", MFAMethodType.SMS.getValue()));
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED,
                     auditContext,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()));
+                    pairs.toArray(AuditService.MetadataPair[]::new));
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -254,18 +254,12 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT,
-                        AUDIT_CONTEXT
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.DEFAULT.name().toLowerCase())));
+                        AUDIT_CONTEXT,
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
+                        pair(
+                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
+                                PriorityIdentifier.DEFAULT.name().toLowerCase()));
     }
 
     @Test
@@ -308,19 +302,10 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(defaultSmsMethod.getDestination())
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.DEFAULT.name().toLowerCase())));
+                        AUDIT_CONTEXT.withPhoneNumber(defaultSmsMethod.getDestination()),
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
+                        pair("mfa-method", PriorityIdentifier.DEFAULT.name().toLowerCase()));
     }
 
     @Test
@@ -341,19 +326,10 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(backupSmsMethod.getDestination())
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.BACKUP.name().toLowerCase())));
+                        AUDIT_CONTEXT.withPhoneNumber(backupSmsMethod.getDestination()),
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
+                        pair("mfa-method", PriorityIdentifier.BACKUP.name().toLowerCase()));
     }
 
     @Test
@@ -420,15 +396,9 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_MISSING_PHONE_NUMBER,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(AuditService.UNKNOWN)
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue())));
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
 
     @Test
@@ -449,19 +419,10 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT,
-                        AUDIT_CONTEXT
-                                .withTxmaAuditEncoded(Optional.empty())
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.DEFAULT.name().toLowerCase())));
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
+                        pair("mfa-method", PriorityIdentifier.DEFAULT.name().toLowerCase()));
     }
 
     @Test
@@ -503,18 +464,10 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT,
-                        AUDIT_CONTEXT
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.DEFAULT.name().toLowerCase())));
+                        AUDIT_CONTEXT,
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
+                        pair("mfa-method", PriorityIdentifier.DEFAULT.name().toLowerCase()));
     }
 
     @Test
@@ -563,14 +516,9 @@ class MfaHandlerTest {
                         FrontendAuditableEvent.AUTH_MFA_MISMATCHED_EMAIL,
                         AUDIT_CONTEXT
                                 .withEmail("wrong.email@gov.uk")
-                                .withPhoneNumber(AuditService.UNKNOWN)
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue())));
+                                .withPhoneNumber(AuditService.UNKNOWN),
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
 
     @Test
@@ -640,15 +588,9 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_MISSING_PHONE_NUMBER,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(AuditService.UNKNOWN)
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue())));
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()));
     }
 
     @Test
@@ -718,10 +660,9 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_INVALID_CODE_REQUEST,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(UK_MOBILE_NUMBER)
-                                .withMetadataItem(pair("journey-type", journeyType))
-                                .withMetadataItem(pair("mfa-type", MFAMethodType.SMS.getValue())));
+                        AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
+                        pair("journey-type", journeyType),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @ParameterizedTest
@@ -750,10 +691,9 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_INVALID_CODE_REQUEST,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(AuditService.UNKNOWN)
-                                .withMetadataItem(pair("journey-type", journeyType))
-                                .withMetadataItem(pair("mfa-type", MFAMethodType.SMS.getValue())));
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
+                        pair("journey-type", journeyType),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @Test
@@ -783,7 +723,8 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         eq(FrontendAuditableEvent.AUTH_MFA_INVALID_CODE_REQUEST),
-                        any(AuditContext.class));
+                        any(AuditContext.class),
+                        any(AuditService.MetadataPair[].class));
     }
 
     @ParameterizedTest
@@ -812,10 +753,9 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_INVALID_CODE_REQUEST,
-                        AUDIT_CONTEXT
-                                .withPhoneNumber(AuditService.UNKNOWN)
-                                .withMetadataItem(pair("journey-type", journeyType))
-                                .withMetadataItem(pair("mfa-type", MFAMethodType.SMS.getValue())));
+                        AUDIT_CONTEXT.withPhoneNumber(AuditService.UNKNOWN),
+                        pair("journey-type", journeyType),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @Test
@@ -842,18 +782,10 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT_FOR_TEST_CLIENT,
-                        AUDIT_CONTEXT
-                                .withMetadataItem(pair("journey-type", JourneyType.SIGN_IN))
-                                .withMetadataItem(
-                                        pair(
-                                                "mfa-type",
-                                                NotificationType.MFA_SMS
-                                                        .getMfaMethodType()
-                                                        .getValue()))
-                                .withMetadataItem(
-                                        pair(
-                                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                                PriorityIdentifier.DEFAULT.name().toLowerCase())));
+                        AUDIT_CONTEXT,
+                        pair("journey-type", JourneyType.SIGN_IN),
+                        pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
+                        pair("mfa-method", PriorityIdentifier.DEFAULT.name().toLowerCase()));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -608,8 +608,8 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT.withMetadataItem(
-                                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
+                        AUDIT_CONTEXT,
+                        pair("mfa-method", "default"),
                         pair("notification-type", MFA_SMS.name()),
                         pair("account-recovery", false),
                         pair(
@@ -621,8 +621,8 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED,
-                        AUDIT_CONTEXT.withMetadataItem(
-                                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
+                        AUDIT_CONTEXT,
+                        pair("mfa-method", "default"),
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccessWithMfa(
@@ -666,8 +666,8 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT.withMetadataItem(
-                                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "backup")),
+                        AUDIT_CONTEXT,
+                        pair("mfa-method", "backup"),
                         pair("notification-type", MFA_SMS.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "SIGN_IN"),
@@ -701,8 +701,8 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT.withMetadataItem(
-                                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default")),
+                        AUDIT_CONTEXT,
+                        pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
                         pair("notification-type", MFA_SMS.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "SIGN_IN"),
@@ -774,13 +774,12 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         eq(FrontendAuditableEvent.AUTH_INVALID_CODE_SENT),
-                        eq(
-                                AUDIT_CONTEXT.withMetadataItem(
-                                        pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"))),
+                        eq(AUDIT_CONTEXT),
                         metadataCaptor.capture());
 
         List<AuditService.MetadataPair> expected =
                 List.of(
+                        pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
                         pair("notification-type", MFA_SMS.name()),
                         pair("account-recovery", false),
                         pair("journey-type", SIGN_IN.name()),
@@ -831,7 +830,8 @@ class VerifyCodeHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                            AUDIT_CONTEXT.withMetadataItem(pair("mfa-method", "default")),
+                            AUDIT_CONTEXT,
+                            pair("mfa-method", "default"),
                             pair("notification-type", MFA_SMS.name()),
                             pair("account-recovery", false),
                             pair(
@@ -868,7 +868,8 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
-                        AUDIT_CONTEXT.withMetadataItem(pair("mfa-method", "default")),
+                        AUDIT_CONTEXT,
+                        pair("mfa-method", "default"),
                         pair("notification-type", RESET_PASSWORD_WITH_CODE.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "PASSWORD_RESET"));

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandler.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/example/ExampleSmsVerificationHandler.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.userpermissions.example;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.userpermissions.PermissionDecisionManager;
 import uk.gov.di.authentication.userpermissions.PermissionDecisions;
@@ -10,6 +11,8 @@ import uk.gov.di.authentication.userpermissions.UserActions;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.Decision;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
+
+import java.util.Arrays;
 
 import static java.lang.String.format;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
@@ -52,9 +55,9 @@ public class ExampleSmsVerificationHandler {
         if (decision instanceof Decision.TemporarilyLockedOut lockedOut) {
             sendAuditEvent(
                     "LOCKED_OUT",
-                    AuditContext.emptyAuditContext()
-                            .withMetadataItem(pair("reason", lockedOut.forbiddenReason()))
-                            .withMetadataItem(pair("until", lockedOut.lockedUntil())));
+                    AuditContext.emptyAuditContext(),
+                    pair("reason", lockedOut.forbiddenReason()),
+                    pair("until", lockedOut.lockedUntil()));
             return (format(
                     "403: User is temporarily locked out due to %s until %s",
                     lockedOut.forbiddenReason(), lockedOut.lockedUntil()));
@@ -67,14 +70,17 @@ public class ExampleSmsVerificationHandler {
 
         sendAuditEvent(
                 "OTP_VERIFIED",
-                AuditContext.emptyAuditContext()
-                        .withMetadataItem(pair("attempts", decision.attemptCount() + 1)));
+                AuditContext.emptyAuditContext(),
+                pair("attempts", decision.attemptCount() + 1));
 
         userActions.correctSmsOtpReceived(journeyType, permissionContext);
         return ("200: Success");
     }
 
-    private void sendAuditEvent(String eventName, AuditContext auditContext) {
-        System.out.println(eventName + auditContext.toString());
+    private void sendAuditEvent(
+            String eventName,
+            AuditContext auditContext,
+            AuditService.MetadataPair... metadataPairs) {
+        System.out.println(eventName + auditContext.toString() + Arrays.toString(metadataPairs));
     }
 }


### PR DESCRIPTION
The final PR switching places where we set metadata items on the audit context over to sending them through as varargs.

This is because:

* the audit context is not supposed to contain any event specific data, just a record for common audit event data that can be used by all events within a handler
* it was confusing to trace how an audit event got its metadata, as the audit context was being treated as a mutable object and passed around in different helper methods in a handler.

The next PR will remove metadata from the audit context entirely.
