### PR TITLE
BAU: send metadata via submitAuditEvent method in SendNotificationHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -73,6 +73,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.FraudCheckMetricsHelper.incrementUserSubmittedCredentialIfNotificationSetupJourney;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class SendNotificationHandler extends BaseFrontendHandler<SendNotificationRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -316,20 +317,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             return generateApiGatewayProxyResponse(400, errorResponse.get());
         }
 
-        auditContext =
-                auditContext.withMetadataItem(
-                        new AuditService.MetadataPair(
-                                AUDIT_EVENT_EXTENSIONS_MFA_METHOD,
-                                AUDIT_EVENT_DEFAULT_MFA_VALUE,
-                                false));
-
-        auditContext =
-                auditContext.withMetadataItem(
-                        new AuditService.MetadataPair(
-                                AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE,
-                                request.getJourneyType(),
-                                false));
-
         return handleNotificationRequest(
                 PhoneNumberHelper.removeWhitespaceFromPhoneNumber(request.getPhoneNumber()),
                 request.getNotificationType(),
@@ -436,10 +423,18 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     notifyRequest.getUniqueNotificationReference());
         }
 
-        auditService.submitAuditEvent(
-                getSuccessfulAuditEventFromNotificationType(
-                        notificationType, testClientWithAllowedEmail),
-                auditContext);
+        if (!testClientWithAllowedEmail && notificationType.isForPhoneNumber()) {
+            auditService.submitAuditEvent(
+                    getSuccessfulAuditEventFromNotificationType(notificationType, false),
+                    auditContext,
+                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, AUDIT_EVENT_DEFAULT_MFA_VALUE),
+                    pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, request.getJourneyType()));
+        } else {
+            auditService.submitAuditEvent(
+                    getSuccessfulAuditEventFromNotificationType(
+                            notificationType, testClientWithAllowedEmail),
+                    auditContext);
+        }
 
         return generateEmptySuccessApiGatewayResponse();
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -270,21 +270,21 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 return postSendNotificationBlockResponse.get();
             }
 
-            switch (request.getNotificationType()) {
-                case VERIFY_EMAIL, VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
-                    return handleNotificationRequest(
-                            request.getEmail(),
-                            request.getNotificationType(),
-                            userContext,
-                            request.isRequestNewCode(),
-                            request,
-                            input,
-                            auditContext);
-                case VERIFY_PHONE_NUMBER:
-                    return handlePhoneNumberVerification(input, request, userContext, auditContext);
-                default:
-                    return generateApiGatewayProxyErrorResponse(400, INVALID_NOTIFICATION_TYPE);
-            }
+            return switch (request.getNotificationType()) {
+                case VERIFY_EMAIL,
+                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES -> handleNotificationRequest(
+                        request.getEmail(),
+                        request.getNotificationType(),
+                        userContext,
+                        request.isRequestNewCode(),
+                        request,
+                        input,
+                        auditContext);
+                case VERIFY_PHONE_NUMBER -> handlePhoneNumberVerification(
+                        input, request, userContext, auditContext);
+                default -> generateApiGatewayProxyErrorResponse(400, INVALID_NOTIFICATION_TYPE);
+            };
+
         } catch (SdkClientException ex) {
             LOG.error("Error sending message to queue");
             return generateApiGatewayProxyResponse(500, "Error sending message to queue");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -486,14 +486,12 @@ class SendNotificationHandlerTest {
                                                             SESSION_ID,
                                                             CLIENT_SESSION_ID)),
                                             "unique_notification_reference")));
-            var priorityPair = pair("mfa-method", "default");
-            var journeyTypePair = pair("journey-type", REGISTRATION);
-            var expectedAuditContext =
-                    auditContext
-                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
-                            .withMetadataItem(priorityPair)
-                            .withMetadataItem(journeyTypePair);
-            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PHONE_CODE_SENT,
+                            auditContext.withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER),
+                            pair("mfa-method", "default"),
+                            pair("journey-type", REGISTRATION));
         }
 
         @ParameterizedTest
@@ -604,12 +602,12 @@ class SendNotificationHandlerTest {
                                                             SESSION_ID,
                                                             CLIENT_SESSION_ID)),
                                             "unique_notification_reference")));
-            var expectedAuditContext =
-                    auditContext
-                            .withPhoneNumber(phoneNumber)
-                            .withMetadataItem(pair("mfa-method", "default"))
-                            .withMetadataItem(pair("journey-type", REGISTRATION));
-            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PHONE_CODE_SENT,
+                            auditContext.withPhoneNumber(phoneNumber),
+                            pair("mfa-method", "default"),
+                            pair("journey-type", REGISTRATION));
         }
 
         @ParameterizedTest
@@ -720,14 +718,12 @@ class SendNotificationHandlerTest {
 
             handler.handleRequest(event, context);
 
-            var priorityPair = pair("mfa-method", "default");
-            var journeyTypePair = pair("journey-type", REGISTRATION);
-            var expectedAuditContext =
-                    auditContext
-                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
-                            .withMetadataItem(priorityPair)
-                            .withMetadataItem(journeyTypePair);
-            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PHONE_CODE_SENT,
+                            auditContext.withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER),
+                            pair("mfa-method", "default"),
+                            pair("journey-type", REGISTRATION));
         }
 
         @Test
@@ -748,14 +744,12 @@ class SendNotificationHandlerTest {
 
             handler.handleRequest(event, context);
 
-            var priorityPair = pair("mfa-method", "default");
-            var journeyTypePair = pair("journey-type", REGISTRATION);
-            var expectedAuditContext =
-                    auditContext
-                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
-                            .withMetadataItem(priorityPair)
-                            .withMetadataItem(journeyTypePair);
-            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PHONE_CODE_SENT,
+                            auditContext.withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER),
+                            pair("mfa-method", "default"),
+                            pair("journey-type", REGISTRATION));
         }
 
         @Test
@@ -769,14 +763,12 @@ class SendNotificationHandlerTest {
 
             handler.handleRequest(event, context);
 
-            var priorityPair = pair("mfa-method", "default");
-            var journeyTypePair = pair("journey-type", REGISTRATION);
-            var expectedAuditContext =
-                    auditContext
-                            .withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER)
-                            .withMetadataItem(priorityPair)
-                            .withMetadataItem(journeyTypePair);
-            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PHONE_CODE_SENT,
+                            auditContext.withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER),
+                            pair("mfa-method", "default"),
+                            pair("journey-type", REGISTRATION));
         }
 
         @Test
@@ -832,14 +824,12 @@ class SendNotificationHandlerTest {
 
             // Business rule: new phone numbers should be reported as the default mfa method in
             // audit events
-            var priorityPair = pair("mfa-method", "default");
-            var journeyTypePair = pair("journey-type", REGISTRATION);
-            var expectedAuditContext =
-                    auditContext
-                            .withPhoneNumber(newPhoneNumber)
-                            .withMetadataItem(priorityPair)
-                            .withMetadataItem(journeyTypePair);
-            verify(auditService).submitAuditEvent(AUTH_PHONE_CODE_SENT, expectedAuditContext);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PHONE_CODE_SENT,
+                            auditContext.withPhoneNumber(newPhoneNumber),
+                            pair("mfa-method", "default"),
+                            pair("journey-type", REGISTRATION));
         }
     }
 


### PR DESCRIPTION
## What

- The AuditContext is intended to rarely change between a handler's
  event emissions
- Metadata pairs are more often event-specific
- Because of this we want to remove the ability to set metadata
  on the AuditContext
- This moves to the new approach in the SendNotificationHandler

## How to review

1. Code Review
