### PR TITLE
ATO-2587 add null check to remove log noise

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/KmsConnectionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/KmsConnectionService.java
@@ -46,8 +46,12 @@ public class KmsConnectionService {
                             .credentialsProvider(DefaultCredentialsProvider.builder().build())
                             .build();
         }
-        warmUp(tokenSigningKeyId);
-        warmUp(newTokenSigningKeyIdV2);
+        if (tokenSigningKeyId != null) {
+            warmUp(tokenSigningKeyId);
+        }
+        if (newTokenSigningKeyIdV2 != null) {
+            warmUp(newTokenSigningKeyIdV2);
+        }
     }
 
     public GetPublicKeyResponse getPublicKey(GetPublicKeyRequest getPublicKeyRequest) {


### PR DESCRIPTION
In the JwksFunction and several other places, there isn't a tokenSigningKeyId available/needed, so the warmUp error log is not useful.

### Wider context of change

In the JwksFunction and several other places, there isn't a tokenSigningKeyId available/needed, so the warmUp error log is not useful.

### What’s changed

We've added a null check on both of the keys used in the warmup to ensure we get less log noise.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.


