### PR TITLE
Aut 5465: Add passkey authentication generated event

### DIFF
--- a/ci/cloudformation/auth/function/start-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/start-passkey-assertion.yaml
@@ -63,6 +63,7 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               amcClientId,
             ]
+          TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
           WEBAUTHN_RELYING_PARTY_ID:
             !FindInMap [
               EnvironmentConfiguration,
@@ -82,6 +83,7 @@ Resources:
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoAuthSessionStoreReadWriteAccessPolicy
         - !Ref AuthToAccountDataSigningKeyPolicy
+        - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
       ProvisionedConcurrencyConfig: !If
         - EnableProvisionedConcurrency
         - ProvisionedConcurrentExecutions:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -62,7 +62,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     AUTH_EMAIL_FRAUD_CHECK_DECISION_USED,
     AUTH_MFA_RESET_REQUESTED,
     AUTH_AMC_AUTHORISATION_REQUESTED,
-    AUTH_AMC_AUTHORISATION_RECEIVED;
+    AUTH_AMC_AUTHORISATION_RECEIVED,
+    AUTH_PASSKEY_AUTHENTICATION_GENERATED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAllowedCredentialSerializer.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAllowedCredentialSerializer.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.frontendapi.entity.passkeys.audit;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class PasskeyAllowedCredentialSerializer
+        implements JsonSerializer<PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential> {
+
+    @Override
+    public JsonElement serialize(
+            PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential src,
+            Type typeOfSrc,
+            JsonSerializationContext context) {
+        var obj = new JsonObject();
+        obj.addProperty("passkey_credential_id", src.passkeyCredentialId());
+        if (src.passkeyCredentialTransports() != null
+                && !src.passkeyCredentialTransports().isEmpty()) {
+            obj.add(
+                    "passkey_credential_transports",
+                    context.serialize(src.passkeyCredentialTransports()));
+        }
+        return obj;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAuthenticationAuditExtension.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAuthenticationAuditExtension.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.frontendapi.entity.passkeys.audit;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public record PasskeyAuthenticationAuditExtension(
+        @Expose @SerializedName("passkey_authentication_request")
+                PasskeyAuthenticationRequest passkeyAuthenticationRequest) {
+    public record PasskeyAuthenticationRequest(
+            @Expose @SerializedName("passkey_request_user_verification")
+                    String passkeyRequestUserVerification) {}
+
+    public static PasskeyAuthenticationAuditExtension fromUserVerification(
+            String userVerification) {
+        return new PasskeyAuthenticationAuditExtension(
+                new PasskeyAuthenticationRequest(userVerification));
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAuthenticationAuditRestricted.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAuthenticationAuditRestricted.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.entity.passkeys.audit;
 
 import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -8,8 +9,8 @@ import java.util.List;
 public record PasskeyAuthenticationAuditRestricted(
         @SerializedName("passkey_allowed_credentials") @Expose
                 List<PasskeyAllowedCredential> passkeyAllowedCredentials) {
+
+    @JsonAdapter(PasskeyAllowedCredentialSerializer.class)
     public record PasskeyAllowedCredential(
-            @SerializedName("passkey_credential_id") @Expose String passkeyCredentialId,
-            @SerializedName("passkey_credential_transports") @Expose
-                    List<String> passkeyCredentialTransports) {}
+            String passkeyCredentialId, List<String> passkeyCredentialTransports) {}
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAuthenticationAuditRestricted.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAuthenticationAuditRestricted.java
@@ -1,0 +1,15 @@
+package uk.gov.di.authentication.frontendapi.entity.passkeys.audit;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public record PasskeyAuthenticationAuditRestricted(
+        @SerializedName("passkey_allowed_credentials") @Expose
+                List<PasskeyAllowedCredential> passkeyAllowedCredentials) {
+    public record PasskeyAllowedCredential(
+            @SerializedName("passkey_credential_id") @Expose String passkeyCredentialId,
+            @SerializedName("passkey_credential_transports") @Expose
+                    List<String> passkeyCredentialTransports) {}
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -12,19 +12,28 @@ import uk.gov.di.authentication.frontendapi.services.webauthn.DefaultPasskeyJson
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.RelyingPartyProvider;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSKEY_AUTHENTICATION_GENERATED;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPasskeyAssertionRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(StartPasskeyAssertionHandler.class);
+    private final AuditService auditService;
     private final PasskeyAssertionService passkeyAssertionService;
 
     public StartPasskeyAssertionHandler() {
@@ -35,13 +44,15 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
             ConfigurationService configurationService,
             AuthenticationService authenticationService,
             AuthSessionService authSessionService,
-            PasskeyAssertionService passkeyAssertionService) {
+            PasskeyAssertionService passkeyAssertionService,
+            AuditService auditService) {
         super(
                 StartPasskeyAssertionRequest.class,
                 configurationService,
                 authenticationService,
                 authSessionService);
         this.passkeyAssertionService = passkeyAssertionService;
+        this.auditService = auditService;
     }
 
     public StartPasskeyAssertionHandler(ConfigurationService configurationService) {
@@ -50,6 +61,7 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                 new PasskeyAssertionService(
                         RelyingPartyProvider.provide(configurationService),
                         new DefaultPasskeyJsonParser());
+        this.auditService = new AuditService(configurationService);
     }
 
     @Override
@@ -69,11 +81,12 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
         if (emailAddress == null || emailAddress.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.EMAIL_ADDRESS_EMPTY);
         }
-        var userProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
-        if (userProfile.isEmpty()) {
+        var maybeUserProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
+        if (maybeUserProfile.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.USER_NOT_FOUND);
         }
-        var publicSubjectId = userProfile.get().getPublicSubjectID();
+        var userProfile = maybeUserProfile.get();
+        var publicSubjectId = userProfile.getPublicSubjectID();
 
         var assertionRequest = passkeyAssertionService.startAssertion(publicSubjectId);
 
@@ -92,6 +105,19 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                 userContext
                         .getAuthSession()
                         .withPasskeyAssertionRequest(assertionRequestJsonToStore));
+
+        var auditContext =
+                auditContextFromUserContext(
+                        userContext,
+                        userContext.getAuthSession().getInternalCommonSubjectId(),
+                        emailAddress,
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+        var journeyTypePair =
+                pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.getValue());
+        auditService.submitAuditEvent(
+                AUTH_PASSKEY_AUTHENTICATION_GENERATED, auditContext, journeyTypePair);
         return generateApiGatewayProxyResponse(200, credentialsJson);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -5,6 +5,10 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.yubico.webauthn.AssertionRequest;
+import com.yubico.webauthn.data.AuthenticatorTransport;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import com.yubico.webauthn.data.UserVerificationRequirement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.StartPasskeyAssertionRequest;
@@ -111,12 +115,16 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                         .getAuthSession()
                         .withPasskeyAssertionRequest(assertionRequestJsonToStore));
 
-        emitAuthPasskeyAuthenticationGeneratedAuditEvent(userContext, input, emailAddress);
+        emitAuthPasskeyAuthenticationGeneratedAuditEvent(
+                userContext, input, emailAddress, assertionRequest);
         return generateApiGatewayProxyResponse(200, credentialsJson);
     }
 
     private void emitAuthPasskeyAuthenticationGeneratedAuditEvent(
-            UserContext userContext, APIGatewayProxyRequestEvent input, String emailAddress) {
+            UserContext userContext,
+            APIGatewayProxyRequestEvent input,
+            String emailAddress,
+            AssertionRequest assertionRequest) {
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
@@ -128,21 +136,34 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
 
         var journeyTypePair =
                 pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.getValue());
-        // TODO work out how to derive this user verification value
+
+        var maybeUserVerification =
+                assertionRequest
+                        .getPublicKeyCredentialRequestOptions()
+                        .getUserVerification()
+                        .map(UserVerificationRequirement::getValue);
         var passkeyUnrestrictedPair =
                 pair(
                         AUDIT_EXTENSIONS_PASSKEY,
-                        PasskeyAuthenticationAuditExtension.fromUserVerification("required"));
+                        PasskeyAuthenticationAuditExtension.fromUserVerification(
+                                maybeUserVerification.orElse(AuditService.UNKNOWN)));
 
-        var dummyAllowedCredentials =
-                new PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential(
-                        "credential-id", List.of("some transport"));
-        var dummyPasskeyAuthenticationAuditRestrictedObject =
-                new PasskeyAuthenticationAuditRestricted(List.of(dummyAllowedCredentials));
+        var allowedCredentials =
+                assertionRequest
+                        .getPublicKeyCredentialRequestOptions()
+                        .getAllowCredentials()
+                        .map(
+                                allowCredentials ->
+                                        allowCredentials.stream()
+                                                .map(
+                                                        StartPasskeyAssertionHandler
+                                                                ::allowCredentialFrom)
+                                                .toList())
+                        .orElse(List.of());
         var restrictedPasskeyPair =
                 pair(
                         AUDIT_EXTENSIONS_PASSKEY,
-                        dummyPasskeyAuthenticationAuditRestrictedObject,
+                        new PasskeyAuthenticationAuditRestricted(allowedCredentials),
                         true);
 
         auditService.submitAuditEvent(
@@ -151,5 +172,15 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                 journeyTypePair,
                 passkeyUnrestrictedPair,
                 restrictedPasskeyPair);
+    }
+
+    private static PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential
+            allowCredentialFrom(PublicKeyCredentialDescriptor credentialDescriptor) {
+        return new PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential(
+                credentialDescriptor.getId().getBase64Url(),
+                credentialDescriptor
+                        .getTransports()
+                        .map(set -> set.stream().map(AuthenticatorTransport::getId).toList())
+                        .orElse(List.of()));
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -28,6 +28,7 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.Comparator;
 import java.util.List;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
@@ -158,6 +159,11 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                                                 .map(
                                                         StartPasskeyAssertionHandler
                                                                 ::allowCredentialFrom)
+                                                .sorted(
+                                                        Comparator.comparing(
+                                                                PasskeyAuthenticationAuditRestricted
+                                                                                .PasskeyAllowedCredential
+                                                                        ::passkeyCredentialId))
                                                 .toList())
                         .orElse(List.of());
         var restrictedPasskeyPair =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.StartPasskeyAssertionRequest;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditExtension;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditRestricted;
 import uk.gov.di.authentication.frontendapi.services.webauthn.DefaultPasskeyJsonParser;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.RelyingPartyProvider;
@@ -22,6 +23,8 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.List;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSKEY_AUTHENTICATION_GENERATED;
@@ -123,17 +126,30 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
-        var journeyTypePair = pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN);
+        var journeyTypePair =
+                pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.getValue());
         // TODO work out how to derive this user verification value
         var passkeyUnrestrictedPair =
                 pair(
                         AUDIT_EXTENSIONS_PASSKEY,
                         PasskeyAuthenticationAuditExtension.fromUserVerification("required"));
 
+        var dummyAllowedCredentials =
+                new PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential(
+                        "credential-id", List.of("some transport"));
+        var dummyPasskeyAuthenticationAuditRestrictedObject =
+                new PasskeyAuthenticationAuditRestricted(List.of(dummyAllowedCredentials));
+        var restrictedPasskeyPair =
+                pair(
+                        AUDIT_EXTENSIONS_PASSKEY,
+                        dummyPasskeyAuthenticationAuditRestrictedObject,
+                        true);
+
         auditService.submitAuditEvent(
                 AUTH_PASSKEY_AUTHENTICATION_GENERATED,
                 auditContext,
                 journeyTypePair,
-                passkeyUnrestrictedPair);
+                passkeyUnrestrictedPair,
+                restrictedPasskeyPair);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.StartPasskeyAssertionRequest;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditExtension;
 import uk.gov.di.authentication.frontendapi.services.webauthn.DefaultPasskeyJsonParser;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.RelyingPartyProvider;
@@ -25,6 +26,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSKEY_AUTHENTICATION_GENERATED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EXTENSIONS_PASSKEY;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
@@ -106,6 +108,12 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                         .getAuthSession()
                         .withPasskeyAssertionRequest(assertionRequestJsonToStore));
 
+        emitAuthPasskeyAuthenticationGeneratedAuditEvent(userContext, input, emailAddress);
+        return generateApiGatewayProxyResponse(200, credentialsJson);
+    }
+
+    private void emitAuthPasskeyAuthenticationGeneratedAuditEvent(
+            UserContext userContext, APIGatewayProxyRequestEvent input, String emailAddress) {
         var auditContext =
                 auditContextFromUserContext(
                         userContext,
@@ -114,10 +122,18 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
-        var journeyTypePair =
-                pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN.getValue());
+
+        var journeyTypePair = pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, JourneyType.SIGN_IN);
+        // TODO work out how to derive this user verification value
+        var passkeyUnrestrictedPair =
+                pair(
+                        AUDIT_EXTENSIONS_PASSKEY,
+                        PasskeyAuthenticationAuditExtension.fromUserVerification("required"));
+
         auditService.submitAuditEvent(
-                AUTH_PASSKEY_AUTHENTICATION_GENERATED, auditContext, journeyTypePair);
-        return generateApiGatewayProxyResponse(200, credentialsJson);
+                AUTH_PASSKEY_AUTHENTICATION_GENERATED,
+                auditContext,
+                journeyTypePair,
+                passkeyUnrestrictedPair);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
@@ -63,7 +63,7 @@ public class AccountDataCredentialRepository implements CredentialRepository {
 
     Set<AuthenticatorTransport> transportStringsToSet(List<String> passkeyTransports) {
         return passkeyTransports.stream()
-                .map(AuthenticatorTransport::valueOf)
+                .map(s -> AuthenticatorTransport.valueOf(s.toUpperCase()))
                 .collect(Collectors.toSet());
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepository.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.services.webauthn;
 
 import com.yubico.webauthn.CredentialRepository;
 import com.yubico.webauthn.RegisteredCredential;
+import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.PublicKeyCredentialType;
@@ -51,12 +52,19 @@ public class AccountDataCredentialRepository implements CredentialRepository {
             return Optional.of(
                     PublicKeyCredentialDescriptor.builder()
                             .id(ByteArray.fromBase64Url(passkey.passkeyId()))
+                            .transports(Optional.of(transportStringsToSet(passkey.transports())))
                             .type(PublicKeyCredentialType.PUBLIC_KEY)
                             .build());
         } catch (Base64UrlException e) {
             LOG.warn("Invalid Base64Url credential ID, skipping passkey", e);
             return Optional.empty();
         }
+    }
+
+    Set<AuthenticatorTransport> transportStringsToSet(List<String> passkeyTransports) {
+        return passkeyTransports.stream()
+                .map(AuthenticatorTransport::valueOf)
+                .collect(Collectors.toSet());
     }
 
     private Optional<String> resolvePublicSubjectId(String email) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAllowedCredentialSerializerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/entity/passkeys/audit/PasskeyAllowedCredentialSerializerTest.java
@@ -1,0 +1,50 @@
+package uk.gov.di.authentication.frontendapi.entity.passkeys.audit;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PasskeyAllowedCredentialSerializerTest {
+
+    private final SerializationService serializer = SerializationService.getInstance();
+
+    @Test
+    void shouldIncludeTransportsWhenPresent() {
+        var credential =
+                new PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential(
+                        "cred-id", List.of("usb", "nfc"));
+
+        String json = serializer.writeValueAsString(credential);
+
+        assertEquals(
+                """
+                {"passkey_credential_id":"cred-id","passkey_credential_transports":["usb","nfc"]}""",
+                json);
+    }
+
+    @Test
+    void shouldOmitTransportsWhenNull() {
+        var credential =
+                new PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential("cred-id", null);
+
+        String json = serializer.writeValueAsString(credential);
+
+        assertEquals("""
+                {"passkey_credential_id":"cred-id"}""", json);
+    }
+
+    @Test
+    void shouldOmitTransportsWhenEmpty() {
+        var credential =
+                new PasskeyAuthenticationAuditRestricted.PasskeyAllowedCredential(
+                        "cred-id", List.of());
+
+        String json = serializer.writeValueAsString(credential);
+
+        assertEquals("""
+                {"passkey_credential_id":"cred-id"}""", json);
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditExtension;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -133,11 +134,17 @@ class StartPasskeyAssertionHandlerTest {
                                             session.getPasskeyAssertionRequest()
                                                     .equals(expectedJson)));
 
+            var expectedUnrestrictedPasskeyPair =
+                    pair(
+                            "passkey",
+                            PasskeyAuthenticationAuditExtension.fromUserVerification("required"));
+
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_PASSKEY_AUTHENTICATION_GENERATED,
                             AUDIT_CONTEXT,
-                            pair("journey-type", "SIGN_IN"));
+                            pair("journey-type", "SIGN_IN"),
+                            expectedUnrestrictedPasskeyPair);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditExtension;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditRestricted;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
@@ -24,6 +26,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -139,12 +142,23 @@ class StartPasskeyAssertionHandlerTest {
                             "passkey",
                             PasskeyAuthenticationAuditExtension.fromUserVerification("required"));
 
+            var expectedPasskeyAuthenticationAuditRestricted =
+                    new PasskeyAuthenticationAuditRestricted(
+                            List.of(
+                                    new PasskeyAuthenticationAuditRestricted
+                                            .PasskeyAllowedCredential(
+                                            "credential-id", List.of("some transport"))));
+
+            var expectedRestrictedPasskeyPair =
+                    pair("passkey", expectedPasskeyAuthenticationAuditRestricted, true);
+
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_PASSKEY_AUTHENTICATION_GENERATED,
                             AUDIT_CONTEXT,
-                            pair("journey-type", "SIGN_IN"),
-                            expectedUnrestrictedPasskeyPair);
+                            pair("journey-type", JourneyType.SIGN_IN.getValue()),
+                            expectedUnrestrictedPasskeyPair,
+                            expectedRestrictedPasskeyPair);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -29,13 +31,21 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSKEY_AUTHENTICATION_GENERATED;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.DI_PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.ENCODED_DEVICE_DETAILS;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNAL_COMMON_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS;
@@ -58,8 +68,25 @@ class StartPasskeyAssertionHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final PasskeyAssertionService passkeyAssertionService =
             mock(PasskeyAssertionService.class);
+    private final AuditService auditService = mock(AuditService.class);
     private StartPasskeyAssertionHandler handler;
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem()
+                    .withSessionId(SESSION_ID)
+                    .withClientId(CLIENT_ID)
+                    .withInternalCommonSubjectId(INTERNAL_COMMON_SUBJECT_ID);
+
+    private static final AuditContext AUDIT_CONTEXT =
+            new AuditContext(
+                    CLIENT_ID,
+                    CLIENT_SESSION_ID,
+                    SESSION_ID,
+                    INTERNAL_COMMON_SUBJECT_ID,
+                    EMAIL,
+                    IP_ADDRESS,
+                    AuditService.UNKNOWN,
+                    DI_PERSISTENT_SESSION_ID,
+                    ENCODED_DEVICE_DETAILS);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -80,7 +107,8 @@ class StartPasskeyAssertionHandlerTest {
                         configurationService,
                         authenticationService,
                         authSessionService,
-                        passkeyAssertionService);
+                        passkeyAssertionService,
+                        auditService);
     }
 
     @Nested
@@ -104,6 +132,12 @@ class StartPasskeyAssertionHandlerTest {
                                     session ->
                                             session.getPasskeyAssertionRequest()
                                                     .equals(expectedJson)));
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_PASSKEY_AUTHENTICATION_GENERATED,
+                            AUDIT_CONTEXT,
+                            pair("journey-type", "SIGN_IN"));
         }
     }
 
@@ -115,6 +149,11 @@ class StartPasskeyAssertionHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.EMAIL_ADDRESS_EMPTY));
+            verify(auditService, never())
+                    .submitAuditEvent(
+                            eq(AUTH_PASSKEY_AUTHENTICATION_GENERATED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
         }
 
         @Test
@@ -125,6 +164,11 @@ class StartPasskeyAssertionHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.EMAIL_ADDRESS_EMPTY));
+            verify(auditService, never())
+                    .submitAuditEvent(
+                            eq(AUTH_PASSKEY_AUTHENTICATION_GENERATED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
         }
 
         @Test
@@ -137,6 +181,11 @@ class StartPasskeyAssertionHandlerTest {
 
             assertThat(result, hasStatus(400));
             assertThat(result, hasJsonBody(ErrorResponse.USER_NOT_FOUND));
+            verify(auditService, never())
+                    .submitAuditEvent(
+                            eq(AUTH_PASSKEY_AUTHENTICATION_GENERATED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
         }
     }
 
@@ -158,6 +207,11 @@ class StartPasskeyAssertionHandlerTest {
 
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR));
+            verify(auditService, never())
+                    .submitAuditEvent(
+                            eq(AUTH_PASSKEY_AUTHENTICATION_GENERATED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
         }
 
         @Test
@@ -175,6 +229,11 @@ class StartPasskeyAssertionHandlerTest {
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR));
             verify(authSessionService, never()).updateSession(any());
+            verify(auditService, never())
+                    .submitAuditEvent(
+                            eq(AUTH_PASSKEY_AUTHENTICATION_GENERATED),
+                            any(AuditContext.class),
+                            any(AuditService.MetadataPair[].class));
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandlerTest.java
@@ -4,8 +4,11 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yubico.webauthn.AssertionRequest;
+import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.PublicKeyCredentialRequestOptions;
+import com.yubico.webauthn.data.UserVerificationRequirement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -28,6 +31,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -122,7 +126,8 @@ class StartPasskeyAssertionHandlerTest {
             authSession.setEmailAddress(EMAIL);
             when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                     .thenReturn(Optional.of(USER_PROFILE));
-            var assertionRequest = createAssertionRequest();
+            var assertionRequest =
+                    createAssertionRequest(List.of(), UserVerificationRequirement.REQUIRED);
             var expectedJson = assertionRequest.toJson();
             when(passkeyAssertionService.startAssertion(any())).thenReturn(assertionRequest);
 
@@ -136,6 +141,36 @@ class StartPasskeyAssertionHandlerTest {
                                     session ->
                                             session.getPasskeyAssertionRequest()
                                                     .equals(expectedJson)));
+        }
+
+        @Test
+        void shouldEmitTheRelevantAuditEvent() {
+            authSession.setEmailAddress(EMAIL);
+            when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                    .thenReturn(Optional.of(USER_PROFILE));
+
+            ByteArray credentialId =
+                    new ByteArray("test-credential-id".getBytes(StandardCharsets.UTF_8));
+
+            String credentialIdBase64 = credentialId.getBase64Url();
+
+            var transports = Set.of(AuthenticatorTransport.BLE, AuthenticatorTransport.INTERNAL);
+            var expectedTransportsInAuditEvent = List.of("ble", "internal");
+
+            var allowCredentials =
+                    PublicKeyCredentialDescriptor.builder()
+                            .id(credentialId)
+                            .transports(transports)
+                            .build();
+
+            var assertionRequest =
+                    createAssertionRequest(
+                            List.of(allowCredentials), UserVerificationRequirement.REQUIRED);
+            when(passkeyAssertionService.startAssertion(any())).thenReturn(assertionRequest);
+
+            var result = handler.handleRequest(startPasskeyAssertionRequest(), context);
+
+            assertThat(result, hasStatus(200));
 
             var expectedUnrestrictedPasskeyPair =
                     pair(
@@ -147,7 +182,7 @@ class StartPasskeyAssertionHandlerTest {
                             List.of(
                                     new PasskeyAuthenticationAuditRestricted
                                             .PasskeyAllowedCredential(
-                                            "credential-id", List.of("some transport"))));
+                                            credentialIdBase64, expectedTransportsInAuditEvent)));
 
             var expectedRestrictedPasskeyPair =
                     pair("passkey", expectedPasskeyAuthenticationAuditRestricted, true);
@@ -218,7 +253,8 @@ class StartPasskeyAssertionHandlerTest {
             when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                     .thenReturn(Optional.of(USER_PROFILE));
 
-            var spyAssertionRequest = spy(createAssertionRequest());
+            var spyAssertionRequest =
+                    spy(createAssertionRequest(List.of(), UserVerificationRequirement.REQUIRED));
             doThrow(new JsonProcessingException("test") {})
                     .when(spyAssertionRequest)
                     .toCredentialsGetJson();
@@ -241,7 +277,8 @@ class StartPasskeyAssertionHandlerTest {
             when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                     .thenReturn(Optional.of(USER_PROFILE));
 
-            var spyAssertionRequest = spy(createAssertionRequest());
+            var spyAssertionRequest =
+                    spy(createAssertionRequest(List.of(), UserVerificationRequirement.REQUIRED));
             doThrow(new JsonProcessingException("test") {}).when(spyAssertionRequest).toJson();
             when(passkeyAssertionService.startAssertion(any())).thenReturn(spyAssertionRequest);
 
@@ -265,10 +302,16 @@ class StartPasskeyAssertionHandlerTest {
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }
 
-    private AssertionRequest createAssertionRequest() {
+    private AssertionRequest createAssertionRequest(
+            List<PublicKeyCredentialDescriptor> allowCredentials,
+            UserVerificationRequirement userVerificationRequirement) {
         var challenge = new ByteArray("test-challenge".getBytes(StandardCharsets.UTF_8));
         var publicKeyCredentialRequestOptions =
-                PublicKeyCredentialRequestOptions.builder().challenge(challenge).build();
+                PublicKeyCredentialRequestOptions.builder()
+                        .challenge(challenge)
+                        .userVerification(userVerificationRequirement)
+                        .allowCredentials(allowCredentials)
+                        .build();
         return AssertionRequest.builder()
                 .publicKeyCredentialRequestOptions(publicKeyCredentialRequestOptions)
                 .build();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.services.webauthn;
 
 import com.yubico.webauthn.CredentialRepository;
+import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialType;
 import org.junit.jupiter.api.Nested;
@@ -16,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -62,6 +64,9 @@ class AccountDataCredentialRepositoryTest {
                     descriptor.getId(),
                     equalTo(new ByteArray(Base64.getUrlDecoder().decode(PASSKEY_ID_BASE64URL))));
             assertThat(descriptor.getType(), equalTo(PublicKeyCredentialType.PUBLIC_KEY));
+            assertThat(
+                    descriptor.getTransports(),
+                    equalTo(Optional.of(Set.of(AuthenticatorTransport.BLE))));
         }
 
         @Test
@@ -231,7 +236,7 @@ class AccountDataCredentialRepositoryTest {
                 "some-aaguid",
                 true,
                 5,
-                List.of(),
+                List.of("BLE"),
                 true,
                 true,
                 true,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/AccountDataCredentialRepositoryTest.java
@@ -66,7 +66,11 @@ class AccountDataCredentialRepositoryTest {
             assertThat(descriptor.getType(), equalTo(PublicKeyCredentialType.PUBLIC_KEY));
             assertThat(
                     descriptor.getTransports(),
-                    equalTo(Optional.of(Set.of(AuthenticatorTransport.BLE))));
+                    equalTo(
+                            Optional.of(
+                                    Set.of(
+                                            AuthenticatorTransport.BLE,
+                                            AuthenticatorTransport.INTERNAL))));
         }
 
         @Test
@@ -236,7 +240,7 @@ class AccountDataCredentialRepositoryTest {
                 "some-aaguid",
                 true,
                 5,
-                List.of("BLE"),
+                List.of("BLE", "internal"),
                 true,
                 true,
                 true,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -138,7 +138,12 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
             var publicSubjectId = userStore.getPublicSubjectIdForEmail(TEST_EMAIL);
 
             stubPasskeysRetrieveEndpoint(
-                    publicSubjectId, 200, passkeysResponse(passkeyJson(FIRST_PASSKEY_ID), passkeyJsonWithTransports(SECOND_PASSKEY_ID, List.of("BLE"))));
+                    publicSubjectId,
+                    200,
+                    passkeysResponse(
+                            passkeyJson(FIRST_PASSKEY_ID),
+                            passkeyJsonWithTransports(
+                                    SECOND_PASSKEY_ID, List.of("BLE", "INTERNAL"))));
 
             var response =
                     makeRequest(
@@ -183,14 +188,20 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
                               "passkey": {
                                 "passkey_allowed_credentials": [
                                   {
+                                    "passkey_credential_id": "%s"
+                                  },
+                                  {
                                     "passkey_credential_id": "%s",
-                                    "passkey_credential_transports": []
+                                    "passkey_credential_transports": [%s]
                                   }
                                 ]
                               }
                             }
                             """,
-                            ENCODED_DEVICE_INFORMATION, FIRST_PASSKEY_ID);
+                            ENCODED_DEVICE_INFORMATION,
+                            FIRST_PASSKEY_ID,
+                            SECOND_PASSKEY_ID,
+                            "\"ble\", \"internal\"");
 
             var restricted = message.getAsJsonObject().get("restricted").getAsJsonObject();
             assertEquals(asJson(expectedAuditEventRestrictedSection), restricted);
@@ -286,9 +297,7 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
 
     private static String passkeyJsonWithTransports(String passkeyId, List<String> transports) {
         var transportsList =
-                transports.stream()
-                        .map(t -> '"' + t + '"')
-                        .collect(Collectors.joining(", "));
+                transports.stream().map(t -> '"' + t + '"').collect(Collectors.joining(", "));
         return """
                 {
                   "id": "%s",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -21,8 +21,10 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -136,7 +138,7 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
             var publicSubjectId = userStore.getPublicSubjectIdForEmail(TEST_EMAIL);
 
             stubPasskeysRetrieveEndpoint(
-                    publicSubjectId, 200, passkeysResponse(passkeyJson(FIRST_PASSKEY_ID)));
+                    publicSubjectId, 200, passkeysResponse(passkeyJson(FIRST_PASSKEY_ID), passkeyJsonWithTransports(SECOND_PASSKEY_ID, List.of("BLE"))));
 
             var response =
                     makeRequest(
@@ -282,6 +284,27 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
                   "lastUsedAt": "another-timestamp"
                 }"""
                 .formatted(passkeyId, COSE_PUBLIC_KEY_BASE64URL);
+    }
+
+    private static String passkeyJsonWithTransports(String passkeyId, List<String> transports) {
+        var transportsList =
+                transports.stream()
+                        .map(t -> '"' + t + '"')
+                        .collect(Collectors.joining(", "));
+        return """
+                {
+                  "id": "%s",
+                  "credential": "%s",
+                  "aaguid": "authenticator-1",
+                  "isAttested": true,
+                  "signCount": 5,
+                  "transports": [%s],
+                  "isBackUpEligible": true,
+                  "isBackedUp": true,
+                  "createdAt": "some-timestamp",
+                  "lastUsedAt": "another-timestamp"
+                }"""
+                .formatted(passkeyId, COSE_PUBLIC_KEY_BASE64URL, transportsList);
     }
 
     private static String passkeysResponse(String... passkeys) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -165,7 +165,7 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
                               "journey-type": "SIGN_IN",
                               "passkey": {
                                 "passkey_authentication_request": {
-                                  "passkey_request_user_verification": "required"
+                                  "passkey_request_user_verification": ""
                                 }
                               }
                             }
@@ -183,16 +183,14 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
                               "passkey": {
                                 "passkey_allowed_credentials": [
                                   {
-                                    "passkey_credential_id": "credential-id",
-                                    "passkey_credential_transports": [
-                                      "some transport"
-                                    ]
+                                    "passkey_credential_id": "%s",
+                                    "passkey_credential_transports": []
                                   }
                                 ]
                               }
                             }
                             """,
-                            ENCODED_DEVICE_INFORMATION);
+                            ENCODED_DEVICE_INFORMATION, FIRST_PASSKEY_ID);
 
             var restricted = message.getAsJsonObject().get("restricted").getAsJsonObject();
             assertEquals(asJson(expectedAuditEventRestrictedSection), restricted);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -29,8 +29,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.hasFieldWithValue;
 
 @ExtendWith(SystemStubsExtension.class)
 class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -125,6 +128,48 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
             var allowCredentials =
                     body.getAsJsonObject("publicKey").getAsJsonArray("allowCredentials");
             assertThat(allowCredentials.size(), equalTo(2));
+        }
+
+        @Test
+        void shouldEmitTheCorrectAuditEvent() {
+            var sessionId = setupUserAndSession();
+            var publicSubjectId = userStore.getPublicSubjectIdForEmail(TEST_EMAIL);
+
+            stubPasskeysRetrieveEndpoint(
+                    publicSubjectId, 200, passkeysResponse(passkeyJson(FIRST_PASSKEY_ID)));
+
+            var response =
+                    makeRequest(
+                            Optional.of(new StartPasskeyAssertionRequest()),
+                            constructFrontendHeaders(sessionId),
+                            Map.of());
+
+            assertThat(response, hasStatus(200));
+
+            var receivedEvents = txmaAuditQueue.getRawMessages();
+
+            assertEquals(1, receivedEvents.size());
+
+            var message = asJson(receivedEvents.get(0));
+
+            assertThat(
+                    message,
+                    hasFieldWithValue(
+                            "event_name", equalTo("AUTH_PASSKEY_AUTHENTICATION_GENERATED")));
+
+            var expectedAuditEventExtensions =
+                    """
+                    {
+                      "journey-type": "SIGN_IN",
+                      "passkey": {
+                        "passkey_authentication_request": {
+                          "passkey_request_user_verification": "required"
+                        }
+                      }
+                    }
+                    """;
+            var extensions = message.getAsJsonObject().get("extensions").getAsJsonObject();
+            assertEquals(asJson(expectedAuditEventExtensions), extensions);
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -159,17 +159,41 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
 
             var expectedAuditEventExtensions =
                     """
-                    {
-                      "journey-type": "SIGN_IN",
-                      "passkey": {
-                        "passkey_authentication_request": {
-                          "passkey_request_user_verification": "required"
-                        }
-                      }
-                    }
-                    """;
+                            {
+                              "journey-type": "SIGN_IN",
+                              "passkey": {
+                                "passkey_authentication_request": {
+                                  "passkey_request_user_verification": "required"
+                                }
+                              }
+                            }
+                            """;
             var extensions = message.getAsJsonObject().get("extensions").getAsJsonObject();
             assertEquals(asJson(expectedAuditEventExtensions), extensions);
+
+            var expectedAuditEventRestrictedSection =
+                    String.format(
+                            """
+                                                {
+                              "device_information": {
+                                "encoded": "%s"
+                              },
+                              "passkey": {
+                                "passkey_allowed_credentials": [
+                                  {
+                                    "passkey_credential_id": "credential-id",
+                                    "passkey_credential_transports": [
+                                      "some transport"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                            """,
+                            ENCODED_DEVICE_INFORMATION);
+
+            var restricted = message.getAsJsonObject().get("restricted").getAsJsonObject();
+            assertEquals(asJson(expectedAuditEventRestrictedSection), restricted);
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -21,6 +21,7 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS = "account_actions";
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS_ERRORS = "account_actions_errors";
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS_FAILED = "account_actions_failed";
+    String AUDIT_EXTENSIONS_PASSKEY = "passkey";
 
     AuditableEvent parseFromName(String name);
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,6 +49,12 @@ class AuditServiceTest {
                     "phone-number",
                     "persistent-session-id",
                     AuditService.UNKNOWN);
+
+    record NestedMetadataObject(@Expose @SerializedName("fieldThree") String FieldThree) {}
+
+    record ComplexMetadataObject(
+            @Expose @SerializedName("fieldOne") String FieldOne,
+            @Expose @SerializedName("fieldTwo") NestedMetadataObject FieldTwo) {}
 
     enum TestEvents implements AuditableEvent {
         AUTH_TEST_EVENT_ONE;
@@ -132,6 +140,78 @@ class AuditServiceTest {
 
         assertThat(restricted, hasFieldWithValue("restrictedKey1", equalTo("restrictedValue1")));
         assertThat(restricted, hasFieldWithValue("restrictedKey2", equalTo("restrictedValue2")));
+    }
+
+    @Test
+    void shouldAddComplexObjectInMetadataPairs() {
+        var metadataObject =
+                new ComplexMetadataObject("value1", new NestedMetadataObject("value3"));
+        auditService.submitAuditEvent(
+                AUTH_TEST_EVENT_ONE,
+                AUDIT_CONTEXT,
+                pair("key", "value"),
+                pair("foo", metadataObject));
+
+        verify(awsSqsClient).send(txmaMessageCaptor.capture());
+        var txmaMessage = asJson(txmaMessageCaptor.getValue());
+
+        assertThat(txmaMessage, hasFieldWithValue("event_name", equalTo("AUTH_TEST_EVENT_ONE")));
+        assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
+
+        var extensions = txmaMessage.getAsJsonObject().get("extensions").getAsJsonObject();
+        var expectedExtensions =
+                """
+                        {
+                          "key": "value",
+                          "foo": {
+                            "fieldOne": "value1",
+                            "fieldTwo": {
+                              "fieldThree": "value3"
+                            }
+                          }
+                        }
+                        """;
+        assertEquals(asJson(expectedExtensions), extensions);
+    }
+
+    @Test
+    void shouldAddComplexObjectInRestrictedMetadataPairs() {
+        var metadataObject =
+                new ComplexMetadataObject("value1", new NestedMetadataObject("value3"));
+        auditService.submitAuditEvent(
+                AUTH_TEST_EVENT_ONE,
+                AUDIT_CONTEXT,
+                pair("key", "value"),
+                pair("foo", metadataObject, true));
+
+        verify(awsSqsClient).send(txmaMessageCaptor.capture());
+        var txmaMessage = asJson(txmaMessageCaptor.getValue());
+
+        assertThat(txmaMessage, hasFieldWithValue("event_name", equalTo("AUTH_TEST_EVENT_ONE")));
+        assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
+
+        var extensions = txmaMessage.getAsJsonObject().get("extensions").getAsJsonObject();
+        var expectedExtensions =
+                """
+                        {
+                          "key": "value"
+                        }
+                        """;
+        assertEquals(asJson(expectedExtensions), extensions);
+
+        var restricted = txmaMessage.getAsJsonObject().get("restricted").getAsJsonObject();
+        var expectedRestricted =
+                """
+                        {
+                          "foo": {
+                            "fieldOne": "value1",
+                            "fieldTwo": {
+                              "fieldThree": "value3"
+                            }
+                          }
+                        }
+                        """;
+        assertEquals(asJson(expectedRestricted), restricted);
     }
 
     @Test


### PR DESCRIPTION
Adds the passkey authentication generated event as the last thing we do in the start passkey assertion handler before returning a response.

Notes:

* we have not yet set the user verification on the passkey request. The event is currently populated from this, so this will be set to an empty string. Future work will set this.

## How to review

1. Code review
