### PR TITLE
BAU: Allow frontend-to-ADAPI communication in local-running

### DIFF
--- a/local-running/.env.local
+++ b/local-running/.env.local
@@ -1,5 +1,6 @@
 # Main config
 AUTHENTICATION_BACKEND_URI=http://host.docker.internal:4402/
+ACCOUNT_DATA_API_URI=http://host.docker.internal:4402/
 AWS_ACCESS_KEY_ID=local
 AWS_EMF_ENVIRONMENT=Local
 AWS_REGION=eu-west-2

--- a/local-running/.env.local
+++ b/local-running/.env.local
@@ -37,6 +37,7 @@ AMC_JWKS_URL=http://localhost/placeholder
 TOKEN_SIGNING_KEY_ALIAS=alias/local-token-signing-key
 MFA_RESET_STORAGE_TOKEN_SIGNING_KEY_ALIAS=alias/local-mfa-reset-storage-token-signing-key
 IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS=alias/local-mfa-reset-jar-signing-key
+AUTH_TO_ACCOUNT_DATA_SIGNING_KEY=alias/local-auth-to-account-data-signing-key
 
 # SQS queues
 TXMA_AUDIT_QUEUE_URL=local-txma-audit-queue

--- a/local-running/.env.local
+++ b/local-running/.env.local
@@ -26,6 +26,12 @@ TEST_CLIENTS_ENABLED=true
 TEST_CLIENT_VERIFY_EMAIL_OTP=123456
 TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP=456789
 TRACING_ENABLED=false
+
+# Passkeys
+SUPPORT_PASSKEYS=true
+WEBAUTHN_RELYING_PARTY_ID=localhost
+PASSKEY_ALLOWED_ORIGIN=http://localhost:4401
+
 # This needs to be set else we get a runtime exception.
 # It does not have to point to a valid JWKS endpoint, as the default behaviour is
 # that if the JWKS verification fails, the orch stub key will be used (which is

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             libs.awsSqs,
             libs.awsSsm,
             libs.awsSecretsManager,
+            libs.bundles.nimbus,
             project(":shared"),
             project(":auth-external-api"),
             project(":frontend-api"),

--- a/local-running/src/main/java/uk/gov/di/authentication/local/App.java
+++ b/local-running/src/main/java/uk/gov/di/authentication/local/App.java
@@ -47,6 +47,8 @@ public class App {
         kmsInitialiser.createKey(
                 "alias/local-mfa-reset-storage-token-signing-key", KeyUsageType.SIGN_VERIFY);
         kmsInitialiser.createKey("alias/local-mfa-reset-jar-signing-key", KeyUsageType.SIGN_VERIFY);
+        kmsInitialiser.createKey(
+                "alias/local-auth-to-account-data-signing-key", KeyUsageType.SIGN_VERIFY);
 
         // Set up localstack SQS queues
         //

--- a/local-running/src/main/java/uk/gov/di/authentication/local/LocalAuthApi.java
+++ b/local-running/src/main/java/uk/gov/di/authentication/local/LocalAuthApi.java
@@ -102,7 +102,7 @@ public class LocalAuthApi {
                             config.routes.get("/userinfo", handlerFor(new UserInfoHandler()));
 
                             // Account Data API
-                            config.routes.post(
+                            config.routes.get(
                                     "/accounts/{publicSubjectId}/authenticators/passkeys",
                                     handlerFor(new PasskeysRetrieveHandler()));
                         });

--- a/local-running/src/main/java/uk/gov/di/authentication/local/handlers/ApiGatewayLambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/authentication/local/handlers/ApiGatewayLambdaHandler.java
@@ -3,11 +3,16 @@ package uk.gov.di.authentication.local.handlers;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.text.ParseException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -46,14 +51,35 @@ public class ApiGatewayLambdaHandler {
                                     Collectors.toMap(
                                             Map.Entry::getKey, (e) -> e.getValue().get(0))));
 
+            var authorizationHeader = ctx.headerMap().get("Authorization");
+            if (authorizationHeader != null) {
+                attachRequestContextToEvent(apiGatewayProxyRequestEvent, authorizationHeader);
+            }
+
             APIGatewayProxyResponseEvent responseEvent =
                     lambdaHandler.handleRequest(apiGatewayProxyRequestEvent, LAMBDA_CONTEXT);
 
             ctx.status(responseEvent.getStatusCode()).json(responseEvent.getBody());
             responseEvent.getHeaders().forEach(ctx::header);
-        } catch (RuntimeException e) {
+        } catch (RuntimeException | ParseException | com.nimbusds.oauth2.sdk.ParseException e) {
             LOG.error("Runtime exception thrown by handler", e);
             ctx.status(500).json(Map.of("message", e.getMessage()));
         }
+    }
+
+    private void attachRequestContextToEvent(
+            APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, String authorizationHeader)
+            throws ParseException, com.nimbusds.oauth2.sdk.ParseException {
+        var accessToken = AccessToken.parse(authorizationHeader, AccessTokenType.BEARER);
+        var signedAccessToken = SignedJWT.parse(accessToken.getValue());
+        var claimsSet = signedAccessToken.getJWTClaimsSet();
+
+        var authorizer = new HashMap<String, Object>();
+        authorizer.put("principalId", claimsSet.getSubject());
+        authorizer.put("scope", claimsSet.getClaim("scope"));
+
+        var requestContext = new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        requestContext.setAuthorizer(authorizer);
+        apiGatewayProxyRequestEvent.setRequestContext(requestContext);
     }
 }


### PR DESCRIPTION
## What

Previously, it wasn't possible for the frontend-api to make requests to account-data-api (ADAPI) when running locally because the KMS key wasn't configured.

This PR sets up required environment variables, local KMS key, and API Gateway-emulating for a locally running frontend-api to make requests to account-data-api.

## How to review

1. Code Review
2. Test the /enter-email page (this requires ADAPI to check if your account has any passkeys)
    * Use the debugger to see that a request was successfully received, validated, and processed by the PasskeyRetrieveHandler