### PR TITLE
BAU: Fix 'java.lang.NoClassDefFoundError at SpanSuppressors.java' errors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ log4jJsonTemplate = "org.apache.logging.log4j:log4j-layout-template-json:2.25.4"
 mockitoCore = "org.mockito:mockito-core:5.23.0"
 nimbusJwt = "com.nimbusds:nimbus-jose-jwt:10.4.2"
 nimbusOidc = "com.nimbusds:oauth2-oidc-sdk:10.13.2"
-openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.19.0-alpha"
+openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.28.1-alpha"
 openTelemetryAwsSdk = { module = "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure" }
 openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }
 pactConsumer = { module = "au.com.dius.pact.consumer:junit5", version.ref = "pact" }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/HttpClientHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/HttpClientHelper.java
@@ -11,6 +11,6 @@ public class HttpClientHelper {
     public static HttpClient newInstrumentedHttpClient() {
         return JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
                 .build()
-                .newHttpClient(HttpClient.newHttpClient());
+                .wrap(HttpClient.newHttpClient());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/HttpClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/HttpClientHelper.java
@@ -11,6 +11,6 @@ public class HttpClientHelper {
     public static HttpClient newInstrumentedHttpClient() {
         return JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
                 .build()
-                .newHttpClient(HttpClient.newHttpClient());
+                .wrap(HttpClient.newHttpClient());
     }
 }


### PR DESCRIPTION

## What

Fix 'java.lang.NoClassDefFoundError at SpanSuppressors.java' errors

The AWS SDK 2.44.4 requires io.opentelemetry:opentelemetry-api:[1.62.0,), which resolved to 1.63.0. But the OTel instrumentation BOM at 2.19.0-alpha was compiled against API 1.53.0. The SpanSuppressors class in the instrumentation library tried to use a class/method that doesn't exist in the newer API version → NoClassDefFoundError.

## How to review

1. Code Review
1. Check that all tests are passing locally and in pre-merge-checks

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
