### PR TITLE
BAU: Recreate client JWT when retrying token request

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -218,10 +218,7 @@ public class DocAppCallbackHandler
             auditService.submitAuditEvent(
                     DocAppAuditableEvent.DOC_APP_AUTHORISATION_RESPONSE_RECEIVED, clientId, user);
 
-            var tokenRequest =
-                    tokenService.constructTokenRequest(
-                            input.getQueryStringParameters().get("code"));
-            var tokenResponse = tokenService.sendTokenRequest(tokenRequest);
+            var tokenResponse = tokenService.getToken(input.getQueryStringParameters().get("code"));
             if (tokenResponse.indicatesSuccess()) {
                 LOG.info("TokenResponse was successful");
                 auditService.submitAuditEvent(

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -64,6 +64,30 @@ public class DocAppCriService {
         this.docAppCriApi = docAppCriApi;
     }
 
+    public TokenResponse getToken(String authCode) {
+        int count = 0;
+        int maxTries = 2;
+        TokenResponse tokenResponse;
+        do {
+            if (count > 0) LOG.warn("Retrying DocApp access token request");
+            count++;
+            // We must generate a new token request every time:
+            // private_key_jwt client auth JWTs are not reusable
+            var tokenRequest = constructTokenRequest(authCode);
+            tokenResponse = sendTokenRequest(tokenRequest);
+            if (!tokenResponse.indicatesSuccess()) {
+                HTTPResponse response = tokenResponse.toHTTPResponse();
+                LOG.warn(
+                        "Unsuccessful {} response from DocApp token endpoint on attempt {}: {} ",
+                        response.getStatusCode(),
+                        count,
+                        response.getContent());
+            }
+        } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+
+        return tokenResponse;
+    }
+
     public TokenRequest constructTokenRequest(String authCode) {
         LOG.info("Constructing token request");
         var codeGrant =
@@ -96,23 +120,8 @@ public class DocAppCriService {
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
         try {
-            LOG.info("Sending TokenRequest");
-            int count = 0;
-            int maxTries = 2;
-            TokenResponse tokenResponse;
-            do {
-                if (count > 0) LOG.warn("Retrying DocApp token request");
-                count++;
-                tokenResponse = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
-                if (!tokenResponse.indicatesSuccess()) {
-                    HTTPResponse response = tokenResponse.toHTTPResponse();
-                    LOG.warn(
-                            format(
-                                    "Unsuccessful %s response from DocApp token endpoint on attempt %d: %s ",
-                                    response.getStatusCode(), count, response.getContent()));
-                }
-            } while (!tokenResponse.indicatesSuccess() && count < maxTries);
-            return tokenResponse;
+            LOG.info("Sending DocApp token request");
+            return TokenResponse.parse(tokenRequest.toHTTPRequest().send());
         } catch (IOException e) {
             LOG.error("Error whilst sending TokenRequest", e);
             throw new RuntimeException(e);

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -186,8 +186,7 @@ class DocAppCallbackHandlerTest {
         responseHeaders.put("state", STATE.getValue());
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(Optional.empty());
-        when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
-        when(tokenService.sendTokenRequest(tokenRequest)).thenReturn(successfulTokenResponse);
+        when(tokenService.getToken(AUTH_CODE.getValue())).thenReturn(successfulTokenResponse);
         when(tokenService.sendCriDataRequest(any(HTTPRequest.class), any(String.class)))
                 .thenReturn(List.of("a-verifiable-credential"));
 
@@ -351,14 +350,12 @@ class DocAppCallbackHandlerTest {
         usingValidClientSession();
         usingValidOrchSession();
         var unsuccessfulTokenResponse = new TokenErrorResponse(new ErrorObject("Error object"));
-        var tokenRequest = mock(TokenRequest.class);
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("code", AUTH_CODE.getValue());
         responseHeaders.put("state", STATE.getValue());
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(Optional.empty());
-        when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
-        when(tokenService.sendTokenRequest(tokenRequest)).thenReturn(unsuccessfulTokenResponse);
+        when(tokenService.getToken(AUTH_CODE.getValue())).thenReturn(unsuccessfulTokenResponse);
 
         var event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(responseHeaders);
@@ -408,8 +405,7 @@ class DocAppCallbackHandlerTest {
         responseHeaders.put("state", STATE.getValue());
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(Optional.empty());
-        when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
-        when(tokenService.sendTokenRequest(tokenRequest)).thenReturn(successfulTokenResponse);
+        when(tokenService.getToken(AUTH_CODE.getValue())).thenReturn(successfulTokenResponse);
         when(tokenService.sendCriDataRequest(any(HTTPRequest.class), any(String.class)))
                 .thenThrow(UnsuccessfulCredentialResponseException.class);
 
@@ -553,14 +549,12 @@ class DocAppCallbackHandlerTest {
         usingValidOrchSession();
         var successfulTokenResponse =
                 new AccessTokenResponse(new Tokens(new BearerAccessToken(), null));
-        var tokenRequest = mock(TokenRequest.class);
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("code", AUTH_CODE.getValue());
         responseHeaders.put("state", STATE.getValue());
         when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(Optional.empty());
-        when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
-        when(tokenService.sendTokenRequest(tokenRequest)).thenReturn(successfulTokenResponse);
+        when(tokenService.getToken(AUTH_CODE.getValue())).thenReturn(successfulTokenResponse);
         when(tokenService.sendCriDataRequest(any(HTTPRequest.class), any(String.class)))
                 .thenThrow(
                         new UnsuccessfulCredentialResponseException(

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -77,7 +78,7 @@ class DocAppCriServiceTest {
 
     @BeforeEach
     void setUp() throws MalformedURLException {
-        docAppCriService = new DocAppCriService(configService, kmsService, docAppCriApi);
+        docAppCriService = spy(new DocAppCriService(configService, kmsService, docAppCriApi));
         when(docAppCriApi.tokenURI()).thenReturn(TOKEN_URI);
         when(configService.getDocAppAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
         when(configService.getAccessTokenExpiry()).thenReturn(300L);
@@ -91,8 +92,6 @@ class DocAppCriServiceTest {
         @Test
         void shouldConstructTokenRequest() throws JOSEException {
             signJWTWithKMS();
-            when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
-                    .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
             TokenRequest tokenRequest =
                     docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
             assertThat(tokenRequest.getEndpointURI().toString(), equalTo(TOKEN_URI.toString()));
@@ -117,8 +116,6 @@ class DocAppCriServiceTest {
             when(configService.getDocAppAudClaim()).thenReturn(newAudience);
 
             signJWTWithKMS();
-            when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
-                    .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
 
             TokenRequest tokenRequest =
                     docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
@@ -141,32 +138,40 @@ class DocAppCriServiceTest {
         }
 
         @Test
-        void shouldRetryCallToTokenIfFirstCallFails() throws IOException {
+        void shouldRetryCallToTokenIfFirstCallFails() throws Exception {
+            signJWTWithKMS();
             var tokenRequest = mock(TokenRequest.class);
+            when(docAppCriService.constructTokenRequest(AUTH_CODE.getValue()))
+                    .thenReturn(tokenRequest);
             when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
 
             when(tokenRequest.toHTTPRequest().send())
                     .thenReturn(new HTTPResponse(500))
                     .thenReturn(getSuccessfulTokenHttpResponse());
 
-            var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+            var tokenResponse = docAppCriService.getToken(AUTH_CODE.getValue());
 
             assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+            verify(docAppCriService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
             verify(tokenRequest.toHTTPRequest(), times(2)).send();
         }
 
         @Test
-        void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws IOException {
+        void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws Exception {
+            signJWTWithKMS();
             var tokenRequest = mock(TokenRequest.class);
+            when(docAppCriService.constructTokenRequest(AUTH_CODE.getValue()))
+                    .thenReturn(tokenRequest);
             when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
 
             when(tokenRequest.toHTTPRequest().send())
                     .thenReturn(new HTTPResponse(500))
                     .thenReturn(new HTTPResponse(500));
 
-            var tokenResponse = docAppCriService.sendTokenRequest(tokenRequest);
+            var tokenResponse = docAppCriService.getToken(AUTH_CODE.getValue());
 
             assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+            verify(docAppCriService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
             verify(tokenRequest.toHTTPRequest(), times(2)).send();
         }
 
@@ -205,6 +210,8 @@ class DocAppCriServiceTest {
                             .build();
 
             when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
+            when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
+                    .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
         }
 
         public HTTPResponse getSuccessfulTokenHttpResponse() {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -64,8 +64,27 @@ public class IPVTokenService {
     }
 
     public TokenResponse getToken(String authCode) {
-        var tokenRequest = constructTokenRequest(authCode);
-        return sendTokenRequest(tokenRequest);
+        int count = 0;
+        int maxTries = 2;
+        TokenResponse tokenResponse;
+        do {
+            if (count > 0) LOG.warn("Retrying IPV access token request");
+            count++;
+            // We must generate a new token request every time:
+            // private_key_jwt client auth JWTs are not reusable
+            var tokenRequest = constructTokenRequest(authCode);
+            tokenResponse = sendTokenRequest(tokenRequest);
+            if (!tokenResponse.indicatesSuccess()) {
+                HTTPResponse response = tokenResponse.toHTTPResponse();
+                LOG.warn(
+                        "Unsuccessful {} response from IPV token endpoint on attempt {}: {} ",
+                        response.getStatusCode(),
+                        count,
+                        response.getContent());
+            }
+        } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+
+        return tokenResponse;
     }
 
     public TokenRequest constructTokenRequest(String authCode) {
@@ -98,23 +117,7 @@ public class IPVTokenService {
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
         try {
             LOG.info("Sending IPV token request");
-            int count = 0;
-            int maxTries = 2;
-            TokenResponse tokenResponse;
-            do {
-                if (count > 0) LOG.warn("Retrying IPV access token request");
-                count++;
-                tokenResponse = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
-                if (!tokenResponse.indicatesSuccess()) {
-                    HTTPResponse response = tokenResponse.toHTTPResponse();
-                    LOG.warn(
-                            format(
-                                    "Unsuccessful %s response from IPV token endpoint on attempt %d: %s ",
-                                    response.getStatusCode(), count, response.getContent()));
-                }
-            } while (!tokenResponse.indicatesSuccess() && count < maxTries);
-
-            return tokenResponse;
+            return TokenResponse.parse(tokenRequest.toHTTPRequest().send());
         } catch (IOException e) {
             LOG.error("Error whilst sending TokenRequest", e);
             throw new RuntimeException(e);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -93,7 +94,7 @@ class IPVTokenServiceTest {
 
     @BeforeEach
     void setUp() throws JOSEException {
-        ipvTokenService = new IPVTokenService(configService, kmsService, jwksService);
+        ipvTokenService = spy(new IPVTokenService(configService, kmsService, jwksService));
         when(configService.getIPVBackendURI()).thenReturn(IPV_URI);
         when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
         when(configService.getAccessTokenExpiry()).thenReturn(300L);
@@ -142,25 +143,31 @@ class IPVTokenServiceTest {
     }
 
     @Test
-    void shouldRetryTokenEndpointOnceAndParseSuccessFulSecondResponse() throws IOException {
+    void shouldRetryTokenEndpointOnceAndParseSuccessfulSecondResponse() throws Exception {
+        mockKmsSigningJwt();
+        when(ipvTokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
         when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
         when(tokenRequest.toHTTPRequest().send())
                 .thenReturn(new HTTPResponse(500))
                 .thenReturn(getSuccessfulTokenHttpResponse());
 
-        var tokenResponse = ipvTokenService.sendTokenRequest(tokenRequest);
+        var tokenResponse = ipvTokenService.getToken(AUTH_CODE.getValue());
 
         assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+        verify(ipvTokenService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
     }
 
     @Test
-    void shouldReturnUnsuccessfulResponseIfTwoCallsToIPVTokenEndpointFail() throws IOException {
+    void shouldReturnUnsuccessfulResponseIfTwoCallsToIPVTokenEndpointFail() throws Exception {
+        mockKmsSigningJwt();
+        when(ipvTokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
         when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
         when(tokenRequest.toHTTPRequest().send()).thenReturn(new HTTPResponse(500));
 
-        var tokenResponse = ipvTokenService.sendTokenRequest(tokenRequest);
+        var tokenResponse = ipvTokenService.getToken(AUTH_CODE.getValue());
 
         assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+        verify(ipvTokenService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
         verify(tokenRequest.toHTTPRequest(), times(2)).send();
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
-import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
@@ -322,10 +321,7 @@ public class AuthenticationCallbackHandler
                         Map.of(ResponseHeaders.SET_COOKIE, List.of(newSessionCookie)));
             }
 
-            var tokenRequest =
-                    tokenService.constructTokenRequest(
-                            input.getQueryStringParameters().get("code"));
-            TokenResponse tokenResponse = tokenService.sendTokenRequest(tokenRequest);
+            var tokenResponse = tokenService.getToken(input.getQueryStringParameters().get("code"));
             if (tokenResponse.indicatesSuccess()) {
                 LOG.info("TokenResponse was successful");
                 auditService.submitAuditEvent(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -57,6 +57,30 @@ public class AuthenticationTokenService {
         this.kmsService = kmsService;
     }
 
+    public TokenResponse getToken(String authCode) {
+        int count = 0;
+        int maxTries = 2;
+        TokenResponse tokenResponse;
+        do {
+            if (count > 0) LOG.warn("Retrying Authentication access token request");
+            count++;
+            // We must generate a new token request every time:
+            // private_key_jwt client auth JWTs are not reusable
+            var tokenRequest = constructTokenRequest(authCode);
+            tokenResponse = sendTokenRequest(tokenRequest);
+            if (!tokenResponse.indicatesSuccess()) {
+                HTTPResponse response = tokenResponse.toHTTPResponse();
+                LOG.warn(
+                        "Unsuccessful {} response from Authentication token endpoint on attempt {}: {} ",
+                        response.getStatusCode(),
+                        count,
+                        response.getContent());
+            }
+        } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+
+        return tokenResponse;
+    }
+
     public TokenRequest constructTokenRequest(String authCode) {
         LOG.info("Constructing token request");
         var codeGrant =
@@ -86,23 +110,8 @@ public class AuthenticationTokenService {
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
         try {
-            LOG.info("Sending TokenRequest");
-            int count = 0;
-            int maxTries = 2;
-            TokenResponse tokenResponse;
-            do {
-                if (count > 0) LOG.warn("Retrying Authentication token request");
-                count++;
-                tokenResponse = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
-                if (!tokenResponse.indicatesSuccess()) {
-                    HTTPResponse response = tokenResponse.toHTTPResponse();
-                    LOG.warn(
-                            format(
-                                    "Unsuccessful %s response from Authentication token endpoint on attempt %d: %s ",
-                                    response.getStatusCode(), count, response.getContent()));
-                }
-            } while (!tokenResponse.indicatesSuccess() && count < maxTries);
-            return tokenResponse;
+            LOG.info("Sending Authentication token request");
+            return TokenResponse.parse(tokenRequest.toHTTPRequest().send());
         } catch (IOException e) {
             LOG.error("Error whilst sending TokenRequest", e);
             throw new TokenRequestException("Error whilst sending TokenRequest", e);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -317,7 +317,7 @@ class AuthenticationCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
 
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
 
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
 
@@ -526,7 +526,7 @@ class AuthenticationCallbackHandlerTest {
 
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
-        when(tokenService.sendTokenRequest(any())).thenReturn(UNSUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(UNSUCCESSFUL_TOKEN_RESPONSE);
 
         var response = handler.handleRequest(event, CONTEXT);
 
@@ -551,7 +551,7 @@ class AuthenticationCallbackHandlerTest {
 
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                 .thenThrow(new UnsuccessfulCredentialResponseException(TEST_ERROR_MESSAGE));
 
@@ -579,7 +579,7 @@ class AuthenticationCallbackHandlerTest {
         usingValidClient();
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
 
         handler.handleRequest(event, CONTEXT);
@@ -606,7 +606,7 @@ class AuthenticationCallbackHandlerTest {
         usingValidClient();
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
 
         handler.handleRequest(event, CONTEXT);
@@ -640,7 +640,7 @@ class AuthenticationCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
 
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
 
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
 
@@ -673,7 +673,7 @@ class AuthenticationCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
 
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
 
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
         when(USER_INFO.getStringClaim(AuthUserInfoClaims.ACHIEVED_CREDENTIAL_STRENGTH.getValue()))
@@ -709,7 +709,7 @@ class AuthenticationCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
 
-        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
 
         when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
 
@@ -763,7 +763,7 @@ class AuthenticationCallbackHandlerTest {
                                             .withAuthenticated(authenticated)));
             usingValidClientSession();
             usingValidClient();
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
             when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                     .thenReturn(USER_INFO);
             when(USER_INFO.getBooleanClaim(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()))
@@ -791,7 +791,7 @@ class AuthenticationCallbackHandlerTest {
         @BeforeEach
         void setup() throws UnsuccessfulCredentialResponseException {
             mockedIdentityHelper = mockStatic(IdentityHelper.class);
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
             when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                     .thenReturn(USER_INFO);
             when(USER_INFO.getSubject()).thenReturn(new Subject(TEST_INTERNAL_COMMON_SUBJECT_ID));
@@ -1138,7 +1138,7 @@ class AuthenticationCallbackHandlerTest {
             var maxAgeOrchSession = withMaxAgeOrchSession(INTERNAL_COMMON_SUBJECT_ID);
             withPreviousOrchSessionDueToMaxAge();
 
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
             when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                     .thenReturn(USER_INFO);
             when(USER_INFO.getSubject()).thenReturn(new Subject(INTERNAL_COMMON_SUBJECT_ID));
@@ -1177,7 +1177,7 @@ class AuthenticationCallbackHandlerTest {
             var maxAgeOrchSession = withMaxAgeOrchSession(INTERNAL_COMMON_SUBJECT_ID);
             withNoPreviousOrchSession();
 
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
             when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                     .thenReturn(USER_INFO);
             when(USER_INFO.getSubject()).thenReturn(new Subject(INTERNAL_COMMON_SUBJECT_ID));
@@ -1212,7 +1212,7 @@ class AuthenticationCallbackHandlerTest {
             var maxAgeOrchSession = withMaxAgeOrchSession(INTERNAL_COMMON_SUBJECT_ID);
             var previousOrchSession = withPreviousOrchSessionDueToMaxAge();
 
-            when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+            when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
             when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                     .thenReturn(USER_INFO);
             when(USER_INFO.getSubject())
@@ -1314,7 +1314,7 @@ class AuthenticationCallbackHandlerTest {
                                         .requestObject(encryptedJwt)
                                         .build());
                 var event = createRequestForSfadJourney();
-                when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+                when(tokenService.getToken(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
 
                 when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
                         .thenReturn(USER_INFO);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
@@ -51,6 +51,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -84,7 +85,7 @@ class AuthenticationTokenServiceTest {
                 .thenReturn(GetPublicKeyResponse.builder().keyId(KEY_ID).build());
 
         authenticationTokenService =
-                new AuthenticationTokenService(configurationService, kmsService);
+                spy(new AuthenticationTokenService(configurationService, kmsService));
     }
 
     @Test
@@ -119,32 +120,40 @@ class AuthenticationTokenServiceTest {
     }
 
     @Test
-    void shouldRetryCallToTokenIfFirstCallFails() throws IOException {
+    void shouldRetryCallToTokenIfFirstCallFails() throws Exception {
+        signJWTWithKMS(KEY_ID);
         var tokenRequest = mock(TokenRequest.class);
+        when(authenticationTokenService.constructTokenRequest(AUTH_CODE.getValue()))
+                .thenReturn(tokenRequest);
         when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
 
         when(tokenRequest.toHTTPRequest().send())
                 .thenReturn(new HTTPResponse(500))
                 .thenReturn(getSuccessfulTokenHttpResponse());
 
-        var tokenResponse = authenticationTokenService.sendTokenRequest(tokenRequest);
+        var tokenResponse = authenticationTokenService.getToken(AUTH_CODE.getValue());
 
         assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+        verify(authenticationTokenService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
         verify(tokenRequest.toHTTPRequest(), times(2)).send();
     }
 
     @Test
-    void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws IOException {
+    void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws Exception {
+        signJWTWithKMS(KEY_ID);
         var tokenRequest = mock(TokenRequest.class);
+        when(authenticationTokenService.constructTokenRequest(AUTH_CODE.getValue()))
+                .thenReturn(tokenRequest);
         when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
 
         when(tokenRequest.toHTTPRequest().send())
                 .thenReturn(new HTTPResponse(500))
                 .thenReturn(new HTTPResponse(500));
 
-        var tokenResponse = authenticationTokenService.sendTokenRequest(tokenRequest);
+        var tokenResponse = authenticationTokenService.getToken(AUTH_CODE.getValue());
 
         assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+        verify(authenticationTokenService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
         verify(tokenRequest.toHTTPRequest(), times(2)).send();
     }
 


### PR DESCRIPTION
### Wider context of change

We have a simple retry on our Token and UserInfo calls. The Token call uses `private_key_jwt` auth, which includes a JWT.

This JWT is not reusable, as per the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication):
> These tokens MUST only be used once, unless conditions for reuse were negotiated between the parties

This means we need to regenerate the client auth when retrying, otherwise the second call will always fail.

### What’s changed

Refactored to construct the token request within the retry logic.

### Manual testing

N/A

### Checklist


- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
