### PR TITLE
Bau/remove unused audit fields

### DIFF
--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
@@ -24,7 +24,6 @@ public class TxmaAuditEvent {
 
     @Expose private TxmaAuditUser user;
 
-    @Expose private Map<String, Object> platform;
     @Expose private Map<String, Object> restricted;
     @Expose private Map<String, Object> extensions;
 
@@ -62,16 +61,6 @@ public class TxmaAuditEvent {
 
     public TxmaAuditEvent withUser(TxmaAuditUser user) {
         this.user = user;
-        return this;
-    }
-
-    public TxmaAuditEvent addPlatform(String key, Object value) {
-        if (this.platform == null) {
-            this.platform = new HashMap<>();
-        }
-
-        this.platform.put(key, value);
-
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditUser.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditUser.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 public class TxmaAuditUser {
 
     @Expose private String userId;
-    @Expose private String transactionId;
     @Expose private String email;
     @Expose private String phone;
     @Expose private String ipAddress;
@@ -21,11 +20,6 @@ public class TxmaAuditUser {
 
     public TxmaAuditUser withUserId(String userId) {
         this.userId = userId;
-        return this;
-    }
-
-    public TxmaAuditUser withTransactionId(String transactionId) {
-        this.transactionId = transactionId;
         return this;
     }
 
@@ -69,7 +63,6 @@ public class TxmaAuditUser {
         if (o == null || getClass() != o.getClass()) return false;
         TxmaAuditUser that = (TxmaAuditUser) o;
         return Objects.equals(userId, that.userId)
-                && Objects.equals(transactionId, that.transactionId)
                 && Objects.equals(email, that.email)
                 && Objects.equals(phone, that.phone)
                 && Objects.equals(ipAddress, that.ipAddress)
@@ -82,7 +75,6 @@ public class TxmaAuditUser {
     public int hashCode() {
         return Objects.hash(
                 userId,
-                transactionId,
                 email,
                 phone,
                 ipAddress,

--- a/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
+++ b/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
@@ -98,24 +98,6 @@ class TxmaAuditEventTest {
     }
 
     @Test
-    void shouldSerializePlatformSubObject() {
-        var event =
-                auditEvent(AUTH_TEST_EVENT)
-                        .addPlatform("key1", "value1")
-                        .addPlatform("key2", 2)
-                        .addPlatform("sub-object", Map.of("key3", "value3"));
-
-        var payload = asJson(event.serialize()).getAsJsonObject().get("platform");
-
-        assertThat(payload, hasFieldWithValue("key1", is("value1")));
-        assertThat(payload, hasNumericFieldWithValue("key2", is(2L)));
-
-        var subObject = payload.getAsJsonObject().get("sub-object");
-
-        assertThat(subObject, hasFieldWithValue("key3", is("value3")));
-    }
-
-    @Test
     void shouldSerializeExtensionsSubObject() {
         var event =
                 auditEvent(AUTH_TEST_EVENT)

--- a/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
+++ b/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
@@ -64,7 +64,6 @@ class TxmaAuditEventTest {
                         .withPersistentSessionId("persistent-id")
                         .withPhone("01110")
                         .withSessionId("session-id")
-                        .withTransactionId("transaction-id")
                         .withGovukSigninJourneyId("journey-id");
 
         var event = auditEvent(AUTH_TEST_EVENT).withUser(user);
@@ -77,7 +76,6 @@ class TxmaAuditEventTest {
         assertThat(payload, hasFieldWithValue("persistent_session_id", is("persistent-id")));
         assertThat(payload, hasFieldWithValue("phone", is("01110")));
         assertThat(payload, hasFieldWithValue("session_id", is("session-id")));
-        assertThat(payload, hasFieldWithValue("transaction_id", is("transaction-id")));
         assertThat(payload, hasFieldWithValue("govuk_signin_journey_id", is("journey-id")));
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -101,7 +101,6 @@ class AuditServiceTest {
                     "persistent_session_id":"persistent-session-id",
                     "govuk_signin_journey_id":"request-id"
                 },
-                "platform":null,
                 "restricted":null,
                 "extensions":null}
                 """;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -94,7 +94,6 @@ class AuditServiceTest {
                 "component_id":"AUTH",
                 "user": {
                     "user_id":"subject-id",
-                    "transaction_id":null,
                     "email":"email",
                     "phone":"phone-number",
                     "ip_address":"ip-address",


### PR DESCRIPTION
Removes two fields which are always null / empty in auth audit events:

* platform which has never as far as I can see been used in any audit event, and is [optional on the txma side](https://github.com/govuk-one-login/txma-event-processing/blob/4934f4e6676358c04f62da4ddb469ccdd10cc0ea/common/types/auditEvent.ts#L9)
* transaction id on the user which is unused on the auth side as of the orch / auth split, and is also [optional on the txma side](https://github.com/govuk-one-login/txma-event-processing/blob/4934f4e6676358c04f62da4ddb469ccdd10cc0ea/common/types/auditEvent.ts#L30).

Neither of these fields appear in the schemas for any AUTH_ events