### PR TITLE
BAU: Replace Optional<String> with String for txmaAuditEncoded in AuditContext

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -38,16 +37,19 @@ public class AuditHelper {
 
     private AuditHelper() {}
 
-    public static Optional<String> getTxmaAuditEncoded(Map<String, String> headers) {
+    public static String getTxmaAuditEncodedHeaderOrUnknown(Map<String, String> headers) {
         String txmaEncodedValue =
                 RequestHeaderHelper.getHeaderValueFromHeaders(
                         headers, TXMA_ENCODED_HEADER_NAME, false);
-        if (txmaEncodedValue != null && !txmaEncodedValue.isEmpty()) {
-            return Optional.of(txmaEncodedValue);
-        } else {
-            LOG.warn("Audit header field value cannot be empty");
-            return Optional.empty();
+        if (txmaEncodedValue == null) {
+            LOG.warn("Encoded device information for audit event is not present.");
+            return AuditService.UNKNOWN;
         }
+        if (txmaEncodedValue.isEmpty()) {
+            LOG.warn("Encoded device information for audit event present but empty.");
+            return AuditService.UNKNOWN;
+        }
+        return txmaEncodedValue;
     }
 
     public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
@@ -74,7 +76,7 @@ public class AuditHelper {
                             IpAddressHelper.extractIpAddress(input),
                             null,
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            getTxmaAuditEncoded(input.getHeaders())));
+                            getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders())));
         } catch (Exception e) {
             LOG.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/AuditHelper.java
@@ -13,11 +13,10 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-
-import java.util.Map;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
@@ -30,27 +29,11 @@ import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair
 public class AuditHelper {
 
     private static final Logger LOG = LogManager.getLogger(AuditHelper.class);
-    public static final String TXMA_ENCODED_HEADER_NAME = "txma-audit-encoded";
     public static final String ERROR_BUILDING_AUDIT_CONTEXT = "Error building audit context";
     public static final AuditService.MetadataPair ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR =
             pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.getValue());
 
     private AuditHelper() {}
-
-    public static String getTxmaAuditEncodedHeaderOrUnknown(Map<String, String> headers) {
-        String txmaEncodedValue =
-                RequestHeaderHelper.getHeaderValueFromHeaders(
-                        headers, TXMA_ENCODED_HEADER_NAME, false);
-        if (txmaEncodedValue == null) {
-            LOG.warn("Encoded device information for audit event is not present.");
-            return AuditService.UNKNOWN;
-        }
-        if (txmaEncodedValue.isEmpty()) {
-            LOG.warn("Encoded device information for audit event present but empty.");
-            return AuditService.UNKNOWN;
-        }
-        return txmaEncodedValue;
-    }
 
     public static Result<ErrorResponse, AuditContext> accountManagementAuditContext(
             ConfigurationService configurationService,
@@ -76,7 +59,7 @@ public class AuditHelper {
                             IpAddressHelper.extractIpAddress(input),
                             null,
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders())));
+                            TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input)));
         } catch (Exception e) {
             LOG.error(ERROR_BUILDING_AUDIT_CONTEXT, e);
             return Result.failure(UNEXPECTED_ACCT_MGMT_ERROR);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -8,7 +8,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.AccountInterventionsInboundResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -90,7 +89,7 @@ public class AuthenticateHandler
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
+                        TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input));
 
         try {
             AuthenticateRequest loginRequest =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -90,7 +90,7 @@ public class AuthenticateHandler
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                        AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
 
         try {
             AuthenticateRequest loginRequest =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.RemoveAccountRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
@@ -19,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -123,7 +123,7 @@ public class RemoveAccountHandler
             accountDeletionService.removeAccount(
                     Optional.of(input),
                     userProfile,
-                    AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()),
+                    TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input),
                     AccountDeletionReason.USER_INITIATED);
 
             return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -123,7 +123,7 @@ public class RemoveAccountHandler
             accountDeletionService.removeAccount(
                     Optional.of(input),
                     userProfile,
-                    AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
+                    AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()),
                     AccountDeletionReason.USER_INITIATED);
 
             return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -403,7 +403,7 @@ public class SendOtpNotificationHandler
                         IpAddressHelper.extractIpAddress(input),
                         sendNotificationRequest.phoneNumber(),
                         extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                        AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
 
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.AUTH_SEND_OTP,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -13,7 +13,6 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.SendNotificationRequest;
 import uk.gov.di.accountmanagement.exceptions.MissingConfigurationParameterException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.audit.AuditContext;
@@ -27,6 +26,7 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.TestUserHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -403,7 +403,7 @@ public class SendOtpNotificationHandler
                         IpAddressHelper.extractIpAddress(input),
                         sendNotificationRequest.phoneNumber(),
                         extractPersistentIdFromHeaders(input.getHeaders()),
-                        AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
+                        TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input));
 
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.AUTH_SEND_OTP,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -12,7 +12,6 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
@@ -32,6 +31,7 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -196,7 +196,7 @@ public class UpdateEmailHandler
                             IpAddressHelper.extractIpAddress(input),
                             userProfile.getPhoneNumber(),
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
+                            TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input));
 
             if (emailCheckResultStatus.equals(EmailCheckResultStatus.PENDING)) {
                 submitEmailFraudCheckBypassedAuditEvent(auditContext);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -196,7 +196,7 @@ public class UpdateEmailHandler
                             IpAddressHelper.extractIpAddress(input),
                             userProfile.getPhoneNumber(),
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                            AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
 
             if (emailCheckResultStatus.equals(EmailCheckResultStatus.PENDING)) {
                 submitEmailFraudCheckBypassedAuditEvent(auditContext);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -11,7 +11,6 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdatePasswordRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.audit.AuditContext;
@@ -24,6 +23,7 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -185,7 +185,7 @@ public class UpdatePasswordHandler
                             IpAddressHelper.extractIpAddress(input),
                             userProfile.getPhoneNumber(),
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
+                            TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input));
 
             auditService.submitAuditEvent(
                     AUTH_UPDATE_PASSWORD, auditContext, AUDIT_EVENT_COMPONENT_ID_AUTH);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -185,7 +185,7 @@ public class UpdatePasswordHandler
                             IpAddressHelper.extractIpAddress(input),
                             userProfile.getPhoneNumber(),
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                            AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
 
             auditService.submitAuditEvent(
                     AUTH_UPDATE_PASSWORD, auditContext, AUDIT_EVENT_COMPONENT_ID_AUTH);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -163,7 +163,7 @@ public class UpdatePhoneNumberHandler
                             IpAddressHelper.extractIpAddress(input),
                             updatePhoneNumberRequest.getPhoneNumber(),
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                            AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
 
             auditService.submitAuditEvent(
                     AUTH_UPDATE_PHONE_NUMBER, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -11,7 +11,6 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdatePhoneNumberRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
@@ -24,6 +23,7 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -163,7 +163,7 @@ public class UpdatePhoneNumberHandler
                             IpAddressHelper.extractIpAddress(input),
                             updatePhoneNumberRequest.getPhoneNumber(),
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                            AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
+                            TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input));
 
             auditService.submitAuditEvent(
                     AUTH_UPDATE_PHONE_NUMBER, auditContext, AUDIT_EVENT_COMPONENT_ID_HOME);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -55,7 +55,7 @@ public class AccountDeletionService {
     public void removeAccount(
             Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
-            Optional<String> txmaAuditEncoded,
+            String txmaAuditEncoded,
             AccountDeletionReason reason)
             throws Json.JsonException {
         removeAccount(input, userProfile, txmaAuditEncoded, reason, true);
@@ -64,7 +64,7 @@ public class AccountDeletionService {
     public void removeAccount(
             Optional<APIGatewayProxyRequestEvent> input,
             UserProfile userProfile,
-            Optional<String> txmaAuditEncoded,
+            String txmaAuditEncoded,
             AccountDeletionReason reason,
             boolean sendNotification)
             throws Json.JsonException {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionService.java
@@ -9,6 +9,7 @@ import uk.gov.di.accountmanagement.entity.LegacyAccountDeletionMessage;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
@@ -52,7 +53,7 @@ public class ManualAccountDeletionService {
             accountDeletionService.removeAccount(
                     Optional.empty(),
                     userProfile,
-                    Optional.empty(),
+                    AuditService.UNKNOWN,
                     accountDeletionReason,
                     sendNotification);
             var deletedAccountPayload =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -12,6 +11,7 @@ import uk.gov.di.authentication.shared.entity.mfa.MfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
@@ -108,7 +108,7 @@ public class MfaMethodsMigrationService {
                         .withSubjectId(input.getPathParameters().get("publicSubjectId"))
                         .withPhoneNumber(userProfile.getPhoneNumber())
                         .withTxmaAuditEncoded(
-                                AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
+                                TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input));
 
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationService.java
@@ -107,7 +107,8 @@ public class MfaMethodsMigrationService {
                         .withPersistentSessionId(persistentSessionId)
                         .withSubjectId(input.getPathParameters().get("publicSubjectId"))
                         .withPhoneNumber(userProfile.getPhoneNumber())
-                        .withTxmaAuditEncoded(AuditHelper.getTxmaAuditEncoded(input.getHeaders()));
+                        .withTxmaAuditEncoded(
+                                AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(input.getHeaders()));
 
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
@@ -26,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.TXMA_ENCODED_HEADER_NAME;
 import static uk.gov.di.authentication.shared.entity.AuthSessionItem.ATTRIBUTE_CLIENT_ID;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -49,42 +47,6 @@ class AuditHelperTest {
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     userProfile.getSubjectID(), URI.create(TEST_INTERNAL_SECTOR_URI), TEST_SALT);
     private APIGatewayProxyRequestEvent input;
-
-    @Nested
-    class TxmaAuditEncodedTests {
-        @Test
-        void shouldRetrieveATxmaAuditEncodedFieldFromAHeader() {
-            String auditValue = "validHeaderValue";
-            var result =
-                    AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(
-                            Map.of(TXMA_ENCODED_HEADER_NAME, auditValue));
-            assertEquals(auditValue, result);
-        }
-
-        @Test
-        void shouldLogAwarningWhenMissingHeader() {
-            var result = AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(Map.of());
-            assertEquals(AuditService.UNKNOWN, result);
-            assertThat(
-                    logging.events(),
-                    hasItem(
-                            withMessageContaining(
-                                    "Encoded device information for audit event is not present")));
-        }
-
-        @Test
-        void shouldLogAWarningWhenEmptyHeader() {
-            var result =
-                    AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(
-                            Map.of(TXMA_ENCODED_HEADER_NAME, ""));
-            assertEquals(AuditService.UNKNOWN, result);
-            assertThat(
-                    logging.events(),
-                    hasItem(
-                            withMessageContaining(
-                                    "Encoded device information for audit event present but empty")));
-        }
-    }
 
     @Nested
     class BuildAuditContextTests {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/AuditHelperTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
@@ -18,7 +19,6 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -56,26 +56,33 @@ class AuditHelperTest {
         void shouldRetrieveATxmaAuditEncodedFieldFromAHeader() {
             String auditValue = "validHeaderValue";
             var result =
-                    AuditHelper.getTxmaAuditEncoded(Map.of(TXMA_ENCODED_HEADER_NAME, auditValue));
-            assertEquals(Optional.of(auditValue), result);
+                    AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(
+                            Map.of(TXMA_ENCODED_HEADER_NAME, auditValue));
+            assertEquals(auditValue, result);
         }
 
         @Test
         void shouldLogAwarningWhenMissingHeader() {
-            var result = AuditHelper.getTxmaAuditEncoded(Map.of());
-            assertEquals(Optional.empty(), result);
+            var result = AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(Map.of());
+            assertEquals(AuditService.UNKNOWN, result);
             assertThat(
                     logging.events(),
-                    hasItem(withMessageContaining("Audit header field value cannot be empty")));
+                    hasItem(
+                            withMessageContaining(
+                                    "Encoded device information for audit event is not present")));
         }
 
         @Test
         void shouldLogAWarningWhenEmptyHeader() {
-            var result = AuditHelper.getTxmaAuditEncoded(Map.of(TXMA_ENCODED_HEADER_NAME, ""));
-            assertEquals(Optional.empty(), result);
+            var result =
+                    AuditHelper.getTxmaAuditEncodedHeaderOrUnknown(
+                            Map.of(TXMA_ENCODED_HEADER_NAME, ""));
+            assertEquals(AuditService.UNKNOWN, result);
             assertThat(
                     logging.events(),
-                    hasItem(withMessageContaining("Audit header field value cannot be empty")));
+                    hasItem(
+                            withMessageContaining(
+                                    "Encoded device information for audit event present but empty")));
         }
     }
 
@@ -107,9 +114,7 @@ class AuditHelperTest {
             assertEquals(CommonTestVariables.SESSION_ID, context.sessionId());
             assertEquals(pairwiseId, context.subjectId());
             assertEquals(TEST_IP_ADDRESS, context.ipAddress());
-            assertEquals(
-                    Optional.of(CommonTestVariables.TXMA_ENCODED_HEADER_VALUE),
-                    context.txmaAuditEncoded());
+            assertEquals(CommonTestVariables.TXMA_ENCODED_HEADER_VALUE, context.txmaAuditEncoded());
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/CommonTestVariables.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/CommonTestVariables.java
@@ -2,6 +2,7 @@ package uk.gov.di.accountmanagement.helpers;
 
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 
 import java.util.Map;
 
@@ -16,6 +17,6 @@ public class CommonTestVariables {
                     PERSISTENT_ID,
                     ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
                     SESSION_ID,
-                    AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                    TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                     TXMA_ENCODED_HEADER_VALUE);
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.*;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountInterventionsResponseException;
@@ -17,6 +16,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.services.AccountInterventionsService;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -50,7 +50,7 @@ class AuthenticateHandlerTest {
             Map.of(
                     PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                     PERSISTENT_SESSION_ID,
-                    AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                    TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                     TXMA_ENCODED_HEADER_VALUE,
                     ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
                     SESSION_ID);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -74,7 +74,7 @@ class AuthenticateHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     PERSISTENT_SESSION_ID,
-                    Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                    TXMA_ENCODED_HEADER_VALUE);
     private String clientSubjectId;
 
     @BeforeEach
@@ -144,7 +144,7 @@ class AuthenticateHandlerTest {
                         auditContext
                                 .withClientSessionId("unknown")
                                 .withSubjectId(clientSubjectId)
-                                .withTxmaAuditEncoded(Optional.empty()),
+                                .withTxmaAuditEncoded(AuditService.UNKNOWN),
                         AUDIT_EVENT_COMPONENT_ID_AUTH);
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -126,13 +126,13 @@ class MFAMethodsCreateHandlerTest {
     private final Json objectMapper = SerializationService.getInstance();
     private static final AuditContext BASE_AUDIT_CONTEXT =
             AuditContext.emptyAuditContext()
-                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withTxmaAuditEncoded(TXMA_ENCODED_HEADER_VALUE)
                     .withEmail(TEST_EMAIL)
                     .withClientSessionId(SESSION_ID)
                     .withSessionId(TEST_NON_CLIENT_SESSION_ID)
                     .withSubjectId(TEST_INTERNAL_SUBJECT)
                     .withIpAddress(IP_ADDRESS)
-                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withTxmaAuditEncoded(TXMA_ENCODED_HEADER_VALUE)
                     .withPersistentSessionId(PERSISTENT_ID);
 
     private MFAMethodsCreateHandler handler;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
@@ -138,7 +138,7 @@ class MFAMethodsDeleteHandlerTest {
                             .withClientSessionId(SESSION_ID)
                             .withSubjectId(TEST_INTERNAL_SUBJECT)
                             .withIpAddress(IP_ADDRESS)
-                            .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                            .withTxmaAuditEncoded(TXMA_ENCODED_HEADER_VALUE)
                             .withPersistentSessionId(PERSISTENT_ID);
 
             verify(auditService)

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -116,12 +116,12 @@ class MFAMethodsPutHandlerTest {
     public static final String INCORRECT_OTP = "111111";
     private static final AuditContext BASE_AUDIT_CONTEXT =
             AuditContext.emptyAuditContext()
-                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withTxmaAuditEncoded(TXMA_ENCODED_HEADER_VALUE)
                     .withEmail(EMAIL)
                     .withClientSessionId(SESSION_ID)
                     .withSubjectId(TEST_INTERNAL_SUBJECT)
                     .withIpAddress(IP_ADDRESS)
-                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE))
+                    .withTxmaAuditEncoded(TXMA_ENCODED_HEADER_VALUE)
                     .withPersistentSessionId(PERSISTENT_ID);
     private static final String NON_MIGRATED_EMAIL = "non-migrated-email@example.com";
     private static final UserProfile NON_MIGRATED_USER =

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -92,7 +92,7 @@ class RemoveAccountHandlerTest {
                 .removeAccount(
                         Optional.of(event),
                         userProfile,
-                        Optional.of(TXMA_ENCODED_HEADER_VALUE),
+                        TXMA_ENCODED_HEADER_VALUE,
                         AccountDeletionReason.USER_INITIATED);
     }
 
@@ -114,7 +114,7 @@ class RemoveAccountHandlerTest {
                 .removeAccount(
                         Optional.of(event),
                         userProfile,
-                        Optional.empty(),
+                        AuditService.UNKNOWN,
                         AccountDeletionReason.USER_INITIATED);
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
@@ -16,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -169,7 +169,7 @@ class RemoveAccountHandlerTest {
                 Map.of(
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
                         PERSISTENT_ID,
-                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                         TXMA_ENCODED_HEADER_VALUE));
 
         return event;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -129,7 +129,7 @@ class SendOtpNotificationHandlerTest {
                     "123.123.123.123",
                     TEST_PHONE_NUMBER,
                     PERSISTENT_ID,
-                    Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                    TXMA_ENCODED_HEADER_VALUE);
 
     private static APIGatewayProxyRequestEvent.ProxyRequestContext eventContext;
 
@@ -719,7 +719,7 @@ class SendOtpNotificationHandlerTest {
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
                         PERSISTENT_ID,
-                        Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                        TXMA_ENCODED_HEADER_VALUE);
 
         @BeforeEach
         void setup() {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -71,12 +71,12 @@ import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.A
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_PHONE_NUMBER;
-import static uk.gov.di.accountmanagement.helpers.AuditHelper.TXMA_ENCODED_HEADER_NAME;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_EMAIL_FORMAT;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.USER_DOES_NOT_HAVE_ACCOUNT;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.PERSISTENT_ID_HEADER_NAME;
+import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INTERNATIONAL_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -198,7 +198,7 @@ class SendOtpNotificationHandlerTest {
                         Map.entry(PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID),
                         Map.entry(SESSION_ID_HEADER, "some-session-id"),
                         Map.entry(CLIENT_SESSION_ID_HEADER, "some-client-session-id"),
-                        Map.entry(TXMA_ENCODED_HEADER_NAME, TXMA_ENCODED_HEADER_VALUE)));
+                        Map.entry(TXMA_AUDIT_ENCODED_HEADER, TXMA_ENCODED_HEADER_VALUE)));
 
         event.setRequestContext(eventContext);
         return event;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -107,7 +107,7 @@ class UpdateEmailHandlerTest {
                     "123.123.123.123",
                     null,
                     PERSISTENT_ID,
-                    Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                    TXMA_ENCODED_HEADER_VALUE);
 
     private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService = mock(AuditService.class);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.audit.AuditContext;
@@ -37,6 +36,7 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -443,7 +443,7 @@ class UpdateEmailHandlerTest {
                         PERSISTENT_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
                         SESSION_ID,
-                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                         TXMA_ENCODED_HEADER_VALUE));
 
         return event;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -123,7 +123,7 @@ class UpdatePasswordHandlerTest {
                                 "123.123.123.123",
                                 userProfile.getPhoneNumber(),
                                 PERSISTENT_ID,
-                                Optional.of(TXMA_ENCODED_HEADER_VALUE)),
+                                TXMA_ENCODED_HEADER_VALUE),
                         AUDIT_EVENT_COMPONENT_ID_AUTH);
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -9,7 +9,6 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -21,6 +20,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
@@ -237,7 +237,7 @@ class UpdatePasswordHandlerTest {
                         PERSISTENT_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
                         SESSION_ID,
-                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                         TXMA_ENCODED_HEADER_VALUE));
 
         return event;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.audit.AuditContext;
@@ -20,6 +19,7 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -216,7 +216,7 @@ class UpdatePhoneNumberHandlerTest {
                         PERSISTENT_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
                         CLIENT_SESSION_ID,
-                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                         TXMA_ENCODED_HEADER_VALUE));
 
         return event;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -119,7 +119,7 @@ class UpdatePhoneNumberHandlerTest {
                                 "123.123.123.123",
                                 NEW_PHONE_NUMBER,
                                 PERSISTENT_ID,
-                                Optional.of(TXMA_ENCODED_HEADER_VALUE)),
+                                TXMA_ENCODED_HEADER_VALUE),
                         AUDIT_EVENT_COMPONENT_ID_HOME);
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -111,7 +111,7 @@ class AccountDeletionServiceTest {
         underTest.removeAccount(
                 Optional.of(input),
                 userProfile,
-                Optional.empty(),
+                AuditService.UNKNOWN,
                 AccountDeletionReason.USER_INITIATED);
         // then
         verify(dynamoDeleteService).deleteAccount(eq(expectedEmail), any());
@@ -132,7 +132,7 @@ class AccountDeletionServiceTest {
                         underTest.removeAccount(
                                 Optional.of(input),
                                 userProfile,
-                                Optional.empty(),
+                                AuditService.UNKNOWN,
                                 AccountDeletionReason.USER_INITIATED));
     }
 
@@ -147,7 +147,7 @@ class AccountDeletionServiceTest {
         underTest.removeAccount(
                 Optional.of(input),
                 userProfile,
-                Optional.empty(),
+                AuditService.UNKNOWN,
                 AccountDeletionReason.USER_INITIATED);
 
         // then
@@ -173,7 +173,7 @@ class AccountDeletionServiceTest {
                         underTest.removeAccount(
                                 Optional.of(input),
                                 userProfile,
-                                Optional.empty(),
+                                AuditService.UNKNOWN,
                                 AccountDeletionReason.USER_INITIATED));
         assertThat(
                 logging.events(),
@@ -204,7 +204,7 @@ class AccountDeletionServiceTest {
                 .thenReturn(TEST_IP_ADDRESS);
 
         // when
-        underTest.removeAccount(Optional.of(input), userProfile, Optional.empty(), reason);
+        underTest.removeAccount(Optional.of(input), userProfile, AuditService.UNKNOWN, reason);
 
         // then
         verify(auditService)
@@ -242,7 +242,7 @@ class AccountDeletionServiceTest {
                         underTest.removeAccount(
                                 Optional.of(input),
                                 userProfile,
-                                Optional.empty(),
+                                AuditService.UNKNOWN,
                                 AccountDeletionReason.USER_INITIATED));
         assertThat(
                 logging.events(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/ManualAccountDeletionServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.DeletedAccountIdentifiers;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.nio.ByteBuffer;
@@ -65,7 +66,7 @@ class ManualAccountDeletionServiceTest {
                 .removeAccount(
                         Optional.empty(),
                         USER_PROFILE,
-                        Optional.empty(),
+                        AuditService.UNKNOWN,
                         AccountDeletionReason.SUPPORT_INITIATED,
                         true);
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -24,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.mfa.request.RequestAuthAppMfaDetai
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
@@ -289,7 +289,7 @@ class MfaMethodsMigrationServiceTest {
                         SESSION_ID,
                         ClientSessionIdHelper.SESSION_ID_HEADER_NAME,
                         TEST_CLIENT,
-                        AuditHelper.TXMA_ENCODED_HEADER_NAME,
+                        TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER,
                         TXMA_ENCODED_HEADER_VALUE);
 
         return new APIGatewayProxyRequestEvent()

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/MfaMethodsMigrationServiceTest.java
@@ -79,7 +79,7 @@ class MfaMethodsMigrationServiceTest {
                     .withSessionId(SESSION_ID)
                     .withSubjectId(TEST_PUBLIC_SUBJECT)
                     .withClientSessionId(TEST_CLIENT)
-                    .withTxmaAuditEncoded(Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                    .withTxmaAuditEncoded(TXMA_ENCODED_HEADER_VALUE);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -312,7 +312,7 @@ class TokenHandlerTest {
                                 AuditService.UNKNOWN,
                                 AuditService.UNKNOWN,
                                 AuditService.UNKNOWN,
-                                Optional.empty()));
+                                AuditService.UNKNOWN));
     }
 
     private Map<String, List<String>> privateKeyJWTParams() throws JOSEException {

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -126,7 +126,7 @@ class UserInfoHandlerTest {
                                 "",
                                 "0123456789",
                                 "",
-                                Optional.empty()));
+                                AuditService.UNKNOWN));
     }
 
     @Test
@@ -168,7 +168,7 @@ class UserInfoHandlerTest {
                                 "",
                                 "0123456789",
                                 "",
-                                Optional.empty()));
+                                AuditService.UNKNOWN));
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS;
@@ -143,7 +142,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
         additionalAmcHeaders.put("x-forwarded-for", IpAddressHelper.extractIpAddress(input));
         additionalAmcHeaders.put("user-language", userContext.getUserLanguage().getLanguage());
 
-        if (Objects.nonNull(userContext.getTxmaAuditEncoded())) {
+        if (!userContext.getTxmaAuditEncoded().isEmpty()) {
             additionalAmcHeaders.put("txma-audit-encoded", userContext.getTxmaAuditEncoded());
         } else {
             LOG.warn("No txma audit header included");
@@ -225,7 +224,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                        Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                        userContext.getTxmaAuditEncoded());
 
         Object journeyType =
                 AMCScope.fromValue(journeyOutcome.scope())

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandler.java
@@ -24,7 +24,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
-import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.getTxmaAuditEncodedHeader;
+import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown;
 
 public class IDReverificationStateHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -59,7 +59,7 @@ public class IDReverificationStateHandler
         try {
             ThreadContext.clearMap();
             attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
-            var txmaAuditEncoded = getTxmaAuditEncodedHeader(input);
+            var txmaAuditEncoded = getTxmaAuditEncodedHeaderOrUnknown(input);
             var auditContext =
                     AuditContext.emptyAuditContext().withTxmaAuditEncoded(txmaAuditEncoded);
             var request =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -59,7 +59,7 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachTraceI
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
-import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.getTxmaAuditEncodedHeader;
+import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class StartHandler
@@ -225,7 +225,7 @@ public class StartHandler
                             input.getHeaders(),
                             CLIENT_SESSION_ID_HEADER,
                             configurationService.getHeadersCaseInsensitive());
-            var txmaAuditHeader = getTxmaAuditEncodedHeader(input);
+            var txmaAuditHeader = getTxmaAuditEncodedHeaderOrUnknown(input);
             String phoneNumber = AuditService.UNKNOWN;
 
             var auditContext =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -22,8 +22,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.Optional;
-
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.audit.AuditContext.emptyAuditContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_ERROR;
@@ -151,6 +149,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             String clientSessionId, String txmaAuditEncoded) {
         return emptyAuditContext()
                 .withClientSessionId(clientSessionId)
-                .withTxmaAuditEncoded(Optional.ofNullable(txmaAuditEncoded));
+                .withTxmaAuditEncoded(txmaAuditEncoded);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -124,6 +124,7 @@ class AMCAuthorizeHandlerTest {
                 .thenReturn(Optional.of(authSession));
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
+        when(userContext.getTxmaAuditEncoded()).thenReturn(AuditService.UNKNOWN);
     }
 
     @Nested

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
@@ -116,7 +116,7 @@ class AMCCallbackHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @BeforeAll
     static void setUp() {
@@ -188,7 +188,7 @@ class AMCCallbackHandlerTest {
 
     @Test
     void shouldTolerateANullTxmaEncodedValue() throws IOException, ParseException {
-        when(USER_CONTEXT.getTxmaAuditEncoded()).thenReturn(null);
+        when(USER_CONTEXT.getTxmaAuditEncoded()).thenReturn(AuditService.UNKNOWN);
         String journeyOutcomeResult =
                 createJourneyOutcomeResultForAMCScope(AMCScope.ACCOUNT_DELETE);
         setupSuccessfulTokenResponse();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -125,7 +125,7 @@ class AccountInterventionsHandlerTest {
                     CommonTestVariables.IP_ADDRESS,
                     AuditService.UNKNOWN,
                     CommonTestVariables.DI_PERSISTENT_SESSION_ID,
-                    Optional.of(CommonTestVariables.ENCODED_DEVICE_DETAILS));
+                    CommonTestVariables.ENCODED_DEVICE_DETAILS);
     private static final Json objectMapper = SerializationService.getInstance();
 
     @RegisterExtension
@@ -632,7 +632,7 @@ class AccountInterventionsHandlerTest {
                 .thenReturn(
                         generateAccountInterventionResponse(
                                 blocked, suspended, reproveIdentity, resetPassword));
-        when(userContext.getTxmaAuditEncoded()).thenReturn(null);
+        when(userContext.getTxmaAuditEncoded()).thenReturn(AuditService.UNKNOWN);
 
         var result =
                 handler.handleRequestWithUserContext(
@@ -642,7 +642,8 @@ class AccountInterventionsHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        AUTH_NO_INTERVENTION, AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()));
+                        AUTH_NO_INTERVENTION,
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN));
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -68,7 +68,7 @@ class AccountRecoveryHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @BeforeEach
     void setup() {
@@ -133,7 +133,7 @@ class AccountRecoveryHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_ACCOUNT_RECOVERY_PERMITTED,
-                        auditContext.withTxmaAuditEncoded(Optional.empty()));
+                        auditContext.withTxmaAuditEncoded(AuditService.UNKNOWN));
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -104,7 +104,7 @@ class AuthenticationAuthCodeHandlerTest {
                     IP_ADDRESS,
                     UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @BeforeEach
     void setUp() throws Json.JsonException {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -113,11 +113,10 @@ class CheckReAuthUserHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     private final AuditContext testAuditContextWithAuditEncoded =
-            testAuditContextWithoutAuditEncoded.withTxmaAuditEncoded(
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+            testAuditContextWithoutAuditEncoded.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS);
 
     private final UserContext userContext = mock(UserContext.class);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -127,7 +127,7 @@ class CheckUserExistsHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -320,7 +320,7 @@ class CheckUserExistsHandlerTest {
                             FrontendAuditableEvent.AUTH_CHECK_USER_KNOWN_EMAIL,
                             AUDIT_CONTEXT
                                     .withSubjectId(getExpectedInternalPairwiseId())
-                                    .withTxmaAuditEncoded(Optional.empty()),
+                                    .withTxmaAuditEncoded(AuditService.UNKNOWN),
                             pair("has_active_passkey", AuditService.UNKNOWN),
                             pair("rpPairwiseId", getExpectedRpPairwiseId()));
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/IDReverificationStateHandlerTest.java
@@ -73,7 +73,7 @@ public class IDReverificationStateHandlerTest {
                         AUTH_REVERIFY_AUTHORISATION_ERROR_RECEIVED,
                         AuditContext.emptyAuditContext()
                                 .withClientSessionId(CLIENT_SESSION_ID)
-                                .withTxmaAuditEncoded(Optional.of(ENCODED_DEVICE_DETAILS)),
+                                .withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("journey-type", "ACCOUNT_RECOVERY"));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -135,7 +135,7 @@ class LoginHandlerReauthenticationRedisTest {
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging = new CaptureLoggingExtension(LoginHandler.class);
@@ -206,8 +206,7 @@ class LoginHandlerReauthenticationRedisTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_INVALID_CREDENTIALS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair(
                                 "incorrectPasswordCount",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -133,7 +133,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     private LoginHandler handler;
 
@@ -239,7 +239,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                                    ENCODED_DEVICE_DETAILS),
                             pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                             pair("incorrect_email_attempt_count", 0),
                             pair("incorrect_password_attempt_count", 5),
@@ -259,7 +259,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .submitAuditEvent(
                             AUTH_INVALID_CREDENTIALS,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                                    ENCODED_DEVICE_DETAILS),
                             pair("internalSubjectId", userProfile.getSubjectID()),
                             pair("incorrectPasswordCount", MAX_ALLOWED_RETRIES),
                             pair(
@@ -362,7 +362,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                                    ENCODED_DEVICE_DETAILS),
                             pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                             pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
                             pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
@@ -442,7 +442,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                                    ENCODED_DEVICE_DETAILS),
                             pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                             pair("incorrect_email_attempt_count", expectedEmailAttemptCount),
                             pair("incorrect_password_attempt_count", expectedPasswordAttemptCount),
@@ -502,7 +502,7 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_REAUTH_FAILED,
                             auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                    Optional.of(ENCODED_DEVICE_DETAILS)),
+                                    ENCODED_DEVICE_DETAILS),
                             pair("rpPairwiseId", TEST_RP_PAIRWISE_ID),
                             pair("incorrect_email_attempt_count", 0),
                             pair("incorrect_password_attempt_count", MAX_ALLOWED_RETRIES),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -182,7 +182,7 @@ class LoginHandlerTest {
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     private final AuditContext auditContextWithoutUserInfo =
             auditContextWithAllUserInfo
@@ -258,8 +258,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(cloudwatchMetricsService)
@@ -302,8 +301,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(cloudwatchMetricsService)
@@ -353,8 +351,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(cloudwatchMetricsService)
@@ -403,8 +400,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(cloudwatchMetricsService)
@@ -730,8 +726,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_LOG_IN_SUCCESS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("passwordResetType", PasswordResetType.FORCED_WEAK_PASSWORD));
         verifyNoInteractions(cloudwatchMetricsService);
@@ -800,8 +795,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_TEMPORARILY_LOCKED,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair("attemptNoFailedAt", maxRetriesAllowed),
                         pair("number_of_attempts_user_allowed_to_login", maxRetriesAllowed));
@@ -842,8 +836,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_INVALID_CREDENTIALS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", userProfile.getSubjectID()),
                         pair(
                                 "incorrectPasswordCount",
@@ -883,8 +876,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_TEMPORARILY_LOCKED,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("attemptNoFailedAt", configurationService.getMaxPasswordRetries()),
                         pair(
@@ -962,8 +954,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_INVALID_CREDENTIALS,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)),
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("incorrectPasswordCount", 1),
                         pair("attemptNoFailedAt", MAX_ALLOWED_PASSWORD_RETRIES));
@@ -1075,8 +1066,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_NO_ACCOUNT_WITH_EMAIL,
-                        auditContextWithoutUserInfo.withTxmaAuditEncoded(
-                                Optional.of(ENCODED_DEVICE_DETAILS)));
+                        auditContextWithoutUserInfo.withTxmaAuditEncoded(ENCODED_DEVICE_DETAILS));
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ACCT_DOES_NOT_EXIST));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -162,7 +162,7 @@ class MfaHandlerTest {
                     IP_ADDRESS,
                     UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     private final AuthSessionItem authSession =
             new AuthSessionItem()
@@ -417,7 +417,7 @@ class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_MFA_CODE_SENT,
-                        AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN),
                         pair("journey-type", JourneyType.SIGN_IN),
                         pair("mfa-type", NotificationType.MFA_SMS.getMfaMethodType().getValue()),
                         pair("mfa-method", PriorityIdentifier.DEFAULT.name().toLowerCase()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -88,7 +88,7 @@ class MfaResetAuthorizeHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
     private static final String ORCHESTRATION_STATE = "ORCHESTRATION_STATE";
     private static final APIGatewayProxyRequestEvent TEST_INVOKE_EVENT =
             ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -135,7 +135,7 @@ class ResetPasswordHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     private ResetPasswordHandler handler;
     private final AuthSessionItem authSession =
@@ -211,7 +211,7 @@ class ResetPasswordHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT,
-                            auditContext.withTxmaAuditEncoded(Optional.empty()));
+                            auditContext.withTxmaAuditEncoded(AuditService.UNKNOWN));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -142,7 +142,7 @@ class ResetPasswordRequestHandlerTest {
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -333,7 +333,7 @@ class ResetPasswordRequestHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_PASSWORD_RESET_REQUESTED,
-                            auditContext.withTxmaAuditEncoded(Optional.empty()),
+                            auditContext.withTxmaAuditEncoded(AuditService.UNKNOWN),
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }
@@ -410,7 +410,7 @@ class ResetPasswordRequestHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_PASSWORD_RESET_REQUESTED_FOR_TEST_CLIENT,
-                            auditContext.withTxmaAuditEncoded(Optional.empty()),
+                            auditContext.withTxmaAuditEncoded(AuditService.UNKNOWN),
                             PASSWORD_RESET_COUNTER,
                             PASSWORD_RESET_TYPE_FORGOTTEN_PASSWORD);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -109,7 +109,7 @@ class ReverificationResultHandlerTest {
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -137,6 +137,7 @@ class ReverificationResultHandlerTest {
                 .thenReturn(new URI("https://api.identity.account.gov.uk/token"));
         when(USER_CONTEXT.getAuthSession()).thenReturn(authSession);
         when(USER_CONTEXT.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
+        when(USER_CONTEXT.getTxmaAuditEncoded()).thenReturn(AuditService.UNKNOWN);
         var userProfile = mock(UserProfile.class);
         when(userProfile.getPhoneNumber()).thenReturn(CommonTestVariables.UK_MOBILE_NUMBER);
         when(USER_CONTEXT.getUserProfile()).thenReturn(Optional.of(userProfile));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -158,7 +158,7 @@ class SendNotificationHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     private final SendNotificationHandler handler =
             new SendNotificationHandler(
@@ -300,7 +300,8 @@ class SendNotificationHandlerTest {
 
                     if (!ticfHeaderPresent) {
                         event.setHeaders(VALID_HEADERS_WITHOUT_AUDIT_ENCODED);
-                        expectedAuditContext = auditContext.withTxmaAuditEncoded(Optional.empty());
+                        expectedAuditContext =
+                                auditContext.withTxmaAuditEncoded(AuditService.UNKNOWN);
                     }
 
                     var result = handler.handleRequest(event, context);
@@ -937,7 +938,7 @@ class SendNotificationHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_EMAIL_INVALID_CODE_REQUEST,
-                            auditContext.withTxmaAuditEncoded(Optional.empty()));
+                            auditContext.withTxmaAuditEncoded(AuditService.UNKNOWN));
         }
 
         @Nested

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -101,7 +101,7 @@ class SignUpHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -217,7 +217,7 @@ class SignUpHandlerTest {
                         FrontendAuditableEvent.AUTH_CREATE_ACCOUNT,
                         AUDIT_CONTEXT
                                 .withSubjectId(expectedCommonSubject)
-                                .withTxmaAuditEncoded(Optional.empty()),
+                                .withTxmaAuditEncoded(AuditService.UNKNOWN),
                         pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()),
                         pair("rpPairwiseId", expectedRpPairwiseId));
     }
@@ -302,7 +302,7 @@ class SignUpHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS,
-                        AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()));
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -117,7 +117,7 @@ class StartHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @BeforeEach
     void beforeEach() {
@@ -261,7 +261,7 @@ class StartHandlerTest {
                         FrontendAuditableEvent.AUTH_REAUTH_REQUESTED,
                         AUDIT_CONTEXT
                                 .withSubjectId(TEST_SUBJECT_ID)
-                                .withTxmaAuditEncoded(Optional.empty()));
+                                .withTxmaAuditEncoded(AuditService.UNKNOWN));
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         CloudwatchMetrics.REAUTH_REQUESTED.getValue(),
@@ -271,7 +271,7 @@ class StartHandlerTest {
                         FrontendAuditableEvent.AUTH_START_INFO_FOUND,
                         AUDIT_CONTEXT
                                 .withSubjectId(TEST_SUBJECT_ID)
-                                .withTxmaAuditEncoded(Optional.empty()),
+                                .withTxmaAuditEncoded(AuditService.UNKNOWN),
                         pair("internalSubjectId", TEST_SUBJECT_ID));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -85,19 +85,10 @@ class UpdateProfileHandlerTest {
                     IP_ADDRESS,
                     UK_MOBILE_NUMBER,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     private final AuditContext auditContextWithOnlyClientSession =
-            new AuditContext(
-                    "",
-                    CLIENT_SESSION_ID,
-                    "",
-                    "",
-                    "",
-                    "",
-                    "",
-                    "",
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+            new AuditContext("", CLIENT_SESSION_ID, "", "", "", "", "", "", ENCODED_DEVICE_DETAILS);
 
     @RegisterExtension
     private final CaptureLoggingExtension logging =
@@ -171,12 +162,13 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
-                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(Optional.empty()));
+                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(
+                                AuditService.UNKNOWN));
 
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(Optional.empty()));
+                        auditContextWithAllUserInfo.withTxmaAuditEncoded(AuditService.UNKNOWN));
     }
 
     @Test
@@ -217,11 +209,13 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
-                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(Optional.empty()));
+                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(
+                                AuditService.UNKNOWN));
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_REQUEST_ERROR,
-                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(Optional.empty()));
+                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(
+                                AuditService.UNKNOWN));
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -173,7 +173,7 @@ class VerifyCodeHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     private final AuditContext AUDIT_CONTEXT_FOR_TEST_CLIENT =
             AUDIT_CONTEXT.withSessionId(authSession.getSessionId()).withClientId(TEST_CLIENT_ID);
@@ -311,7 +311,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
+                        AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN),
                         pair("notification-type", emailNotificationType.name()),
                         pair(
                                 "account-recovery",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -192,7 +192,7 @@ class VerifyMfaCodeHandlerTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     DI_PERSISTENT_SESSION_ID,
-                    Optional.of(ENCODED_DEVICE_DETAILS));
+                    ENCODED_DEVICE_DETAILS);
 
     @BeforeEach
     void setUp() {
@@ -301,7 +301,7 @@ class VerifyMfaCodeHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                            AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
+                            AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN),
                             pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
                             pair("account-recovery", false),
                             pair("journey-type", REGISTRATION),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -96,7 +96,7 @@ class AuthAppCodeProcessorTest {
                     IP_ADDRESS,
                     AuditService.UNKNOWN,
                     PERSISTENT_ID,
-                    Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                    TXMA_ENCODED_HEADER_VALUE);
 
     @BeforeEach
     void setUp() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -105,7 +105,7 @@ class PhoneNumberCodeProcessorTest {
                     IP_ADDRESS,
                     CommonTestVariables.UK_MOBILE_NUMBER,
                     PERSISTENT_ID,
-                    Optional.of(TXMA_ENCODED_HEADER_VALUE));
+                    TXMA_ENCODED_HEADER_VALUE);
 
     @BeforeEach
     void setup() {

--- a/shared/src/main/java/uk/gov/di/audit/AuditContext.java
+++ b/shared/src/main/java/uk/gov/di/audit/AuditContext.java
@@ -3,8 +3,6 @@ package uk.gov.di.audit;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.util.Optional;
-
 public record AuditContext(
         String clientId,
         String clientSessionId,
@@ -14,7 +12,7 @@ public record AuditContext(
         String ipAddress,
         String phoneNumber,
         String persistentSessionId,
-        Optional<String> txmaAuditEncoded) {
+        String txmaAuditEncoded) {
 
     public static AuditContext auditContextFromUserContext(
             UserContext userContext,
@@ -32,7 +30,7 @@ public record AuditContext(
                 ipAddress,
                 phoneNumber,
                 persistentSessionId,
-                Optional.ofNullable(userContext.getTxmaAuditEncoded()));
+                userContext.getTxmaAuditEncoded());
     }
 
     public static AuditContext emptyAuditContext() {
@@ -45,7 +43,7 @@ public record AuditContext(
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
-                Optional.empty());
+                AuditService.UNKNOWN);
     }
 
     public AuditContext withPhoneNumber(String phoneNumber) {
@@ -65,7 +63,7 @@ public record AuditContext(
         return withSubjectId(subjectId);
     }
 
-    public AuditContext withTxmaAuditEncoded(Optional<String> txmaAuditEncoded) {
+    public AuditContext withTxmaAuditEncoded(String txmaAuditEncoded) {
         return new AuditContext(
                 clientId,
                 clientSessionId,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TxmaAuditHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TxmaAuditHelper.java
@@ -1,18 +1,32 @@
 package uk.gov.di.authentication.shared.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
 
 public class TxmaAuditHelper {
+    private static final Logger LOG = LogManager.getLogger(TxmaAuditHelper.class);
     public static final String TXMA_AUDIT_ENCODED_HEADER = "txma-audit-encoded";
 
     private TxmaAuditHelper() {}
 
-    public static Optional<String> getTxmaAuditEncodedHeader(APIGatewayProxyRequestEvent request) {
-        return getOptionalHeaderValueFromHeaders(
-                request.getHeaders(), TXMA_AUDIT_ENCODED_HEADER, false);
+    public static String getTxmaAuditEncodedHeaderOrUnknown(APIGatewayProxyRequestEvent request) {
+        Optional<String> header =
+                getOptionalHeaderValueFromHeaders(
+                        request.getHeaders(), TXMA_AUDIT_ENCODED_HEADER, false);
+        if (header.isEmpty()) {
+            LOG.warn("Encoded device information for audit event is not present.");
+            return AuditService.UNKNOWN;
+        }
+        if (header.get().isEmpty()) {
+            LOG.warn("Encoded device information for audit event present but empty.");
+            return AuditService.UNKNOWN;
+        }
+        return header.get();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -39,7 +39,7 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessio
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachTraceId;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getOptionalHeaderValueFromHeaders;
-import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.getTxmaAuditEncodedHeader;
+import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown;
 
 public abstract class BaseFrontendHandler<T>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -121,7 +121,7 @@ public abstract class BaseFrontendHandler<T>
             attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
         }
 
-        String txmaAuditEncoded = getTxmaAuditEncodedHeader(input).orElse(null);
+        String txmaAuditEncoded = getTxmaAuditEncodedHeaderOrUnknown(input);
 
         var sessionId =
                 getOptionalHeaderValueFromHeaders(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -1,7 +1,5 @@
 package uk.gov.di.authentication.shared.services;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.audit.TxmaAuditEvent;
 import uk.gov.di.audit.TxmaAuditUser;
@@ -18,7 +16,6 @@ import static java.util.function.Predicate.not;
 import static uk.gov.di.audit.TxmaAuditEvent.auditEventWithTime;
 
 public class AuditService {
-    private static final Logger LOG = LogManager.getLogger(AuditService.class);
 
     public static final String UNKNOWN = "";
     public static final String COMPONENT_ID = "AUTH";
@@ -41,22 +38,14 @@ public class AuditService {
     }
 
     private static void addRestrictedSectionToAuditEvent(
-            Optional<String> txmaAuditEncoded,
-            TxmaAuditEvent txmaAuditEvent,
-            MetadataPair... metadataPairs) {
+            String txmaAuditEncoded, TxmaAuditEvent txmaAuditEvent, MetadataPair... metadataPairs) {
         Arrays.stream(metadataPairs)
                 .filter(MetadataPair::isRestricted)
                 .forEach(pair -> txmaAuditEvent.addRestricted(pair.key(), pair.value()));
 
-        txmaAuditEncoded.ifPresentOrElse(
-                s -> {
-                    if (!s.isEmpty()) {
-                        txmaAuditEvent.addRestricted("device_information", Map.of("encoded", s));
-                    } else {
-                        LOG.warn("Encoded device information for audit event present but empty.");
-                    }
-                },
-                () -> LOG.warn("Encoded device information for audit event is not present."));
+        if (!txmaAuditEncoded.isEmpty()) {
+            txmaAuditEvent.addRestricted("device_information", Map.of("encoded", txmaAuditEncoded));
+        }
     }
 
     private static void addExtensionSectionToAuditEvent(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -72,7 +72,7 @@ public class UserContext {
         private boolean userAuthenticated = false;
         private SupportedLanguage userLanguage;
         private String clientSessionId;
-        private String txmaAuditEncoded;
+        private String txmaAuditEncoded = "";
 
         protected Builder(AuthSessionItem authSession) {
             this.authSession = authSession;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TxmaAuditHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TxmaAuditHelperTest.java
@@ -3,10 +3,10 @@ package uk.gov.di.authentication.shared.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.HashMap;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.shared.helpers.TxmaAuditHelper.TXMA_AUDIT_ENCODED_HEADER;
@@ -23,9 +23,9 @@ class TxmaAuditHelperTest {
         headers.put(TXMA_AUDIT_ENCODED_HEADER, "test");
         apiRequest.setHeaders(headers);
 
-        var result = TxmaAuditHelper.getTxmaAuditEncodedHeader(apiRequest);
+        var result = TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(apiRequest);
 
-        assertEquals(Optional.of("test"), result);
+        assertEquals("test", result);
     }
 
     @Test
@@ -35,19 +35,19 @@ class TxmaAuditHelperTest {
         headers.put(TXMA_AUDIT_ENCODED_HEADER.toUpperCase(), "test");
         apiRequest.setHeaders(headers);
 
-        var result = TxmaAuditHelper.getTxmaAuditEncodedHeader(apiRequest);
+        var result = TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(apiRequest);
 
-        assertEquals(Optional.empty(), result);
+        assertEquals(AuditService.UNKNOWN, result);
     }
 
     @Test
-    void missingTxMAAuditEncodedHeaderReturnsEmptyOptional() {
+    void missingTxMAAuditEncodedHeaderReturnsUnknown() {
         var apiRequest = new APIGatewayProxyRequestEvent();
         var headers = new HashMap<String, String>();
         apiRequest.setHeaders(headers);
 
-        var result = TxmaAuditHelper.getTxmaAuditEncodedHeader(apiRequest);
+        var result = TxmaAuditHelper.getTxmaAuditEncodedHeaderOrUnknown(apiRequest);
 
-        assertEquals(Optional.empty(), result);
+        assertEquals(AuditService.UNKNOWN, result);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -47,7 +46,7 @@ class AuditServiceTest {
                     "ip-address",
                     "phone-number",
                     "persistent-session-id",
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     enum TestEvents implements AuditableEvent {
         AUTH_TEST_EVENT_ONE;
@@ -76,7 +75,7 @@ class AuditServiceTest {
                         "ip-address",
                         "phone-number",
                         "persistent-session-id",
-                        Optional.empty());
+                        AuditService.UNKNOWN);
 
         auditService.submitAuditEvent(AUTH_TEST_EVENT_ONE, myContext);
 
@@ -164,7 +163,7 @@ class AuditServiceTest {
 
         auditService.submitAuditEvent(
                 AUTH_TEST_EVENT_ONE,
-                AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.of(auditEncodedHeaderValue)),
+                AUDIT_CONTEXT.withTxmaAuditEncoded(auditEncodedHeaderValue),
                 pair("restrictedKey1", "restrictedValue1", true));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
@@ -174,8 +173,7 @@ class AuditServiceTest {
 
     @Test
     void anEmptyTXMAHeaderShouldNotBeAddedToAuditEventWhenNoOtherRestrictedData() {
-        auditService.submitAuditEvent(
-                AUTH_TEST_EVENT_ONE, AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()));
+        auditService.submitAuditEvent(AUTH_TEST_EVENT_ONE, AUDIT_CONTEXT);
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
         assertThatTheRestrictedSectionDoesNotExist();
@@ -185,7 +183,7 @@ class AuditServiceTest {
     void anEmptyTXMAHeaderShouldNotBeAddedToAuditEventWhenOtherRestrictedDataHasBeenWritten() {
         auditService.submitAuditEvent(
                 AUTH_TEST_EVENT_ONE,
-                AUDIT_CONTEXT.withTxmaAuditEncoded(Optional.empty()),
+                AUDIT_CONTEXT,
                 pair("restrictedKey1", "restrictedValue1", true));
 
         verify(awsSqsClient).send(txmaMessageCaptor.capture());

--- a/test-services-api/src/test/java/uk/gov/di/authentication/testservices/DeleteSyntheticsUserHandlerTest.java
+++ b/test-services-api/src/test/java/uk/gov/di/authentication/testservices/DeleteSyntheticsUserHandlerTest.java
@@ -51,7 +51,7 @@ class DeleteSyntheticsUserHandlerTest {
                     "123.123.123.123",
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
-                    Optional.empty());
+                    AuditService.UNKNOWN);
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
## What

- Remove Optional wrapping from txmaAuditEncoded in AuditContext
  and all call sites
- Use AuditService.UNKNOWN as for missing values, consistent with
  all other audit context fields
- Move warning logs from AuditService event emission to point of
  header extraction in TxmaAuditHelper and AuditHelper
- Rename methods to getTxmaAuditEncodedHeaderOrUnknown to signal
  that null is never returned
- Deduplicate txma audit header extraction in account management, use existing shared functionality instead

## How to review

1. Code Review
