### PR TITLE
BAU: Rename auth session verified attributes to be clearer

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -343,7 +343,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             }
         }
 
-        LOG.info("Setting hasVerifiedPassword to true");
+        LOG.info("Setting hasVerifiedWithPassword to true");
         userActionsManager.correctPasswordReceived(journeyType, permissionContext);
 
         authSessionService.updateSession(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -212,7 +212,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                         .withEmailAddress(userCredentials.getEmail())
                         .withAuthSessionItem(userContext.getAuthSession());
 
-        LOG.info("Setting hasVerifiedPassword to true");
+        LOG.info("Setting hasVerifiedWithPassword to true");
         userActionsManager.passwordReset(
                 JourneyType.PASSWORD_RESET, permissionContextBuilder.build());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -153,7 +153,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                             .withEmailAddress(request.getEmail())
                             .withInternalCommonSubjectId(internalCommonSubjectId.getValue()));
 
-            LOG.info("Setting hasVerifiedPassword to true");
+            LOG.info("Setting hasVerifiedWithPassword to true");
             var permissionContext =
                     PermissionContext.builder().withAuthSessionItem(authSessionItem).build();
             userActionsManager.createdPassword(JourneyType.REGISTRATION, permissionContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -211,10 +211,10 @@ public class StartHandler
 
             if (reauthenticate) {
                 LOG.info(
-                        "Reauthentication - Setting hasVerifiedPassword, hasVerifiedMfa & hasVerifiedPasskey to false");
-                authSession.setHasVerifiedPassword(false);
-                authSession.setHasVerifiedMfa(false);
-                authSession.setHasVerifiedPasskey(false);
+                        "Reauthentication - Setting hasVerifiedWithPassword, hasVerifiedWithMfa & hasVerifiedWithPasskey to false");
+                authSession.setHasVerifiedWithPassword(false);
+                authSession.setHasVerifiedWithMfa(false);
+                authSession.setHasVerifiedWithPasskey(false);
             }
 
             Optional<String> maybeInternalSubject =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -535,7 +535,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     journeyType,
                     countryCode);
 
-            LOG.info("Setting hasVerifiedMfa to true");
+            LOG.info("Setting hasVerifiedWithMfa to true");
             var permissionContext =
                     PermissionContext.builder().withAuthSessionItem(authSession).build();
             userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -573,7 +573,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     authSession.withResetMfaState(AuthSessionItem.ResetMfaState.SUCCEEDED));
         }
 
-        LOG.info("Setting hasVerifiedMfa to true");
+        LOG.info("Setting hasVerifiedWithMfa to true");
         PermissionContext permissionContext =
                 PermissionContext.builder().withAuthSessionItem(authSession).build();
         if (codeRequest.getMfaMethodType() == MFAMethodType.SMS) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -903,9 +903,9 @@ class StartHandlerTest {
                         .withSessionId(SESSION_ID)
                         .withClientId(CLIENT_ID)
                         .withInternalCommonSubjectId(TEST_SUBJECT_ID)
-                        .withHasVerifiedPassword(true)
-                        .withHasVerifiedMfa(true)
-                        .withHasVerifiedPasskey(true);
+                        .withHasVerifiedWithPassword(true)
+                        .withHasVerifiedWithMfa(true)
+                        .withHasVerifiedWithPasskey(true);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
                 .thenReturn(authSession);
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
@@ -918,8 +918,8 @@ class StartHandlerTest {
 
         // Assert
         assertThat(result, hasStatus(200));
-        assertFalse(authSession.getHasVerifiedPassword());
-        assertFalse(authSession.getHasVerifiedMfa());
-        assertFalse(authSession.getHasVerifiedPasskey());
+        assertFalse(authSession.getHasVerifiedWithPassword());
+        assertFalse(authSession.getHasVerifiedWithMfa());
+        assertFalse(authSession.getHasVerifiedWithPasskey());
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -153,7 +153,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         authSessionExtension.addAchievedCredentialTrustToSession(
                 sessionId, CredentialTrustLevel.LOW_LEVEL);
         var session = authSessionExtension.getSession(sessionId).orElseThrow();
-        session.setHasVerifiedPassword(true);
+        session.setHasVerifiedWithPassword(true);
         authSessionExtension.updateSession(session);
         return sessionId;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -44,9 +44,9 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_SUBJECT_TYPE = "SubjectType";
     public static final String ATTRIBUTE_RP_SECTOR_IDENTIFIER_HOST = "RpSectorIdentifierHost";
     public static final String ATTRIBUTE_PASSKEY_ASSERTION_REQUEST = "PasskeyAssertionRequest";
-    public static final String ATTRIBUTE_HAS_VERIFIED_PASSWORD = "HasVerifiedPassword";
-    public static final String ATTRIBUTE_HAS_VERIFIED_MFA = "HasVerifiedMfa";
-    public static final String ATTRIBUTE_HAS_VERIFIED_PASSKEY = "HasVerifiedPasskey";
+    public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSWORD = "HasVerifiedWithPassword";
+    public static final String ATTRIBUTE_HAS_VERIFIED_WITH_MFA = "HasVerifiedWithMfa";
+    public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY = "HasVerifiedWithPasskey";
     public static final String ATTRIBUTE_IS_PARTIALLY_CREATED_ACCOUNT = "IsPartiallyCreatedAccount";
 
     public enum AccountState {
@@ -91,9 +91,9 @@ public class AuthSessionItem {
     private String subjectType;
     private String rpSectorIdentifierHost;
     private String passkeyAssertionRequest;
-    private boolean hasVerifiedPassword;
-    private boolean hasVerifiedMfa;
-    private boolean hasVerifiedPasskey;
+    private boolean hasVerifiedWithPassword;
+    private boolean hasVerifiedWithMfa;
+    private boolean hasVerifiedWithPasskey;
     private boolean isPartiallyCreatedAccount;
 
     public AuthSessionItem() {
@@ -500,45 +500,45 @@ public class AuthSessionItem {
         return this;
     }
 
-    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_PASSWORD)
-    public boolean getHasVerifiedPassword() {
-        return hasVerifiedPassword;
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_PASSWORD)
+    public boolean getHasVerifiedWithPassword() {
+        return hasVerifiedWithPassword;
     }
 
-    public void setHasVerifiedPassword(boolean hasVerifiedPassword) {
-        this.hasVerifiedPassword = hasVerifiedPassword;
+    public void setHasVerifiedWithPassword(boolean hasVerifiedWithPassword) {
+        this.hasVerifiedWithPassword = hasVerifiedWithPassword;
     }
 
-    public AuthSessionItem withHasVerifiedPassword(boolean hasVerifiedPassword) {
-        this.hasVerifiedPassword = hasVerifiedPassword;
+    public AuthSessionItem withHasVerifiedWithPassword(boolean hasVerifiedWithPassword) {
+        this.hasVerifiedWithPassword = hasVerifiedWithPassword;
         return this;
     }
 
-    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_MFA)
-    public boolean getHasVerifiedMfa() {
-        return hasVerifiedMfa;
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_MFA)
+    public boolean getHasVerifiedWithMfa() {
+        return hasVerifiedWithMfa;
     }
 
-    public void setHasVerifiedMfa(boolean hasVerifiedMfa) {
-        this.hasVerifiedMfa = hasVerifiedMfa;
+    public void setHasVerifiedWithMfa(boolean hasVerifiedWithMfa) {
+        this.hasVerifiedWithMfa = hasVerifiedWithMfa;
     }
 
-    public AuthSessionItem withHasVerifiedMfa(boolean hasVerifiedMfa) {
-        this.hasVerifiedMfa = hasVerifiedMfa;
+    public AuthSessionItem withHasVerifiedWithMfa(boolean hasVerifiedWithMfa) {
+        this.hasVerifiedWithMfa = hasVerifiedWithMfa;
         return this;
     }
 
-    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_PASSKEY)
-    public boolean getHasVerifiedPasskey() {
-        return hasVerifiedPasskey;
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY)
+    public boolean getHasVerifiedWithPasskey() {
+        return hasVerifiedWithPasskey;
     }
 
-    public void setHasVerifiedPasskey(boolean hasVerifiedPasskey) {
-        this.hasVerifiedPasskey = hasVerifiedPasskey;
+    public void setHasVerifiedWithPasskey(boolean hasVerifiedWithPasskey) {
+        this.hasVerifiedWithPasskey = hasVerifiedWithPasskey;
     }
 
-    public AuthSessionItem withHasVerifiedPasskey(boolean hasVerifiedPasskey) {
-        this.hasVerifiedPasskey = hasVerifiedPasskey;
+    public AuthSessionItem withHasVerifiedWithPasskey(boolean hasVerifiedWithPasskey) {
+        this.hasVerifiedWithPasskey = hasVerifiedWithPasskey;
         return this;
     }
 
@@ -577,12 +577,12 @@ public class AuthSessionItem {
                 + internalCommonSubjectId
                 + "', upliftRequired = '"
                 + upliftRequired
-                + "', hasVerifiedPassword = '"
-                + hasVerifiedPassword
-                + "', hasVerifiedMfa = '"
-                + hasVerifiedMfa
-                + "', hasVerifiedPasskey = '"
-                + hasVerifiedPasskey
+                + "', hasVerifiedWithPassword = '"
+                + hasVerifiedWithPassword
+                + "', hasVerifiedWithMfa = '"
+                + hasVerifiedWithMfa
+                + "', hasVerifiedWithPasskey = '"
+                + hasVerifiedWithPasskey
                 + "'}}";
     }
 }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -387,22 +387,22 @@ public class PermissionDecisionManager implements PermissionDecisions {
     public boolean canIssueAuthCode(AuthSessionItem authSession) {
         var achievedCredentialStrength = authSession.getAchievedCredentialStrength();
         var requestedCredentialStrength = authSession.getRequestedCredentialStrength();
-        var hasVerifiedPasskey = authSession.getHasVerifiedPasskey();
-        var hasVerifiedPassword = authSession.getHasVerifiedPassword();
-        var hasVerifiedMfa = authSession.getHasVerifiedMfa();
+        var hasVerifiedWithPasskey = authSession.getHasVerifiedWithPasskey();
+        var hasVerifiedWithPassword = authSession.getHasVerifiedWithPassword();
+        var hasVerifiedWithMfa = authSession.getHasVerifiedWithMfa();
 
         LOG.info(
                 "Checking if auth code is blocked - "
                         + "achievedCredentialStrength='{}', "
                         + "requestedCredentialStrength='{}', "
-                        + "hasVerifiedPasskey='{}', "
-                        + "hasVerifiedPassword='{}', "
-                        + "hasVerifiedMfa='{}'",
+                        + "hasVerifiedWithPasskey='{}', "
+                        + "hasVerifiedWithPassword='{}', "
+                        + "hasVerifiedWithMfa='{}'",
                 achievedCredentialStrength == null ? null : achievedCredentialStrength.getValue(),
                 requestedCredentialStrength == null ? null : requestedCredentialStrength.getValue(),
-                hasVerifiedPasskey,
-                hasVerifiedPassword,
-                hasVerifiedMfa);
+                hasVerifiedWithPasskey,
+                hasVerifiedWithPassword,
+                hasVerifiedWithMfa);
 
         if (achievedCredentialStrength == null) {
             LOG.info("Auth code blocked: no credential strength achieved");
@@ -420,20 +420,20 @@ public class PermissionDecisionManager implements PermissionDecisions {
             return false;
         }
 
-        if (hasVerifiedPasskey) {
+        if (hasVerifiedWithPasskey) {
             LOG.info("Auth code permitted");
             return true;
         }
 
         LOG.info("Passkey not verified");
 
-        if (!hasVerifiedPassword) {
+        if (!hasVerifiedWithPassword) {
             LOG.info("Auth code blocked: password not verified");
             return false;
         }
 
         if (requestedCredentialStrength == CredentialTrustLevel.MEDIUM_LEVEL) {
-            if (!hasVerifiedMfa) {
+            if (!hasVerifiedWithMfa) {
                 LOG.info("Auth code blocked: mfa not verified");
                 return false;
             }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -202,7 +202,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> createdPassword(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPassword(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -210,7 +210,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctPasswordReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPassword(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -224,7 +224,7 @@ public class UserActionsManager implements UserActions {
         getCodeStorageService()
                 .deleteBlockForEmail(permissionContext.emailAddress(), codeBlockedKeyPrefix);
 
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPassword(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
 
         return Result.success(null);
@@ -276,7 +276,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithMfa(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -290,7 +290,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithMfa(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -301,7 +301,7 @@ public class UserActionsManager implements UserActions {
         var updatedSession =
                 permissionContext
                         .authSessionItem()
-                        .withHasVerifiedPasskey(true)
+                        .withHasVerifiedWithPasskey(true)
                         .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
@@ -310,7 +310,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectPasskeyReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPasskey(false);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPasskey(false);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -1262,9 +1262,9 @@ class PermissionDecisionManagerTest {
         void shouldReturnCorrectAssessmentForDifferentSessions(
                 CredentialTrustLevel achievedCredentialTrustLevel,
                 CredentialTrustLevel requiredCredentialTrustLevel,
-                boolean hasVerifiedPasskey,
-                boolean hasVerifiedPassword,
-                boolean hasVerifiedMfa,
+                boolean hasVerifiedWithPasskey,
+                boolean hasVerifiedWithPassword,
+                boolean hasVerifiedWithMfa,
                 boolean shouldIssueAuthCode) {
             // Arrange
             var mockSession = mock(AuthSessionItem.class);
@@ -1272,9 +1272,9 @@ class PermissionDecisionManagerTest {
                     .thenReturn(achievedCredentialTrustLevel);
             when(mockSession.getRequestedCredentialStrength())
                     .thenReturn(requiredCredentialTrustLevel);
-            when(mockSession.getHasVerifiedPasskey()).thenReturn(hasVerifiedPasskey);
-            when(mockSession.getHasVerifiedPassword()).thenReturn(hasVerifiedPassword);
-            when(mockSession.getHasVerifiedMfa()).thenReturn(hasVerifiedMfa);
+            when(mockSession.getHasVerifiedWithPasskey()).thenReturn(hasVerifiedWithPasskey);
+            when(mockSession.getHasVerifiedWithPassword()).thenReturn(hasVerifiedWithPassword);
+            when(mockSession.getHasVerifiedWithMfa()).thenReturn(hasVerifiedWithMfa);
 
             // Act
             var result = permissionDecisionManager.canIssueAuthCode(mockSession);

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -76,7 +76,7 @@ class UserActionsManagerTest {
     @Nested
     class CreatedPasswordOperations {
         @Test
-        void passwordCreatedShouldSetHasVerifiedPasswordToTrue() {
+        void passwordCreatedShouldSetHasVerifiedWithPasswordToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -86,7 +86,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPassword());
+            assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
     }
@@ -94,7 +94,7 @@ class UserActionsManagerTest {
     @Nested
     class CorrectPasswordReceivedOperations {
         @Test
-        void correctPasswordReceivedShouldSetHasVerifiedPasswordToTrue() {
+        void correctPasswordReceivedShouldSetHasVerifiedWithPasswordToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -104,7 +104,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPassword());
+            assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
     }
@@ -139,7 +139,7 @@ class UserActionsManagerTest {
         }
 
         @Test
-        void passwordResetShouldSetHasVerifiedPasswordToTrue() {
+        void passwordResetShouldSetHasVerifiedWithPasswordToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -149,7 +149,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPassword());
+            assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
     }
@@ -414,7 +414,7 @@ class UserActionsManagerTest {
     @Nested
     class CorrectSmsOtpReceived {
         @Test
-        void correctSmsOtpReceivedShouldSetHasVerifiedMfaToTrue() {
+        void correctSmsOtpReceivedShouldSetHasVerifiedWithMfaToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -424,7 +424,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(capturedSession.getHasVerifiedWithMfa());
             assertTrue(result.isSuccess());
         }
     }
@@ -574,7 +574,7 @@ class UserActionsManagerTest {
     @Nested
     class CorrectAuthAppOtpReceived {
         @Test
-        void correctAuthAppOtpReceivedShouldSetHasVerifiedMfaToTrue() {
+        void correctAuthAppOtpReceivedShouldSetHasVerifiedWithMfaToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -584,7 +584,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(capturedSession.getHasVerifiedWithMfa());
             assertTrue(result.isSuccess());
         }
     }
@@ -593,7 +593,7 @@ class UserActionsManagerTest {
     class CorrectPasskeyReceived {
         @Test
         void
-                correctPasskeyReceivedShouldSetHasVerifiedPasskeyToTrueAndCredentialStrengthToMedium() {
+                correctPasskeyReceivedShouldSetHasVerifiedWithPasskeyToTrueAndCredentialStrengthToMedium() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -603,7 +603,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPasskey());
+            assertTrue(capturedSession.getHasVerifiedWithPasskey());
             assertEquals(
                     CredentialTrustLevel.MEDIUM_LEVEL,
                     capturedSession.getAchievedCredentialStrength());
@@ -614,7 +614,7 @@ class UserActionsManagerTest {
     @Nested
     class IncorrectPasskeyReceived {
         @Test
-        void incorrectPasskeyReceivedShouldSetHasVerifiedPasskeyToFalse() {
+        void incorrectPasskeyReceivedShouldSetHasVerifiedWithPasskeyToFalse() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -624,7 +624,7 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertFalse(capturedSession.getHasVerifiedPasskey());
+            assertFalse(capturedSession.getHasVerifiedWithPasskey());
             assertTrue(result.isSuccess());
         }
     }


### PR DESCRIPTION
## What

Rename the hasVerified<Authenticator> attributes to hasVerifiedWith<Authenticator> to make it clearer that the attributes mean the user has verified with a particular authenticator (rather than the user has a type of authenticator).

## How to review

1. Code review
