### PR TITLE
Aut 5503: Remove is mfa method management api enabled flag

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -136,14 +136,6 @@ public class MFAMethodsCreateHandler
 
     private Result<APIGatewayProxyResponseEvent, UserProfile>
             getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
-        if (!configurationService.isMfaMethodManagementApiEnabled()) {
-            LOG.error(
-                    "Request to create MFA method in {} environment but feature is switched off.",
-                    configurationService.getEnvironment());
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(400, ErrorResponse.MM_API_NOT_AVAILABLE));
-        }
-
         var subject = input.getPathParameters().get("publicSubjectId");
 
         if (subject == null) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandler.java
@@ -98,13 +98,6 @@ public class MFAMethodsDeleteHandler
 
         addSessionIdToLogs(input);
 
-        if (!configurationService.isMfaMethodManagementApiEnabled()) {
-            LOG.error(
-                    "Request to delete MFA method in {} environment but feature is switched off.",
-                    configurationService.getEnvironment());
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MM_API_NOT_AVAILABLE);
-        }
-
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
         var mfaIdentifier = input.getPathParameters().get("mfaIdentifier");
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -139,13 +139,6 @@ public class MFAMethodsPutHandler
             APIGatewayProxyRequestEvent input, Context context) throws Json.JsonException {
         addSessionIdToLogs(input);
 
-        if (!configurationService.isMfaMethodManagementApiEnabled()) {
-            LOG.error(
-                    "Request to update MFA method in {} environment but feature is switched off.",
-                    configurationService.getEnvironment());
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MM_API_NOT_AVAILABLE);
-        }
-
         var validRequestOrErrorResponse = validatePutRequest(input);
 
         if (validRequestOrErrorResponse.isFailure()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandler.java
@@ -67,13 +67,6 @@ public class MFAMethodsRetrieveHandler
 
         addSessionIdToLogs(input);
 
-        if (!configurationService.isMfaMethodManagementApiEnabled()) {
-            LOG.error(
-                    "Request to create MFA method in {} environment but feature is switched off.",
-                    configurationService.getEnvironment());
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.MM_API_NOT_AVAILABLE);
-        }
-
         var publicSubjectId = input.getPathParameters().get("publicSubjectId");
 
         if (publicSubjectId.isEmpty()) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -191,7 +191,6 @@ class MFAMethodsCreateHandlerTest {
     @BeforeEach
     void setUp() {
         reset(mfaMethodsService, cloudwatchMetricsService);
-        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(true);
         when(configurationService.isAccountManagementInternationalSmsEnabled()).thenReturn(true);
         when(configurationService.getEnvironment()).thenReturn("test");
         handler =
@@ -508,23 +507,6 @@ class MFAMethodsCreateHandlerTest {
             assertTrue(result.getBody().contains(String.valueOf(expectedError.getCode())));
             assertTrue(result.getBody().contains(expectedError.getMessage()));
             verifyNoInteractions(sqsClient);
-        }
-
-        @Test
-        void shouldReturn400IfRequestIsMadeInEnvWhereApiNotEnabled() {
-            when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(false);
-
-            var event =
-                    generateApiGatewayEvent(
-                            PriorityIdentifier.BACKUP,
-                            new RequestAuthAppMfaDetail(TEST_CREDENTIAL),
-                            TEST_INTERNAL_SUBJECT);
-
-            var result = handler.handleRequest(event, context);
-
-            assertThat(result, hasStatus(400));
-            verifyNoInteractions(sqsClient);
-            verifyNoInteractions(auditService);
         }
 
         @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsDeleteHandlerTest.java
@@ -97,7 +97,6 @@ class MFAMethodsDeleteHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(true);
         handler =
                 new MFAMethodsDeleteHandler(
                         configurationService,
@@ -245,18 +244,6 @@ class MFAMethodsDeleteHandlerTest {
             var result = handler.handleRequest(eventWithoutMfaIdentifier, context);
 
             assertThat(result, hasStatus(400));
-
-            verifyNoInteractions(sqsClient);
-        }
-
-        @Test
-        void shouldReturn400WhenFeatureFlagDisabled() {
-            when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(false);
-
-            var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
-
-            var result = handler.handleRequest(event, context);
-            assertEquals(400, result.getStatusCode());
 
             verifyNoInteractions(sqsClient);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -144,7 +144,6 @@ class MFAMethodsPutHandlerTest {
                 sqsClient,
                 mfaMethodsMigrationService);
 
-        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(true);
         when(configurationService.isAccountManagementInternationalSmsEnabled()).thenReturn(true);
         when(configurationService.getEnvironment()).thenReturn("test");
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
@@ -1170,19 +1169,6 @@ class MFAMethodsPutHandlerTest {
                 .updateMfaMethod(
                         eq(EMAIL), eq(DEFAULT_SMS_METHOD), eq(List.of(DEFAULT_SMS_METHOD)), any());
         verify(sqsClient).send(any());
-    }
-
-    @Test
-    void shouldReturn400WhenFeatureFlagDisabled() {
-        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(false);
-
-        var event = requestWithPublicSubjectAndMfaIdentifier(TEST_PUBLIC_SUBJECT, MFA_IDENTIFIER);
-
-        var result = handler.handleRequest(event, context);
-        assertEquals(400, result.getStatusCode());
-
-        verify(sqsClient, never()).send(any());
-        verifyNoInteractions(auditService);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsRetrieveHandlerTest.java
@@ -53,7 +53,6 @@ class MFAMethodsRetrieveHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(true);
         handler =
                 new MFAMethodsRetrieveHandler(
                         configurationService, dynamoService, mfaMethodsService);
@@ -88,16 +87,6 @@ class MFAMethodsRetrieveHandlerTest {
         var event =
                 generateApiGatewayEvent(TEST_INTERNAL_SUBJECT)
                         .withPathParameters((Map.of("publicSubjectId", "")));
-
-        var result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(400));
-    }
-
-    @Test
-    void shouldReturn400IfRequestIsMadeInEnvironmentWhereApiIsDisabled() {
-        when(configurationService.isMfaMethodManagementApiEnabled()).thenReturn(false);
-        var event = generateApiGatewayEvent(TEST_INTERNAL_SUBJECT);
 
         var result = handler.handleRequest(event, context);
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -101,7 +101,7 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @BeforeEach
     void setUp() {
-        handler = new MFAMethodsCreateHandler(ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE);
+        handler = new MFAMethodsCreateHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
         testPublicSubject =
                 userStore.getUserProfileFromEmail(TEST_EMAIL).get().getPublicSubjectID();

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsDeleteHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsDeleteHandlerIntegrationTest.java
@@ -73,7 +73,7 @@ class MFAMethodsDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @BeforeEach
     void setUp() {
-        handler = new MFAMethodsDeleteHandler(ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE);
+        handler = new MFAMethodsDeleteHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         publicSubjectId = userStore.signUp(EMAIL, PASSWORD);
         byte[] salt = userStore.addSalt(EMAIL);
         testInternalSubject =

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsPutHandlerIntegrationTest.java
@@ -151,7 +151,7 @@ class MFAMethodsPutHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         userProfile.getSubjectID(), INTERNAL_SECTOR_HOST, salt);
 
-        handler = new MFAMethodsPutHandler(ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE);
+        handler = new MFAMethodsPutHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
 
         notificationsQueue.clear();
         txmaAuditQueue.clear();

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsRetrieveHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsRetrieveHandlerIntegrationTest.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.Collections;
@@ -33,14 +32,7 @@ class MFAMethodsRetrieveHandlerIntegrationTest extends ApiGatewayHandlerIntegrat
     @BeforeEach
     void setUp() {
         publicSubjectId = userStore.signUp(EMAIL, PASSWORD);
-        ConfigurationService mfaMethodEnabledConfigurationService =
-                new ConfigurationService() {
-                    @Override
-                    public boolean isMfaMethodManagementApiEnabled() {
-                        return true;
-                    }
-                };
-        handler = new MFAMethodsRetrieveHandler(mfaMethodEnabledConfigurationService);
+        handler = new MFAMethodsRetrieveHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         byte[] salt = userStore.addSalt(EMAIL);
         testInternalSubject =
                 ClientSubjectHelper.calculatePairwiseIdentifier(

--- a/ci/cloudformation/account-management/function/mfa-methods-create.yaml
+++ b/ci/cloudformation/account-management/function/mfa-methods-create.yaml
@@ -26,7 +26,6 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          MFA_METHOD_MANAGEMENT_API_ENABLED: "true"
           ACCOUNT_MANAGEMENT_INTERNATIONAL_SMS_ENABLED:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/account-management/function/mfa-methods-delete.yaml
+++ b/ci/cloudformation/account-management/function/mfa-methods-delete.yaml
@@ -23,7 +23,6 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          MFA_METHOD_MANAGEMENT_API_ENABLED: "true"
           EMAIL_QUEUE_URL: !GetAtt EmailNotificationQueue.QueueUrl
           INTERNAl_SECTOR_URI: !If
             - IsNotProduction

--- a/ci/cloudformation/account-management/function/mfa-methods-retrieve.yaml
+++ b/ci/cloudformation/account-management/function/mfa-methods-retrieve.yaml
@@ -15,7 +15,6 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          MFA_METHOD_MANAGEMENT_API_ENABLED: "true"
           EMAIL_QUEUE_URL: !GetAtt EmailNotificationQueue.QueueUrl
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"

--- a/ci/cloudformation/account-management/function/mfa-methods-update.yaml
+++ b/ci/cloudformation/account-management/function/mfa-methods-update.yaml
@@ -24,7 +24,6 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          MFA_METHOD_MANAGEMENT_API_ENABLED: "true"
           ACCOUNT_MANAGEMENT_INTERNATIONAL_SMS_ENABLED:
             !FindInMap [
               EnvironmentConfiguration,

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -200,6 +200,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 }
             };
 
+    // TODO remove
     protected static final ConfigurationService
             ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -200,22 +200,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 }
             };
 
-    // TODO remove
-    protected static final ConfigurationService
-            ACCOUNT_MANAGEMENT_TXMA_ENABLED_CONFIGUARION_SERVICE =
-                    new IntegrationTestConfigurationService(
-                            notificationsQueue, tokenSigner, configurationParameters) {
-                        @Override
-                        public String getTxmaAuditQueueUrl() {
-                            return txmaAuditQueue.getQueueUrl();
-                        }
-
-                        @Override
-                        public boolean isMfaMethodManagementApiEnabled() {
-                            return true;
-                        }
-                    };
-
     protected static final ConfigurationService
             ACCOUNT_MANAGEMENT_INT_SMS_DISABLED_TXMA_ENABLED_CONFIGUARION_SERVICE =
                     new IntegrationTestConfigurationService(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -213,11 +213,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
                         public boolean isAccountManagementInternationalSmsEnabled() {
                             return false;
                         }
-
-                        @Override
-                        public boolean isMfaMethodManagementApiEnabled() {
-                            return true;
-                        }
                     };
 
     protected static final ConfigurationService

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -835,12 +835,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
-    public boolean isMfaMethodManagementApiEnabled() {
-        return System.getenv()
-                .getOrDefault("MFA_METHOD_MANAGEMENT_API_ENABLED", FEATURE_SWITCH_OFF)
-                .equals(FEATURE_SWITCH_ON);
-    }
-
     public boolean isAuthSessionUsingStronglyConsistentReads() {
         return System.getenv()
                 .getOrDefault("AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS", FEATURE_SWITCH_OFF)


### PR DESCRIPTION
Remove the isMfaMethodManagementApiEnabled feature flag as this was only intended to be in use during the development of the new mfa method management api.

It is on in all environments and we have no plans to switch it off. Removing the feature flag from code and cloudformation to simplify our code and config.
