### PR TITLE
BAU: Add new verified authenticator attributes for clarity

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -213,8 +213,11 @@ public class StartHandler
                 LOG.info(
                         "Reauthentication - Setting hasVerifiedPassword, hasVerifiedMfa & hasVerifiedPasskey to false");
                 authSession.setHasVerifiedPassword(false);
+                authSession.setHasVerifiedWithPassword(false);
                 authSession.setHasVerifiedMfa(false);
+                authSession.setHasVerifiedWithMfa(false);
                 authSession.setHasVerifiedPasskey(false);
+                authSession.setHasVerifiedWithPasskey(false);
             }
 
             Optional<String> maybeInternalSubject =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -902,8 +902,11 @@ class StartHandlerTest {
                         .withClientId(CLIENT_ID)
                         .withInternalCommonSubjectId(TEST_SUBJECT_ID)
                         .withHasVerifiedPassword(true)
+                        .withHasVerifiedWithPassword(true)
                         .withHasVerifiedMfa(true)
-                        .withHasVerifiedPasskey(true);
+                        .withHasVerifiedWithMfa(true)
+                        .withHasVerifiedPasskey(true)
+                        .withHasVerifiedWithPasskey(true);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
                 .thenReturn(authSession);
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
@@ -917,7 +920,10 @@ class StartHandlerTest {
         // Assert
         assertThat(result, hasStatus(200));
         assertFalse(authSession.getHasVerifiedPassword());
+        assertFalse(authSession.getHasVerifiedWithPassword());
         assertFalse(authSession.getHasVerifiedMfa());
+        assertFalse(authSession.getHasVerifiedWithMfa());
         assertFalse(authSession.getHasVerifiedPasskey());
+        assertFalse(authSession.getHasVerifiedWithPasskey());
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -154,6 +154,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 sessionId, CredentialTrustLevel.LOW_LEVEL);
         var session = authSessionExtension.getSession(sessionId).orElseThrow();
         session.setHasVerifiedPassword(true);
+        session.setHasVerifiedWithPassword(true);
         authSessionExtension.updateSession(session);
         return sessionId;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -47,6 +47,9 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_HAS_VERIFIED_PASSWORD = "HasVerifiedPassword";
     public static final String ATTRIBUTE_HAS_VERIFIED_MFA = "HasVerifiedMfa";
     public static final String ATTRIBUTE_HAS_VERIFIED_PASSKEY = "HasVerifiedPasskey";
+    public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSWORD = "HasVerifiedWithPassword";
+    public static final String ATTRIBUTE_HAS_VERIFIED_WITH_MFA = "HasVerifiedWithMfa";
+    public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY = "HasVerifiedWithPasskey";
     public static final String ATTRIBUTE_IS_PARTIALLY_CREATED_ACCOUNT = "IsPartiallyCreatedAccount";
 
     public enum AccountState {
@@ -94,6 +97,9 @@ public class AuthSessionItem {
     private boolean hasVerifiedPassword;
     private boolean hasVerifiedMfa;
     private boolean hasVerifiedPasskey;
+    private boolean hasVerifiedWithPassword;
+    private boolean hasVerifiedWithMfa;
+    private boolean hasVerifiedWithPasskey;
     private boolean isPartiallyCreatedAccount;
 
     public AuthSessionItem() {
@@ -514,6 +520,20 @@ public class AuthSessionItem {
         return this;
     }
 
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_PASSWORD)
+    public boolean getHasVerifiedWithPassword() {
+        return hasVerifiedWithPassword;
+    }
+
+    public void setHasVerifiedWithPassword(boolean hasVerifiedWithPassword) {
+        this.hasVerifiedWithPassword = hasVerifiedWithPassword;
+    }
+
+    public AuthSessionItem withHasVerifiedWithPassword(boolean hasVerifiedWithPassword) {
+        this.hasVerifiedWithPassword = hasVerifiedWithPassword;
+        return this;
+    }
+
     @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_MFA)
     public boolean getHasVerifiedMfa() {
         return hasVerifiedMfa;
@@ -528,6 +548,20 @@ public class AuthSessionItem {
         return this;
     }
 
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_MFA)
+    public boolean getHasVerifiedWithMfa() {
+        return hasVerifiedWithMfa;
+    }
+
+    public void setHasVerifiedWithMfa(boolean hasVerifiedWithMfa) {
+        this.hasVerifiedWithMfa = hasVerifiedWithMfa;
+    }
+
+    public AuthSessionItem withHasVerifiedWithMfa(boolean hasVerifiedWithMfa) {
+        this.hasVerifiedWithMfa = hasVerifiedWithMfa;
+        return this;
+    }
+
     @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_PASSKEY)
     public boolean getHasVerifiedPasskey() {
         return hasVerifiedPasskey;
@@ -539,6 +573,20 @@ public class AuthSessionItem {
 
     public AuthSessionItem withHasVerifiedPasskey(boolean hasVerifiedPasskey) {
         this.hasVerifiedPasskey = hasVerifiedPasskey;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY)
+    public boolean getHasVerifiedWithPasskey() {
+        return hasVerifiedWithPasskey;
+    }
+
+    public void setHasVerifiedWithPasskey(boolean hasVerifiedWithPasskey) {
+        this.hasVerifiedWithPasskey = hasVerifiedWithPasskey;
+    }
+
+    public AuthSessionItem withHasVerifiedWithPasskey(boolean hasVerifiedWithPasskey) {
+        this.hasVerifiedWithPasskey = hasVerifiedWithPasskey;
         return this;
     }
 
@@ -583,6 +631,12 @@ public class AuthSessionItem {
                 + hasVerifiedMfa
                 + "', hasVerifiedPasskey = '"
                 + hasVerifiedPasskey
+                + "', hasVerifiedWithPassword = '"
+                + hasVerifiedWithPassword
+                + "', hasVerifiedWithMfa = '"
+                + hasVerifiedWithMfa
+                + "', hasVerifiedWithPasskey = '"
+                + hasVerifiedWithPasskey
                 + "'}}";
     }
 }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -388,21 +388,30 @@ public class PermissionDecisionManager implements PermissionDecisions {
         var achievedCredentialStrength = authSession.getAchievedCredentialStrength();
         var requestedCredentialStrength = authSession.getRequestedCredentialStrength();
         var hasVerifiedPasskey = authSession.getHasVerifiedPasskey();
+        var hasVerifiedWithPasskey = authSession.getHasVerifiedWithPasskey();
         var hasVerifiedPassword = authSession.getHasVerifiedPassword();
+        var hasVerifiedWithPassword = authSession.getHasVerifiedWithPassword();
         var hasVerifiedMfa = authSession.getHasVerifiedMfa();
+        var hasVerifiedWithMfa = authSession.getHasVerifiedWithMfa();
 
         LOG.info(
                 "Checking if auth code is blocked - "
                         + "achievedCredentialStrength='{}', "
                         + "requestedCredentialStrength='{}', "
                         + "hasVerifiedPasskey='{}', "
+                        + "hasVerifiedWithPasskey='{}', "
                         + "hasVerifiedPassword='{}', "
-                        + "hasVerifiedMfa='{}'",
+                        + "hasVerifiedWithPassword='{}', "
+                        + "hasVerifiedMfa='{}', "
+                        + "hasVerifiedWithMfa='{}'",
                 achievedCredentialStrength == null ? null : achievedCredentialStrength.getValue(),
                 requestedCredentialStrength == null ? null : requestedCredentialStrength.getValue(),
                 hasVerifiedPasskey,
+                hasVerifiedWithPasskey,
                 hasVerifiedPassword,
-                hasVerifiedMfa);
+                hasVerifiedWithPassword,
+                hasVerifiedMfa,
+                hasVerifiedWithMfa);
 
         if (achievedCredentialStrength == null) {
             LOG.info("Auth code blocked: no credential strength achieved");

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -202,7 +202,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> createdPassword(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPassword(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedPassword(true)
+                        .withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -210,7 +214,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctPasswordReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPassword(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedPassword(true)
+                        .withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -224,7 +232,11 @@ public class UserActionsManager implements UserActions {
         getCodeStorageService()
                 .deleteBlockForEmail(permissionContext.emailAddress(), codeBlockedKeyPrefix);
 
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPassword(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedPassword(true)
+                        .withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
 
         return Result.success(null);
@@ -276,7 +288,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedMfa(true)
+                        .withHasVerifiedWithMfa(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -290,7 +306,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedMfa(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedMfa(true)
+                        .withHasVerifiedWithMfa(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -302,6 +322,7 @@ public class UserActionsManager implements UserActions {
                 permissionContext
                         .authSessionItem()
                         .withHasVerifiedPasskey(true)
+                        .withHasVerifiedWithPasskey(true)
                         .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
@@ -310,7 +331,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectPasskeyReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedPasskey(false);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedPasskey(false)
+                        .withHasVerifiedWithPasskey(false);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -87,6 +87,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedPassword());
+            assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
     }
@@ -105,6 +106,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedPassword());
+            assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
     }
@@ -150,6 +152,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedPassword());
+            assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
     }
@@ -425,6 +428,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(capturedSession.getHasVerifiedWithMfa());
             assertTrue(result.isSuccess());
         }
     }
@@ -585,6 +589,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedMfa());
+            assertTrue(capturedSession.getHasVerifiedWithMfa());
             assertTrue(result.isSuccess());
         }
     }
@@ -604,6 +609,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedPasskey());
+            assertTrue(capturedSession.getHasVerifiedWithPasskey());
             assertEquals(
                     CredentialTrustLevel.MEDIUM_LEVEL,
                     capturedSession.getAchievedCredentialStrength());
@@ -625,6 +631,7 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertFalse(capturedSession.getHasVerifiedPasskey());
+            assertFalse(capturedSession.getHasVerifiedWithPasskey());
             assertTrue(result.isSuccess());
         }
     }


### PR DESCRIPTION
## What

Currently, we have `HasVerified<Authenticator>` attributes in the AuthSessionItem, but this naming isn't indicative of what this attribute is. We set these attributes when a user has authenticated with one of the authenticators (eg if they authenticate with a passkey we set `HasVerifiedPasskey` to true). A clearer name would be `HasVerifiedWith<Authenticator>`. 

This PR adds these new attributes and writes to them in the same way we were writing to the `HasVerified<Authenticator>` attributes. After approximately an hour after merging, we know that all of these attributes should align in all sessions (as session expiration is set to an hour). We can then remove the old attributes and use the new ones in our validation.

## How to review

1. Code review 
2. Deploy to a dev env, and check that at the end of a successful journey with a given authenticator, in the `orch-auth-code-lambda` you can see the `Checking if auth code is blocked` and the hasVerified<Authenticator> and hasVerifiedWith<Authenticator> attributes align

## Checklist

