### PR TITLE
ATO-2632: Rejig feature flags

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -125,6 +125,7 @@ Conditions:
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseCloudfront: !Equals [dev, !Ref Environment]
+  DeployAlternateDomainRecord: false
   CreateApiGwCustomDomain: !Equals [dev, !Ref Environment]
   #endregion
 
@@ -166,6 +167,7 @@ Mappings:
         "alg": "ES256"
         }]'
       oidcDomainName: "oidc.dev.account.gov.uk"
+      oidcAlternateDomainName: "oidc-orch.dev.account.gov.uk"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -201,6 +203,8 @@ Mappings:
         "y": "7UOFJn9pipVDB1PlAbD57wk6a7RzjjyjIvJTbPGIfNw",
         "alg": "ES256"
         }]'
+      oidcDomainName: "oidc.build.account.gov.uk"
+      oidcAlternateDomainName: "oidc-orch.build.account.gov.uk"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -238,6 +242,8 @@ Mappings:
         "y": "KCkzB3M9l4tcDchHM8agucY05giwCvSuNTB0M-W3--Y",
         "alg": "ES256"
         }]'
+      oidcDomainName: "oidc.staging.account.gov.uk"
+      oidcAlternateDomainName: "oidc-orch.staging.account.gov.uk"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -273,6 +279,8 @@ Mappings:
         "y": "QzrvsnDy3oY1yuz55voaAq9B1M5tfhgW3FBjh_n_F0U",
         "alg": "ES256"
         }]'
+      oidcDomainName: "oidc.integration.account.gov.uk"
+      oidcAlternateDomainName: "oidc-orch.integration.account.gov.uk"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -308,6 +316,8 @@ Mappings:
         "y": "ONF88GoP9xQJtq8RRV6zquggcd7xtggzZ20yW-PljHE",
         "alg": "ES256"
         }]'
+      oidcDomainName: "oidc.account.gov.uk"
+      oidcAlternateDomainName: "oidc-orch.account.gov.uk"
 
 Globals:
   Function:
@@ -5983,6 +5993,27 @@ Resources:
           Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
         HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
         EvaluateTargetHealth: false
+
+  #region AlternateDomainRecordSet
+  OrchestrationOidcAlternateCloudFrontRecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: DeployAlternateDomainRecord
+    Properties:
+      Name:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          oidcAlternateDomainName,
+        ]
+      Type: A
+      HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc-orch/hosted-zone-id}}"
+      AliasTarget:
+        DNSName:
+          Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
+        HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
+        EvaluateTargetHealth: false
+
+  #endregion
 
   #endregion
 

--- a/template.yaml
+++ b/template.yaml
@@ -126,7 +126,16 @@ Conditions:
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseCloudfront: !Equals [dev, !Ref Environment]
-  DeployAlternateDomainRecord: false
+  DeployAlternateDomainRecord:
+    !Not [
+      !Or [
+        !Equals [dev, !Ref Environment],
+        !Equals [build, !Ref Environment],
+        !Equals [staging, !Ref Environment],
+        !Equals [integration, !Ref Environment],
+        !Equals [production, !Ref Environment],
+      ],
+    ]
   DeployMigratedRecords: !Equals [dev, !Ref Environment]
   SwapLiveTrafficToCloudfront:
     !And [!Condition DeployMigratedRecords, !Equals [dev, !Ref Environment]]

--- a/template.yaml
+++ b/template.yaml
@@ -102,10 +102,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  ProvisionNewApiGateway: !Equals [dev, !Ref Environment]
-  UseCloudfront: !Equals [dev, !Ref Environment]
-  ProvisionNewApiClientRegistryApiKey:
-    !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseStoredOldIdTokenPublicKeys:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -122,6 +118,14 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
+
+  #region API Migration Feature Flags
+  # Please keep separate from the other ones
+  ProvisionNewApiGateway: !Equals [dev, !Ref Environment]
+  ProvisionNewApiClientRegistryApiKey:
+    !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
+  UseCloudfront: !Equals [dev, !Ref Environment]
+  #endregion
 
 Mappings:
   EnvironmentConfiguration:

--- a/template.yaml
+++ b/template.yaml
@@ -125,6 +125,7 @@ Conditions:
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseCloudfront: !Equals [dev, !Ref Environment]
+  CreateApiGwCustomDomain: !Equals [dev, !Ref Environment]
   #endregion
 
 Mappings:
@@ -5931,7 +5932,7 @@ Resources:
 
   OrchestrationOidcApiCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
-    Condition: UseCloudfront
+    Condition: CreateApiGwCustomDomain
     Properties:
       DomainName:
         !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
@@ -5941,7 +5942,7 @@ Resources:
 
   OrchestrationOidcApiBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
-    Condition: UseCloudfront
+    Condition: CreateApiGwCustomDomain
     Properties:
       DomainName:
         !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
@@ -5952,7 +5953,7 @@ Resources:
 
   OrchestrationOidcOriginRecordSet:
     Type: AWS::Route53::RecordSet
-    Condition: UseCloudfront
+    Condition: CreateApiGwCustomDomain
     Properties:
       Name: !Sub
         - "origin.${oidcDomain}"

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,7 @@ Metadata:
             - none
       ignore_checks:
         - E1011 # FindInMap within FindInMap DefaultValue is currently not working w/ cfn-lint
+        - W1028 # Our API Migration flags currently have "unreachable" If conditions because they all apply to one env
 
 Parameters:
   Environment:
@@ -126,7 +127,16 @@ Conditions:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
   UseCloudfront: !Equals [dev, !Ref Environment]
   DeployAlternateDomainRecord: false
-  CreateApiGwCustomDomain: !Equals [dev, !Ref Environment]
+  DeployMigratedRecords: !Equals [dev, !Ref Environment]
+  SwapLiveTrafficToCloudfront:
+    !And [!Condition DeployMigratedRecords, !Equals [dev, !Ref Environment]]
+  CreateApiGwCustomDomain:
+    !And [
+      !Condition SwapLiveTrafficToCloudfront,
+      !Equals [dev, !Ref Environment],
+    ]
+  SwapOriginToApiGateway:
+    !And [!Condition CreateApiGwCustomDomain, !Equals [dev, !Ref Environment]]
   #endregion
 
 Mappings:
@@ -5963,7 +5973,7 @@ Resources:
 
   OrchestrationOidcOriginRecordSet:
     Type: AWS::Route53::RecordSet
-    Condition: CreateApiGwCustomDomain
+    Condition: DeployMigratedRecords
     Properties:
       Name: !Sub
         - "origin.${oidcDomain}"
@@ -5976,21 +5986,29 @@ Resources:
       Type: A
       HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc/hosted-zone-id}}"
       AliasTarget:
-        DNSName: !GetAtt OrchestrationOidcApiCustomDomain.RegionalDomainName
-        HostedZoneId: !GetAtt OrchestrationOidcApiCustomDomain.RegionalHostedZoneId
+        DNSName: !If
+          - SwapOriginToApiGateway
+          - !GetAtt OrchestrationOidcApiCustomDomain.RegionalDomainName
+          - "{{resolve:ssm:/deploy/api-migration/old-api-gateway-regional-domain-name}}"
+        HostedZoneId: !If
+          - SwapOriginToApiGateway
+          - !GetAtt OrchestrationOidcApiCustomDomain.RegionalHostedZoneId
+          - "{{resolve:ssm:/deploy/api-migration/old-api-gateway-regional-hosted-zone-id}}"
         EvaluateTargetHealth: false
 
   OrchestrationOidcCloudFrontRecordSet:
     Type: AWS::Route53::RecordSet
-    Condition: UseCloudfront
+    Condition: DeployMigratedRecords
     Properties:
       Name:
         !FindInMap [EnvironmentConfiguration, !Ref Environment, oidcDomainName]
       Type: A
       HostedZoneId: "{{resolve:ssm:/deploy/hosted-zone/oidc/hosted-zone-id}}"
       AliasTarget:
-        DNSName:
-          Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
+        DNSName: !If
+          - SwapLiveTrafficToCloudfront
+          - Fn::ImportValue: !Sub "${Environment}-oidc-cloudfront-DistributionDomain"
+          - "{{resolve:ssm:/deploy/api-migration/old-cloudfront-distribution-domain}}"
         HostedZoneId: "Z2FDTNDATAQYW2" # Cloudfront Hosted Zone ID: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-route53-recordset-aliastarget.html#:~:text=vpc%2Dendpoints.-,CloudFront%20distribution,-Specify%20Z2FDTNDATAQYW2.%20This
         EvaluateTargetHealth: false
 


### PR DESCRIPTION
### Wider context of change

During our API migration, we're going to have several intermediate states which we will need to be able to switch on via feature flags. Currently our template is not organised to support this. This solves that by breaking each distinct step which involves this template into separate feature flags we can turn on. There is some built in dependency between these, which represent an ordering of steps.  

### What’s changed:
- Adds several new feature flags to represent our intermediate states during the migration 
- All of these resources were behind the `UseCloudfront` feature flag, which only applied to dev
- They are now broken down into different feature flags, which allow us to turn parts on step-by-step

### Manual testing
- Deployed to dev - observe no change because all the new flags are switched on - representing our end state
- No changes to our DNS records observed 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
