### PR TITLE
ATO-2491: deploy alt domain Cloudfront build

### DIFF
--- a/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/alternative-parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/alternative-parameters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc-orch.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:767397776536:certificate/3195d9c0-c4c5-4d34-8db0-f1fb1df75a3a"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "ApiGatewayOriginDomain",
+    "ParameterValue": "w2kildk4ee.execute-api.eu-west-2.amazonaws.com"
+  },
+  {
+    "ParameterKey": "OriginPath",
+    "ParameterValue": "/build"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/tags.json
+++ b/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "FMSGlobalCustomPolicy",
+    "Value": "true"
+  },
+  {
+    "Key": "FMSGlobalCustomPolicyName",
+    "Value": "cloudfrontoidc"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/cloudfront-monitoring-alarm/parameters.json
+++ b/ci/stack-orchestration/configuration/build/cloudfront-monitoring-alarm/parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "CloudFrontAdditionaldMetricsEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmSNSTopicARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:767397776536:build-CloudFrontCacheHitSlackAlerts"
+  },
+  {
+    "ParameterKey": "CloudfrontDistribution",
+    "ParameterValue": "E1Y9USKKKLIQMA"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmDescription",
+    "ParameterValue": "Cache Hit detected for build OIDC Cloudfront. Runbook: https://govukverify.atlassian.net/wiki/x/AYC0gwE"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/cloudfront-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/build/cloudfront-notifications/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "DeploySlackNotificationTopic",
+    "ParameterValue": "Yes"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/cloudfront-tls-certificate/alternative-parameters.json
+++ b/ci/stack-orchestration/configuration/build/cloudfront-tls-certificate/alternative-parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "HostedZoneID",
+    "ParameterValue": "Z00708333PQTWOVF0F769"
+  },
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "oidc-orch.build.account.gov.uk"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/hosted-zone/alternative-domain-parameters.json
+++ b/ci/stack-orchestration/configuration/build/hosted-zone/alternative-domain-parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": "-orch"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/hosted-zone/alternative-domain-parameters.json
+++ b/ci/stack-orchestration/configuration/build/hosted-zone/alternative-domain-parameters.json
@@ -5,7 +5,7 @@
   },
   {
     "ParameterKey": "DeployCertificate",
-    "ParameterValue": "No"
+    "ParameterValue": "Yes"
   },
   {
     "ParameterKey": "EndpointSuffix",

--- a/ci/stack-orchestration/deploy-build.sh
+++ b/ci/stack-orchestration/deploy-build.sh
@@ -16,6 +16,8 @@ PROVISION_BASE_STACKS=false
 PROVISION_VPC_STACK=false
 PROVISION_PIPELINE_STACK=false
 PROVISION_TXMA_STACK=false
+PROVISION_HOSTED_ZONE=false
+DOMAIN_TO_PROVISION="live"
 
 ENVIRONMENT=build
 
@@ -55,6 +57,7 @@ function usage() {
     -p, --pipelines                        Provision secure pipelines
     -v, --vpc                              Provision VPC stack
     -t, --txma                             Provision the manual TxMA stack for auditing.
+    -h, --hosted-zone                      Provisions the hosted zone stack for the OIDC domain.
 USAGE
 }
 
@@ -98,6 +101,19 @@ while [[ $# -gt 0 ]]; do
       ;;
     -t | --txma)
       PROVISION_TXMA_STACK=true
+      ;;
+    -h | --hosted-zone)
+      PROVISION_HOSTED_ZONE=true
+      DOMAIN_TO_PROVISION=${2}
+
+      PERMITTED_VALUES="live alternative"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${DOMAIN_TO_PROVISION}( |$) ]]; then
+        echo "Hosted zone arg provided: ${DOMAIN_TO_PROVISION} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
+      shift
       ;;
     *)
       usage
@@ -170,6 +186,27 @@ function provision_pipeline_stack() {
   echo "Provisioned secure pipeline stack"
 }
 
+function provision_hosted_zone_stack() {
+  export AWS_REGION="eu-west-2"
+
+  # shellcheck disable=SC2155
+  local parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/parameters.json"
+
+  echo "Provisioning hosted zone stack"
+  TEMPLATE_FILE="$(pwd)/manual-stacks/domains/template.yaml"
+  if [ ! -f "${TEMPLATE_FILE}" ]; then
+    echo "Could not find the hosted zone stack template at path: ${TEMPLATE_FILE}"
+    exit 1
+  fi
+
+  if [ "${DOMAIN_TO_PROVISION}" == "alternative" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/alternative-domain-parameters.json"
+  fi
+
+  PARAMETERS_FILE="${parameters_file}" ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
+  echo "Provisioned hosted zone stack"
+}
+
 # --------------------
 # Run provision commands
 # --------------------
@@ -178,6 +215,7 @@ function provision_pipeline_stack() {
 
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_VPC_STACK}" == "true" ] && provision_vpc_stack
+[ "${PROVISION_HOSTED_ZONE}" == "true" ] && provision_hosted_zone_stack
 
 # Now we can deploy the pipeline stack
 

--- a/template.yaml
+++ b/template.yaml
@@ -118,17 +118,9 @@ Conditions:
     !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
-  UseCloudfront: !Equals [dev, !Ref Environment]
-  DeployAlternateDomainRecord:
-    !Not [
-      !Or [
-        !Equals [dev, !Ref Environment],
-        !Equals [build, !Ref Environment],
-        !Equals [staging, !Ref Environment],
-        !Equals [integration, !Ref Environment],
-        !Equals [production, !Ref Environment],
-      ],
-    ]
+  UseCloudfront:
+    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
+  DeployAlternateDomainRecord: !Equals [build, !Ref Environment]
   DeployMigratedRecords: !Equals [dev, !Ref Environment]
   SwapLiveTrafficToCloudfront:
     !And [!Condition DeployMigratedRecords, !Equals [dev, !Ref Environment]]


### PR DESCRIPTION
### Wider context of change:

We have been deploying some stacks to build, to enable us to deploy the Cloudfront on an alternative domain. This will enable us to create the distribution and do some testing of the new infrastructure before the cutover.


### What’s changed
- Adds params for various stacks 
- Deployed the stacks to the build env 
- Deploys the A record and attaches the Cloudfront WAF to our API Gateway in build

### Manual testing
- N/A 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
