### PR TITLE
Aut 5467/passkey deletion events

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -22,7 +22,8 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     AUTH_INVALID_CODE_SENT,
     AUTH_PHONE_CODE_SENT,
     AUTH_UPDATE_PROFILE_AUTH_APP,
-    AUTH_EMAIL_FRAUD_CHECK_DECISION_USED;
+    AUTH_EMAIL_FRAUD_CHECK_DECISION_USED,
+    AUTH_PASSKEY_DELETE_SUCCESSFUL;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -23,7 +23,8 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     AUTH_PHONE_CODE_SENT,
     AUTH_UPDATE_PROFILE_AUTH_APP,
     AUTH_EMAIL_FRAUD_CHECK_DECISION_USED,
-    AUTH_PASSKEY_DELETE_SUCCESSFUL;
+    AUTH_PASSKEY_DELETE_SUCCESSFUL,
+    AUTH_PASSKEY_DELETE_FAILED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -11,6 +11,9 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.PasskeysDeleteProxyFailureReason;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyDeleteSuccessful;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -24,7 +27,9 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.http.HttpResponse;
+import java.time.Clock;
 
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -41,6 +46,7 @@ public class PasskeysDeleteProxyHandler
     private final AwsSqsClient sqsClient;
     private final DynamoService dynamoService;
     private final AuditService auditService;
+    private final StructuredAuditService structuredAuditService;
 
     public PasskeysDeleteProxyHandler() {
         this(ConfigurationService.getInstance());
@@ -56,6 +62,7 @@ public class PasskeysDeleteProxyHandler
                         configurationService.getSqsEndpointUri());
         this.dynamoService = new DynamoService(configurationService);
         this.auditService = new AuditService(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     public PasskeysDeleteProxyHandler(
@@ -63,12 +70,14 @@ public class PasskeysDeleteProxyHandler
             AccountDataApiService accountDataApiService,
             AwsSqsClient sqsClient,
             DynamoService dynamoService,
-            AuditService auditService) {
+            AuditService auditService,
+            StructuredAuditService structuredAuditService) {
         this.configurationService = configurationService;
         this.accountDataApiService = accountDataApiService;
         this.sqsClient = sqsClient;
         this.dynamoService = dynamoService;
         this.auditService = auditService;
+        this.structuredAuditService = structuredAuditService;
     }
 
     @Override
@@ -93,6 +102,18 @@ public class PasskeysDeleteProxyHandler
         var userProfile = userProfileResult.getSuccess();
         var userEmail = userProfile.getEmail();
 
+        var auditContextResult =
+                accountManagementAuditContext(
+                        configurationService, dynamoService, input, userProfile);
+        if (auditContextResult.isFailure()) {
+            LOG.error(
+                    "Error when building audit context with error code {}. No events raised",
+                    auditContextResult.getFailure());
+            return generateApiGatewayProxyErrorResponse(
+                    500, ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
+        }
+        var auditContext = auditContextResult.getSuccess();
+
         var currentPasskeyCountResult = getPasskeyCount(request);
         if (currentPasskeyCountResult.isFailure()) {
             return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
@@ -115,6 +136,7 @@ public class PasskeysDeleteProxyHandler
                     deletePasskeyResponse.statusCode(),
                     request.publicSubjectId);
         } else {
+            emitSuccessAuditEvent(auditContext, request, currentPasskeyCount);
             sendEmailNotification(request, userEmail, currentPasskeyCount);
         }
 
@@ -203,6 +225,18 @@ public class PasskeysDeleteProxyHandler
                 "Notify request sent with notification type '{}' and publicSubjectId '{}'",
                 notificationType,
                 request.publicSubjectId);
+    }
+
+    private void emitSuccessAuditEvent(
+            AuditContext auditContext, PasskeysDeleteRequest request, int currentPasskeyCount) {
+        var newPasskeyCount = currentPasskeyCount - 1;
+        var passkeyId = request.passkeyId;
+
+        var event =
+                AuthPasskeyDeleteSuccessful.create(
+                        auditContext, newPasskeyCount, passkeyId, Clock.systemUTC());
+
+        structuredAuditService.submitAuditEvent(event);
     }
 
     private record PasskeysDeleteRequest(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -34,8 +34,8 @@ import java.util.Map;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_RESTRICTED_PASSKEY;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_RESTRICTED_PASSKEY_CREDENTIAL_ID;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_RESTRICTED_PASSKEY;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_RESTRICTED_PASSKEY_CREDENTIAL_ID;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -252,8 +252,10 @@ public class PasskeysDeleteProxyHandler
     private void emitFailedAuditEvent(AuditContext auditContext, PasskeysDeleteRequest request) {
         var restrictedPasskeyPair =
                 pair(
-                        AUDIT_EVENT_RESTRICTED_PASSKEY,
-                        Map.of(AUDIT_EVENT_RESTRICTED_PASSKEY_CREDENTIAL_ID, request.passkeyId),
+                        AUDIT_EVENT_EXTENSIONS_RESTRICTED_PASSKEY,
+                        Map.of(
+                                AUDIT_EVENT_EXTENSIONS_RESTRICTED_PASSKEY_CREDENTIAL_ID,
+                                request.passkeyId),
                         true);
 
         auditService.submitAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -28,13 +28,19 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.http.HttpResponse;
 import java.time.Clock;
+import java.util.Map;
 
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED;
+import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_RESTRICTED_PASSKEY;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_RESTRICTED_PASSKEY_CREDENTIAL_ID;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class PasskeysDeleteProxyHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -116,12 +122,14 @@ public class PasskeysDeleteProxyHandler
 
         var currentPasskeyCountResult = getPasskeyCount(request);
         if (currentPasskeyCountResult.isFailure()) {
+            emitFailedAuditEvent(auditContext, request);
             return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
         }
         var currentPasskeyCount = currentPasskeyCountResult.getSuccess();
 
         var deletePasskeyResponseResult = deletePasskey(request);
         if (deletePasskeyResponseResult.isFailure()) {
+            emitFailedAuditEvent(auditContext, request);
             return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
         }
         HttpResponse<String> deletePasskeyResponse = deletePasskeyResponseResult.getSuccess();
@@ -135,6 +143,7 @@ public class PasskeysDeleteProxyHandler
                     "Passkey Deleted Email notification not sent because delete passkey response was {} for Public Subject ID {}",
                     deletePasskeyResponse.statusCode(),
                     request.publicSubjectId);
+            emitFailedAuditEvent(auditContext, request);
         } else {
             emitSuccessAuditEvent(auditContext, request, currentPasskeyCount);
             sendEmailNotification(request, userEmail, currentPasskeyCount);
@@ -237,6 +246,20 @@ public class PasskeysDeleteProxyHandler
                         auditContext, newPasskeyCount, passkeyId, Clock.systemUTC());
 
         structuredAuditService.submitAuditEvent(event);
+    }
+
+    private void emitFailedAuditEvent(AuditContext auditContext, PasskeysDeleteRequest request) {
+        var restrictedPasskeyPair =
+                pair(
+                        AUDIT_EVENT_RESTRICTED_PASSKEY,
+                        Map.of(AUDIT_EVENT_RESTRICTED_PASSKEY_CREDENTIAL_ID, request.passkeyId),
+                        true);
+
+        auditService.submitAuditEvent(
+                AUTH_PASSKEY_DELETE_FAILED,
+                auditContext,
+                ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
+                restrictedPasskeyPair);
     }
 
     private record PasskeysDeleteRequest(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -13,10 +13,12 @@ import uk.gov.di.accountmanagement.entity.PasskeysDeleteProxyFailureReason;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -38,6 +40,7 @@ public class PasskeysDeleteProxyHandler
     private final SerializationService serializationService = SerializationService.getInstance();
     private final AwsSqsClient sqsClient;
     private final DynamoService dynamoService;
+    private final AuditService auditService;
 
     public PasskeysDeleteProxyHandler() {
         this(ConfigurationService.getInstance());
@@ -52,17 +55,20 @@ public class PasskeysDeleteProxyHandler
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.dynamoService = new DynamoService(configurationService);
+        this.auditService = new AuditService(configurationService);
     }
 
     public PasskeysDeleteProxyHandler(
             ConfigurationService configurationService,
             AccountDataApiService accountDataApiService,
             AwsSqsClient sqsClient,
-            DynamoService dynamoService) {
+            DynamoService dynamoService,
+            AuditService auditService) {
         this.configurationService = configurationService;
         this.accountDataApiService = accountDataApiService;
         this.sqsClient = sqsClient;
         this.dynamoService = dynamoService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -80,11 +86,12 @@ public class PasskeysDeleteProxyHandler
 
         PasskeysDeleteRequest request = extractPasskeyDeleteRequest(input);
 
-        var userEmailResult = getUserEmailFromPublicSubjectId(request.publicSubjectId);
-        if (userEmailResult.isFailure()) {
+        var userProfileResult = getUserProfile(request.publicSubjectId);
+        if (userProfileResult.isFailure()) {
             return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
         }
-        var userEmail = userEmailResult.getSuccess();
+        var userProfile = userProfileResult.getSuccess();
+        var userEmail = userProfile.getEmail();
 
         var currentPasskeyCountResult = getPasskeyCount(request);
         if (currentPasskeyCountResult.isFailure()) {
@@ -138,7 +145,7 @@ public class PasskeysDeleteProxyHandler
         return new PasskeysDeleteRequest(publicSubjectId, token, passkeyIdentifier, userLanguage);
     }
 
-    private Result<PasskeysDeleteProxyFailureReason, String> getUserEmailFromPublicSubjectId(
+    private Result<PasskeysDeleteProxyFailureReason, UserProfile> getUserProfile(
             String publicSubjectId) {
         var userProfile = dynamoService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
 
@@ -147,7 +154,7 @@ public class PasskeysDeleteProxyHandler
             return Result.failure(PasskeysDeleteProxyFailureReason.FAILED_TO_FIND_USER_PROFILE);
         }
 
-        return Result.success(userProfile.get().getEmail());
+        return Result.success(userProfile.get());
     }
 
     private Result<PasskeysDeleteProxyFailureReason, Integer> getPasskeyCount(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.accountmanagement.entity.PasskeysDeleteProxyFailureReason;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyDeleteSuccessful;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -258,6 +259,7 @@ public class PasskeysDeleteProxyHandler
         auditService.submitAuditEvent(
                 AUTH_PASSKEY_DELETE_FAILED,
                 auditContext,
+                ComponentId.HOME.getValue(),
                 ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR,
                 restrictedPasskeyPair);
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResp
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AccountDataApiService;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -51,6 +52,7 @@ class PasskeysDeleteProxyHandlerTest {
     private final AccountDataApiService accountDataApiService = mock(AccountDataApiService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
+    private final AuditService auditService = mock(AuditService.class);
 
     private static final String ADAPI_TOKEN_HEADER = "X-ADAPI-AccessToken";
     private static final String TOKEN = "token";
@@ -67,7 +69,11 @@ class PasskeysDeleteProxyHandlerTest {
 
         handler =
                 new PasskeysDeleteProxyHandler(
-                        configurationService, accountDataApiService, sqsClient, dynamoService);
+                        configurationService,
+                        accountDataApiService,
+                        sqsClient,
+                        dynamoService,
+                        auditService);
     }
 
     private static final String PASSKEY_IDENTIFIER = "test-passkey-id";

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
@@ -12,6 +12,8 @@ import org.mockito.ArgumentCaptor;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyDeleteSuccessful;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.passkeys.PasskeysRetrieveResponse;
@@ -25,6 +27,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +36,8 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,6 +58,8 @@ class PasskeysDeleteProxyHandlerTest {
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
 
     private static final String ADAPI_TOKEN_HEADER = "X-ADAPI-AccessToken";
     private static final String TOKEN = "token";
@@ -66,6 +73,9 @@ class PasskeysDeleteProxyHandlerTest {
                 new UserProfile().withSubjectID(PUBLIC_SUBJECT_ID).withEmail(TEST_EMAIL_ADDRESS);
         when(dynamoService.getOptionalUserProfileFromPublicSubject(PUBLIC_SUBJECT_ID))
                 .thenReturn(Optional.of(userProfile));
+        when(dynamoService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn("test-salt".getBytes(StandardCharsets.UTF_8));
+        when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
 
         handler =
                 new PasskeysDeleteProxyHandler(
@@ -73,7 +83,8 @@ class PasskeysDeleteProxyHandlerTest {
                         accountDataApiService,
                         sqsClient,
                         dynamoService,
-                        auditService);
+                        auditService,
+                        structuredAuditService);
     }
 
     private static final String PASSKEY_IDENTIFIER = "test-passkey-id";
@@ -146,6 +157,39 @@ class PasskeysDeleteProxyHandlerTest {
             assertThat(sentNotifyRequest.getNotificationType(), equalTo(expectedNotificationType));
             assertThat(sentNotifyRequest.getLanguage(), equalTo(SupportedLanguage.EN));
         }
+
+        @Test
+        void shouldEmitSuccessAuditEventOnSuccessfulDeletion()
+                throws UnsuccessfulAccountDataApiResponseException, Json.JsonException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN))
+                    .thenReturn(
+                            new PasskeysRetrieveResponse(
+                                    List.of(
+                                            aPasskeyResponse(PASSKEY_IDENTIFIER),
+                                            aPasskeyResponse(OTHER_PASSKEY_IDENTIFIER))));
+            when(mockHttpResponse.statusCode()).thenReturn(204);
+            when(mockHttpResponse.body()).thenReturn("");
+            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN))
+                    .thenReturn(mockHttpResponse);
+
+            // Act
+            handler.handleRequest(passkeysDeleteProxyRequest(), context);
+
+            // Assert
+
+            ArgumentCaptor<AuthPasskeyDeleteSuccessful> auditEventCaptor =
+                    ArgumentCaptor.forClass(AuthPasskeyDeleteSuccessful.class);
+            verify(structuredAuditService).submitAuditEvent(auditEventCaptor.capture());
+            var submittedAuditEvent = auditEventCaptor.getValue();
+
+            assertEquals("AUTH_PASSKEY_DELETE_SUCCESSFUL", submittedAuditEvent.eventName());
+            assertEquals(1, submittedAuditEvent.user().passkeyCount());
+            assertEquals(
+                    PASSKEY_IDENTIFIER,
+                    submittedAuditEvent.restricted().passkey().passkeyCredentialId());
+        }
     }
 
     @Nested
@@ -176,13 +220,16 @@ class PasskeysDeleteProxyHandlerTest {
         var headersWithToken = new HashMap<>(VALID_HEADERS);
         headersWithToken.put(ADAPI_TOKEN_HEADER, TOKEN);
 
+        var requestContext = contextWithSourceIp(IP_ADDRESS);
+        requestContext.setAuthorizer(Map.of("clientId", "test-client-id"));
+
         return new APIGatewayProxyRequestEvent()
                 .withPathParameters(
                         Map.of(
                                 "publicSubjectId", PUBLIC_SUBJECT_ID,
                                 "passkeyIdentifier", PASSKEY_IDENTIFIER))
                 .withHeaders(headersWithToken)
-                .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+                .withRequestContext(requestContext);
     }
 
     private static PasskeysRetrieveResponse.PasskeyResponse aPasskeyResponse(String passkeyId) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
@@ -216,6 +216,7 @@ class PasskeysDeleteProxyHandlerTest {
                     .submitAuditEvent(
                             eq(AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED),
                             any(),
+                            eq("HOME"),
                             eq(AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR),
                             argThat(
                                     metadataPair ->
@@ -245,6 +246,7 @@ class PasskeysDeleteProxyHandlerTest {
                     .submitAuditEvent(
                             eq(AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED),
                             any(),
+                            eq("HOME"),
                             eq(AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR),
                             argThat(
                                     metadataPair ->
@@ -268,6 +270,7 @@ class PasskeysDeleteProxyHandlerTest {
                     .submitAuditEvent(
                             eq(AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED),
                             any(),
+                            eq("HOME"),
                             eq(AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR),
                             argThat(
                                     metadataPair ->

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
@@ -9,12 +9,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
+import uk.gov.di.accountmanagement.helpers.AuditHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyDeleteSuccessful;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
-import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.passkeys.PasskeysRetrieveResponse;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
@@ -38,6 +39,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,7 +51,6 @@ import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
-import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class PasskeysDeleteProxyHandlerTest {
@@ -195,7 +197,7 @@ class PasskeysDeleteProxyHandlerTest {
     @Nested
     class FailedRequest {
         @Test
-        void shouldReturn500IfServiceThrowsException()
+        void shouldEmitFailedAuditEventWhenDeleteThrowsException()
                 throws UnsuccessfulAccountDataApiResponseException, Json.JsonException {
             // Arrange
             when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN))
@@ -210,9 +212,67 @@ class PasskeysDeleteProxyHandlerTest {
 
             // Assert
             assertThat(result, hasStatus(500));
-            assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
-            verify(accountDataApiService)
-                    .deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN);
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED),
+                            any(),
+                            eq(AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR),
+                            argThat(
+                                    metadataPair ->
+                                            metadataPair.key().equals("passkey")
+                                                    && metadataPair.isRestricted()));
+        }
+
+        @Test
+        void shouldEmitFailedAuditEventWhenDeleteReturnsNon204()
+                throws UnsuccessfulAccountDataApiResponseException, Json.JsonException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN))
+                    .thenReturn(
+                            new PasskeysRetrieveResponse(
+                                    List.of(aPasskeyResponse(PASSKEY_IDENTIFIER))));
+            when(mockHttpResponse.statusCode()).thenReturn(404);
+            when(mockHttpResponse.body()).thenReturn("{\"error\": \"not found\"}");
+            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER, TOKEN))
+                    .thenReturn(mockHttpResponse);
+
+            // Act
+            handler.handleRequest(passkeysDeleteProxyRequest(), context);
+
+            // Assert
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED),
+                            any(),
+                            eq(AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR),
+                            argThat(
+                                    metadataPair ->
+                                            metadataPair.key().equals("passkey")
+                                                    && metadataPair.isRestricted()));
+        }
+
+        @Test
+        void shouldEmitFailedAuditEventWhenPasskeyCountRetrievalFails()
+                throws UnsuccessfulAccountDataApiResponseException, Json.JsonException {
+            // Arrange
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID, TOKEN))
+                    .thenThrow(new UnsuccessfulAccountDataApiResponseException("error", 0));
+
+            // Act
+            var result = handler.handleRequest(passkeysDeleteProxyRequest(), context);
+
+            // Assert
+            assertThat(result, hasStatus(500));
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(AccountManagementAuditableEvent.AUTH_PASSKEY_DELETE_FAILED),
+                            any(),
+                            eq(AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR),
+                            argThat(
+                                    metadataPair ->
+                                            metadataPair.key().equals("passkey")
+                                                    && metadataPair.isRestricted()));
         }
     }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysDeleteProxyHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysDeleteProxyHandlerIntegrationTest.java
@@ -57,6 +57,8 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                     }
                     """;
 
+    private static final String TEST_CLIENT_ID = "test-client-id";
+
     @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
 
     @BeforeEach
@@ -69,6 +71,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                 "ACCOUNT_DATA_API_URI", "http://localhost:" + accountDataApiWireMockServer.port());
 
         notificationsQueue.clear();
+        txmaAuditQueue.clear();
     }
 
     @AfterAll
@@ -82,7 +85,11 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void shouldProxy204ResponseFromAccountDataApi() {
         // Arrange
         var publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
-        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+        userStore.addSalt(TEST_EMAIL);
+        handler =
+                new PasskeysDeleteProxyHandler(
+                        supportPasskeysAndTxmaEnabledConfigurationService(
+                                "http://localhost:" + accountDataApiWireMockServer.port()));
 
         var passkeyId = "def";
         var token = "hij";
@@ -108,7 +115,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                         Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
-                        Collections.emptyMap(),
+                        Map.ofEntries(Map.entry("clientId", TEST_CLIENT_ID)),
                         Optional.of("delete"));
 
         // Assert
@@ -128,7 +135,11 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void shouldSendPasskeyDeletedEmailNotification() {
         // Arrange
         var publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
-        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+        userStore.addSalt(TEST_EMAIL);
+        handler =
+                new PasskeysDeleteProxyHandler(
+                        supportPasskeysAndTxmaEnabledConfigurationService(
+                                "http://localhost:" + accountDataApiWireMockServer.port()));
 
         var passkeyId = "def";
         var token = "hij";
@@ -175,7 +186,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                         Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
-                        Collections.emptyMap(),
+                        Map.ofEntries(Map.entry("clientId", TEST_CLIENT_ID)),
                         Optional.of("delete"));
 
         // Assert
@@ -202,7 +213,11 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void shouldProxy404ResponseFromAccountDataApi() {
         // Arrange
         var publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
-        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+        userStore.addSalt(TEST_EMAIL);
+        handler =
+                new PasskeysDeleteProxyHandler(
+                        supportPasskeysAndTxmaEnabledConfigurationService(
+                                "http://localhost:" + accountDataApiWireMockServer.port()));
 
         var passkeyId = "def";
         var token = "hij";
@@ -235,7 +250,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                         Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
-                        Collections.emptyMap(),
+                        Map.ofEntries(Map.entry("clientId", TEST_CLIENT_ID)),
                         Optional.of("delete"));
 
         // Assert
@@ -256,7 +271,11 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void shouldProxy500ResponseFromAccountDataApi() {
         // Arrange
         var publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
-        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+        userStore.addSalt(TEST_EMAIL);
+        handler =
+                new PasskeysDeleteProxyHandler(
+                        supportPasskeysAndTxmaEnabledConfigurationService(
+                                "http://localhost:" + accountDataApiWireMockServer.port()));
 
         var passkeyId = "def";
         var token = "hij";
@@ -289,7 +308,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                         Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
-                        Collections.emptyMap(),
+                        Map.ofEntries(Map.entry("clientId", TEST_CLIENT_ID)),
                         Optional.of("delete"));
 
         // Assert
@@ -310,7 +329,11 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     void shouldNotDeletePasskeyIfPasskeysRetrievalFails() {
         // Arrange
         var publicSubjectId = userStore.signUp(TEST_EMAIL, TEST_PASSWORD);
-        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+        userStore.addSalt(TEST_EMAIL);
+        handler =
+                new PasskeysDeleteProxyHandler(
+                        supportPasskeysAndTxmaEnabledConfigurationService(
+                                "http://localhost:" + accountDataApiWireMockServer.port()));
 
         var passkeyId = "def";
         var token = "hij";
@@ -326,7 +349,7 @@ class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegra
                         Map.of("X-ADAPI-AccessToken", token),
                         Collections.emptyMap(),
                         Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
-                        Collections.emptyMap(),
+                        Map.ofEntries(Map.entry("clientId", TEST_CLIENT_ID)),
                         Optional.of("delete"));
 
         // Assert

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyDeleteSuccessful.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyDeleteSuccessful.java
@@ -1,7 +1,5 @@
 package uk.gov.di.authentication.auditevents.entity;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformation;
@@ -63,12 +61,4 @@ public record AuthPasskeyDeleteSuccessful(
             EncodedDeviceInformation deviceInformation, PasskeyWithCredentialId passkey) {}
 
     public record Extensions(@SerializedName("journey-type") String journeyType) {}
-
-    public String serialize() {
-        var gson =
-                new GsonBuilder()
-                        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                        .create();
-        return gson.toJson(this);
-    }
 }

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyDeleteSuccessful.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyDeleteSuccessful.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformation;
+import uk.gov.di.authentication.auditevents.entity.shared.PasskeyWithCredentialId;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public record AuthPasskeyDeleteSuccessful(
+        String eventName,
+        long timestamp,
+        long eventTimestampMs,
+        String clientId,
+        String componentId,
+        User user,
+        Restricted restricted,
+        Extensions extensions)
+        implements StructuredAuditEvent {
+
+    public static AuthPasskeyDeleteSuccessful create(
+            AuditContext auditContext, int passkeyCount, String deletedCredentialId, Clock clock) {
+        Instant now = clock.instant();
+        var user =
+                new User(
+                        auditContext.email(),
+                        auditContext.clientSessionId(),
+                        auditContext.ipAddress(),
+                        auditContext.persistentSessionId(),
+                        auditContext.sessionId(),
+                        auditContext.subjectId(),
+                        passkeyCount);
+        var restrictedSection =
+                new Restricted(
+                        new EncodedDeviceInformation(auditContext.txmaAuditEncoded()),
+                        new PasskeyWithCredentialId(deletedCredentialId));
+        var extensions = new Extensions(JourneyType.ACCOUNT_MANAGEMENT.getValue());
+        return new AuthPasskeyDeleteSuccessful(
+                "AUTH_PASSKEY_DELETE_SUCCESSFUL",
+                now.getEpochSecond(),
+                now.toEpochMilli(),
+                auditContext.clientId(),
+                ComponentId.HOME.getValue(),
+                user,
+                restrictedSection,
+                extensions);
+    }
+
+    public record User(
+            String email,
+            String govukSigninJourneyId,
+            String ipAddress,
+            String persistentSessionId,
+            String sessionId,
+            String userId,
+            int passkeyCount) {}
+
+    public record Restricted(
+            EncodedDeviceInformation deviceInformation, PasskeyWithCredentialId passkey) {}
+
+    public record Extensions(@SerializedName("journey-type") String journeyType) {}
+
+    public String serialize() {
+        var gson =
+                new GsonBuilder()
+                        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                        .create();
+        return gson.toJson(this);
+    }
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/ComponentId.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/ComponentId.java
@@ -1,7 +1,8 @@
 package uk.gov.di.authentication.auditevents.entity;
 
 public enum ComponentId {
-    AUTH("AUTH");
+    AUTH("AUTH"),
+    HOME("HOME");
 
     private final String value;
 

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/StructuredAuditEvent.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/StructuredAuditEvent.java
@@ -1,5 +1,8 @@
 package uk.gov.di.authentication.auditevents.entity;
 
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.GsonBuilder;
+
 public interface StructuredAuditEvent {
     String eventName();
 
@@ -10,4 +13,12 @@ public interface StructuredAuditEvent {
     String clientId();
 
     String componentId();
+
+    default String serialize() {
+        var gson =
+                new GsonBuilder()
+                        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                        .create();
+        return gson.toJson(this);
+    }
 }

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/EncodedDeviceInformation.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/EncodedDeviceInformation.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.auditevents.entity.shared;
+
+public record EncodedDeviceInformation(String encoded) {}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/PasskeyWithCredentialId.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/PasskeyWithCredentialId.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.auditevents.entity.shared;
+
+public record PasskeyWithCredentialId(String passkeyCredentialId) {}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/services/StructuredAuditService.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/services/StructuredAuditService.java
@@ -1,8 +1,5 @@
 package uk.gov.di.authentication.auditevents.services;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
@@ -15,7 +12,6 @@ public class StructuredAuditService {
     public static final String UNKNOWN = "";
 
     private final AwsSqsClient awsSqsClient;
-    private final Gson gson;
 
     public StructuredAuditService(ConfigurationService configurationService) {
         this.awsSqsClient =
@@ -23,28 +19,16 @@ public class StructuredAuditService {
                         configurationService.getAwsRegion(),
                         configurationService.getTxmaAuditQueueUrl(),
                         configurationService.getLocalstackEndpointUri());
-        this.gson = createGson();
     }
 
     public StructuredAuditService(AwsSqsClient awsSqsClient) {
         this.awsSqsClient = awsSqsClient;
-        this.gson = createGson();
-    }
-
-    private static Gson createGson() {
-        return new GsonBuilder()
-                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create();
     }
 
     public void submitAuditEvent(StructuredAuditEvent auditEvent) {
         LOG.info("Sending audit event to SQS: {}", auditEvent.eventName());
 
-        String serializedEvent = serialize(auditEvent);
+        String serializedEvent = auditEvent.serialize();
         awsSqsClient.send(serializedEvent);
-    }
-
-    private String serialize(StructuredAuditEvent auditEvent) {
-        return gson.toJson(auditEvent);
     }
 }

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyDeleteSuccessfulTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyDeleteSuccessfulTest.java
@@ -1,0 +1,69 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
+
+class AuthPasskeyDeleteSuccessfulTest {
+
+    @Test
+    void shouldSerialiseAnAuthPasskeyDeleteSuccessfulAuditEvent() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client-id")
+                        .withEmail("test@example.com")
+                        .withSubjectId("internal-common-subject-id")
+                        .withPersistentSessionId("persistent-session-id")
+                        .withSessionId("session-id")
+                        .withClientSessionId("signin-journey-id")
+                        .withIpAddress("192.0.2.0/24")
+                        .withTxmaAuditEncoded("encoded-device-info");
+
+        var fixedInstant = Instant.parse("2026-06-10T13:13:04.730565Z");
+        var fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
+
+        var event =
+                AuthPasskeyDeleteSuccessful.create(auditContext, 2, "credential-id", fixedClock);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_PASSKEY_DELETE_SUCCESSFUL",
+                  "timestamp": 1781097184,
+                  "event_timestamp_ms": 1781097184730,
+                  "client_id": "client-id",
+                  "component_id": "HOME",
+                  "user": {
+                    "email": "test@example.com",
+                    "govuk_signin_journey_id": "signin-journey-id",
+                    "ip_address": "192.0.2.0/24",
+                    "persistent_session_id": "persistent-session-id",
+                    "session_id": "session-id",
+                    "user_id": "internal-common-subject-id",
+                    "passkey_count": 2
+                  },
+                  "restricted": {
+                    "device_information": {
+                      "encoded": "encoded-device-info"
+                    },
+                    "passkey": {
+                      "passkey_credential_id": "credential-id"
+                    }
+                  },
+                  "extensions": {
+                    "journey-type": "ACCOUNT_MANAGEMENT"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+}

--- a/ci/cloudformation/account-management/function/passkeys-delete-proxy.yaml
+++ b/ci/cloudformation/account-management/function/passkeys-delete-proxy.yaml
@@ -30,6 +30,7 @@ Resources:
                   accountDataApiId,
                 ]
           EMAIL_QUEUE_URL: !GetAtt EmailNotificationQueue.QueueUrl
+          TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
             - DataStoreAccountId:
@@ -38,12 +39,20 @@ Resources:
                   !Ref Environment,
                   dataStoreAccountId,
                 ]
+          INTERNAl_SECTOR_URI: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://identity.${SubEnvironment}.dev.account.gov.uk"
+              - !Sub "https://identity.${Environment}.account.gov.uk"
+            - "https://identity.account.gov.uk"
       LoggingConfig:
         LogGroup: !Ref PasskeysDeleteProxyFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
         - !Ref UserProfileTableKmsPolicy
+        - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
       SnapStart:
         ApplyOn: PublishedVersions
       VpcConfig:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -34,7 +34,7 @@ import java.util.List;
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_PASSKEY_AUTHENTICATION_GENERATED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EXTENSIONS_PASSKEY;
+import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PASSKEY;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
@@ -145,7 +145,7 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                         .map(UserVerificationRequirement::getValue);
         var passkeyUnrestrictedPair =
                 pair(
-                        AUDIT_EXTENSIONS_PASSKEY,
+                        AUDIT_EVENT_EXTENSIONS_PASSKEY,
                         PasskeyAuthenticationAuditExtension.fromUserVerification(
                                 maybeUserVerification.orElse(AuditService.UNKNOWN)));
 
@@ -168,7 +168,7 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
                         .orElse(List.of());
         var restrictedPasskeyPair =
                 pair(
-                        AUDIT_EXTENSIONS_PASSKEY,
+                        AUDIT_EVENT_EXTENSIONS_PASSKEY,
                         new PasskeyAuthenticationAuditRestricted(allowedCredentials),
                         true);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -21,9 +21,9 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS = "account_actions";
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS_ERRORS = "account_actions_errors";
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS_FAILED = "account_actions_failed";
-    String AUDIT_EXTENSIONS_PASSKEY = "passkey";
-    String AUDIT_EVENT_RESTRICTED_PASSKEY = "passkey";
-    String AUDIT_EVENT_RESTRICTED_PASSKEY_CREDENTIAL_ID = "passkey_credential_id";
+    String AUDIT_EVENT_EXTENSIONS_PASSKEY = "passkey";
+    String AUDIT_EVENT_EXTENSIONS_RESTRICTED_PASSKEY = "passkey";
+    String AUDIT_EVENT_EXTENSIONS_RESTRICTED_PASSKEY_CREDENTIAL_ID = "passkey_credential_id";
 
     AuditableEvent parseFromName(String name);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -22,6 +22,8 @@ public interface AuditableEvent {
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS_ERRORS = "account_actions_errors";
     String AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS_FAILED = "account_actions_failed";
     String AUDIT_EXTENSIONS_PASSKEY = "passkey";
+    String AUDIT_EVENT_RESTRICTED_PASSKEY = "passkey";
+    String AUDIT_EVENT_RESTRICTED_PASSKEY_CREDENTIAL_ID = "passkey_credential_id";
 
     AuditableEvent parseFromName(String name);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountDataApiResponseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountDataApiResponseException.java
@@ -45,7 +45,7 @@ public class UnsuccessfulAccountDataApiResponseException extends Exception {
             Integer statusCode, Object body) {
         return new UnsuccessfulAccountDataApiResponseException(
                 format(
-                        "Error %s when attempting to call Account Data API outbound endpoint: %s",
+                        "Received response with status code %s when attempting to call Account Data API outbound endpoint: %s",
                         statusCode, body),
                 statusCode);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
@@ -16,6 +16,7 @@ import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 
 import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.httpResponseCodeException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.interruptedException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.ioException;
 import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.timeoutException;
@@ -41,6 +42,10 @@ public class AccountDataApiService {
             throws Json.JsonException, UnsuccessfulAccountDataApiResponseException {
         try {
             var response = retrievePasskeysAsJson(publicSubjectId, token);
+            if (response.statusCode() != 200) {
+                LOG.error("Failed to get successful response from retrieve passkeys");
+                throw httpResponseCodeException(response.statusCode(), response.body());
+            }
             return serializationService.readValue(
                     response.body(), PasskeysRetrieveResponse.class, true);
         } catch (Json.JsonException e) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -157,6 +157,24 @@ class AccountDataApiServiceTest {
             assertThat(result.passkeys().get(1).passkeyId(), equalTo("credential-id-456"));
             assertThat(result.passkeys().get(1).isAttested(), equalTo(false));
         }
+
+        @Test
+        void shouldNotAttemptToDeserialiseIfResponseStatusIsNot200()
+                throws IOException, InterruptedException {
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(mockHttpResponse.statusCode()).thenReturn(404);
+            String errorResponse =
+                    """
+                    {
+                        "error": "this will not decode as a passkeys response"
+                    """;
+            when(mockHttpResponse.body()).thenReturn(errorResponse);
+            when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
+
+            assertThrows(
+                    UnsuccessfulAccountDataApiResponseException.class,
+                    () -> service.retrievePasskeys("testPublicSubjectId", TOKEN));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Add `AUTH_PASSKEY_DELETE_SUCCESSFUL` and `AUTH_PASSKEY_DELETE_FAILED` audit events to the `PasskeysDeleteProxyHandler`.

For the moment, the success event is emitted from the structured audit service, and the failed event from the normal audit service. We can switch the failed event over when we have a bit more time.

## How to review

1. Code Review
1. Deploy to a dev env, send some requests to the lambda, review the `*-account-mgmt-txma-audit-queue` SQS queue and check that these match the expected schemas (as defined in the event catalogue).

## Testing

1. Deployed to authdev1
2. Added multiple passkeys to the `authdev1-authenticator` DynamoDB table

<details>
<summary>Example passkey item</summary>
(ENSURE to replace `PUB_SUB_ID_HERE` with your own value)

```
{
  "PublicSubjectID": {
    "S": "PUB_SUB_ID_HERE"
  },
  "SK": {
    "S": "PASSKEY#aut-5467-pk-1"
  },
  "Created": {
    "S": "2026-06-09:12:00:00.00"
  },
  "Credential": {
    "S": "pQECAyYgASFYIE3WjrJM2QShxjbTYvoHxvQH_QGlYCGnvvZPyGmc6daKIlggOwQOT16fim0iJ1N5K1_-qr53oCXzB7ArtY2SB-QPwqg"
  },
  "CredentialId": {
    "S": "aut-5467-pk-1"
  },
  "PasskeyAaguid": {
    "S": "d2717a32-9851-48a8-9961-b264c97a411a"
  },
  "PasskeyBackedUp": {
    "BOOL": false
  },
  "PasskeyBackupEligible": {
    "BOOL": false
  },
  "PasskeyIsAttested": {
    "BOOL": true
  },
  "PasskeyIsResidentKey": {
    "BOOL": true
  },
  "PasskeySignCount": {
    "N": "0"
  },
  "PasskeyTransports": {
    "L": [
      {
        "S": "internal"
      }
    ]
  }
}
```

</details>

3. Locally, ran `aws sso login --profile di-authentication-development-AdministratorAccessPermission`
4. Locally, ran `python3 ./generate_account_data_token.py --public-subject-id= PUB_SUB_ID_HERE --scope "passkey-create passkey-retrieve passkey-delete" --profile di-authentication-development-AdministratorAccessPermission` (ENSURE to replace `PUB_SUB_ID_HERE ` with your own value)
5. In the AWS Console, located the `authdev2-passkeys-delete-proxy-lambda` lambda, submitted a test event and reviewed output

<details>
<summary>Example test event</summary>
(ENSURE to replace `PUB_SUB_ID_HERE` and `YOUR_TOKEN_HERE_FROM_THE_SCRIPT_RUN` with your own values)

```
{
  "pathParameters": {
    "publicSubjectId": "PUB_SUB_ID_HERE",
    "passkeyIdentifier": "aut-5467-pk-1"
  },
  "headers": {
    "X-ADAPI-AccessToken": "YOUR_TOKEN_HERE_FROM_THE_SCRIPT_RUN",
    "Session-Id": "test-session-id",
    "Client-Session-Id": "test-client-session-id",
    "di-persistent-session-id": "test-persistent-session-id",
    "txma-audit-encoded": "test-encoded-header"
  },
  "requestContext": {
    "identity": {
      "sourceIp": "127.0.0.1"
    },
    "authorizer": {
      "ClientId": "your-client-id"
    }
  }
}
```

</details>

6. Reviewed messages on the `authdev1-account-mgmt-txma-audit-queue` SQS queue.

<details>
<summary>Raw success</summary>

```
{
  "event_name": "AUTH_PASSKEY_DELETE_SUCCESSFUL",
  "timestamp": 1781172682,
  "event_timestamp_ms": 1781172682870,
  "client_id": "",
  "component_id": "HOME",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "test-client-session-id",
    "ip_address": "[REDACTED]",
    "persistent_session_id": "test-persistent-session-id",
    "session_id": "test-session-id",
    "user_id": "[REDACTED]",
    "passkey_count": 0
  },
  "restricted": {
    "device_information": {
      "encoded": "test-encoded-header"
    },
    "passkey": {
      "passkey_credential_id": "abcd"
    }
  },
  "extensions": {
    "journey-type": "ACCOUNT_MANAGEMENT"
  }
}
```

</details>

<details>
<summary>Raw failure</summary>

```
{
  "timestamp": 1781172579,
  "event_timestamp_ms": 1781172579791,
  "event_name": "AUTH_PASSKEY_DELETE_FAILED",
  "client_id": "",
  "component_id": "HOME",
  "user": {
    "user_id": "[REDACTED]",
    "email": "[REDACTED]",
    "phone": null,
    "ip_address": "[REDACTED]",
    "session_id": "test-session-id",
    "persistent_session_id": "test-persistent-session-id",
    "govuk_signin_journey_id": "test-client-session-id"
  },
  "restricted": {
    "passkey": {
      "passkey_credential_id": "fedc"
    },
    "device_information": {
      "encoded": "test-encoded-header"
    }
  },
  "extensions": {
    "journey-type": "ACCOUNT_MANAGEMENT"
  }
}
```

</details>

