### PR TITLE
AUT-5449: Send passkey information to the TICF-CRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,53 @@ To run the integration tests in this repo, you can run the following command
 If the tests aren't running in `account-management-integration-tests` refer to the [Local Running README](./local-running/README.md) and make sure
 you have the correct repositories up to date.
 
+### Contract (Pact):
+
+Contract tests verify that two services agree on the format of their API communication without needing to run them together. They use [Pact](https://docs.pact.io/) to define a shared contract between a **consumer** (the service making requests) and a **provider** (the service handling them).
+
+Most of the contract tests in this repo are **consumer-side** Pact tests. They live in `contract` packages within each module (e.g. `frontend-api/src/test/java/.../contract/`).
+For example, the frontend-api is the consumer — it makes outbound requests to external services (TICF CRI, Account Interventions, IPV, etc.).
+
+#### How they work
+
+1. Each test class defines the expected request/response interactions using `@Pact` methods
+2. A Pact mock server starts locally and acts as the provider
+3. The real handler code runs against the mock server
+4. If the handler sends a request matching the pact definition and handles the response correctly, the test passes
+5. A **pact file** (JSON) is generated in `<module>/build/pacts/`
+6. On merge, the pact file is published to a Pact Broker
+7. The provider team runs the pact file against their real service to verify they satisfy the contract
+
+This means both sides can test independently. If either side drifts from the contract, their tests fail.
+
+#### Running contract tests
+
+Run all contract tests for a module:
+
+```shell
+./gradlew frontend-api:pactConsumerTests
+```
+
+#### Running in IntelliJ
+
+Contract tests are **excluded** from the standard `test` task, so clicking the play button won't work with the default Gradle test runner. Two options:
+
+1. **Change IntelliJ's test runner** — Go to Settings → Build, Execution, Deployment → Build Tools → Gradle → change "Run tests using" to **IntelliJ IDEA**. The play button will then work directly.
+
+2. **Create a Gradle run configuration** — Run → Edit Configurations → + → Gradle. Set the task to `frontend-api:pactConsumerTests` (but this can only run all the tests unless you specify a configuration per test)
+
+#### When to update contract tests
+
+- **Adding a new field to an outbound request** — Add the field to the pact definition if it will be present in the JSON payload
+- **Changing the shape of a request/response** — Update the relevant `@Pact` method
+- **Adding a new external service interaction** — Create a new test class
+
+#### Important notes
+
+- Null fields stripped during serialization don't need to be in the pact definition.
+- The provider team must verify against your updated pact before the change is safe to deploy to production. Ensure you communicate with the team that have the provider tests.
+- Pact files are published automatically on merge via CI (requires `PACT_URL`, `PACT_USER`, `PACT_PASSWORD` env vars - see [contract-tests.yaml](.github/workflows/contract-tests.yml)).
+
 ## Alarm Management
 
 The `alarm-management.sh` script provides utilities for managing CloudWatch alarms and SNS subscriptions. It allows you to test alarm functionality, manage SNS topic subscriptions, and verify alarm configurations across different environments. The script supports operations like triggering test alarms, subscribing/unsubscribing from SNS topics, and validating alarm states.

--- a/ci/cloudformation/auth/function/ticf-cri.yaml
+++ b/ci/cloudformation/auth/function/ticf-cri.yaml
@@ -42,6 +42,12 @@ Resources:
               - "{{resolve:secretsmanager:/deploy/${env}/ticf_cri_service_uri}}"
               - env:
                   !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          SUPPORT_PASSKEYS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              supportPasskeys,
+            ]
       LoggingConfig:
         LogGroup: !Ref TicfCriFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/function/ticf-cri.yaml
+++ b/ci/cloudformation/auth/function/ticf-cri.yaml
@@ -11,42 +11,6 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.TicfCriHandler::handleRequest
       Environment:
         Variables:
-          VERIFY_EMAIL_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/verify_email_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          VERIFY_PHONE_NUMBER_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/verify_phone_number_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          MFA_SMS_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/mfa_sms_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/password_reset_confirmation_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/account_created_confirmation_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          RESET_PASSWORD_WITH_CODE_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/reset_password_with_code_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          PASSWORD_RESET_CONFIRMATION_SMS_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/password_reset_confirmation_sms_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/verify_change_how_get_security_codes_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID: !Sub
-            - "{{resolve:ssm:/deploy/${env}/change_how_get_security_codes_confirmation_template_id}}"
-            - env:
-                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           TICF_CRI_SERVICE_CALL_TIMEOUT: !Sub
             - "{{resolve:ssm:/deploy/${env}/ticf_cri_service_call_timeout}}"
             - env:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -193,7 +193,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                                 : authSession.getIsNewAccount(),
                         authSession.getResetPasswordState(),
                         authSession.getResetMfaState(),
-                        authSession.getVerifiedMfaMethodType());
+                        authSession.getVerifiedMfaMethodType(),
+                        authSession.getHasVerifiedPasskey());
             }
 
             LOG.info("Generating Account Interventions outbound response for frontend");
@@ -214,7 +215,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             AuthSessionItem.AccountState accountState,
             AuthSessionItem.ResetPasswordState resetPasswordState,
             AuthSessionItem.ResetMfaState resetMfaState,
-            MFAMethodType verifiedMfaMethodType) {
+            MFAMethodType verifiedMfaMethodType,
+            boolean hasVerifiedWithPasskey) {
         var vtr = new ArrayList<String>();
 
         try {
@@ -237,7 +239,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                         accountState,
                         resetPasswordState,
                         resetMfaState,
-                        verifiedMfaMethodType);
+                        verifiedMfaMethodType,
+                        hasVerifiedWithPasskey);
 
         String payload;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -56,7 +56,7 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
         LOG.debug("received request to TICF CRI Handler");
         var environmentForMetrics = Map.entry("Environment", configurationService.getEnvironment());
         try {
-            var response = sendRequest(input);
+            var response = sendRequest(input, configurationService.supportPasskeys());
             var statusCode = response.statusCode();
             var logMessage =
                     format("Response received from TICF CRI Service with status %s", statusCode);
@@ -96,9 +96,11 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
                 metric, Map.of("Environment", configurationService.getEnvironment()));
     }
 
-    private HttpResponse<String> sendRequest(InternalTICFCRIRequest internalTICFCRIRequest)
+    private HttpResponse<String> sendRequest(
+            InternalTICFCRIRequest internalTICFCRIRequest, boolean supportPasskeys)
             throws IOException, InterruptedException {
-        var externalRequest = ExternalTICFCRIRequest.fromInternalRequest(internalTICFCRIRequest);
+        var externalRequest =
+                ExternalTICFCRIRequest.fromInternalRequest(internalTICFCRIRequest, supportPasskeys);
         var body = serialisationService.writeValueAsStringNoNulls(externalRequest);
         var timeoutInMilliseconds =
                 Duration.ofMillis(configurationService.getTicfCriServiceCallTimeout());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/TicfCriServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/TicfCriServiceTest.java
@@ -90,7 +90,8 @@ class TicfCriServiceTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
-                        MFAMethodType.SMS);
+                        MFAMethodType.SMS,
+                        false);
 
         assertDoesNotThrow(() -> ticfCriHandler.handleRequest(request, null));
         verify(configService).getTicfCriServiceURI();
@@ -128,7 +129,8 @@ class TicfCriServiceTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.ATTEMPTED,
                         AuthSessionItem.ResetMfaState.NONE,
-                        MFAMethodType.SMS);
+                        MFAMethodType.SMS,
+                        false);
 
         assertDoesNotThrow(() -> ticfCriHandler.handleRequest(request, null));
         verify(configService).getTicfCriServiceURI();
@@ -178,7 +180,8 @@ class TicfCriServiceTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
-                        MFAMethodType.SMS);
+                        MFAMethodType.SMS,
+                        false);
 
         assertDoesNotThrow(() -> ticfCriHandler.handleRequest(request, null));
         verify(configService).getTicfCriServiceURI();
@@ -207,7 +210,8 @@ class TicfCriServiceTest {
                         AuthSessionItem.AccountState.EXISTING,
                         AuthSessionItem.ResetPasswordState.NONE,
                         AuthSessionItem.ResetMfaState.NONE,
-                        MFAMethodType.SMS);
+                        MFAMethodType.SMS,
+                        false);
 
         assertDoesNotThrow(() -> ticfCriHandler.handleRequest(request, null));
         verify(configService).getTicfCriServiceURI();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -264,14 +264,16 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         false,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
 
                 // Testing initial registration combinations
                 Arguments.of(
@@ -280,14 +282,16 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         false,
                         AccountState.NEW,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
 
                 // Testing password reset combinations
                 Arguments.of(
@@ -296,14 +300,16 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.SUCCEEDED,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"SUCCEEDED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"SUCCEEDED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         false,
                         AccountState.EXISTING,
                         ResetPasswordState.ATTEMPTED,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"ATTEMPTED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"ATTEMPTED\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
 
                 // Testing mfa reset combinations
                 Arguments.of(
@@ -312,21 +318,24 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.SUCCEEDED,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"SUCCEEDED\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"SUCCEEDED\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.ATTEMPTED,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         false,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.ATTEMPTED,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":false,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"ATTEMPTED\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
 
                 // Testing mfa method combinations
                 Arguments.of(
@@ -335,28 +344,50 @@ class AccountInterventionsHandlerTest {
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.NONE,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.EMAIL,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"EMAIL\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"EMAIL\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.SMS,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"SMS\"}"),
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"SMS\",\"hasVerifiedWithPasskey\":false}"),
                 Arguments.of(
                         true,
                         AccountState.EXISTING,
                         ResetPasswordState.NONE,
                         ResetMfaState.NONE,
                         MFAMethodType.AUTH_APP,
-                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\"}"));
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\",\"hasVerifiedWithPasskey\":false}"),
+
+                // Testing verified with passkey combinations
+                Arguments.of(
+                        true,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
+                        MFAMethodType.AUTH_APP,
+                        true,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\",\"hasVerifiedWithPasskey\":true}"),
+                Arguments.of(
+                        true,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
+                        MFAMethodType.AUTH_APP,
+                        false,
+                        "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"EXISTING\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"AUTH_APP\",\"hasVerifiedWithPasskey\":false}"));
     }
 
     @ParameterizedTest
@@ -367,6 +398,7 @@ class AccountInterventionsHandlerTest {
             ResetPasswordState resetPasswordState,
             ResetMfaState resetMfaState,
             MFAMethodType usedMfaMethodType,
+            boolean hasVerifiedWithPasskey,
             String expectedPayload)
             throws UnsuccessfulAccountInterventionsResponseException {
         when(configurationService.accountInterventionsServiceActionEnabled()).thenReturn(false);
@@ -380,7 +412,8 @@ class AccountInterventionsHandlerTest {
                         .withAccountState(accountState)
                         .withResetPasswordState(resetPasswordState)
                         .withResetMfaState(resetMfaState)
-                        .withVerifiedMfaMethodType(usedMfaMethodType);
+                        .withVerifiedMfaMethodType(usedMfaMethodType)
+                        .withHasVerifiedPasskey(hasVerifiedWithPasskey);
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSessionWithChanges));
 
@@ -429,7 +462,7 @@ class AccountInterventionsHandlerTest {
         verify(mockLambdaInvokerService, times(1))
                 .invokeAsyncWithPayload(
                         eq(
-                                "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\"}"),
+                                "{\"internalCommonSubjectIdentifier\":\"urn:fdc:gov.uk:2022:mSm2hCZ-klPlOON7Z_KbaheBxJu88nDWbUn7fR6xD2g\",\"vtr\":[\"Cl\"],\"govukSigninJourneyId\":\"known-client-session-id\",\"authenticated\":true,\"accountState\":\"NEW\",\"resetPasswordState\":\"NONE\",\"resetMfaState\":\"NONE\",\"mfaMethodType\":\"NONE\",\"hasVerifiedWithPasskey\":false}"),
                         any());
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -1,10 +1,12 @@
 package uk.gov.di.authentication.frontendapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -32,6 +34,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -100,7 +103,8 @@ class TicfCriHandlerTest {
                         EXISTING_ACCOUNT_STATE,
                         NA_RESET_PASSWORD_STATE,
                         NA_RESET_MFA_STATE,
-                        NA_USED_MFA_METHOD_TYPE);
+                        NA_USED_MFA_METHOD_TYPE,
+                        false);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"}",
@@ -137,7 +141,8 @@ class TicfCriHandlerTest {
                         accountState,
                         NA_RESET_PASSWORD_STATE,
                         NA_RESET_MFA_STATE,
-                        NA_USED_MFA_METHOD_TYPE);
+                        NA_USED_MFA_METHOD_TYPE,
+                        false);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"%s}",
@@ -187,7 +192,8 @@ class TicfCriHandlerTest {
                         EXISTING_ACCOUNT_STATE,
                         resetPasswordState,
                         NA_RESET_MFA_STATE,
-                        NA_USED_MFA_METHOD_TYPE);
+                        NA_USED_MFA_METHOD_TYPE,
+                        false);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"%s}",
@@ -236,7 +242,8 @@ class TicfCriHandlerTest {
                         EXISTING_ACCOUNT_STATE,
                         NA_RESET_PASSWORD_STATE,
                         resetMfaState,
-                        NA_USED_MFA_METHOD_TYPE);
+                        NA_USED_MFA_METHOD_TYPE,
+                        false);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"%s}",
@@ -283,7 +290,8 @@ class TicfCriHandlerTest {
                         EXISTING_ACCOUNT_STATE,
                         NA_RESET_PASSWORD_STATE,
                         NA_RESET_MFA_STATE,
-                        usedMfaMethodType);
+                        usedMfaMethodType,
+                        false);
         var expectedRequestBody =
                 format(
                         "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"Y\"%s}",
@@ -296,6 +304,83 @@ class TicfCriHandlerTest {
 
         when(httpResponse.statusCode()).thenReturn(200);
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        handler.handleRequest(ticfRequest, context);
+
+        var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(httpRequestCaptor.capture(), ArgumentMatchers.any());
+
+        var actualRequestBody =
+                bodyPublisherToString(httpRequestCaptor.getValue().bodyPublisher().get());
+
+        var expectedUri = URI.create(SERVICE_URI + "/auth");
+        assertEquals(expectedUri, httpRequestCaptor.getValue().uri());
+        assertEquals(expectedRequestBody, actualRequestBody);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void shouldMakeTheCorrectCallToTheTicfCriForPasskey(boolean hasVerifiedWithPasskey)
+            throws IOException, InterruptedException, ExecutionException {
+        var ticfRequest =
+                new InternalTICFCRIRequest(
+                        COMMON_SUBJECTID,
+                        VECTORS_OF_TRUST,
+                        JOURNEY_ID,
+                        true,
+                        EXISTING_ACCOUNT_STATE,
+                        NA_RESET_PASSWORD_STATE,
+                        NA_RESET_MFA_STATE,
+                        NA_USED_MFA_METHOD_TYPE,
+                        hasVerifiedWithPasskey);
+
+        var expectedBody = new LinkedHashMap<String, Object>();
+        expectedBody.put("sub", COMMON_SUBJECTID);
+        expectedBody.put("vtr", VECTORS_OF_TRUST);
+        expectedBody.put("govuk_signin_journey_id", JOURNEY_ID);
+        expectedBody.put("authenticated", "Y");
+        if (hasVerifiedWithPasskey) {
+            expectedBody.put("passkey", "Y");
+        }
+        var expectedRequestBody = new Gson().toJson(expectedBody);
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        when(configurationService.supportPasskeys()).thenReturn(true);
+        handler.handleRequest(ticfRequest, context);
+
+        var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(httpRequestCaptor.capture(), ArgumentMatchers.any());
+
+        var actualRequestBody =
+                bodyPublisherToString(httpRequestCaptor.getValue().bodyPublisher().get());
+
+        var expectedUri = URI.create(SERVICE_URI + "/auth");
+        assertEquals(expectedUri, httpRequestCaptor.getValue().uri());
+        assertEquals(expectedRequestBody, actualRequestBody);
+    }
+
+    @Test
+    void shouldNotIncludePasskeyInCallToTicfIfPasskeysNotEnabled()
+            throws IOException, InterruptedException, ExecutionException {
+        var ticfRequest =
+                new InternalTICFCRIRequest(
+                        COMMON_SUBJECTID,
+                        VECTORS_OF_TRUST,
+                        JOURNEY_ID,
+                        true,
+                        EXISTING_ACCOUNT_STATE,
+                        NA_RESET_PASSWORD_STATE,
+                        NA_RESET_MFA_STATE,
+                        NA_USED_MFA_METHOD_TYPE,
+                        true);
+        var expectedRequestBody =
+                format(
+                        "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"}",
+                        COMMON_SUBJECTID, jsonArrayFrom(VECTORS_OF_TRUST), JOURNEY_ID, "Y");
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        when(configurationService.supportPasskeys()).thenReturn(false);
         handler.handleRequest(ticfRequest, context);
 
         var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -329,7 +414,8 @@ class TicfCriHandlerTest {
                         EXISTING_ACCOUNT_STATE,
                         NA_RESET_PASSWORD_STATE,
                         NA_RESET_MFA_STATE,
-                        NA_USED_MFA_METHOD_TYPE);
+                        NA_USED_MFA_METHOD_TYPE,
+                        false);
         when(httpResponse.statusCode()).thenReturn(statusCode);
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
@@ -380,7 +466,8 @@ class TicfCriHandlerTest {
                         EXISTING_ACCOUNT_STATE,
                         NA_RESET_PASSWORD_STATE,
                         NA_RESET_MFA_STATE,
-                        NA_USED_MFA_METHOD_TYPE),
+                        NA_USED_MFA_METHOD_TYPE,
+                        false),
                 context);
 
         verify(cloudwatchMetricsService).incrementCounter(metricName, METRICS_CONTEXT);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -162,6 +162,15 @@ class TicfCriHandlerTest {
         assertEquals(expectedRequestBody, actualRequestBody);
     }
 
+    private static List<Arguments> resetPassword() {
+        return List.of(
+                Arguments.of(false, ResetPasswordState.NONE, false),
+                Arguments.of(true, ResetPasswordState.NONE, false),
+                Arguments.of(false, ResetPasswordState.ATTEMPTED, true),
+                Arguments.of(true, ResetPasswordState.ATTEMPTED, false),
+                Arguments.of(true, ResetPasswordState.SUCCEEDED, true));
+    }
+
     @ParameterizedTest
     @MethodSource("resetPassword")
     void shouldMakeTheCorrectCallToTheTicfCriForResetPassword(
@@ -203,13 +212,14 @@ class TicfCriHandlerTest {
         assertEquals(expectedRequestBody, actualRequestBody);
     }
 
-    private static List<Arguments> resetPassword() {
+    private static List<Arguments> resetMfa() {
         return List.of(
-                Arguments.of(false, ResetPasswordState.NONE, false),
-                Arguments.of(true, ResetPasswordState.NONE, false),
-                Arguments.of(false, ResetPasswordState.ATTEMPTED, true),
-                Arguments.of(true, ResetPasswordState.ATTEMPTED, false),
-                Arguments.of(true, ResetPasswordState.SUCCEEDED, true));
+                Arguments.of(false, ResetMfaState.NONE, false),
+                Arguments.of(true, ResetMfaState.NONE, false),
+                Arguments.of(false, ResetMfaState.ATTEMPTED, true),
+                Arguments.of(true, ResetMfaState.ATTEMPTED, false),
+                Arguments.of(false, ResetMfaState.SUCCEEDED, true),
+                Arguments.of(true, ResetMfaState.SUCCEEDED, true));
     }
 
     @ParameterizedTest
@@ -251,14 +261,12 @@ class TicfCriHandlerTest {
         assertEquals(expectedRequestBody, actualRequestBody);
     }
 
-    private static List<Arguments> resetMfa() {
+    private static List<Arguments> usedMfaMethodType() {
         return List.of(
-                Arguments.of(false, ResetMfaState.NONE, false),
-                Arguments.of(true, ResetMfaState.NONE, false),
-                Arguments.of(false, ResetMfaState.ATTEMPTED, true),
-                Arguments.of(true, ResetMfaState.ATTEMPTED, false),
-                Arguments.of(false, ResetMfaState.SUCCEEDED, true),
-                Arguments.of(true, ResetMfaState.SUCCEEDED, true));
+                Arguments.of(MFAMethodType.NONE, null),
+                Arguments.of(MFAMethodType.EMAIL, null),
+                Arguments.of(MFAMethodType.SMS, "SMS"),
+                Arguments.of(MFAMethodType.AUTH_APP, "AUTH_APP"));
     }
 
     @ParameterizedTest
@@ -301,12 +309,11 @@ class TicfCriHandlerTest {
         assertEquals(expectedRequestBody, actualRequestBody);
     }
 
-    private static List<Arguments> usedMfaMethodType() {
+    private static List<Arguments> statusCodes() {
         return List.of(
-                Arguments.of(MFAMethodType.NONE, null),
-                Arguments.of(MFAMethodType.EMAIL, null),
-                Arguments.of(MFAMethodType.SMS, "SMS"),
-                Arguments.of(MFAMethodType.AUTH_APP, "AUTH_APP"));
+                Arguments.of(200, Level.INFO),
+                Arguments.of(404, Level.ERROR),
+                Arguments.of(500, Level.INFO));
     }
 
     @ParameterizedTest
@@ -344,11 +351,18 @@ class TicfCriHandlerTest {
                                         statusCode))));
     }
 
-    private static List<Arguments> statusCodes() {
+    private static List<Arguments> exceptions() {
         return List.of(
-                Arguments.of(200, Level.INFO),
-                Arguments.of(404, Level.ERROR),
-                Arguments.of(500, Level.INFO));
+                Arguments.of(
+                        new IOException("an IO Exception"), "TicfCriServiceError", Level.ERROR),
+                Arguments.of(
+                        new InterruptedException("an Interrputed exception"),
+                        "TicfCriServiceError",
+                        Level.ERROR),
+                Arguments.of(
+                        new HttpTimeoutException("timed out"),
+                        "TicfCriServiceTimeout",
+                        Level.WARN));
     }
 
     @ParameterizedTest
@@ -373,20 +387,6 @@ class TicfCriHandlerTest {
         assertThat(
                 logging.events(),
                 hasItem(withLevelAndMessageContaining(expectedLogLevel, format(e.getMessage()))));
-    }
-
-    private static List<Arguments> exceptions() {
-        return List.of(
-                Arguments.of(
-                        new IOException("an IO Exception"), "TicfCriServiceError", Level.ERROR),
-                Arguments.of(
-                        new InterruptedException("an Interrputed exception"),
-                        "TicfCriServiceError",
-                        Level.ERROR),
-                Arguments.of(
-                        new HttpTimeoutException("timed out"),
-                        "TicfCriServiceTimeout",
-                        Level.WARN));
     }
 
     private JsonArray jsonArrayFrom(List<String> elements) {

--- a/shared/src/main/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequest.java
@@ -19,10 +19,11 @@ public record ExternalTICFCRIRequest(
         @Expose @SerializedName("initial_registration") String initialRegistration,
         @Expose @SerializedName("password_reset") String passwordReset,
         @Expose @SerializedName("2fa_reset") String mfaReset,
-        @Expose @SerializedName("2fa_method") List<String> mfaMethod) {
+        @Expose @SerializedName("2fa_method") List<String> mfaMethod,
+        @Expose String passkey) {
 
     public static ExternalTICFCRIRequest fromInternalRequest(
-            InternalTICFCRIRequest internalRequest) {
+            InternalTICFCRIRequest internalRequest, boolean supportPasskeys) {
         boolean passwordResetSuccess =
                 internalRequest.resetPasswordState().equals(ResetPasswordState.SUCCEEDED);
         boolean reportablePasswordAttempted =
@@ -54,7 +55,8 @@ public record ExternalTICFCRIRequest(
                 mfaReset ? "Y" : null,
                 sanitisedMfaMethodType != null
                         ? Collections.singletonList(sanitisedMfaMethodType)
-                        : null);
+                        : null,
+                internalRequest.hasVerifiedWithPasskey() && supportPasskeys ? "Y" : null);
     }
 
     @Override
@@ -76,6 +78,8 @@ public record ExternalTICFCRIRequest(
                 + mfaReset
                 + "', mfaMethod='"
                 + mfaMethod
+                + "', passkey='"
+                + passkey
                 + "'}";
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/entity/InternalTICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/InternalTICFCRIRequest.java
@@ -16,4 +16,5 @@ public record InternalTICFCRIRequest(
         @Expose AccountState accountState,
         @Expose ResetPasswordState resetPasswordState,
         @Expose ResetMfaState resetMfaState,
-        MFAMethodType mfaMethodType) {}
+        MFAMethodType mfaMethodType,
+        @Expose boolean hasVerifiedWithPasskey) {}

--- a/shared/src/test/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequestTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequestTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.entity;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,12 +27,14 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -45,12 +48,14 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "N",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -66,13 +71,15 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.NEW,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "Y",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null)),
@@ -85,13 +92,15 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.NEW,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "N",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null)),
@@ -105,7 +114,8 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.SUCCEEDED,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
@@ -113,6 +123,7 @@ class ExternalTICFCRIRequestTest {
                                 "Y",
                                 null,
                                 "Y",
+                                null,
                                 null,
                                 null)),
                 Arguments.of(
@@ -124,7 +135,8 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.ATTEMPTED,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
@@ -132,6 +144,7 @@ class ExternalTICFCRIRequestTest {
                                 "N",
                                 null,
                                 "Y",
+                                null,
                                 null,
                                 null)),
                 Arguments.of(
@@ -143,12 +156,14 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.ATTEMPTED,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -163,7 +178,8 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.SUCCEEDED,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
@@ -172,6 +188,7 @@ class ExternalTICFCRIRequestTest {
                                 null,
                                 null,
                                 "Y",
+                                null,
                                 null)),
                 Arguments.of(
                         new InternalTICFCRIRequest(
@@ -182,12 +199,14 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.ATTEMPTED,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -201,7 +220,8 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.ATTEMPTED,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
@@ -210,6 +230,7 @@ class ExternalTICFCRIRequestTest {
                                 null,
                                 null,
                                 "Y",
+                                null,
                                 null)),
 
                 // Testing mfa method combinations
@@ -222,12 +243,14 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.NONE,
                                 ResetMfaState.NONE,
-                                MFAMethodType.NONE),
+                                MFAMethodType.NONE,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -241,12 +264,14 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.ATTEMPTED,
                                 ResetMfaState.NONE,
-                                MFAMethodType.EMAIL),
+                                MFAMethodType.EMAIL,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
                                 "test-journey-id",
                                 "Y",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -260,7 +285,8 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.ATTEMPTED,
                                 ResetMfaState.NONE,
-                                MFAMethodType.SMS),
+                                MFAMethodType.SMS,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
@@ -269,7 +295,8 @@ class ExternalTICFCRIRequestTest {
                                 null,
                                 null,
                                 null,
-                                List.of("SMS"))),
+                                List.of("SMS"),
+                                null)),
                 Arguments.of(
                         new InternalTICFCRIRequest(
                                 "test-sub",
@@ -279,7 +306,8 @@ class ExternalTICFCRIRequestTest {
                                 AccountState.EXISTING,
                                 ResetPasswordState.ATTEMPTED,
                                 ResetMfaState.NONE,
-                                MFAMethodType.AUTH_APP),
+                                MFAMethodType.AUTH_APP,
+                                false),
                         new ExternalTICFCRIRequest(
                                 "test-sub",
                                 List.of("Cl.Cm"),
@@ -288,13 +316,90 @@ class ExternalTICFCRIRequestTest {
                                 null,
                                 null,
                                 null,
-                                List.of("AUTH_APP"))));
+                                List.of("AUTH_APP"),
+                                null)),
+
+                // Testing passkey combinations
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE,
+                                false),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null,
+                                null)),
+                Arguments.of(
+                        new InternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                true,
+                                AccountState.EXISTING,
+                                ResetPasswordState.NONE,
+                                ResetMfaState.NONE,
+                                MFAMethodType.NONE,
+                                true),
+                        new ExternalTICFCRIRequest(
+                                "test-sub",
+                                List.of("Cl.Cm"),
+                                "test-journey-id",
+                                "Y",
+                                null,
+                                null,
+                                null,
+                                null,
+                                "Y")));
     }
 
     @ParameterizedTest
     @MethodSource("ticfParametersSource")
     void shouldCorrectlyBeConstructedFromInternalRequest(
             InternalTICFCRIRequest provided, ExternalTICFCRIRequest expected) {
-        assertEquals(expected, ExternalTICFCRIRequest.fromInternalRequest(provided));
+        assertEquals(expected, ExternalTICFCRIRequest.fromInternalRequest(provided, true));
+    }
+
+    @Test
+    void shouldNotSendPasskeyIfPasskeysNotSupported() {
+        var userSignedInWithPasskeyInternalTicfRequest =
+                new InternalTICFCRIRequest(
+                        "test-sub",
+                        List.of("Cl.Cm"),
+                        "test-journey-id",
+                        true,
+                        AccountState.EXISTING,
+                        ResetPasswordState.NONE,
+                        ResetMfaState.NONE,
+                        MFAMethodType.NONE,
+                        true);
+
+        var expectedExternalTicfCriRequest =
+                new ExternalTICFCRIRequest(
+                        "test-sub",
+                        List.of("Cl.Cm"),
+                        "test-journey-id",
+                        "Y",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
+
+        assertEquals(
+                ExternalTICFCRIRequest.fromInternalRequest(
+                        userSignedInWithPasskeyInternalTicfRequest, false),
+                expectedExternalTicfCriRequest);
     }
 }

--- a/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
+++ b/ticf-cri-stub/src/main/java/uk/gov/di/authentication/ticf/cri/stub/lambda/TICFCRIStubHandler.java
@@ -27,14 +27,15 @@ public class TICFCRIStubHandler
         try {
             var request = objectMapper.readValue(input.getBody(), ExternalTICFCRIRequest.class);
             LOG.info(
-                    "TICF Request - govuk_signin_journey_id: {}, vtr: {}, authenticated: {}, initial_registration: {}, password_reset: {}, 2fa_reset: {}, 2fa_method: {}",
+                    "TICF Request - govuk_signin_journey_id: {}, vtr: {}, authenticated: {}, initial_registration: {}, password_reset: {}, 2fa_reset: {}, 2fa_method: {}, passkey: {}",
                     request.govukSigninJourneyId(),
                     request.vtr(),
                     request.authenticated(),
                     request.initialRegistration(),
                     request.passwordReset(),
                     request.mfaReset(),
-                    request.mfaMethod());
+                    request.mfaMethod(),
+                    request.passkey());
         } catch (Json.JsonException e) {
             LOG.error("Invalid ExternalTICFCRIRequest", e.getMessage());
             throw new RuntimeException(e);


### PR DESCRIPTION
## What

- Use the hasVerifiedPasskey property on the AuthSessionItem as an indicator of whether the user has used a passkey to sign in (note, the name of this will be changed in a subsequent PR to be more reflective of what this attribute is - hasVerifiedWithPasskey)
- If the `hasVerifiedPasskey` attribute is true, send `"passkey": "Y"` to TICF in accordance with this [interface](https://govukverify.atlassian.net/wiki/spaces/FPAD/pages/6206488582/26+02+Passkeys#Auth-%E2%86%92-TICF-CRI-Interface-(RFC0063))
- Not added any new contract tests in this PR as that would require talking to TICF to ensure they update their provider tests aswell. These tests will be done in another ticket.

## How to review

1. Code review
