### PR TITLE
BAU: Try to optimise storage token jwk latency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ awsSqs = { module = "software.amazon.awssdk:sqs", version.ref = "awsSdk" }
 awsSsm = { module = "software.amazon.awssdk:ssm", version.ref = "awsSdk" }
 awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "awsSdk" }
 bouncyCastle = "org.bouncycastle:bcpkix-jdk18on:1.84"
+crac = "org.crac:crac:1.4.0"
 govUkNotify = "uk.gov.service.notify:notifications-java-client:6.0.0-RELEASE"
 gson = "com.google.code.gson:gson:2.14.0"
 hamcrest = "org.hamcrest:hamcrest:3.0"

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -25,7 +25,8 @@ dependencies {
             libs.jetbrainsAnnotations,
             project(":orchestration-shared"),
             project(":client-registry-api"),
-            project(":doc-checking-app-api")
+            project(":doc-checking-app-api"),
+            libs.crac
 
     runtimeOnly platform(libs.openTelemetryBom),
             libs.openTelemetryAwsSdk

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/StorageTokenJwkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/StorageTokenJwkHandler.java
@@ -9,6 +9,8 @@ import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import org.crac.Core;
+import org.crac.Resource;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
@@ -24,7 +26,8 @@ import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFiel
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class StorageTokenJwkHandler
-        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>,
+                Resource {
 
     private final JwksService jwksService;
     private static final Logger LOG = LogManager.getLogger(StorageTokenJwkHandler.class);
@@ -41,7 +44,17 @@ public class StorageTokenJwkHandler
 
     public StorageTokenJwkHandler() {
         this(ConfigurationService.getInstance());
+        Core.getGlobalContext().register(this);
     }
+
+    @Override
+    public void beforeCheckpoint(org.crac.Context<? extends Resource> context) throws Exception {
+        LOG.info("Executing before checkpoint");
+        this.storageTokenJwkRequestHandler();
+    }
+
+    @Override
+    public void afterRestore(org.crac.Context<? extends Resource> context) throws Exception {}
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/StorageTokenJwkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/StorageTokenJwkHandler.java
@@ -51,6 +51,11 @@ public class StorageTokenJwkHandler
     public void beforeCheckpoint(org.crac.Context<? extends Resource> context) throws Exception {
         LOG.info("Executing before checkpoint");
         this.storageTokenJwkRequestHandler();
+        // Empty key cache, so we can force the key to be re-fetched everytime
+        // the SnapStart image is restored. This allows us to fetch the key
+        // on every restore, but continue to cache it for the duration that
+        // the same lambda exists.
+        this.jwksService.emptyCache();
     }
 
     @Override

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -155,4 +155,8 @@ public class JwksService {
             throw new RuntimeException();
         }
     }
+
+    public void emptyCache() {
+        KEY_CACHE.clear();
+    }
 }


### PR DESCRIPTION
### Wider context of change

This lambda is called fairly infrequently and therefore has poor latency with snapstart enabled. To try and fix this, we can try what AWS refer to as "Invoke priming"[1]. Given our lambda handler has relatively few side-effects and is argumentless, we can call the handler in the beforeCheckpoint hook. This ensures that the classes in our hot code path are pre JIT compiled at the time the snapshot is created. This should hopefully ensure we have less latency on this endpoint

[1] - https://aws.amazon.com/blogs/compute/optimizing-cold-start-performance-of-aws-lambda-using-advanced-priming-strategies-with-snapstart/

### What’s changed
- Adds a new dependency `crac` to add the interface for our runtime hooks
- Implements the `beforeCheckpoint` and calls our handler.

### Manual testing
Deployed to dev and test by hitting the `/.well-known/storage-token-jwk.json` endpoint

Our latency on a new restore on this lambda in dev before:  ~4.4 seconds
Our latency one a new restore  after these changes: 470ms

These both included an initial KMS call, showing that the key was not cached on the first request

Inspected the restore logs:
- Before: `Restore Duration: 1269.88 ms`
- After `Restore Duration: 1084.98 ms`


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
