### PR TITLE
AUT-5447: Give Txma AWS account access to Audit Queue

### DIFF
--- a/ci/cloudformation/auth/queue/phonecheck-queue.yaml
+++ b/ci/cloudformation/auth/queue/phonecheck-queue.yaml
@@ -41,6 +41,20 @@ Resources:
               - kms:GenerateDataKey
               - kms:Decrypt
             Resource: "*"
+          - Sid: AllowTxmaAccessToKmsAuditEncryptionKey
+            Effect: Allow
+            Principal:
+              AWS: !Sub
+                - "{{resolve:secretsmanager:/deploy/${env}/txma_account_id}}"
+                - env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+            Action:
+              - kms:Decrypt
+            Resource: "*"
 
   PendingPhoneCheckQueueEncryptionKeyAlias:
     Type: AWS::KMS::Alias
@@ -158,6 +172,23 @@ Resources:
               - sqs:ChangeMessageVisibility
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
+            Resource: !GetAtt ExperianPhoneCheckQueue.Arn
+          - Sid: AllowTXMAAcctCrossAccountAccess
+            Effect: Allow
+            Principal:
+              AWS: !Sub
+                - "{{resolve:secretsmanager:/deploy/${env}/txma_account_id}}"
+                - env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+            Action:
+              - sqs:ChangeMessageVisibility
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:ReceiveMessage
             Resource: !GetAtt ExperianPhoneCheckQueue.Arn
 
   ExperianPhoneCheckDlQueuePolicy:


### PR DESCRIPTION
## What

AUT-5447: Give Txma AWS account access to new phone check Audit Queue

## How to review

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-