### PR TITLE
BAU: Read from hasVerifiedWith<Authenticator> attributes 

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -194,7 +194,7 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
                         authSession.getResetPasswordState(),
                         authSession.getResetMfaState(),
                         authSession.getVerifiedMfaMethodType(),
-                        authSession.getHasVerifiedPasskey());
+                        authSession.getHasVerifiedWithPasskey());
             }
 
             LOG.info("Generating Account Interventions outbound response for frontend");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -413,7 +413,7 @@ class AccountInterventionsHandlerTest {
                         .withResetPasswordState(resetPasswordState)
                         .withResetMfaState(resetMfaState)
                         .withVerifiedMfaMethodType(usedMfaMethodType)
-                        .withHasVerifiedPasskey(hasVerifiedWithPasskey);
+                        .withHasVerifiedWithPasskey(hasVerifiedWithPasskey);
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSessionWithChanges));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -919,11 +919,8 @@ class StartHandlerTest {
 
         // Assert
         assertThat(result, hasStatus(200));
-        assertFalse(authSession.getHasVerifiedPassword());
         assertFalse(authSession.getHasVerifiedWithPassword());
-        assertFalse(authSession.getHasVerifiedMfa());
         assertFalse(authSession.getHasVerifiedWithMfa());
-        assertFalse(authSession.getHasVerifiedPasskey());
         assertFalse(authSession.getHasVerifiedWithPasskey());
     }
 }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManager.java
@@ -387,30 +387,21 @@ public class PermissionDecisionManager implements PermissionDecisions {
     public boolean canIssueAuthCode(AuthSessionItem authSession) {
         var achievedCredentialStrength = authSession.getAchievedCredentialStrength();
         var requestedCredentialStrength = authSession.getRequestedCredentialStrength();
-        var hasVerifiedPasskey = authSession.getHasVerifiedPasskey();
         var hasVerifiedWithPasskey = authSession.getHasVerifiedWithPasskey();
-        var hasVerifiedPassword = authSession.getHasVerifiedPassword();
         var hasVerifiedWithPassword = authSession.getHasVerifiedWithPassword();
-        var hasVerifiedMfa = authSession.getHasVerifiedMfa();
         var hasVerifiedWithMfa = authSession.getHasVerifiedWithMfa();
 
         LOG.info(
                 "Checking if auth code is blocked - "
                         + "achievedCredentialStrength='{}', "
                         + "requestedCredentialStrength='{}', "
-                        + "hasVerifiedPasskey='{}', "
                         + "hasVerifiedWithPasskey='{}', "
-                        + "hasVerifiedPassword='{}', "
                         + "hasVerifiedWithPassword='{}', "
-                        + "hasVerifiedMfa='{}', "
                         + "hasVerifiedWithMfa='{}'",
                 achievedCredentialStrength == null ? null : achievedCredentialStrength.getValue(),
                 requestedCredentialStrength == null ? null : requestedCredentialStrength.getValue(),
-                hasVerifiedPasskey,
                 hasVerifiedWithPasskey,
-                hasVerifiedPassword,
                 hasVerifiedWithPassword,
-                hasVerifiedMfa,
                 hasVerifiedWithMfa);
 
         if (achievedCredentialStrength == null) {
@@ -429,20 +420,20 @@ public class PermissionDecisionManager implements PermissionDecisions {
             return false;
         }
 
-        if (hasVerifiedPasskey) {
+        if (hasVerifiedWithPasskey) {
             LOG.info("Auth code permitted");
             return true;
         }
 
         LOG.info("Passkey not verified");
 
-        if (!hasVerifiedPassword) {
+        if (!hasVerifiedWithPassword) {
             LOG.info("Auth code blocked: password not verified");
             return false;
         }
 
         if (requestedCredentialStrength == CredentialTrustLevel.MEDIUM_LEVEL) {
-            if (!hasVerifiedMfa) {
+            if (!hasVerifiedWithMfa) {
                 LOG.info("Auth code blocked: mfa not verified");
                 return false;
             }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -1272,9 +1272,9 @@ class PermissionDecisionManagerTest {
                     .thenReturn(achievedCredentialTrustLevel);
             when(mockSession.getRequestedCredentialStrength())
                     .thenReturn(requiredCredentialTrustLevel);
-            when(mockSession.getHasVerifiedPasskey()).thenReturn(hasVerifiedPasskey);
-            when(mockSession.getHasVerifiedPassword()).thenReturn(hasVerifiedPassword);
-            when(mockSession.getHasVerifiedMfa()).thenReturn(hasVerifiedMfa);
+            when(mockSession.getHasVerifiedWithPasskey()).thenReturn(hasVerifiedPasskey);
+            when(mockSession.getHasVerifiedWithPassword()).thenReturn(hasVerifiedPassword);
+            when(mockSession.getHasVerifiedWithMfa()).thenReturn(hasVerifiedMfa);
 
             // Act
             var result = permissionDecisionManager.canIssueAuthCode(mockSession);

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -86,7 +86,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPassword());
             assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
@@ -105,7 +104,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPassword());
             assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
@@ -151,7 +149,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPassword());
             assertTrue(capturedSession.getHasVerifiedWithPassword());
             assertTrue(result.isSuccess());
         }
@@ -427,7 +424,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
             assertTrue(capturedSession.getHasVerifiedWithMfa());
             assertTrue(result.isSuccess());
         }
@@ -588,7 +584,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedMfa());
             assertTrue(capturedSession.getHasVerifiedWithMfa());
             assertTrue(result.isSuccess());
         }
@@ -608,7 +603,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertTrue(capturedSession.getHasVerifiedPasskey());
             assertTrue(capturedSession.getHasVerifiedWithPasskey());
             assertEquals(
                     CredentialTrustLevel.MEDIUM_LEVEL,
@@ -630,7 +624,6 @@ class UserActionsManagerTest {
             // Assert
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
-            assertFalse(capturedSession.getHasVerifiedPasskey());
             assertFalse(capturedSession.getHasVerifiedWithPasskey());
             assertTrue(result.isSuccess());
         }


### PR DESCRIPTION
## What

- Read from the new attributes only. Once confirmed working in production, we can remove the hasVerified<Authenticator> attributes and their setters. During canary deployments, a Lambda instance running old code could still be reading from the hasVerified<Authenticator> attributes, so we must ensure all instances are reading from the new attribute before removing the old one.


## How to review

1. Code review
2. Deploy to dev env and check acceptance tests still pass