### PR TITLE
BAU: fix proxy script

### DIFF
--- a/ci/terraform/account-management/api-proxy.sh
+++ b/ci/terraform/account-management/api-proxy.sh
@@ -7,22 +7,24 @@ PORT=${2:-8123}
 
 export AWS_PROFILE="${AWS_PROFILE?AWS_PROFILE environment variable must be set}"
 
+INSTANCE_NAME="${ENVIRONMENT}-am-api-proxy-host"
+
 echo "Fetching the instance ID from AWS..."
 INSTANCE_ID=$(aws ec2 describe-instances \
-  --filters "Name=tag:Name,Values=${ENVIRONMENT}-mm-api-developer-proxy" "Name=instance-state-name,Values=running" \
+  --filters "Name=tag:Name,Values=${INSTANCE_NAME}" "Name=instance-state-name,Values=running" \
   --query "Reservations[0].Instances[0].InstanceId" \
   --output text)
 
 if [ -z "${INSTANCE_ID}" ] || [ "${INSTANCE_ID}" == "None" ]; then
-  echo "No running instance found for ${ENVIRONMENT}-mm-api-developer-proxy"
+  echo "No running instance found for ${INSTANCE_NAME}"
   exit 1
 fi
 
-echo "Starting port forwarding from localhost:${PORT} to ${ENVIRONMENT} Method Management API proxy..."
+echo "Starting port forwarding from localhost:${PORT} to ${ENVIRONMENT} AM API proxy..."
 if ! aws ssm start-session \
   --target "${INSTANCE_ID}" \
-  --document-name "${ENVIRONMENT}-mm-api-developer-proxy-ssm-document" \
-  --parameters "{\"localPortNumber\":[\"${PORT}\"]}"; then
+  --document-name AWS-StartPortForwardingSession \
+  --parameters "{\"localPortNumber\":[\"${PORT}\"],\"portNumber\":[\"80\"]}"; then
 
   # shellcheck disable=SC2016
   echo 'If the session failed to start, try installing the AWS CLI Session manager plugin: `brew install session-manager-plugin`.'

--- a/scripts/api-proxy.sh
+++ b/scripts/api-proxy.sh
@@ -20,7 +20,7 @@ esac
 
 case "${ENVIRONMENT}" in
   authdev* | dev)
-    export AWS_PROFILE="di-auth-development-AdministratorAccessPermission"
+    export AWS_PROFILE="di-authentication-development-AdministratorAccessPermission"
     ;;
   *)
     echo "Invalid environment: ${ENVIRONMENT}. Valid environments are: authdev1, authdev2, dev"


### PR DESCRIPTION
## What

was referencing the wrong proxy, using wrong account and role

## How to review

1. Code Review
2. Run the related authentication-acceptance-tests [PR](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/921)'s `rundocker.sh dev-api` script with the following `env-override-api.env`:

```
HOST_ENVIRONMENT="local"
CUCUMBER_FILTER_TAGS="@AccountManagementAPI"
NEW_AM_ENV=true
```

see it runs hitting the AM API successfully. not all tests will pass, primarily international numbers

