### PR TITLE
BAU: provision acceptance test params as IaC

### DIFF
--- a/ci/cloudformation/account-management/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/account-management/parameters/acceptance-test-tags.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Conditions:
+  HasAcceptanceTests:
+    Fn::Or:
+      - Fn::Equals: [!Ref Environment, dev]
+      - Fn::Equals: [!Ref Environment, build]
+      - Fn::Equals: [!Ref Environment, staging]
+
+# /acceptance-tests/{env}/AM_CUCUMBER_FILTER_TAGS
+Mappings:
+  AcceptanceTestTags:
+    dev:
+      tags: >-
+        @AccountManagementAPI and not (@under-development or
+        @AcceptInternationalNumbers)
+    build:
+      tags: >-
+        @AccountManagementAPI and not (@under-development
+        or @AcceptInternationalNumbers)
+    staging:
+      tags: >-
+        @AccountManagementAPI and not (@under-development
+        or @AcceptInternationalNumbers or @new-mfa-reset-with-ipv)
+
+Resources:
+  AcceptanceTestAMCucumberFilterTags:
+    Type: AWS::SSM::Parameter
+    Condition: HasAcceptanceTests
+    Properties:
+      Name: !Sub /acceptance-tests/${Environment}/AM_CUCUMBER_FILTER_TAGS
+      Type: String
+      Value: !FindInMap
+        - AcceptanceTestTags
+        - !Ref Environment
+        - tags
+        - DefaultValue: "unused"

--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Conditions:
+  HasAcceptanceTests:
+    Fn::Or:
+      - Fn::Equals: [!Ref Environment, dev]
+      - Fn::Equals: [!Ref Environment, build]
+      - Fn::Equals: [!Ref Environment, staging]
+
+# /acceptance-tests/{env}/API_CUCUMBER_FILTER_TAGS
+Mappings:
+  AcceptanceTestTags:
+    dev:
+      tags: >-
+        @UI and not (@AccountInterventions or @Reauth or @old-mfa-without-ipv or
+        @AccountRecovery or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled)
+        and not (@InternationalNumbersIndefiniteLockout and @under-development)
+    build:
+      tags: >-
+        @UI and not (@under-development or @AccountInterventions or @Reauth or
+        @old-mfa-without-ipv or @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
+        or @PasskeysEnabled or @PasskeyUsageEnabled)
+    staging:
+      tags: >-
+        @UI and not (@under-development or @AccountInterventions or @Reauth or
+        @old-mfa-without-ipv or @new-mfa-reset-with-ipv or @AcceptInternationalNumbers
+        or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled or @EnvironmentWithAMCStubDeployed)
+
+Resources:
+  AcceptanceTestAPICucumberFilterTags:
+    Type: AWS::SSM::Parameter
+    Condition: HasAcceptanceTests
+    Properties:
+      Name: !Sub /acceptance-tests/${Environment}/API_CUCUMBER_FILTER_TAGS
+      Type: String
+      Value: !FindInMap
+        - AcceptanceTestTags
+        - !Ref Environment
+        - tags
+        - DefaultValue: "unused"


### PR DESCRIPTION
## What

SSM parameters introduced to be deployed on a per-module/pipeline basis, as opposed to the current approach of manually provisioning.

When this is merged the pipeline will have to be reserved so that we can delete the existing, manually provisioned SSM params to then be re-created.

## How to review

1. Code Review
2. Delete all cucumber tags in parameter store, trigger the utils pipeline in dev, see the tags re-created. Trigger auth api, FE, and AM pipeline runs and observe tests work as expected

