### PR TITLE
AUT-5517: Store algorithm value for passkey in the account-data-api

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/PasskeysCreateHandlerIntegrationTest.java
@@ -63,7 +63,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             var expectedSortKey = format("PASSKEY#%s", PRIMARY_PASSKEY_ID);
 
             // When
@@ -84,6 +85,7 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
             assertThat(savedPasskey.getCredentialId(), equalTo(PRIMARY_PASSKEY_ID));
             assertThat(savedPasskey.getSortKey(), equalTo(expectedSortKey));
+            assertThat(savedPasskey.getPasskeyAlgorithm(), equalTo(-7));
         }
     }
 
@@ -104,7 +106,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
 
             // When
             var response =
@@ -138,7 +141,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
 
             // When
             var response =
@@ -169,7 +173,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
 
             // When
             var response =
@@ -195,7 +200,8 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
             List<String> transports,
             boolean isBackUpEligible,
             boolean isBackedUp,
-            boolean isResidentKey)
+            boolean isResidentKey,
+            int algorithm)
             throws Json.JsonException {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("id", id);
@@ -207,6 +213,7 @@ class PasskeysCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         requestBody.put("isBackedUpEligible", String.valueOf(isBackUpEligible));
         requestBody.put("isBackedUp", String.valueOf(isBackedUp));
         requestBody.put("isResidentKey", String.valueOf(isResidentKey));
+        requestBody.put("algorithm", String.valueOf(algorithm));
 
         return objectMapper.writeValueAsString(requestBody);
     }

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
@@ -56,7 +56,8 @@ class DynamoPasskeyServiceIntegrationTest {
                             PASSKEY_TRANSPORTS,
                             true,
                             false,
-                            true);
+                            true,
+                            -7);
 
             var expectedSortKey = "PASSKEY#" + PRIMARY_PASSKEY_ID;
 
@@ -86,6 +87,7 @@ class DynamoPasskeyServiceIntegrationTest {
             assertThat(savedPasskey.getPasskeyBackupEligible(), equalTo(true));
             assertThat(savedPasskey.getPasskeyBackedUp(), equalTo(false));
             assertThat(savedPasskey.getLastUsed(), equalTo(null));
+            assertThat(savedPasskey.getPasskeyAlgorithm(), equalTo(-7));
         }
 
         @Test
@@ -124,7 +126,8 @@ class DynamoPasskeyServiceIntegrationTest {
                             PASSKEY_TRANSPORTS,
                             true,
                             false,
-                            true));
+                            true,
+                            -10));
             dynamoPasskeyService.savePasskeyIfUnique(
                     buildGenericPasskeyForUserWithSubjectId(
                             CommonTestVariables.ANOTHER_PUBLIC_SUBJECT_ID,
@@ -145,6 +148,8 @@ class DynamoPasskeyServiceIntegrationTest {
                     equalTo(CommonTestVariables.SECONDARY_PASSKEY_ID));
             assertThat(primaryPasskey.getPasskeyIsAttested(), equalTo(true));
             assertThat(secondaryPasskey.getPasskeyIsAttested(), equalTo(false));
+            assertThat(primaryPasskey.getPasskeyAlgorithm(), equalTo(-7));
+            assertThat(secondaryPasskey.getPasskeyAlgorithm(), equalTo(-10));
         }
 
         @Test

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/Passkey.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/Passkey.java
@@ -17,6 +17,7 @@ public class Passkey extends Authenticator<Passkey> {
     public static final String ATTRIBUTE_PASSKEY_BACKUP_ELIGIBLE = "PasskeyBackupEligible";
     public static final String ATTRIBUTE_PASSKEY_BACKED_UP = "PasskeyBackedUp";
     public static final String ATTRIBUTE_PASSKEY_IS_RESIDENT_KEY = "PasskeyIsResidentKey";
+    public static final String ATTRIBUTE_PASSKEY_ALGORITHM = "PasskeyAlgorithm";
 
     private String passkeyAaguid;
     private boolean passkeyIsAttested;
@@ -25,6 +26,7 @@ public class Passkey extends Authenticator<Passkey> {
     private boolean passkeyBackupEligible;
     private boolean passkeyBackedUp;
     private boolean passkeyIsResidentKey;
+    private int passkeyAlgorithm;
 
     @Override
     protected Passkey self() {
@@ -131,6 +133,20 @@ public class Passkey extends Authenticator<Passkey> {
 
     public Passkey withPasskeyIsResidentKey(boolean passkeyIsResidentKey) {
         this.passkeyIsResidentKey = passkeyIsResidentKey;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_PASSKEY_ALGORITHM)
+    public int getPasskeyAlgorithm() {
+        return passkeyAlgorithm;
+    }
+
+    public void setPasskeyAlgorithm(int passkeyAlgorithm) {
+        this.passkeyAlgorithm = passkeyAlgorithm;
+    }
+
+    public Passkey withPasskeyAlgorithm(int passkeyAlgorithm) {
+        this.passkeyAlgorithm = passkeyAlgorithm;
         return this;
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysCreateRequest.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysCreateRequest.java
@@ -8,11 +8,12 @@ import java.util.List;
 
 public record PasskeysCreateRequest(
         @SerializedName("id") @Expose @Required String passkeyId,
-        @SerializedName("credential") @Expose @Required String credential,
-        @SerializedName("aaguid") @Expose @Required String aaguid,
-        @SerializedName("isAttested") @Expose @Required boolean isAttested,
-        @SerializedName("signCount") @Expose @Required int signCount,
-        @SerializedName("transports") @Expose @Required List<String> transports,
-        @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
-        @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,
-        @SerializedName("isResidentKey") @Expose @Required boolean isResidentKey) {}
+        @Expose @Required String credential,
+        @Expose @Required String aaguid,
+        @Expose @Required boolean isAttested,
+        @Expose @Required int signCount,
+        @Expose @Required List<String> transports,
+        @Expose @Required boolean isBackUpEligible,
+        @Expose @Required boolean isBackedUp,
+        @Expose @Required boolean isResidentKey,
+        @Expose @Required int algorithm) {}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
@@ -20,7 +20,8 @@ public record PasskeysRetrieveResponse(
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,
             @SerializedName("isResidentKey") @Expose @Required boolean isResidentKey,
             @SerializedName("createdAt") @Expose @Required String createdAt,
-            @SerializedName("lastUsedAt") @Expose String lastUsedAt) {}
+            @SerializedName("lastUsedAt") @Expose String lastUsedAt,
+            @SerializedName("algorithm") @Expose @Required int algorithm) {}
 
     public static PasskeyResponse from(Passkey passkey) {
         return new PasskeyResponse(
@@ -34,6 +35,7 @@ public record PasskeysRetrieveResponse(
                 passkey.getPasskeyBackedUp(),
                 passkey.getPasskeyIsResidentKey(),
                 passkey.getCreated(),
-                passkey.getLastUsed());
+                passkey.getLastUsed(),
+                passkey.getPasskeyAlgorithm());
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/PasskeysTestHelper.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/PasskeysTestHelper.java
@@ -21,7 +21,8 @@ public class PasskeysTestHelper {
                 CommonTestVariables.PASSKEY_TRANSPORTS,
                 true,
                 false,
-                true);
+                true,
+                -7);
     }
 
     public static Passkey buildPasskeyForUser(
@@ -34,7 +35,8 @@ public class PasskeysTestHelper {
             List<String> transports,
             boolean backupEligible,
             boolean backedUp,
-            boolean isResidentKey) {
+            boolean isResidentKey,
+            int algorithm) {
         var created = LocalDateTime.now().toString();
         return new Passkey()
                 .withPublicSubjectId(publicSubjectId)
@@ -48,6 +50,7 @@ public class PasskeysTestHelper {
                 .withPasskeyTransports(transports)
                 .withPasskeyBackupEligible(backupEligible)
                 .withPasskeyBackedUp(backedUp)
-                .withPasskeyIsResidentKey(isResidentKey);
+                .withPasskeyIsResidentKey(isResidentKey)
+                .withPasskeyAlgorithm(algorithm);
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
@@ -50,7 +50,8 @@ public class PasskeysService {
                         .withPasskeyTransports(passkeysCreateRequest.transports())
                         .withPasskeyBackupEligible(passkeysCreateRequest.isBackUpEligible())
                         .withPasskeyBackedUp(passkeysCreateRequest.isBackedUp())
-                        .withPasskeyIsResidentKey(passkeysCreateRequest.isResidentKey());
+                        .withPasskeyIsResidentKey(passkeysCreateRequest.isResidentKey())
+                        .withPasskeyAlgorithm(passkeysCreateRequest.algorithm());
 
         var result = dynamoPasskeyService.savePasskeyIfUnique(passkey);
 

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysCreateHandlerTest.java
@@ -64,7 +64,8 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
                     .thenReturn(Result.success(null));
             var request =
@@ -96,7 +97,35 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
+            var request =
+                    passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
+
+            // When
+            var result = handler.handleRequest(request, context);
+
+            // Then
+            assertThat(result, hasStatus(400));
+            assertThat(result, hasJsonBody(ErrorResponse.INVALID_REQUEST_BODY));
+        }
+
+        @Test
+        void shouldReturn400WhenAlgorithmIsNotProvided() throws Json.JsonException {
+            // Given
+            var pathParams = Map.of("publicSubjectId", PUBLIC_SUBJECT_ID);
+            var passkeysCreateRequestBody =
+                    buildPasskeysCreateRequestBody(
+                            CREDENTIAL,
+                            PRIMARY_PASSKEY_ID,
+                            TEST_AAGUID,
+                            false,
+                            0,
+                            PASSKEY_TRANSPORTS,
+                            false,
+                            false,
+                            false,
+                            null);
             var request =
                     passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
@@ -122,7 +151,8 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             var request =
                     passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
@@ -148,7 +178,8 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
                     .thenReturn(Result.failure(PasskeysCreateFailureReason.FAILED_TO_SAVE_PASSKEY));
             var request =
@@ -176,7 +207,8 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             when(passkeysService.createPasskey(any(), eq(PUBLIC_SUBJECT_ID)))
                     .thenReturn(Result.failure(PasskeysCreateFailureReason.PASSKEY_EXISTS));
             var request =
@@ -204,7 +236,8 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             var request =
                     passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
@@ -230,7 +263,8 @@ class PasskeysCreateHandlerTest {
                             PASSKEY_TRANSPORTS,
                             false,
                             false,
-                            false);
+                            false,
+                            -7);
             var request =
                     passkeysCreateRequest(passkeysCreateRequestBody, pathParams, AUTHORIZER_PARAMS);
 
@@ -260,7 +294,8 @@ class PasskeysCreateHandlerTest {
                         PASSKEY_TRANSPORTS,
                         false,
                         false,
-                        false);
+                        false,
+                        -7);
         var authorizerParams =
                 Map.<String, Object>of(
                         "principalId", "different-subject-id", "scope", "passkey-create");
@@ -289,7 +324,8 @@ class PasskeysCreateHandlerTest {
                         PASSKEY_TRANSPORTS,
                         false,
                         false,
-                        false);
+                        false,
+                        -7);
         var authorizerParams =
                 Map.<String, Object>of(
                         "principalId", PUBLIC_SUBJECT_ID, "scope", "passkey-retrieve");
@@ -313,7 +349,8 @@ class PasskeysCreateHandlerTest {
             List<String> transports,
             boolean isBackUpEligible,
             boolean isBackedUp,
-            boolean isResidentKey)
+            boolean isResidentKey,
+            Integer algorithm)
             throws Json.JsonException {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("id", id);
@@ -325,6 +362,7 @@ class PasskeysCreateHandlerTest {
         requestBody.put("isBackedUpEligible", String.valueOf(isBackUpEligible));
         requestBody.put("isBackedUp", String.valueOf(isBackedUp));
         requestBody.put("isResidentKey", String.valueOf(isResidentKey));
+        requestBody.put("algorithm", String.valueOf(algorithm));
 
         return objectMapper.writeValueAsString(requestBody);
     }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/PasskeysServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/PasskeysServiceTest.java
@@ -65,7 +65,8 @@ class PasskeysServiceTest {
                                 PASSKEY_TRANSPORTS,
                                 false,
                                 false,
-                                false);
+                                false,
+                                -7);
 
                 // When
                 var result =
@@ -94,7 +95,8 @@ class PasskeysServiceTest {
                                 PASSKEY_TRANSPORTS,
                                 false,
                                 false,
-                                false);
+                                false,
+                                -7);
 
                 // When
                 var result =
@@ -122,7 +124,8 @@ class PasskeysServiceTest {
                                 PASSKEY_TRANSPORTS,
                                 false,
                                 false,
-                                false);
+                                false,
+                                -7);
 
                 // When
                 var result =
@@ -145,7 +148,8 @@ class PasskeysServiceTest {
                 List<String> transports,
                 boolean isBackUpEligible,
                 boolean isBackedUp,
-                boolean isResidentKey) {
+                boolean isResidentKey,
+                int algorithm) {
             return new PasskeysCreateRequest(
                     credential,
                     passkeyId,
@@ -155,7 +159,8 @@ class PasskeysServiceTest {
                     transports,
                     isBackUpEligible,
                     isBackedUp,
-                    isResidentKey);
+                    isResidentKey,
+                    algorithm);
         }
     }
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysRetrieveProxyHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysRetrieveProxyHandlerIntegrationTest.java
@@ -72,7 +72,8 @@ class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerInteg
                       "isBackupEligible": true,
                       "isBackedUp": true,
                       "createdAt": "some-timestamp",
-                      "lastUsedAt": "another-timestamp"
+                      "lastUsedAt": "another-timestamp",
+                      "algorithm": -7
                     }
                   ]
                 }


### PR DESCRIPTION
## What

- Add the required `algorithm` field to the Authenticator table when saving a Passkey
- Make this field required during a create and retrieve passkey

## How to review

1. Code review
2. Deploy to dev env, save a passkey with an algorithm (you can directly call the lambda for this) and retrieve that same passkey checking the algorithm is there

## Checklist

