### PR TITLE
AUT-5521: Set the user verification of the StartAssertionOptions to be REQUIRED

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -9,6 +9,7 @@ import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
 import com.yubico.webauthn.data.PublicKeyCredential;
+import com.yubico.webauthn.data.UserVerificationRequirement;
 import com.yubico.webauthn.exception.AssertionFailedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,7 +32,10 @@ public class PasskeyAssertionService {
     public AssertionRequest startAssertion(String publicSubjectId) {
         var userHandle = new ByteArray(publicSubjectId.getBytes(StandardCharsets.UTF_8));
         return relyingParty.startAssertion(
-                StartAssertionOptions.builder().userHandle(Optional.of(userHandle)).build());
+                StartAssertionOptions.builder()
+                        .userHandle(Optional.of(userHandle))
+                        .userVerification(UserVerificationRequirement.REQUIRED)
+                        .build());
     }
 
     public Result<FinishPasskeyAssertionFailureReason, AssertionResult> finishAssertion(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yubico.webauthn.AssertionRequest;
 import com.yubico.webauthn.AssertionResult;
 import com.yubico.webauthn.RelyingParty;
+import com.yubico.webauthn.StartAssertionOptions;
+import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredential;
+import com.yubico.webauthn.data.UserVerificationRequirement;
 import com.yubico.webauthn.exception.AssertionFailedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -12,11 +15,15 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 
 public class PasskeyAssertionServiceTest {
     private final RelyingParty relyingParty = mock(RelyingParty.class);
@@ -38,12 +45,23 @@ public class PasskeyAssertionServiceTest {
                 var mockAssertionRequest = mock(AssertionRequest.class);
                 when(relyingParty.startAssertion(any())).thenReturn(mockAssertionRequest);
 
+                var expectedStartAssertionOptions =
+                        StartAssertionOptions.builder()
+                                .userHandle(
+                                        Optional.of(
+                                                new ByteArray(
+                                                        PUBLIC_SUBJECT_ID.getBytes(
+                                                                StandardCharsets.UTF_8))))
+                                .userVerification(UserVerificationRequirement.REQUIRED)
+                                .build();
+
                 // When
                 AssertionRequest actualAssertionRequest =
-                        passkeyAssertionService.startAssertion("");
+                        passkeyAssertionService.startAssertion(PUBLIC_SUBJECT_ID);
 
                 // Then
                 assertEquals(mockAssertionRequest, actualAssertionRequest);
+                verify(relyingParty).startAssertion(expectedStartAssertionOptions);
             }
         }
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartPasskeyAssertionHandlerIntegrationTest.java
@@ -170,7 +170,7 @@ class StartPasskeyAssertionHandlerIntegrationTest extends ApiGatewayHandlerInteg
                               "journey-type": "SIGN_IN",
                               "passkey": {
                                 "passkey_authentication_request": {
-                                  "passkey_request_user_verification": ""
+                                  "passkey_request_user_verification": "required"
                                 }
                               }
                             }


### PR DESCRIPTION
## What

- In order to force the browser authenticator to require the user to authenticate with their device with a password/biometrics, we need to set the userVerification to REQUIRED

## How to review

1. Code review