### PR TITLE
ATO-2638: Add TXT record param to hosted zone template

### DIFF
--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -44,6 +44,12 @@ Parameters:
     AllowedValues:
       - "Yes"
       - "No"
+  CloudfrontTxtRecordValue:
+    # See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-create-target.html
+    Description: >
+      (Optional) A value to provide to create a TXT record of the format "_oidc.account.gov.uk TXT 'CloudfrontTxtRecordValue' "
+    Type: String
+    Default: "none"
 
 Conditions:
   DeployDevSubDomains:
@@ -52,6 +58,8 @@ Conditions:
       !Equals [!Ref DeploySubEnvDomains, "Yes"],
     ]
   DeployCertificate: !Equals [!Ref DeployCertificate, "Yes"]
+  CreateCloudFrontTxtRecord:
+    !Not [!Equals [!Ref CloudfrontTxtRecordValue, "none"]]
 
 Mappings:
   EnvironmentConfiguration:
@@ -168,6 +176,16 @@ Resources:
       Name: !Sub "/deploy/hosted-zone/oidc${EndpointSuffix}/certificate-Arn"
       Type: String
       Value: !Ref OidcHostedZoneRootCertificate
+
+  OidcDomainValidationTxtRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Sub "_oidc.${DomainSuffix}" # See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-create-target.html
+      Type: TXT
+      HostedZoneId: !Ref OidcHostedZone
+      ResourceRecords:
+        - !Sub '"${CloudfrontTxtRecordValue}"' # Needs quotes as it's YAML and we need the record to be "d111111abcdef8.cloudfront.net"
+      TTL: 900
 
   Orchdev1HostedZone:
     Condition: DeployDevSubDomains


### PR DESCRIPTION
### Wider context of change

Adds a new parameter to our template to create a TXT record on the oidc hosted zone which will be used to validate domain ownership

### What’s changed

Adds a new optional parameter to our hosted zone template to add the expected TXT record to our hosted zone

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
