### PR TITLE
AUT-5522: Return mfaRequired in StartHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -12,4 +12,5 @@ public record UserStartInfo(
         @SerializedName("cookieConsent") @Expose String cookieConsent,
         @SerializedName("gaCrossDomainTrackingId") @Expose String gaCrossDomainTrackingId,
         @SerializedName("mfaMethodType") @Expose MFAMethodType mfaMethodType,
-        @SerializedName("isBlockedForReauth") @Expose boolean isBlockedForReauth) {}
+        @SerializedName("isBlockedForReauth") @Expose boolean isBlockedForReauth,
+        @SerializedName("mfaRequired") @Expose boolean isMfaRequired) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder.getReauthFailureReasonFromCountTypes;
+import static uk.gov.di.authentication.shared.conditions.MfaHelper.mfaRequired;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
@@ -299,7 +300,8 @@ public class StartHandler
                             reauthenticate,
                             isBlockedForReauth,
                             isUserAuthenticatedWithValidProfile,
-                            upliftRequired);
+                            upliftRequired,
+                            mfaRequired(requestedCredentialTrustLevel));
 
             StartResponse startResponse = new StartResponse(userStartInfo, clientStartInfo);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -86,18 +86,20 @@ public class StartService {
             boolean reauthenticate,
             boolean isBlockedForReauth,
             boolean isAuthenticated,
-            boolean upliftRequired) {
+            boolean upliftRequired,
+            boolean isMfaRequired) {
 
         var userIsAuthenticated = isAuthenticated && !reauthenticate;
 
         LOG.info(
-                "Found UserStartInfo for Authenticated: {} UpliftRequired: {} IdentityRequired: {}. CookieConsent: {}. GATrackingId: {}. IsBlockedForReauth: {}",
+                "Found UserStartInfo for Authenticated: {} UpliftRequired: {} IdentityRequired: {}. CookieConsent: {}. GATrackingId: {}. IsBlockedForReauth: {}. IsMfaRequired: {}.",
                 userIsAuthenticated,
                 upliftRequired,
                 identityRequired,
                 cookieConsent,
                 gaTrackingId,
-                isBlockedForReauth);
+                isBlockedForReauth,
+                isMfaRequired);
 
         return new UserStartInfo(
                 upliftRequired,
@@ -106,7 +108,8 @@ public class StartService {
                 cookieConsent,
                 gaTrackingId,
                 getMfaMethodType(userContext),
-                isBlockedForReauth);
+                isBlockedForReauth,
+                isMfaRequired);
     }
 
     private boolean authApp(UserContext userContext) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -182,7 +182,7 @@ class StartHandlerTest {
     void shouldReturn200WithAuthenticatedFalseWhenAReauthenticationJourney()
             throws Json.JsonException {
         var isAuthenticated = false;
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -223,7 +223,7 @@ class StartHandlerTest {
             throws Json.JsonException {
         var isAuthenticated = false;
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(false);
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
 
         // This should not be called. Setup here is to ensure that the feature flag is determining
         // this test's behaviour
@@ -243,7 +243,7 @@ class StartHandlerTest {
     @Test
     void checkAuditEventStillEmittedWhenTICFHeaderNotProvided() throws Json.JsonException {
         var isAuthenticated = false;
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -278,7 +278,7 @@ class StartHandlerTest {
     @Test
     void shouldConsiderUserNotAuthenticatedWhenUserProfileNotPresent() throws Json.JsonException {
         withNoUserProfilePresent();
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -297,13 +297,14 @@ class StartHandlerTest {
                         anyBoolean(),
                         anyBoolean(),
                         eq(false),
+                        anyBoolean(),
                         anyBoolean());
     }
 
     @Test
     void considersUserAuthenticatedWhenUserProfilePresent() throws Json.JsonException {
         withUserProfilePresent();
-        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -322,6 +323,7 @@ class StartHandlerTest {
                         anyBoolean(),
                         anyBoolean(),
                         eq(true),
+                        anyBoolean(),
                         anyBoolean());
     }
 
@@ -332,7 +334,7 @@ class StartHandlerTest {
         var isAuthenticated = true;
         useValidSession();
         var userStartInfo =
-                new UserStartInfo(false, false, isAuthenticated, null, null, null, false);
+                new UserStartInfo(false, false, isAuthenticated, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
 
         var event =
@@ -388,7 +390,7 @@ class StartHandlerTest {
             int expectedOtpAttemptCount,
             String expectedFailureReason)
             throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true);
+        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
@@ -469,7 +471,7 @@ class StartHandlerTest {
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {
         return new UserStartInfo(
-                false, false, true, cookieConsent, gaCrossDomainTrackingId, null, false);
+                false, false, true, cookieConsent, gaCrossDomainTrackingId, null, false, false);
     }
 
     private void usingStartServiceThatReturns(
@@ -482,6 +484,7 @@ class StartHandlerTest {
                         eq(userContext),
                         any(),
                         any(),
+                        anyBoolean(),
                         anyBoolean(),
                         anyBoolean(),
                         anyBoolean(),
@@ -611,7 +614,7 @@ class StartHandlerTest {
 
     @Test
     void shouldHandleReauthWithBlockedCountTypesButNoSubjectId() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, true);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, true, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
 
@@ -695,7 +698,7 @@ class StartHandlerTest {
 
     @Test
     void shouldHandleEmptyPreviousSigninJourneyIdInReauth() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -720,7 +723,7 @@ class StartHandlerTest {
 
     @Test
     void shouldHandleEmptyRpPairwiseIdInReauth() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -748,7 +751,7 @@ class StartHandlerTest {
     @Test
     void shouldHandleNullPreviousSigninJourneyIdAndRpPairwiseIdInReauth()
             throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -767,7 +770,7 @@ class StartHandlerTest {
 
     @Test
     void shouldHandleReauthWithNullReauthenticateHeader() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         useValidSession();
 
@@ -790,7 +793,7 @@ class StartHandlerTest {
 
     @Test
     void shouldHandleNullFailureReasonInCloudwatchMetrics() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true);
+        var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
@@ -826,7 +829,7 @@ class StartHandlerTest {
 
     @Test
     void shouldHandleReauthWhenAttemptsServiceDisabled() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         when(configurationService.isAuthenticationAttemptsServiceEnabled())
                 .thenReturn(false); // Disabled
@@ -909,7 +912,7 @@ class StartHandlerTest {
                         .withHasVerifiedWithPasskey(true);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
                 .thenReturn(authSession);
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false);
+        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
         var body = makeRequestBody(null, null, TEST_RP_PAIRWISE_ID, false);
         var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
@@ -922,5 +925,70 @@ class StartHandlerTest {
         assertFalse(authSession.getHasVerifiedWithPassword());
         assertFalse(authSession.getHasVerifiedWithMfa());
         assertFalse(authSession.getHasVerifiedWithPasskey());
+    }
+
+    private static Stream<Arguments> credentialTrustLevelToMfaRequired() {
+        return Stream.of(
+                Arguments.of(CredentialTrustLevel.LOW_LEVEL, false),
+                Arguments.of(CredentialTrustLevel.MEDIUM_LEVEL, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("credentialTrustLevelToMfaRequired")
+    void shouldReturnCorrectIsMfaRequiredForCredentialTrustLevel(
+            CredentialTrustLevel credentialTrustLevel, boolean expectedMfaRequired)
+            throws Json.JsonException {
+        // Arrange
+        useValidSession();
+        var userStartInfo =
+                new UserStartInfo(
+                        false, false, false, null, null, null, false, expectedMfaRequired);
+        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
+
+        var body =
+                objectMapper.writeValueAsString(
+                        new StartRequest(
+                                null,
+                                null,
+                                null,
+                                false,
+                                COOKIE_CONSENT,
+                                null,
+                                credentialTrustLevel.getValue(),
+                                LevelOfConfidence.NONE.getValue(),
+                                STATE.toString(),
+                                TEST_CLIENT_ID,
+                                REDIRECT_URL.toString(),
+                                SCOPE.toString(),
+                                CLIENT_NAME,
+                                ServiceType.MANDATORY.toString(),
+                                false,
+                                false,
+                                false,
+                                TEST_SUBJECT_TYPE,
+                                false,
+                                TEST_RP_SUBJECT_ID_HOST));
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
+
+        // Act
+        var result = handler.handleRequest(event, context);
+
+        // Assert
+        assertThat(result, hasStatus(200));
+
+        var response = objectMapper.readValue(result.getBody(), StartResponse.class);
+        assertThat(response.user().isMfaRequired(), equalTo(expectedMfaRequired));
+
+        verify(startService)
+                .buildUserStartInfo(
+                        any(),
+                        any(),
+                        any(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        eq(expectedMfaRequired));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -107,14 +107,18 @@ class StartServiceTest {
 
     private static Stream<Arguments> userStartInfo() {
         return Stream.of(
-                Arguments.of("some-cookie-consent", null, false),
-                Arguments.of(null, "ga-tracking-id", true));
+                Arguments.of("some-cookie-consent", null, false, false),
+                Arguments.of(null, "ga-tracking-id", true, false),
+                Arguments.of("some-cookie-consent", "ga-tracking-id", false, true));
     }
 
     @ParameterizedTest
     @MethodSource("userStartInfo")
     void shouldCreateUserStartInfo(
-            String cookieConsent, String gaTrackingId, boolean isAuthenticated) {
+            String cookieConsent,
+            String gaTrackingId,
+            boolean isAuthenticated,
+            boolean isMfaRequired) {
         var userContext =
                 buildUserContext(
                         Optional.of(
@@ -131,7 +135,8 @@ class StartServiceTest {
                         false,
                         false,
                         isAuthenticated,
-                        false);
+                        false,
+                        isMfaRequired);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(false));
@@ -139,6 +144,7 @@ class StartServiceTest {
         assertThat(userStartInfo.gaCrossDomainTrackingId(), equalTo(gaTrackingId));
         assertThat(userStartInfo.isAuthenticated(), equalTo(isAuthenticated));
         assertThat(userStartInfo.isBlockedForReauth(), equalTo(false));
+        assertThat(userStartInfo.isMfaRequired(), equalTo(isMfaRequired));
     }
 
     @ParameterizedTest
@@ -156,6 +162,7 @@ class StartServiceTest {
                         true,
                         false,
                         isBlockedForReauth,
+                        false,
                         false,
                         false);
 
@@ -275,6 +282,7 @@ class StartServiceTest {
                         true,
                         false,
                         true,
+                        false,
                         false);
 
         assertThat(userStartInfo.isAuthenticated(), equalTo(false));
@@ -303,7 +311,8 @@ class StartServiceTest {
                         false,
                         false,
                         false,
-                        upliftRequired);
+                        upliftRequired,
+                        false);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(expectedUpliftRequiredValue));
     }
@@ -368,7 +377,15 @@ class StartServiceTest {
 
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, "true", "tracking-id", true, false, false, false, false);
+                        userContext,
+                        "true",
+                        "tracking-id",
+                        true,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false);
 
         assertThat(userStartInfo.mfaMethodType(), equalTo(expectedMfaMethodType));
     }
@@ -385,7 +402,15 @@ class StartServiceTest {
 
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, "true", "tracking-id", true, false, false, false, false);
+                        userContext,
+                        "true",
+                        "tracking-id",
+                        true,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false);
 
         assertThat(userStartInfo.mfaMethodType(), equalTo(MFAMethodType.NONE));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -80,11 +80,17 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static Stream<Arguments> successfulRequests() {
         return Stream.of(
-                Arguments.of(Optional.empty(), MEDIUM_LEVEL, false, false),
-                Arguments.of(Optional.empty(), MEDIUM_LEVEL, false, true),
-                Arguments.of(Optional.of(LevelOfConfidence.NONE), MEDIUM_LEVEL, false, false),
+                Arguments.of(Optional.empty(), MEDIUM_LEVEL, false, false, true),
+                Arguments.of(Optional.empty(), MEDIUM_LEVEL, false, true, true),
+                Arguments.of(Optional.of(LevelOfConfidence.NONE), MEDIUM_LEVEL, false, false, true),
                 Arguments.of(
-                        Optional.of(LevelOfConfidence.MEDIUM_LEVEL), MEDIUM_LEVEL, true, false));
+                        Optional.of(LevelOfConfidence.MEDIUM_LEVEL),
+                        MEDIUM_LEVEL,
+                        true,
+                        false,
+                        true),
+                Arguments.of(
+                        Optional.of(LevelOfConfidence.LOW_LEVEL), LOW_LEVEL, true, false, false));
     }
 
     @ParameterizedTest
@@ -93,7 +99,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             Optional<LevelOfConfidence> requestedLevelOfConfidenceOpt,
             CredentialTrustLevel requestedCredentialTrustLevel,
             boolean identityRequired,
-            boolean isAuthenticated)
+            boolean isAuthenticated,
+            boolean isMfaRequired)
             throws Json.JsonException {
         String sessionId = IdGenerator.generate();
         userStore.signUp(EMAIL, "password");
@@ -131,9 +138,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 "cookieConsent":null,
                 "gaCrossDomainTrackingId":null,
                 "mfaMethodType":null,
-                "isBlockedForReauth":false}
+                "isBlockedForReauth":false,
+                "mfaRequired":%b}
                 """,
-                        identityRequired, isAuthenticated);
+                        identityRequired, isAuthenticated, isMfaRequired);
 
         var client =
                 format(


### PR DESCRIPTION
## What

- Currently, the frontend sets the mfaRequired property in the session when the user submits a correct password. However, for passkeys, we need to know whether mfa is required when a user hasn't entered a password (for dynamic content on the "we could not sign you in" page.
- This PR returns the `mfaRequired` in the UserStartInfo. Follow up PRs will be done to save the info on the frontend and remove the redundant `mfaRequired` response in the login handler

## How to review

1. Code review
2. Deploy to dev env, check that you can run through a journey successfully. Test the response from the StartHandler correctly sets mfaRequired depending on `requestedCredentialStrength`

## Checklist

