### PR TITLE
BAU: fix spec to specify /authenticate should require token

### DIFF
--- a/account-management-api/api-contract/openapi_v3_unreleased.yaml
+++ b/account-management-api/api-contract/openapi_v3_unreleased.yaml
@@ -10,7 +10,6 @@ paths:
     post:
       security:
         - authorise-access-token: []
-        - {}
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"


### PR DESCRIPTION
## What

- The behaviour should be unchanged and match the existing AM API authorizer behaviour. This PR realigns `/authenticate` with the existing production spec

## How to review

1. Code Review

