### PR TITLE
BAU: remove the old hasVerified<Authenticator> attributes and their setters

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -343,7 +343,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             }
         }
 
-        LOG.info("Setting hasVerifiedPassword to true");
+        LOG.info("Setting hasVerifiedWithPassword to true");
         userActionsManager.correctPasswordReceived(journeyType, permissionContext);
 
         authSessionService.updateSession(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -212,7 +212,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                         .withEmailAddress(userCredentials.getEmail())
                         .withAuthSessionItem(userContext.getAuthSession());
 
-        LOG.info("Setting hasVerifiedPassword to true");
+        LOG.info("Setting hasVerifiedWithPassword to true");
         userActionsManager.passwordReset(
                 JourneyType.PASSWORD_RESET, permissionContextBuilder.build());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -153,7 +153,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                             .withEmailAddress(request.getEmail())
                             .withInternalCommonSubjectId(internalCommonSubjectId.getValue()));
 
-            LOG.info("Setting hasVerifiedPassword to true");
+            LOG.info("Setting hasVerifiedWithPassword to true");
             var permissionContext =
                     PermissionContext.builder().withAuthSessionItem(authSessionItem).build();
             userActionsManager.createdPassword(JourneyType.REGISTRATION, permissionContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -211,12 +211,9 @@ public class StartHandler
 
             if (reauthenticate) {
                 LOG.info(
-                        "Reauthentication - Setting hasVerifiedPassword, hasVerifiedMfa & hasVerifiedPasskey to false");
-                authSession.setHasVerifiedPassword(false);
+                        "Reauthentication - Setting hasVerifiedWithPassword, hasVerifiedWithMfa & hasVerifiedWithPasskey to false");
                 authSession.setHasVerifiedWithPassword(false);
-                authSession.setHasVerifiedMfa(false);
                 authSession.setHasVerifiedWithMfa(false);
-                authSession.setHasVerifiedPasskey(false);
                 authSession.setHasVerifiedWithPasskey(false);
             }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -533,7 +533,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     journeyType,
                     countryCode);
 
-            LOG.info("Setting hasVerifiedMfa to true");
+            LOG.info("Setting hasVerifiedWithMfa to true");
             var permissionContext =
                     PermissionContext.builder().withAuthSessionItem(authSession).build();
             userActionsManager.correctSmsOtpReceived(journeyType, permissionContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -573,7 +573,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     authSession.withResetMfaState(AuthSessionItem.ResetMfaState.SUCCEEDED));
         }
 
-        LOG.info("Setting hasVerifiedMfa to true");
+        LOG.info("Setting hasVerifiedWithMfa to true");
         PermissionContext permissionContext =
                 PermissionContext.builder().withAuthSessionItem(authSession).build();
         if (codeRequest.getMfaMethodType() == MFAMethodType.SMS) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -901,11 +901,8 @@ class StartHandlerTest {
                         .withSessionId(SESSION_ID)
                         .withClientId(CLIENT_ID)
                         .withInternalCommonSubjectId(TEST_SUBJECT_ID)
-                        .withHasVerifiedPassword(true)
                         .withHasVerifiedWithPassword(true)
-                        .withHasVerifiedMfa(true)
                         .withHasVerifiedWithMfa(true)
-                        .withHasVerifiedPasskey(true)
                         .withHasVerifiedWithPasskey(true);
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
                 .thenReturn(authSession);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -153,7 +153,6 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         authSessionExtension.addAchievedCredentialTrustToSession(
                 sessionId, CredentialTrustLevel.LOW_LEVEL);
         var session = authSessionExtension.getSession(sessionId).orElseThrow();
-        session.setHasVerifiedPassword(true);
         session.setHasVerifiedWithPassword(true);
         authSessionExtension.updateSession(session);
         return sessionId;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthSessionItem.java
@@ -44,9 +44,6 @@ public class AuthSessionItem {
     public static final String ATTRIBUTE_SUBJECT_TYPE = "SubjectType";
     public static final String ATTRIBUTE_RP_SECTOR_IDENTIFIER_HOST = "RpSectorIdentifierHost";
     public static final String ATTRIBUTE_PASSKEY_ASSERTION_REQUEST = "PasskeyAssertionRequest";
-    public static final String ATTRIBUTE_HAS_VERIFIED_PASSWORD = "HasVerifiedPassword";
-    public static final String ATTRIBUTE_HAS_VERIFIED_MFA = "HasVerifiedMfa";
-    public static final String ATTRIBUTE_HAS_VERIFIED_PASSKEY = "HasVerifiedPasskey";
     public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSWORD = "HasVerifiedWithPassword";
     public static final String ATTRIBUTE_HAS_VERIFIED_WITH_MFA = "HasVerifiedWithMfa";
     public static final String ATTRIBUTE_HAS_VERIFIED_WITH_PASSKEY = "HasVerifiedWithPasskey";
@@ -94,9 +91,6 @@ public class AuthSessionItem {
     private String subjectType;
     private String rpSectorIdentifierHost;
     private String passkeyAssertionRequest;
-    private boolean hasVerifiedPassword;
-    private boolean hasVerifiedMfa;
-    private boolean hasVerifiedPasskey;
     private boolean hasVerifiedWithPassword;
     private boolean hasVerifiedWithMfa;
     private boolean hasVerifiedWithPasskey;
@@ -506,20 +500,6 @@ public class AuthSessionItem {
         return this;
     }
 
-    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_PASSWORD)
-    public boolean getHasVerifiedPassword() {
-        return hasVerifiedPassword;
-    }
-
-    public void setHasVerifiedPassword(boolean hasVerifiedPassword) {
-        this.hasVerifiedPassword = hasVerifiedPassword;
-    }
-
-    public AuthSessionItem withHasVerifiedPassword(boolean hasVerifiedPassword) {
-        this.hasVerifiedPassword = hasVerifiedPassword;
-        return this;
-    }
-
     @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_PASSWORD)
     public boolean getHasVerifiedWithPassword() {
         return hasVerifiedWithPassword;
@@ -534,20 +514,6 @@ public class AuthSessionItem {
         return this;
     }
 
-    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_MFA)
-    public boolean getHasVerifiedMfa() {
-        return hasVerifiedMfa;
-    }
-
-    public void setHasVerifiedMfa(boolean hasVerifiedMfa) {
-        this.hasVerifiedMfa = hasVerifiedMfa;
-    }
-
-    public AuthSessionItem withHasVerifiedMfa(boolean hasVerifiedMfa) {
-        this.hasVerifiedMfa = hasVerifiedMfa;
-        return this;
-    }
-
     @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_WITH_MFA)
     public boolean getHasVerifiedWithMfa() {
         return hasVerifiedWithMfa;
@@ -559,20 +525,6 @@ public class AuthSessionItem {
 
     public AuthSessionItem withHasVerifiedWithMfa(boolean hasVerifiedWithMfa) {
         this.hasVerifiedWithMfa = hasVerifiedWithMfa;
-        return this;
-    }
-
-    @DynamoDbAttribute(ATTRIBUTE_HAS_VERIFIED_PASSKEY)
-    public boolean getHasVerifiedPasskey() {
-        return hasVerifiedPasskey;
-    }
-
-    public void setHasVerifiedPasskey(boolean hasVerifiedPasskey) {
-        this.hasVerifiedPasskey = hasVerifiedPasskey;
-    }
-
-    public AuthSessionItem withHasVerifiedPasskey(boolean hasVerifiedPasskey) {
-        this.hasVerifiedPasskey = hasVerifiedPasskey;
         return this;
     }
 
@@ -625,12 +577,6 @@ public class AuthSessionItem {
                 + internalCommonSubjectId
                 + "', upliftRequired = '"
                 + upliftRequired
-                + "', hasVerifiedPassword = '"
-                + hasVerifiedPassword
-                + "', hasVerifiedMfa = '"
-                + hasVerifiedMfa
-                + "', hasVerifiedPasskey = '"
-                + hasVerifiedPasskey
                 + "', hasVerifiedWithPassword = '"
                 + hasVerifiedWithPassword
                 + "', hasVerifiedWithMfa = '"

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -202,11 +202,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> createdPassword(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession =
-                permissionContext
-                        .authSessionItem()
-                        .withHasVerifiedPassword(true)
-                        .withHasVerifiedWithPassword(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -214,11 +210,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctPasswordReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession =
-                permissionContext
-                        .authSessionItem()
-                        .withHasVerifiedPassword(true)
-                        .withHasVerifiedWithPassword(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -232,11 +224,7 @@ public class UserActionsManager implements UserActions {
         getCodeStorageService()
                 .deleteBlockForEmail(permissionContext.emailAddress(), codeBlockedKeyPrefix);
 
-        var updatedSession =
-                permissionContext
-                        .authSessionItem()
-                        .withHasVerifiedPassword(true)
-                        .withHasVerifiedWithPassword(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
         getAuthSessionService().updateSession(updatedSession);
 
         return Result.success(null);
@@ -288,11 +276,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctSmsOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession =
-                permissionContext
-                        .authSessionItem()
-                        .withHasVerifiedMfa(true)
-                        .withHasVerifiedWithMfa(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithMfa(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -306,11 +290,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctAuthAppOtpReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession =
-                permissionContext
-                        .authSessionItem()
-                        .withHasVerifiedMfa(true)
-                        .withHasVerifiedWithMfa(true);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithMfa(true);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }
@@ -321,7 +301,6 @@ public class UserActionsManager implements UserActions {
         var updatedSession =
                 permissionContext
                         .authSessionItem()
-                        .withHasVerifiedPasskey(true)
                         .withHasVerifiedWithPasskey(true)
                         .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         getAuthSessionService().updateSession(updatedSession);
@@ -331,11 +310,7 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> incorrectPasskeyReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession =
-                permissionContext
-                        .authSessionItem()
-                        .withHasVerifiedPasskey(false)
-                        .withHasVerifiedWithPasskey(false);
+        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPasskey(false);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/PermissionDecisionManagerTest.java
@@ -1262,9 +1262,9 @@ class PermissionDecisionManagerTest {
         void shouldReturnCorrectAssessmentForDifferentSessions(
                 CredentialTrustLevel achievedCredentialTrustLevel,
                 CredentialTrustLevel requiredCredentialTrustLevel,
-                boolean hasVerifiedPasskey,
-                boolean hasVerifiedPassword,
-                boolean hasVerifiedMfa,
+                boolean hasVerifiedWithPasskey,
+                boolean hasVerifiedWithPassword,
+                boolean hasVerifiedWithMfa,
                 boolean shouldIssueAuthCode) {
             // Arrange
             var mockSession = mock(AuthSessionItem.class);
@@ -1272,9 +1272,9 @@ class PermissionDecisionManagerTest {
                     .thenReturn(achievedCredentialTrustLevel);
             when(mockSession.getRequestedCredentialStrength())
                     .thenReturn(requiredCredentialTrustLevel);
-            when(mockSession.getHasVerifiedWithPasskey()).thenReturn(hasVerifiedPasskey);
-            when(mockSession.getHasVerifiedWithPassword()).thenReturn(hasVerifiedPassword);
-            when(mockSession.getHasVerifiedWithMfa()).thenReturn(hasVerifiedMfa);
+            when(mockSession.getHasVerifiedWithPasskey()).thenReturn(hasVerifiedWithPasskey);
+            when(mockSession.getHasVerifiedWithPassword()).thenReturn(hasVerifiedWithPassword);
+            when(mockSession.getHasVerifiedWithMfa()).thenReturn(hasVerifiedWithMfa);
 
             // Act
             var result = permissionDecisionManager.canIssueAuthCode(mockSession);

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -76,7 +76,7 @@ class UserActionsManagerTest {
     @Nested
     class CreatedPasswordOperations {
         @Test
-        void passwordCreatedShouldSetHasVerifiedPasswordToTrue() {
+        void passwordCreatedShouldSetHasVerifiedWithPasswordToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -94,7 +94,7 @@ class UserActionsManagerTest {
     @Nested
     class CorrectPasswordReceivedOperations {
         @Test
-        void correctPasswordReceivedShouldSetHasVerifiedPasswordToTrue() {
+        void correctPasswordReceivedShouldSetHasVerifiedWithPasswordToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -139,7 +139,7 @@ class UserActionsManagerTest {
         }
 
         @Test
-        void passwordResetShouldSetHasVerifiedPasswordToTrue() {
+        void passwordResetShouldSetHasVerifiedWithPasswordToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -414,7 +414,7 @@ class UserActionsManagerTest {
     @Nested
     class CorrectSmsOtpReceived {
         @Test
-        void correctSmsOtpReceivedShouldSetHasVerifiedMfaToTrue() {
+        void correctSmsOtpReceivedShouldSetHasVerifiedWithMfaToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -574,7 +574,7 @@ class UserActionsManagerTest {
     @Nested
     class CorrectAuthAppOtpReceived {
         @Test
-        void correctAuthAppOtpReceivedShouldSetHasVerifiedMfaToTrue() {
+        void correctAuthAppOtpReceivedShouldSetHasVerifiedWithMfaToTrue() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -593,7 +593,7 @@ class UserActionsManagerTest {
     class CorrectPasskeyReceived {
         @Test
         void
-                correctPasskeyReceivedShouldSetHasVerifiedPasskeyToTrueAndCredentialStrengthToMedium() {
+                correctPasskeyReceivedShouldSetHasVerifiedWithPasskeyToTrueAndCredentialStrengthToMedium() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 
@@ -614,7 +614,7 @@ class UserActionsManagerTest {
     @Nested
     class IncorrectPasskeyReceived {
         @Test
-        void incorrectPasskeyReceivedShouldSetHasVerifiedPasskeyToFalse() {
+        void incorrectPasskeyReceivedShouldSetHasVerifiedWithPasskeyToFalse() {
             // Arrange
             ArgumentCaptor<AuthSessionItem> captor = ArgumentCaptor.forClass(AuthSessionItem.class);
 


### PR DESCRIPTION
## What

We are now using the `hasVerifiedWith<authenticator>` attributes across the codebase. This was part of a process to improve the name of the old `hasVerified<authenticator>` attributes which suggested the user has a verified authenticator when instead it means they have verified with a given authenticator. 

This has been a multi PR process where there were PRs to 
1. [Add the new attributes](https://github.com/govuk-one-login/authentication-api/pull/8437)
2. [Read from the new attributes but keep the old attributes and their setters due to canary deployments](https://github.com/govuk-one-login/authentication-api/pull/8447)

We can now remove the old attributes as the codebase is setting and reading from the new attributes and this should be the case for all user sessions.

## How to review

1. Code review