### PR TITLE
BAU: Add client ID to client registry API logs

### DIFF
--- a/client-registry-api/src/main/resources/LambdaJsonLayout.json
+++ b/client-registry-api/src/main/resources/LambdaJsonLayout.json
@@ -71,5 +71,9 @@
   "trace-id": {
     "$resolver": "mdc",
     "key": "dt.trace_id"
+  },
+  "client-id": {
+    "$resolver": "mdc",
+    "key": "clientId"
   }
 }


### PR DESCRIPTION
This was previously missing

# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
