### PR TITLE
AUT-5523: Fix password related achieved low cred strength

### DIFF
--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -214,7 +214,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> correctPasswordReceived(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedWithPassword(true)
+                        .withAchievedCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -202,7 +202,11 @@ public class UserActionsManager implements UserActions {
     @Override
     public Result<TrackingError, Void> createdPassword(
             JourneyType journeyType, PermissionContext permissionContext) {
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedWithPassword(true)
+                        .withAchievedCredentialStrength(CredentialTrustLevel.LOW_LEVEL);
         getAuthSessionService().updateSession(updatedSession);
         return Result.success(null);
     }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -232,7 +232,11 @@ public class UserActionsManager implements UserActions {
         getCodeStorageService()
                 .deleteBlockForEmail(permissionContext.emailAddress(), codeBlockedKeyPrefix);
 
-        var updatedSession = permissionContext.authSessionItem().withHasVerifiedWithPassword(true);
+        var updatedSession =
+                permissionContext
+                        .authSessionItem()
+                        .withHasVerifiedWithPassword(true)
+                        .withAchievedCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
         getAuthSessionService().updateSession(updatedSession);
 
         return Result.success(null);

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -108,6 +108,9 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedWithPassword());
+            assertEquals(
+                    CredentialTrustLevel.LOW_LEVEL,
+                    capturedSession.getAchievedCredentialStrength());
             assertTrue(result.isSuccess());
         }
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -156,6 +156,9 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedWithPassword());
+            assertEquals(
+                    CredentialTrustLevel.MEDIUM_LEVEL,
+                    capturedSession.getAchievedCredentialStrength());
             assertTrue(result.isSuccess());
         }
     }

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -87,6 +87,9 @@ class UserActionsManagerTest {
             verify(authSessionService).updateSession(captor.capture());
             AuthSessionItem capturedSession = captor.getValue();
             assertTrue(capturedSession.getHasVerifiedWithPassword());
+            assertEquals(
+                    CredentialTrustLevel.LOW_LEVEL,
+                    capturedSession.getAchievedCredentialStrength());
             assertTrue(result.isSuccess());
         }
     }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The achieved credential strength was not being set on the session for the following cases:
- password created
- correct password received
- password reset

This change adds an achieved credential strength of `LOW_LEVEL` to the session. Note that `hasVerifiedWithPassword` was already being set at the same point of the change.

Long term we will likely move from an explicit achieved credential strength being stored in the session, to one derived just-in-time from the other flags (e.g., `hasVerifiedWithPassword`) - this is out of scope of this ticket.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- shouldn't impact existing sessions, no renames etc, setting something that should probably be set at these points**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required) **- N/A**