### PR TITLE
BAU: Bump js-yaml to 4.2.0 to fix CVE-2026-53550

### DIFF
--- a/orchestration-alerting/package-lock.json
+++ b/orchestration-alerting/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@aws-sdk/client-ssm": "3.994.0",
         "jest": "^30.1.3",
-        "js-yaml": ">=4.1.1"
+        "js-yaml": ">=4.2.0"
       },
       "engines": {
         "node": "24.15.x"
@@ -5843,10 +5843,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/orchestration-alerting/package.json
+++ b/orchestration-alerting/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@aws-sdk/client-ssm": "3.994.0",
     "jest": "^30.1.3",
-    "js-yaml": ">=4.1.1"
+    "js-yaml": ">=4.2.0"
   },
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.27.1",


### PR DESCRIPTION
## What

- CVE-2026-53550: quadratic-complexity DoS in merge key handling via repeated aliases in js-yaml. Bumps the constraint in orchestration-alerting from >=4.1.1 to >=4.2.0 where the fix was released.

## How to review

1. Code Review