### PR TITLE
BAU: Constrain netty-transport-native-kqueue to fix CVE-2026-45536

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,10 @@ subprojects {
                     because 'CVE-2026-45674 is fixed in io.netty:netty-resolver-dns:4.2.15.Final and higher'
                 }
 
+                classpath('io.netty:netty-transport-native-kqueue:[4.1.135.Final,4.2.0)') {
+                    because 'CVE-2026-45536 is fixed in io.netty:netty-transport-native-kqueue:4.1.135.Final and higher'
+                }
+
                 // Apache Commons constraints
                 classpath('commons-beanutils:commons-beanutils:[1.11.0,)') {
                     because 'CVE-2025-48734 is fixed in commons-beanutils:commons-beanutils:1.11.0 and higher'
@@ -169,6 +173,10 @@ subprojects {
 
                     add(conf.name, 'io.netty:netty-transport-native-epoll:[4.2.13.Final,5.0)') {
                         because 'CVE-2026-42577 is fixed in io.netty:netty-transport-native-epoll:4.2.13.Final and higher'
+                    }
+
+                    add(conf.name, 'io.netty:netty-transport-native-kqueue:[4.1.135.Final,4.2.0)') {
+                        because 'CVE-2026-45536 is fixed in io.netty:netty-transport-native-kqueue:4.1.135.Final and higher'
                     }
 
                     add(conf.name, 'io.netty:netty-handler-proxy:[4.1.133.Final,4.2.0)') {


### PR DESCRIPTION
## What

- CVE-2026-45536: Unix-socket fd receive leaks descriptors when peer sends two at once in netty-transport-native-kqueue. Constrains to >=4.1.135.Final where the fix was released. Added to both buildscript and main dependency constraint blocks.

## How to review

1. Code Review