### PR TITLE
ATO-2648: Add script to update the TTL of NS records

### DIFF
--- a/ci/stack-orchestration/update-ns-records-ttl.sh
+++ b/ci/stack-orchestration/update-ns-records-ttl.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NEW_TTL_VALUE=300
+
+function usage() {
+  cat << USAGE
+  Script to lower the ttl of NS records in a specified hosted zone
+
+  Usage:
+    $0 [-z|--zone-id] <ZONE-ID> [-t|--ttl] <TTL>
+    ex: ./update-ns-records-ttl.sh -z Z148QEXAMPLE8V -ttl 900 -e dev
+
+  Options:
+    -z, --zone-id         The zone ID of the Hosted Zone in which you would like to lower the TTL of NS records
+    -e, --environment     The environment you are lowering the TTL for.
+    -t, --ttl             The TTL you would like to set for the NS records. Default is 300 seconds (5 minutes)
+USAGE
+}
+
+if [ $# -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    -z | --zone-id)
+      HOSTED_ZONE_ID="${2}"
+      shift
+      ;;
+    -t | --ttl)
+      if ! [[ ${2} =~ ^[0-9]+$ ]] || [[ ${2} -lt 300 ]] || [[ ${2} -gt 172800 ]]; then
+        echo "TTL must be at least 300 seconds and less than 172800 (2 days). You provided: ${1}"
+        exit 1
+      fi
+      NEW_TTL_VALUE=${2}
+      shift
+      ;;
+    -e | --environment)
+      ENVIRONMENT="${2}"
+
+      PERMITTED_ENVIRONMENTS="dev build staging integration production"
+      if ! [[ ${PERMITTED_ENVIRONMENTS} =~ ( |^)${ENVIRONMENT}( |$) ]]; then
+        echo "Environment provided: ${ENVIRONMENT} is not one of ${PERMITTED_ENVIRONMENTS}"
+        exit 1
+      fi
+      shift
+      ;;
+    *)
+      echo "Bad argument: ${1}"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+case "${ENVIRONMENT}" in
+  "dev")
+    DOMAIN_NAME="oidc.dev.account.gov.uk"
+    ;;
+  "build")
+    DOMAIN_NAME="oidc.build.account.gov.uk"
+    ;;
+  "staging")
+    DOMAIN_NAME="oidc.staging.account.gov.uk"
+    ;;
+  "integration")
+    DOMAIN_NAME="oidc.integration.account.gov.uk"
+    ;;
+  "production")
+    DOMAIN_NAME="oidc.account.gov.uk"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+
+function update_ns_ttl() {
+
+  echo "Getting NS records for domain name: ${DOMAIN_NAME}"
+  local ns_records_json=""
+  # Route53 has a trailing '.' on the domain name when calling list-resource-records
+  ns_records_json=$(aws route53 list-resource-record-sets \
+    --hosted-zone-id "${HOSTED_ZONE_ID}" \
+    --query "ResourceRecordSets[?Type == 'NS' && Name == '${DOMAIN_NAME}.']" \
+    --output json)
+
+  if [ -z "${ns_records_json}" ] || [ "${ns_records_json}" == "[]" ]; then
+    echo "Error: Could not find an NS record for ${DOMAIN_NAME} in ${HOSTED_ZONE_ID}."
+    exit 1
+  fi
+
+  echo "Formatting to change batch set"
+  # shellcheck disable=SC2155
+  local resource_records=$(echo "${ns_records_json}" | jq -r '.[0].ResourceRecords')
+
+  # See https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-migrating.html#hosted-zones-migrating-prepare
+  #The trailing '.' here is fine as route53 treats the "Name":wwww.example.com. equivalent to Name:wwww.example.com
+  # See: https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html#:~:text=This%20means%20that%20Route%2053%20treats%20www.example.com%20(without%20a%20trailing%20dot)%20and%20www.example.com.%20(with%20a%20trailing%20dot)%20as%20identical.
+
+  local change_batch="{
+      \"Comment\": \"Updating NS record TTL\",
+      \"Changes\": [
+          {
+              \"Action\": \"UPSERT\",
+              \"ResourceRecordSet\": {
+                  \"Name\": \"${DOMAIN_NAME}.\",
+                  \"Type\": \"NS\",
+                  \"TTL\": ${NEW_TTL_VALUE},
+                  \"ResourceRecords\": ${resource_records}
+              }
+          }
+      ]
+  }
+  "
+
+  # shellcheck disable=SC2155
+  local new_resource_records=$(echo "${change_batch}" | jq ".Changes[0].ResourceRecordSet")
+
+  echo "Diff of changes:
+  "
+  # needs || true as diff returns non-zero exit code when a difference is present
+  diff -ys <(echo "${ns_records_json}" | jq --sort-keys '.[0]') <(echo "${new_resource_records}" | jq --sort-keys .) || true
+
+  while true; do
+    read -rp "Happy with the diff? (yY/nN): " yn
+    case ${yn} in
+      [Yy]*)
+        echo "Proceeding..."
+        break
+        ;;
+      [Nn]*)
+        echo "Exiting..."
+        exit 0
+        ;;
+      *)
+        echo "Please answer yes or no."
+        ;;
+    esac
+  done
+
+  echo "Submitting update request to Route 53..."
+  local change_id=""
+  change_id=$(aws route53 change-resource-record-sets \
+    --hosted-zone-id "${HOSTED_ZONE_ID}" \
+    --change-batch "${change_batch}" \
+    --query "ChangeInfo.Id" \
+    --output text)
+
+  echo "Change submitted (ID: ${change_id}). Wait for propagation..."
+}
+
+update_ns_ttl


### PR DESCRIPTION
### Wider context of change:

As part of migrating our hosted zone, we would like to lower the TTL of our NS records in both the old and new hosted zone. This is so that, ahead of the migration, we can ensure that our clients are re-fetching our records frequently and that if we go live with a bad record set, the records are not cached for the default TTL (2 days)

### What’s changed

Adds a script to update the TTL of our NS records in a hosted zone for a given hosted zone ID. Has some sensible limits on the TTL: can't be more than the default of two days 172800,  or less than 5 mins (300) - the latter is just a arbitrary decision as the real minimum is 60 seconds

### Manual testing

- Ran against dev: 
- Lowered our TTL to one day 
- Raised it back to the default

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
