### PR TITLE
ATO-2573: Add script to export and import records

### DIFF
--- a/ci/stack-orchestration/migrate-record-set.sh
+++ b/ci/stack-orchestration/migrate-record-set.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure we are in the directory of the script
+cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 || exit
+
+EXPORT_RECORDS=false
+IMPORT_RECORDS=false
+
+RECORDS_BATCH_CHANGES_SUFFIX="migrated-records"
+
+function usage() {
+  cat << USAGE
+  Script to lower the ttl of NS records in a specified hosted zone
+
+  Usage:
+    $0 [-z|--zone-id] <ZONE-ID> [-e|--environment] --import OR --export
+    ex: ./migrate-record-set.sh -z Z148QEXAMPLE8V --export -e dev
+
+  Options:
+    -z, --zone-id         The zone ID of the Hosted Zone in which you would like run the current operation on.
+    -e, --environment     The environment which you are running the script against. This is mainly used in the
+                          filename for the recordset.
+    --import              Imports the records stored at <ENVIRONMENT>-migrated-records.json to the specified hosted zone
+    --export              Exports the records from the specified hosted zone to a file called <ENVIRONMENT>-migrated-records.json
+USAGE
+}
+
+if [ $# -lt 3 ]; then
+  usage
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    -z | --zone-id)
+      HOSTED_ZONE_ID="${2}"
+      shift
+      ;;
+    -e | --environment)
+      ENVIRONMENT="${2}"
+
+      PERMITTED_ENVIRONMENTS="dev build staging integration production"
+      if ! [[ ${PERMITTED_ENVIRONMENTS} =~ ( |^)${ENVIRONMENT}( |$) ]]; then
+        echo "Environment provided: ${ENVIRONMENT} is not one of ${PERMITTED_ENVIRONMENTS}"
+        exit 1
+      fi
+      shift
+      ;;
+    --import)
+      IMPORT_RECORDS=true
+      ;;
+    --export)
+      EXPORT_RECORDS=true
+      ;;
+    *)
+      echo "Bad argument: ${1}"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ ${IMPORT_RECORDS} == "true" ]] && [[ ${EXPORT_RECORDS} == "true" ]]; then
+  echo "Cannot both import and export a records set in one action!"
+  exit 1
+fi
+
+function export_record_set() {
+  # SOA and NS records should not be copied over as they are specific to the hosted zone
+  # We're gonna manage the A records in Cloudformation
+  local records_excluding_ns_soa_and_a=""
+  records_excluding_ns_soa_and_a=$(aws route53 list-resource-record-sets \
+    --hosted-zone-id "${HOSTED_ZONE_ID}" \
+    --query "ResourceRecordSets[? (Type != 'NS' && Type != 'SOA' && Type != 'A')]" \
+    --output json) || exit 1
+
+  # shellcheck disable=SC2128
+  if [ -z "${records_excluding_ns_soa_and_a}" ] || [ "${records_excluding_ns_soa_and_a}" == "[]" ]; then
+    echo "Error: Could not record set for hosted zone ID: ${HOSTED_ZONE_ID}."
+    exit 1
+  fi
+
+  jq '{
+      Comment: "Importing records from old hosted zone",
+      Changes: [
+           {
+            Action: "CREATE",
+            ResourceRecordSet: .[]  | select(.Type != "SOA" and .Type != "NS" and .Type != "A")
+          }
+      ]
+    }' <<< "${records_excluding_ns_soa_and_a}" > "$(pwd)/${ENVIRONMENT}-${RECORDS_BATCH_CHANGES_SUFFIX}.json"
+}
+
+function import_record_set() {
+  local batch_records_file=""
+  batch_records_file="$(pwd)/${ENVIRONMENT}-${RECORDS_BATCH_CHANGES_SUFFIX}.json"
+
+  local change_id=""
+  change_id=$(aws route53 change-resource-record-sets \
+    --hosted-zone-id "${HOSTED_ZONE_ID}" \
+    --change-batch "file://${batch_records_file}" \
+    --query "ChangeInfo.Id" \
+    --output text) || exit 1
+
+  echo "Change submitted (ID: ${change_id}). Wait for propagation..."
+}
+
+[ "${EXPORT_RECORDS}" == "true" ] && export_record_set && exit 0
+
+[ "${IMPORT_RECORDS}" == "true" ] && import_record_set && exit 0


### PR DESCRIPTION
### Wider context of change

As [part of migrating a hosted zone from one AWS account to another](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-migrating.html#hosted-zones-migrating-old-to-new) we need to be able to migrate records from the old hosted zone to the new one, ensuring they are equivalent. 

### What’s changed:
- Adds a script to export and import records from a hosted zone

### Manual testing

- Ran against dev using the `--export` flag
- Change batch set file was correctly formatted

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
