### PR TITLE
Aut 5466: Emit passkey verification success and failure events

### DIFF
--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailed.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailed.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformati
 import uk.gov.di.authentication.auditevents.entity.shared.Users.UserWithoutPhone;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.RestrictedPasskeySection;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 
 import java.time.Clock;
@@ -51,9 +52,6 @@ public record AuthPasskeyVerificationFailed(
 
     public record Extensions(
             @SerializedName("journey-type") String journeyType, PasskeyDetail passkey) {}
-
-    public record RestrictedPasskeySection(
-            List<PasskeyAllowCredentials> passkeyAllowedCredentials, String passkeyCredentialId) {}
 
     public record Restricted(
             EncodedDeviceInformation deviceInformation, RestrictedPasskeySection passkey) {}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformati
 import uk.gov.di.authentication.auditevents.entity.shared.Users.UserWithoutPhone;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.RestrictedPasskeySection;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 
 import java.time.Clock;
@@ -48,9 +49,6 @@ public record AuthPasskeyVerificationSuccessful(
                 restricted,
                 extensions);
     }
-
-    public record RestrictedPasskeySection(
-            List<PasskeyAllowCredentials> passkeyAllowedCredentials, String passkeyCredentialId) {}
 
     public record Restricted(
             EncodedDeviceInformation deviceInformation, RestrictedPasskeySection passkey) {}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
@@ -5,7 +5,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformation;
 import uk.gov.di.authentication.auditevents.entity.shared.Users.UserWithoutPhone;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
-import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAuthenticationRequest;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 
@@ -49,13 +48,6 @@ public record AuthPasskeyVerificationSuccessful(
                 restricted,
                 extensions);
     }
-
-    public record Passkey(
-            int passkeyCounter,
-            boolean passkeyCredentialBackedUp,
-            String passkeyCredentialDeviceType,
-            boolean passkeyUserVerified,
-            PasskeyAuthenticationRequest passkeyAuthenticationRequest) {}
 
     public record RestrictedPasskeySection(
             List<PasskeyAllowCredentials> passkeyAllowedCredentials, String passkeyCredentialId) {}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
@@ -37,8 +37,7 @@ public record AuthPasskeyVerificationSuccessful(
         var restricted =
                 new Restricted(
                         EncodedDeviceInformation.from(auditContext),
-                        new RestrictedPasskeySection(passkeyAllowedCredentials),
-                        credentialId);
+                        new RestrictedPasskeySection(passkeyAllowedCredentials, credentialId));
         var extensions = new Extensions(journeyType.getValue(), passkey);
         return new AuthPasskeyVerificationSuccessful(
                 eventName,
@@ -59,12 +58,10 @@ public record AuthPasskeyVerificationSuccessful(
             PasskeyAuthenticationRequest passkeyAuthenticationRequest) {}
 
     public record RestrictedPasskeySection(
-            List<PasskeyAllowCredentials> passkeyAllowedCredentials) {}
+            List<PasskeyAllowCredentials> passkeyAllowedCredentials, String passkeyCredentialId) {}
 
     public record Restricted(
-            EncodedDeviceInformation deviceInformation,
-            RestrictedPasskeySection passkey,
-            String passkeyCredentialId) {}
+            EncodedDeviceInformation deviceInformation, RestrictedPasskeySection passkey) {}
 
     public record Extensions(
             @SerializedName("journey-type") String journeyType, PasskeyDetail passkey) {}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
@@ -6,13 +6,13 @@ public record PasskeyDetail(
         boolean passkeyCredentialBackedUp,
         String passkeyCredentialDeviceType,
         boolean passkeyUserVerified,
-        String passkeyVerificationFailureReason) {
+        String passkeyAuthenticationFailureReason) {
     public static PasskeyDetail verificationFailed(
             String userVerification,
             long passkeyCounter,
             boolean passkeyCredentialBackedUp,
             String passkeyCredentialDeviceType,
-            String failureReason) {
+            String authenticationFailureReason) {
         var userVerified = false;
         return new PasskeyDetail(
                 new PasskeyAuthenticationRequest(userVerification),
@@ -20,7 +20,7 @@ public record PasskeyDetail(
                 passkeyCredentialBackedUp,
                 passkeyCredentialDeviceType,
                 userVerified,
-                failureReason);
+                authenticationFailureReason);
     }
 
     public static PasskeyDetail verificationSuccessful(

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
@@ -2,14 +2,14 @@ package uk.gov.di.authentication.auditevents.entity.shared.passkeys;
 
 public record PasskeyDetail(
         PasskeyAuthenticationRequest passkeyAuthenticationRequest,
-        int passkeyCounter,
+        long passkeyCounter,
         boolean passkeyCredentialBackedUp,
         String passkeyCredentialDeviceType,
         boolean passkeyUserVerified,
         String passkeyVerificationFailureReason) {
     public static PasskeyDetail verificationFailed(
             String userVerification,
-            int passkeyCounter,
+            long passkeyCounter,
             boolean passkeyCredentialBackedUp,
             String passkeyCredentialDeviceType,
             String failureReason) {
@@ -25,7 +25,7 @@ public record PasskeyDetail(
 
     public static PasskeyDetail verificationSuccessful(
             String userVerification,
-            int passkeyCounter,
+            long passkeyCounter,
             boolean passkeyCredentialBackedUp,
             String passkeyCredentialDeviceType) {
         var userVerified = true;
@@ -39,7 +39,7 @@ public record PasskeyDetail(
     }
 
     public static PasskeyDetail authenticationSuccessful(
-            int passkeyCounter,
+            long passkeyCounter,
             boolean passkeyCredentialBackedUp,
             String passkeyCredentialDeviceType) {
         var userVerified = false;

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/RestrictedPasskeySection.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/RestrictedPasskeySection.java
@@ -1,0 +1,6 @@
+package uk.gov.di.authentication.auditevents.entity.shared.passkeys;
+
+import java.util.List;
+
+public record RestrictedPasskeySection(
+        List<PasskeyAllowCredentials> passkeyAllowedCredentials, String passkeyCredentialId) {}

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
@@ -97,7 +97,7 @@ class AuthPasskeyVerificationFailedTest {
                       "passkey_credential_backed_up": true,
                       "passkey_credential_device_type": "multi-device",
                       "passkey_user_verified": false,
-                      "passkey_verification_failure_reason": "UserVerificationError"
+                      "passkey_authentication_failure_reason": "UserVerificationError"
                     }
                   }
                 }

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessfulTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessfulTest.java
@@ -79,9 +79,9 @@ class AuthPasskeyVerificationSuccessfulTest {
                             "ble"
                           ]
                         }
-                      ]
-                    },
-                    "passkey_credential_id": "credential-1"
+                      ],
+                      "passkey_credential_id": "credential-1"
+                    }
                   },
                   "extensions": {
                     "journey-type": "SIGN_IN",

--- a/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
+++ b/ci/cloudformation/auth/function/finish-passkey-assertion.yaml
@@ -63,6 +63,7 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               amcClientId,
             ]
+          TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
           WEBAUTHN_RELYING_PARTY_ID:
             !FindInMap [
               EnvironmentConfiguration,
@@ -82,6 +83,7 @@ Resources:
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoAuthSessionStoreReadWriteAccessPolicy
         - !Ref AuthToAccountDataSigningKeyPolicy
+        - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
       SnapStart:
         ApplyOn: PublishedVersions
       VpcConfig:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelper.java
@@ -1,0 +1,38 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import com.yubico.webauthn.AssertionRequest;
+import com.yubico.webauthn.data.AuthenticatorTransport;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
+
+import java.util.List;
+
+public class PasskeyAuditExtensionsHelper {
+    private PasskeyAuditExtensionsHelper() {
+        /* This utility class should not be instantiated */
+    }
+
+    public static List<PasskeyAllowCredentials> passkeyAllowedCredentialsFrom(
+            AssertionRequest assertionRequest) {
+        var allowCredentials =
+                assertionRequest
+                        .getPublicKeyCredentialRequestOptions()
+                        .getAllowCredentials()
+                        .orElse(List.of());
+        return allowCredentials.stream()
+                .map(
+                        c ->
+                                new PasskeyAllowCredentials(
+                                        c.getId().getBase64Url(), getNullableTransports(c)))
+                .toList();
+    }
+
+    private static List<String> getNullableTransports(PublicKeyCredentialDescriptor credential) {
+        var transportsAsList =
+                credential
+                        .getTransports()
+                        .map(set -> set.stream().map(AuthenticatorTransport::getId).toList())
+                        .orElse(List.of());
+        return transportsAsList.isEmpty() ? null : transportsAsList;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelper.java
@@ -3,7 +3,9 @@ package uk.gov.di.authentication.frontendapi.helpers;
 import com.yubico.webauthn.AssertionRequest;
 import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import com.yubico.webauthn.data.UserVerificationRequirement;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
+import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.util.List;
 
@@ -25,6 +27,14 @@ public class PasskeyAuditExtensionsHelper {
                                 new PasskeyAllowCredentials(
                                         c.getId().getBase64Url(), getNullableTransports(c)))
                 .toList();
+    }
+
+    public static String userVerificationStringFrom(AssertionRequest assertionRequest) {
+        return assertionRequest
+                .getPublicKeyCredentialRequestOptions()
+                .getUserVerification()
+                .map(UserVerificationRequirement::getValue)
+                .orElse(AuditService.UNKNOWN);
     }
 
     private static List<String> getNullableTransports(PublicKeyCredentialDescriptor credential) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.helpers;
 
 import com.yubico.webauthn.AssertionRequest;
+import com.yubico.webauthn.AssertionResult;
 import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.UserVerificationRequirement;
@@ -13,6 +14,9 @@ public class PasskeyAuditExtensionsHelper {
     private PasskeyAuditExtensionsHelper() {
         /* This utility class should not be instantiated */
     }
+
+    private static final String MULTI_DEVICE = "multi-device";
+    private static final String SINGLE_DEVICE = "single-device";
 
     public static List<PasskeyAllowCredentials> passkeyAllowedCredentialsFrom(
             AssertionRequest assertionRequest) {
@@ -35,6 +39,11 @@ public class PasskeyAuditExtensionsHelper {
                 .getUserVerification()
                 .map(UserVerificationRequirement::getValue)
                 .orElse(AuditService.UNKNOWN);
+    }
+
+    @SuppressWarnings("deprecation")
+    public static String passkeyCredentialDeviceTypeFrom(AssertionResult assertionResult) {
+        return assertionResult.isBackupEligible() ? MULTI_DEVICE : SINGLE_DEVICE;
     }
 
     private static List<String> getNullableTransports(PublicKeyCredentialDescriptor credential) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.yubico.webauthn.AssertionResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionRequest;
 import uk.gov.di.authentication.frontendapi.services.webauthn.DefaultPasskeyJsonParser;
@@ -56,7 +57,8 @@ public class FinishPasskeyAssertionHandler
         this.passkeyAssertionService =
                 new PasskeyAssertionService(
                         RelyingPartyProvider.provide(configurationService),
-                        new DefaultPasskeyJsonParser());
+                        new DefaultPasskeyJsonParser(),
+                        new StructuredAuditService(configurationService));
         this.userActionsManager = new UserActionsManager(configurationService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.yubico.webauthn.AssertionResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionRequest;
@@ -15,7 +16,10 @@ import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionSe
 import uk.gov.di.authentication.frontendapi.services.webauthn.RelyingPartyProvider;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -77,7 +81,7 @@ public class FinishPasskeyAssertionHandler
 
         LOG.info("FinishPasskeyAssertionHandler called");
 
-        return verifyPasskeyAssertion(userContext, request)
+        return verifyPasskeyAssertion(userContext, request, input)
                 .flatMap(this::updatePasskeyRecord)
                 .map(success -> reportCorrectPasskeyReceived(userContext))
                 .fold(
@@ -96,9 +100,21 @@ public class FinishPasskeyAssertionHandler
     }
 
     private Result<FinishPasskeyAssertionFailureReason, AssertionResult> verifyPasskeyAssertion(
-            UserContext userContext, FinishPasskeyAssertionRequest request) {
+            UserContext userContext,
+            FinishPasskeyAssertionRequest request,
+            APIGatewayProxyRequestEvent input) {
+        var auditContext =
+                AuditContext.auditContextFromUserContext(
+                        userContext,
+                        userContext.getAuthSession().getInternalCommonSubjectId(),
+                        userContext.getAuthSession().getEmailAddress(),
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
         return passkeyAssertionService.finishAssertion(
-                userContext.getAuthSession().getPasskeyAssertionRequest(), request.pkc());
+                userContext.getAuthSession().getPasskeyAssertionRequest(),
+                request.pkc(),
+                auditContext);
     }
 
     private Result<FinishPasskeyAssertionFailureReason, Void> updatePasskeyRecord(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartPasskeyAssertionHandler.java
@@ -11,6 +11,7 @@ import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.UserVerificationRequirement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.StartPasskeyAssertionRequest;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditExtension;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.audit.PasskeyAuthenticationAuditRestricted;
@@ -70,7 +71,8 @@ public class StartPasskeyAssertionHandler extends BaseFrontendHandler<StartPassk
         this.passkeyAssertionService =
                 new PasskeyAssertionService(
                         RelyingPartyProvider.provide(configurationService),
-                        new DefaultPasskeyJsonParser());
+                        new DefaultPasskeyJsonParser(),
+                        new StructuredAuditService(configurationService));
         this.auditService = new AuditService(configurationService);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -119,7 +119,7 @@ public class PasskeyAssertionService {
         var passkeyDetail =
                 PasskeyDetail.verificationFailed(
                         userVerification,
-                        (int) assertionResult.getSignatureCount(), // TODO change to long
+                        assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceType,
                         "UserVerificationError");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -21,13 +21,13 @@ import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom;
+import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.userVerificationStringFrom;
 
 public class PasskeyAssertionService {
     private final RelyingParty relyingParty;
@@ -107,18 +107,11 @@ public class PasskeyAssertionService {
             AssertionResult assertionResult,
             PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
                     publicKeyCredential) {
-        var passkeyAllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
-        var userVerification =
-                assertionRequest
-                        .getPublicKeyCredentialRequestOptions()
-                        .getUserVerification()
-                        .map(UserVerificationRequirement::getValue)
-                        .orElse(AuditService.UNKNOWN);
         var passkeyCredentialDeviceType =
                 assertionResult.isBackupEligible() ? "multi-device" : "single-device";
         var passkeyDetail =
                 PasskeyDetail.verificationFailed(
-                        userVerification,
+                        userVerificationStringFrom(assertionRequest),
                         assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceType,
@@ -127,7 +120,7 @@ public class PasskeyAssertionService {
                 AuthPasskeyVerificationFailed.create(
                         auditContext,
                         JourneyType.SIGN_IN,
-                        passkeyAllowedCredentials,
+                        passkeyAllowedCredentialsFrom(assertionRequest),
                         publicKeyCredential.getId().getBase64Url(),
                         passkeyDetail,
                         Clock.systemUTC());
@@ -141,26 +134,19 @@ public class PasskeyAssertionService {
             AssertionResult assertionResult,
             PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
                     publicKeyCredential) {
-        var passkeyAllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
-        var userVerification =
-                assertionRequest
-                        .getPublicKeyCredentialRequestOptions()
-                        .getUserVerification()
-                        .map(UserVerificationRequirement::getValue)
-                        .orElse(AuditService.UNKNOWN);
         var passkeyCredentialDeviceType =
                 assertionResult.isBackupEligible() ? "multi-device" : "single-device";
         var passkeyDetail =
                 PasskeyDetail.verificationSuccessful(
-                        userVerification,
-                        (int) assertionResult.getSignatureCount(), // TODO change to long
+                        userVerificationStringFrom(assertionRequest),
+                        assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceType);
         var event =
                 AuthPasskeyVerificationSuccessful.create(
                         auditContext,
                         JourneyType.SIGN_IN,
-                        passkeyAllowedCredentials,
+                        passkeyAllowedCredentialsFrom(assertionRequest),
                         passkeyDetail,
                         publicKeyCredential.getId().getBase64Url(),
                         Clock.systemUTC());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -27,6 +27,7 @@ import java.time.Clock;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom;
+import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.passkeyCredentialDeviceTypeFrom;
 import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.userVerificationStringFrom;
 
 public class PasskeyAssertionService {
@@ -107,14 +108,12 @@ public class PasskeyAssertionService {
             AssertionResult assertionResult,
             PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
                     publicKeyCredential) {
-        var passkeyCredentialDeviceType =
-                assertionResult.isBackupEligible() ? "multi-device" : "single-device";
         var passkeyDetail =
                 PasskeyDetail.verificationFailed(
                         userVerificationStringFrom(assertionRequest),
                         assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
-                        passkeyCredentialDeviceType,
+                        passkeyCredentialDeviceTypeFrom(assertionResult),
                         "UserVerificationError");
         var event =
                 AuthPasskeyVerificationFailed.create(
@@ -134,14 +133,12 @@ public class PasskeyAssertionService {
             AssertionResult assertionResult,
             PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
                     publicKeyCredential) {
-        var passkeyCredentialDeviceType =
-                assertionResult.isBackupEligible() ? "multi-device" : "single-device";
         var passkeyDetail =
                 PasskeyDetail.verificationSuccessful(
                         userVerificationStringFrom(assertionRequest),
                         assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
-                        passkeyCredentialDeviceType);
+                        passkeyCredentialDeviceTypeFrom(assertionResult));
         var event =
                 AuthPasskeyVerificationSuccessful.create(
                         auditContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -14,6 +14,7 @@ import com.yubico.webauthn.exception.AssertionFailedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationFailed;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSuccessful;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
@@ -86,14 +87,53 @@ public class PasskeyAssertionService {
 
         if (!assertionResult.isSuccess()) {
             LOG.warn("Passkey assertion unsuccessful");
+            emitAuthPasskeyVerificationFailedEvent(
+                    AuditContext.emptyAuditContext(),
+                    assertionRequest,
+                    assertionResult,
+                    credential);
             return Result.failure(FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR);
         }
 
-        //TODO pass in audit context to this function
+        // TODO pass in audit context to this function
         emitAuthPasskeyVerificationSuccessEvent(
                 AuditContext.emptyAuditContext(), assertionRequest, assertionResult, credential);
 
         return Result.success(assertionResult);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void emitAuthPasskeyVerificationFailedEvent(
+            AuditContext auditContext,
+            AssertionRequest assertionRequest,
+            AssertionResult assertionResult,
+            PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
+                    publicKeyCredential) {
+        var passkeyAllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
+        var userVerification =
+                assertionRequest
+                        .getPublicKeyCredentialRequestOptions()
+                        .getUserVerification()
+                        .map(UserVerificationRequirement::getValue)
+                        .orElse(AuditService.UNKNOWN);
+        var passkeyCredentialDeviceType =
+                assertionResult.isBackupEligible() ? "multi-device" : "single-device";
+        var passkeyDetail =
+                PasskeyDetail.verificationFailed(
+                        userVerification,
+                        (int) assertionResult.getSignatureCount(), // TODO change to long
+                        assertionResult.isBackedUp(),
+                        passkeyCredentialDeviceType,
+                        "UserVerificationError");
+        var event =
+                AuthPasskeyVerificationFailed.create(
+                        auditContext,
+                        JourneyType.SIGN_IN,
+                        passkeyAllowedCredentials,
+                        publicKeyCredential.getId().getBase64Url(),
+                        passkeyDetail,
+                        Clock.systemUTC());
+        structuredAuditService.submitAuditEvent(event);
     }
 
     @SuppressWarnings("deprecation")

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -114,7 +114,7 @@ public class PasskeyAssertionService {
                         assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceTypeFrom(assertionResult),
-                        "UserVerificationError");
+                        "UnknownError");
         var event =
                 AuthPasskeyVerificationFailed.create(
                         auditContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -13,6 +13,7 @@ import com.yubico.webauthn.data.UserVerificationRequirement;
 import com.yubico.webauthn.exception.AssertionFailedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
 
@@ -23,10 +24,15 @@ public class PasskeyAssertionService {
     private final RelyingParty relyingParty;
     private final PasskeyJsonParser jsonParser;
     private static final Logger LOG = LogManager.getLogger(PasskeyAssertionService.class);
+    private final StructuredAuditService structuredAuditService;
 
-    public PasskeyAssertionService(RelyingParty relyingParty, PasskeyJsonParser jsonParser) {
+    public PasskeyAssertionService(
+            RelyingParty relyingParty,
+            PasskeyJsonParser jsonParser,
+            StructuredAuditService structuredAuditService) {
         this.relyingParty = relyingParty;
         this.jsonParser = jsonParser;
+        this.structuredAuditService = structuredAuditService;
     }
 
     public AssertionRequest startAssertion(String publicSubjectId) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -54,7 +54,9 @@ public class PasskeyAssertionService {
     }
 
     public Result<FinishPasskeyAssertionFailureReason, AssertionResult> finishAssertion(
-            String assertionRequestJson, String publicKeyCredentialJson) {
+            String assertionRequestJson,
+            String publicKeyCredentialJson,
+            AuditContext auditContext) {
 
         AssertionRequest assertionRequest;
         try {
@@ -88,16 +90,12 @@ public class PasskeyAssertionService {
         if (!assertionResult.isSuccess()) {
             LOG.warn("Passkey assertion unsuccessful");
             emitAuthPasskeyVerificationFailedEvent(
-                    AuditContext.emptyAuditContext(),
-                    assertionRequest,
-                    assertionResult,
-                    credential);
+                    auditContext, assertionRequest, assertionResult, credential);
             return Result.failure(FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR);
         }
 
-        // TODO pass in audit context to this function
         emitAuthPasskeyVerificationSuccessEvent(
-                AuditContext.emptyAuditContext(), assertionRequest, assertionResult, credential);
+                auditContext, assertionRequest, assertionResult, credential);
 
         return Result.success(assertionResult);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -13,12 +13,20 @@ import com.yubico.webauthn.data.UserVerificationRequirement;
 import com.yubico.webauthn.exception.AssertionFailedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSuccessful;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Optional;
+
+import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom;
 
 public class PasskeyAssertionService {
     private final RelyingParty relyingParty;
@@ -81,6 +89,43 @@ public class PasskeyAssertionService {
             return Result.failure(FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR);
         }
 
+        //TODO pass in audit context to this function
+        emitAuthPasskeyVerificationSuccessEvent(
+                AuditContext.emptyAuditContext(), assertionRequest, assertionResult, credential);
+
         return Result.success(assertionResult);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void emitAuthPasskeyVerificationSuccessEvent(
+            AuditContext auditContext,
+            AssertionRequest assertionRequest,
+            AssertionResult assertionResult,
+            PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
+                    publicKeyCredential) {
+        var passkeyAllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
+        var userVerification =
+                assertionRequest
+                        .getPublicKeyCredentialRequestOptions()
+                        .getUserVerification()
+                        .map(UserVerificationRequirement::getValue)
+                        .orElse(AuditService.UNKNOWN);
+        var passkeyCredentialDeviceType =
+                assertionResult.isBackupEligible() ? "multi-device" : "single-device";
+        var passkeyDetail =
+                PasskeyDetail.verificationSuccessful(
+                        userVerification,
+                        (int) assertionResult.getSignatureCount(), // TODO change to long
+                        assertionResult.isBackedUp(),
+                        passkeyCredentialDeviceType);
+        var event =
+                AuthPasskeyVerificationSuccessful.create(
+                        auditContext,
+                        JourneyType.SIGN_IN,
+                        passkeyAllowedCredentials,
+                        passkeyDetail,
+                        publicKeyCredential.getId().getBase64Url(),
+                        Clock.systemUTC());
+        structuredAuditService.submitAuditEvent(event);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.helpers;
 
 import com.yubico.webauthn.AssertionRequest;
+import com.yubico.webauthn.AssertionResult;
 import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
@@ -8,15 +9,21 @@ import com.yubico.webauthn.data.PublicKeyCredentialRequestOptions;
 import com.yubico.webauthn.data.UserVerificationRequirement;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class PasskeyAuditExtensionsHelperTest {
 
@@ -158,6 +165,28 @@ class PasskeyAuditExtensionsHelperTest {
             var result = PasskeyAuditExtensionsHelper.userVerificationStringFrom(assertionRequest);
 
             assertEquals("", result);
+        }
+    }
+
+    @Nested
+    class PasskeyCredentialDeviceType {
+        private static Stream<Arguments> backupEligibleToExpectedDeviceType() {
+            return Stream.of(
+                    Arguments.of(false, "single-device"), Arguments.of(true, "multi-device"));
+        }
+
+        @MethodSource("backupEligibleToExpectedDeviceType")
+        @ParameterizedTest
+        @SuppressWarnings("deprecation")
+        void getsCredentialDeviceTypeDependentOnBackupEligible(
+                boolean isBackupEligible, String expectedCredentialDeviceType) {
+            var assertionResult = mock(AssertionResult.class);
+            when(assertionResult.isBackupEligible()).thenReturn(isBackupEligible);
+
+            var actualCredentialDeviceType =
+                    PasskeyAuditExtensionsHelper.passkeyCredentialDeviceTypeFrom(assertionResult);
+
+            assertEquals(expectedCredentialDeviceType, actualCredentialDeviceType);
         }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelperTest.java
@@ -1,0 +1,120 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import com.yubico.webauthn.AssertionRequest;
+import com.yubico.webauthn.data.AuthenticatorTransport;
+import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import com.yubico.webauthn.data.PublicKeyCredentialRequestOptions;
+import com.yubico.webauthn.data.UserVerificationRequirement;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class PasskeyAuditExtensionsHelperTest {
+
+    private static AssertionRequest buildAssertionRequest(
+            List<PublicKeyCredentialDescriptor> allowCredentials) {
+        var options =
+                PublicKeyCredentialRequestOptions.builder()
+                        .challenge(new ByteArray("test-challenge".getBytes(StandardCharsets.UTF_8)))
+                        .userVerification(UserVerificationRequirement.REQUIRED)
+                        .allowCredentials(allowCredentials)
+                        .build();
+        return AssertionRequest.builder().publicKeyCredentialRequestOptions(options).build();
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoAllowCredentials() {
+        var assertionRequest = buildAssertionRequest(List.of());
+
+        var result = PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(assertionRequest);
+
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void shouldMapCredentialIdToBase64UrlAndTransports() {
+        var credentialId = new ByteArray("cred-1".getBytes(StandardCharsets.UTF_8));
+        var descriptor =
+                PublicKeyCredentialDescriptor.builder()
+                        .id(credentialId)
+                        .transports(Set.of(AuthenticatorTransport.USB))
+                        .build();
+
+        var result =
+                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                        buildAssertionRequest(List.of(descriptor)));
+
+        assertEquals(1, result.size());
+        assertEquals(
+                new PasskeyAllowCredentials(credentialId.getBase64Url(), List.of("usb")),
+                result.get(0));
+    }
+
+    @Test
+    void shouldMapMultipleTransports() {
+        var credentialId = new ByteArray("cred-2".getBytes(StandardCharsets.UTF_8));
+        var descriptor =
+                PublicKeyCredentialDescriptor.builder()
+                        .id(credentialId)
+                        .transports(
+                                Set.of(AuthenticatorTransport.BLE, AuthenticatorTransport.INTERNAL))
+                        .build();
+
+        var result =
+                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                        buildAssertionRequest(List.of(descriptor)));
+
+        assertEquals(1, result.size());
+        assertEquals(credentialId.getBase64Url(), result.get(0).passkeyCredentialId());
+        // Sets are unordered, so check contents rather than order
+        assertEquals(
+                Set.of("ble", "internal"), Set.copyOf(result.get(0).passkeyCredentialTransports()));
+    }
+
+    @Test
+    void shouldSetTransportsToNullWhenAbsent() {
+        var credentialId = new ByteArray("cred-3".getBytes(StandardCharsets.UTF_8));
+        // builder without .transports() leaves transports absent
+        var descriptor = PublicKeyCredentialDescriptor.builder().id(credentialId).build();
+
+        var result =
+                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                        buildAssertionRequest(List.of(descriptor)));
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).passkeyCredentialTransports());
+    }
+
+    @Test
+    void shouldMapMultipleCredentials() {
+        var id1 = new ByteArray("cred-a".getBytes(StandardCharsets.UTF_8));
+        var id2 = new ByteArray("cred-b".getBytes(StandardCharsets.UTF_8));
+        var descriptors =
+                List.of(
+                        PublicKeyCredentialDescriptor.builder()
+                                .id(id1)
+                                .transports(Set.of(AuthenticatorTransport.USB))
+                                .build(),
+                        PublicKeyCredentialDescriptor.builder()
+                                .id(id2)
+                                .transports(Set.of(AuthenticatorTransport.NFC))
+                                .build());
+
+        var result =
+                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                        buildAssertionRequest(descriptors));
+
+        assertEquals(2, result.size());
+        assertEquals(
+                new PasskeyAllowCredentials(id1.getBase64Url(), List.of("usb")), result.get(0));
+        assertEquals(
+                new PasskeyAllowCredentials(id2.getBase64Url(), List.of("nfc")), result.get(1));
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyAuditExtensionsHelperTest.java
@@ -6,11 +6,13 @@ import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.PublicKeyCredentialRequestOptions;
 import com.yubico.webauthn.data.UserVerificationRequirement;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,98 +25,139 @@ class PasskeyAuditExtensionsHelperTest {
         var options =
                 PublicKeyCredentialRequestOptions.builder()
                         .challenge(new ByteArray("test-challenge".getBytes(StandardCharsets.UTF_8)))
-                        .userVerification(UserVerificationRequirement.REQUIRED)
                         .allowCredentials(allowCredentials)
                         .build();
         return AssertionRequest.builder().publicKeyCredentialRequestOptions(options).build();
     }
 
-    @Test
-    void shouldReturnEmptyListWhenNoAllowCredentials() {
-        var assertionRequest = buildAssertionRequest(List.of());
+    private static AssertionRequest buildAssertionRequest(
+            Optional<UserVerificationRequirement> mayebUserVerificationRequirement) {
 
-        var result = PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(assertionRequest);
-
-        assertEquals(List.of(), result);
+        var optionsBuilder =
+                PublicKeyCredentialRequestOptions.builder()
+                        .challenge(
+                                new ByteArray("test-challenge".getBytes(StandardCharsets.UTF_8)));
+        mayebUserVerificationRequirement.ifPresent(optionsBuilder::userVerification);
+        var options = optionsBuilder.build();
+        return AssertionRequest.builder().publicKeyCredentialRequestOptions(options).build();
     }
 
-    @Test
-    void shouldMapCredentialIdToBase64UrlAndTransports() {
-        var credentialId = new ByteArray("cred-1".getBytes(StandardCharsets.UTF_8));
-        var descriptor =
-                PublicKeyCredentialDescriptor.builder()
-                        .id(credentialId)
-                        .transports(Set.of(AuthenticatorTransport.USB))
-                        .build();
+    @Nested
+    class PasskeyAllowedCredentialsFrom {
 
-        var result =
-                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
-                        buildAssertionRequest(List.of(descriptor)));
+        @Test
+        void shouldReturnEmptyListWhenNoAllowCredentials() {
+            var assertionRequest = buildAssertionRequest(List.of());
 
-        assertEquals(1, result.size());
-        assertEquals(
-                new PasskeyAllowCredentials(credentialId.getBase64Url(), List.of("usb")),
-                result.get(0));
+            var result =
+                    PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(assertionRequest);
+
+            assertEquals(List.of(), result);
+        }
+
+        @Test
+        void shouldMapCredentialIdToBase64UrlAndTransports() {
+            var credentialId = new ByteArray("cred-1".getBytes(StandardCharsets.UTF_8));
+            var descriptor =
+                    PublicKeyCredentialDescriptor.builder()
+                            .id(credentialId)
+                            .transports(Set.of(AuthenticatorTransport.USB))
+                            .build();
+
+            var result =
+                    PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                            buildAssertionRequest(List.of(descriptor)));
+
+            assertEquals(1, result.size());
+            assertEquals(
+                    new PasskeyAllowCredentials(credentialId.getBase64Url(), List.of("usb")),
+                    result.get(0));
+        }
+
+        @Test
+        void shouldMapMultipleTransports() {
+            var credentialId = new ByteArray("cred-2".getBytes(StandardCharsets.UTF_8));
+            var descriptor =
+                    PublicKeyCredentialDescriptor.builder()
+                            .id(credentialId)
+                            .transports(
+                                    Set.of(
+                                            AuthenticatorTransport.BLE,
+                                            AuthenticatorTransport.INTERNAL))
+                            .build();
+
+            var result =
+                    PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                            buildAssertionRequest(List.of(descriptor)));
+
+            assertEquals(1, result.size());
+            assertEquals(credentialId.getBase64Url(), result.get(0).passkeyCredentialId());
+            // Sets are unordered, so check contents rather than order
+            assertEquals(
+                    Set.of("ble", "internal"),
+                    Set.copyOf(result.get(0).passkeyCredentialTransports()));
+        }
+
+        @Test
+        void shouldSetTransportsToNullWhenAbsent() {
+            var credentialId = new ByteArray("cred-3".getBytes(StandardCharsets.UTF_8));
+            // builder without .transports() leaves transports absent
+            var descriptor = PublicKeyCredentialDescriptor.builder().id(credentialId).build();
+
+            var result =
+                    PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                            buildAssertionRequest(List.of(descriptor)));
+
+            assertEquals(1, result.size());
+            assertNull(result.get(0).passkeyCredentialTransports());
+        }
+
+        @Test
+        void shouldMapMultipleCredentials() {
+            var id1 = new ByteArray("cred-a".getBytes(StandardCharsets.UTF_8));
+            var id2 = new ByteArray("cred-b".getBytes(StandardCharsets.UTF_8));
+            var descriptors =
+                    List.of(
+                            PublicKeyCredentialDescriptor.builder()
+                                    .id(id1)
+                                    .transports(Set.of(AuthenticatorTransport.USB))
+                                    .build(),
+                            PublicKeyCredentialDescriptor.builder()
+                                    .id(id2)
+                                    .transports(Set.of(AuthenticatorTransport.NFC))
+                                    .build());
+
+            var result =
+                    PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
+                            buildAssertionRequest(descriptors));
+
+            assertEquals(2, result.size());
+            assertEquals(
+                    new PasskeyAllowCredentials(id1.getBase64Url(), List.of("usb")), result.get(0));
+            assertEquals(
+                    new PasskeyAllowCredentials(id2.getBase64Url(), List.of("nfc")), result.get(1));
+        }
     }
 
-    @Test
-    void shouldMapMultipleTransports() {
-        var credentialId = new ByteArray("cred-2".getBytes(StandardCharsets.UTF_8));
-        var descriptor =
-                PublicKeyCredentialDescriptor.builder()
-                        .id(credentialId)
-                        .transports(
-                                Set.of(AuthenticatorTransport.BLE, AuthenticatorTransport.INTERNAL))
-                        .build();
+    @Nested
+    class UserVerificationStringFrom {
+        @Test
+        void getsUserVerificationStringIfItExists() {
+            var assertionRequest =
+                    buildAssertionRequest(Optional.of(UserVerificationRequirement.REQUIRED));
 
-        var result =
-                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
-                        buildAssertionRequest(List.of(descriptor)));
+            var result = PasskeyAuditExtensionsHelper.userVerificationStringFrom(assertionRequest);
 
-        assertEquals(1, result.size());
-        assertEquals(credentialId.getBase64Url(), result.get(0).passkeyCredentialId());
-        // Sets are unordered, so check contents rather than order
-        assertEquals(
-                Set.of("ble", "internal"), Set.copyOf(result.get(0).passkeyCredentialTransports()));
-    }
+            assertEquals("required", result);
+        }
 
-    @Test
-    void shouldSetTransportsToNullWhenAbsent() {
-        var credentialId = new ByteArray("cred-3".getBytes(StandardCharsets.UTF_8));
-        // builder without .transports() leaves transports absent
-        var descriptor = PublicKeyCredentialDescriptor.builder().id(credentialId).build();
+        @Test
+        void getsEmptyStringIfUserRequirementNotOnAssertionRequest() {
+            var assertionRequest = buildAssertionRequest(Optional.empty());
 
-        var result =
-                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
-                        buildAssertionRequest(List.of(descriptor)));
+            var result = PasskeyAuditExtensionsHelper.userVerificationStringFrom(assertionRequest);
 
-        assertEquals(1, result.size());
-        assertNull(result.get(0).passkeyCredentialTransports());
-    }
-
-    @Test
-    void shouldMapMultipleCredentials() {
-        var id1 = new ByteArray("cred-a".getBytes(StandardCharsets.UTF_8));
-        var id2 = new ByteArray("cred-b".getBytes(StandardCharsets.UTF_8));
-        var descriptors =
-                List.of(
-                        PublicKeyCredentialDescriptor.builder()
-                                .id(id1)
-                                .transports(Set.of(AuthenticatorTransport.USB))
-                                .build(),
-                        PublicKeyCredentialDescriptor.builder()
-                                .id(id2)
-                                .transports(Set.of(AuthenticatorTransport.NFC))
-                                .build());
-
-        var result =
-                PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom(
-                        buildAssertionRequest(descriptors));
-
-        assertEquals(2, result.size());
-        assertEquals(
-                new PasskeyAllowCredentials(id1.getBase64Url(), List.of("usb")), result.get(0));
-        assertEquals(
-                new PasskeyAllowCredentials(id2.getBase64Url(), List.of("nfc")), result.get(1));
+            assertEquals("", result);
+        }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -63,7 +63,7 @@ class FinishPasskeyAssertionHandlerTest {
         void shouldReturn200WhenPasskeyAssertionSuccessful() {
             // Given
             AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
                     .thenReturn(Result.success(mockAssertionResult));
 
             // When
@@ -77,7 +77,7 @@ class FinishPasskeyAssertionHandlerTest {
         void shouldReportCorrectPasskeyReceivedWhenAssertionSuccessful() {
             // Given
             AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
                     .thenReturn(Result.success(mockAssertionResult));
 
             // When
@@ -110,7 +110,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReportIncorrectPasskeyReceivedWhenAssertionUnsuccessful() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR));
@@ -126,7 +126,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReturn500WhenAssertionRequestDeserializationFails() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason
@@ -143,7 +143,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReturn400WhenPKCDeserializationFails() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
                     .thenReturn(
                             Result.failure(FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR));
 
@@ -158,7 +158,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReturn401WhenPasskeyAssertionFailed() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -5,37 +5,62 @@ import com.yubico.webauthn.AssertionRequest;
 import com.yubico.webauthn.AssertionResult;
 import com.yubico.webauthn.RelyingParty;
 import com.yubico.webauthn.StartAssertionOptions;
+import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
+import com.yubico.webauthn.data.AuthenticatorTransport;
 import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
 import com.yubico.webauthn.data.PublicKeyCredential;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import com.yubico.webauthn.data.PublicKeyCredentialRequestOptions;
 import com.yubico.webauthn.data.UserVerificationRequirement;
+import com.yubico.webauthn.data.exception.Base64UrlException;
 import com.yubico.webauthn.exception.AssertionFailedException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSuccessful;
+import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 
-public class PasskeyAssertionServiceTest {
+class PasskeyAssertionServiceTest {
     private final RelyingParty relyingParty = mock(RelyingParty.class);
     private final PasskeyJsonParser jsonParser = mock(PasskeyJsonParser.class);
     private PasskeyAssertionService passkeyAssertionService;
+    private static final String CREDENTIAL_ID = "Q6pkKSucKCqDzOuFky3pQAA";
+    private static final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
 
     @BeforeEach
     void setup() {
         passkeyAssertionService =
-                new PasskeyAssertionService(
-                        relyingParty, jsonParser, mock(StructuredAuditService.class));
+                new PasskeyAssertionService(relyingParty, jsonParser, structuredAuditService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reset(structuredAuditService);
     }
 
     @Nested
@@ -76,13 +101,13 @@ public class PasskeyAssertionServiceTest {
             @Test
             @SuppressWarnings("unchecked")
             void shouldReturnAssertionResultIfAssertionSucceeded()
-                    throws IOException, AssertionFailedException {
+                    throws IOException, AssertionFailedException, Base64UrlException {
                 // Given
-                when(jsonParser.parseAssertionRequest(any()))
-                        .thenReturn(mock(AssertionRequest.class));
-                when(jsonParser.parsePublicKeyCredential(any()))
-                        .thenReturn(mock(PublicKeyCredential.class));
-                AssertionResult mockAssertionResult = mock(AssertionResult.class);
+                var assertionRequest = setupAssertionRequest();
+                when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
+                var publicKeyCredential = setupPublicKeyCredential(CREDENTIAL_ID);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
+                AssertionResult mockAssertionResult = setupAnySuccessfulMockAssertionResult();
                 when(mockAssertionResult.isSuccess()).thenReturn(true);
                 when(relyingParty.finishAssertion(any())).thenReturn(mockAssertionResult);
 
@@ -92,6 +117,63 @@ public class PasskeyAssertionServiceTest {
 
                 // Then
                 assertEquals(actualAssertionResult, mockAssertionResult);
+            }
+
+            @Test
+            void shouldEmitAuditEventIfAssertionSucceeded()
+                    throws IOException, AssertionFailedException, Base64UrlException {
+                // Given
+                var signCount = 10;
+                var isBackedUp = false;
+                var isBackupEligible = true;
+                var userVerification = UserVerificationRequirement.REQUIRED;
+                var assertionIsSuccess = true;
+                var allowedCredentialsMap = Map.of(CREDENTIAL_ID, "BLE");
+
+                var assertionRequest =
+                        setupAssertionRequest(allowedCredentialsMap, userVerification);
+                var publicKeyCredential = setupPublicKeyCredential(CREDENTIAL_ID);
+                var assertionResult =
+                        setupMockAssertionResult(
+                                signCount, isBackupEligible, isBackedUp, assertionIsSuccess);
+
+                when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
+                when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
+
+                // When
+                passkeyAssertionService.finishAssertion("", "").getSuccess();
+
+                // Then
+                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
+
+                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+                var capturedAuditEvent = argCaptor.getValue();
+
+                assertEquals(
+                        "AUTH_PASSKEY_VERIFICATION_SUCCESSFUL", capturedAuditEvent.eventName());
+
+                var authPasskeyVerificationSuccessful =
+                        (AuthPasskeyVerificationSuccessful) capturedAuditEvent;
+
+                var expectedPasskeyDetail =
+                        PasskeyDetail.verificationSuccessful(
+                                userVerification.getValue(), signCount, isBackedUp, "multi-device");
+                assertEquals(
+                        expectedPasskeyDetail,
+                        authPasskeyVerificationSuccessful.extensions().passkey());
+
+                assertEquals(
+                        CREDENTIAL_ID,
+                        authPasskeyVerificationSuccessful.restricted().passkeyCredentialId());
+                var restrictedPasskeySection =
+                        new AuthPasskeyVerificationSuccessful.RestrictedPasskeySection(
+                                List.of(
+                                        new PasskeyAllowCredentials(
+                                                CREDENTIAL_ID, List.of("BLE"))));
+                assertEquals(
+                        restrictedPasskeySection,
+                        authPasskeyVerificationSuccessful.restricted().passkey());
             }
         }
 
@@ -112,6 +194,8 @@ public class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR,
                         actualFailureReason);
+
+                verify(structuredAuditService, never()).submitAuditEvent(any());
             }
 
             @Test
@@ -128,6 +212,7 @@ public class PasskeyAssertionServiceTest {
                 // Then
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR, actualFailureReason);
+                verify(structuredAuditService, never()).submitAuditEvent(any());
             }
 
             @Test
@@ -149,6 +234,7 @@ public class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR,
                         actualFailureReason);
+                verify(structuredAuditService, never()).submitAuditEvent(any());
             }
 
             @Test
@@ -172,7 +258,72 @@ public class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR,
                         actualFailureReason);
+                verify(structuredAuditService, never()).submitAuditEvent(any());
             }
         }
+    }
+
+    private static AssertionResult setupAnySuccessfulMockAssertionResult() {
+        return setupMockAssertionResult(10, false, false, true);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static AssertionResult setupMockAssertionResult(
+            long signCount, boolean isBackupEligible, boolean isBackedUp, boolean isSuccess) {
+        var mock = mock(AssertionResult.class);
+        when(mock.getSignatureCount()).thenReturn(signCount);
+        when(mock.isBackupEligible()).thenReturn(isBackupEligible);
+        when(mock.isBackedUp()).thenReturn(isBackedUp);
+        when(mock.isSuccess()).thenReturn(isSuccess);
+        return mock;
+    }
+
+    private static AssertionRequest setupAssertionRequest(
+            Map<String, String> credentials,
+            UserVerificationRequirement userVerificationRequirement) {
+        var assertionRequest = mock(AssertionRequest.class);
+        var publicKeyCredentialRequestOptions = mock(PublicKeyCredentialRequestOptions.class);
+        var allPublicKeyCredentialDescriptors = new ArrayList<PublicKeyCredentialDescriptor>();
+        credentials.forEach(
+                (k, v) -> {
+                    try {
+                        var descriptor =
+                                PublicKeyCredentialDescriptor.builder()
+                                        .id(ByteArray.fromBase64Url(CREDENTIAL_ID))
+                                        .transports(Set.of(AuthenticatorTransport.of(v)))
+                                        .build();
+                        allPublicKeyCredentialDescriptors.add(descriptor);
+                    } catch (Base64UrlException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        when(publicKeyCredentialRequestOptions.getAllowCredentials())
+                .thenReturn(Optional.of(allPublicKeyCredentialDescriptors));
+        when(publicKeyCredentialRequestOptions.getUserVerification())
+                .thenReturn(Optional.of(userVerificationRequirement));
+        when(assertionRequest.getPublicKeyCredentialRequestOptions())
+                .thenReturn(publicKeyCredentialRequestOptions);
+
+        return assertionRequest;
+    }
+
+    private static AssertionRequest setupAssertionRequest() {
+        var assertionRequest = mock(AssertionRequest.class);
+        var publicKeyCredentialRequestOptions = mock(PublicKeyCredentialRequestOptions.class);
+        when(publicKeyCredentialRequestOptions.getAllowCredentials()).thenReturn(Optional.empty());
+        when(publicKeyCredentialRequestOptions.getUserVerification())
+                .thenReturn(Optional.of(UserVerificationRequirement.REQUIRED));
+        when(assertionRequest.getPublicKeyCredentialRequestOptions())
+                .thenReturn(publicKeyCredentialRequestOptions);
+
+        return assertionRequest;
+    }
+
+    private static PublicKeyCredential<
+                    AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
+            setupPublicKeyCredential(String credentialId) throws Base64UrlException {
+        var credential = mock(PublicKeyCredential.class);
+        when(credential.getId()).thenReturn(ByteArray.fromBase64Url(credentialId));
+        return credential;
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationFailed;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSuccessful;
 import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
@@ -37,6 +38,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -240,15 +242,14 @@ class PasskeyAssertionServiceTest {
             @Test
             @SuppressWarnings("unchecked")
             void shouldFailWithAssertionFailedErrorWhenAssertionIsNotSuccessful()
-                    throws IOException, AssertionFailedException {
+                    throws IOException, AssertionFailedException, Base64UrlException {
                 // Given
-                when(jsonParser.parseAssertionRequest(any()))
-                        .thenReturn(mock(AssertionRequest.class));
-                when(jsonParser.parsePublicKeyCredential(any()))
-                        .thenReturn(mock(PublicKeyCredential.class));
-                AssertionResult mockAssertionResult = mock(AssertionResult.class);
-                when(mockAssertionResult.isSuccess()).thenReturn(false);
-                when(relyingParty.finishAssertion(any())).thenReturn(mockAssertionResult);
+                var assertionRequest = setupAssertionRequest();
+                var publicKeyCredential = setupPublicKeyCredential(CREDENTIAL_ID);
+                var assertionResult = setupAnyFailureMockAssertionResult();
+                when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
+                when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
@@ -258,13 +259,80 @@ class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR,
                         actualFailureReason);
-                verify(structuredAuditService, never()).submitAuditEvent(any());
+                verify(structuredAuditService)
+                        .submitAuditEvent(
+                                argThat(
+                                        event ->
+                                                event.eventName()
+                                                        .equals(
+                                                                "AUTH_PASSKEY_VERIFICATION_FAILED")));
+            }
+
+            @Test
+            @SuppressWarnings("unchecked")
+            void shouldEmitVerificationFailedAuditEventWhenAssertionIsNotSuccessful()
+                    throws IOException, AssertionFailedException, Base64UrlException {
+                // Given
+
+                var assertionIsSuccess = false;
+                var signCount = 10;
+                var isBackedUp = false;
+                var isBackupEligible = false;
+                var userVerification = UserVerificationRequirement.PREFERRED;
+                var allowedCredentialsMap = Map.of(CREDENTIAL_ID, "BLE");
+
+                var assertionRequest =
+                        setupAssertionRequest(allowedCredentialsMap, userVerification);
+                var publicKeyCredential = setupPublicKeyCredential(CREDENTIAL_ID);
+                var assertionResult =
+                        setupMockAssertionResult(
+                                signCount, isBackupEligible, isBackedUp, assertionIsSuccess);
+                when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
+                when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
+
+                // When
+                passkeyAssertionService.finishAssertion("", "").getFailure();
+
+                // Then
+                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
+
+                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+                var capturedAuditEvent = argCaptor.getValue();
+
+                assertEquals("AUTH_PASSKEY_VERIFICATION_FAILED", capturedAuditEvent.eventName());
+
+                var authPasskeyVerificationFailed =
+                        (AuthPasskeyVerificationFailed) capturedAuditEvent;
+
+                var expectedPasskeyDetail =
+                        PasskeyDetail.verificationFailed(
+                                userVerification.getValue(),
+                                signCount,
+                                isBackedUp,
+                                "single-device",
+                                "UserVerificationError");
+                assertEquals(
+                        expectedPasskeyDetail,
+                        authPasskeyVerificationFailed.extensions().passkey());
+
+                var restrictedPasskeySection =
+                        new AuthPasskeyVerificationFailed.RestrictedPasskeySection(
+                                List.of(new PasskeyAllowCredentials(CREDENTIAL_ID, List.of("BLE"))),
+                                CREDENTIAL_ID);
+                assertEquals(
+                        restrictedPasskeySection,
+                        authPasskeyVerificationFailed.restricted().passkey());
             }
         }
     }
 
     private static AssertionResult setupAnySuccessfulMockAssertionResult() {
         return setupMockAssertionResult(10, false, false, true);
+    }
+
+    private static AssertionResult setupAnyFailureMockAssertionResult() {
+        return setupMockAssertionResult(10, false, false, false);
     }
 
     @SuppressWarnings("deprecation")

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -12,6 +12,7 @@ import com.yubico.webauthn.exception.AssertionFailedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 
 import java.io.IOException;
@@ -32,7 +33,9 @@ public class PasskeyAssertionServiceTest {
 
     @BeforeEach
     void setup() {
-        passkeyAssertionService = new PasskeyAssertionService(relyingParty, jsonParser);
+        passkeyAssertionService =
+                new PasskeyAssertionService(
+                        relyingParty, jsonParser, mock(StructuredAuditService.class));
     }
 
     @Nested

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationFailed;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSuccessful;
 import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
@@ -44,6 +45,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 
 class PasskeyAssertionServiceTest {
@@ -115,7 +117,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 AssertionResult actualAssertionResult =
-                        passkeyAssertionService.finishAssertion("", "").getSuccess();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AuditContext.emptyAuditContext())
+                                .getSuccess();
 
                 // Then
                 assertEquals(actualAssertionResult, mockAssertionResult);
@@ -144,7 +148,9 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "").getSuccess();
+                passkeyAssertionService
+                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
+                        .getSuccess();
 
                 // Then
                 var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
@@ -157,6 +163,8 @@ class PasskeyAssertionServiceTest {
 
                 var authPasskeyVerificationSuccessful =
                         (AuthPasskeyVerificationSuccessful) capturedAuditEvent;
+
+                assertEquals(EMAIL, authPasskeyVerificationSuccessful.user().email());
 
                 var expectedPasskeyDetail =
                         PasskeyDetail.verificationSuccessful(
@@ -190,7 +198,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "").getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AuditContext.emptyAuditContext())
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -209,7 +219,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "").getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AuditContext.emptyAuditContext())
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -230,7 +242,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "").getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AuditContext.emptyAuditContext())
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -253,7 +267,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "").getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AuditContext.emptyAuditContext())
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -290,9 +306,10 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
                 when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
                 when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
+                var auditContext = AuditContext.emptyAuditContext().withEmail(EMAIL);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "").getFailure();
+                passkeyAssertionService.finishAssertion("", "", auditContext).getFailure();
 
                 // Then
                 var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
@@ -304,6 +321,8 @@ class PasskeyAssertionServiceTest {
 
                 var authPasskeyVerificationFailed =
                         (AuthPasskeyVerificationFailed) capturedAuditEvent;
+
+                assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
 
                 var expectedPasskeyDetail =
                         PasskeyDetail.verificationFailed(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -327,7 +327,7 @@ class PasskeyAssertionServiceTest {
                                 signCount,
                                 isBackedUp,
                                 "single-device",
-                                "UserVerificationError");
+                                "UnknownError");
                 assertEquals(
                         expectedPasskeyDetail,
                         authPasskeyVerificationFailed.extensions().passkey());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSucces
 import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.RestrictedPasskeySection;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 
@@ -173,14 +174,10 @@ class PasskeyAssertionServiceTest {
                         expectedPasskeyDetail,
                         authPasskeyVerificationSuccessful.extensions().passkey());
 
-                assertEquals(
-                        CREDENTIAL_ID,
-                        authPasskeyVerificationSuccessful.restricted().passkeyCredentialId());
                 var restrictedPasskeySection =
-                        new AuthPasskeyVerificationSuccessful.RestrictedPasskeySection(
-                                List.of(
-                                        new PasskeyAllowCredentials(
-                                                CREDENTIAL_ID, List.of("BLE"))));
+                        new RestrictedPasskeySection(
+                                List.of(new PasskeyAllowCredentials(CREDENTIAL_ID, List.of("BLE"))),
+                                CREDENTIAL_ID);
                 assertEquals(
                         restrictedPasskeySection,
                         authPasskeyVerificationSuccessful.restricted().passkey());
@@ -336,7 +333,7 @@ class PasskeyAssertionServiceTest {
                         authPasskeyVerificationFailed.extensions().passkey());
 
                 var restrictedPasskeySection =
-                        new AuthPasskeyVerificationFailed.RestrictedPasskeySection(
+                        new RestrictedPasskeySection(
                                 List.of(new PasskeyAllowCredentials(CREDENTIAL_ID, List.of("BLE"))),
                                 CREDENTIAL_ID);
                 assertEquals(


### PR DESCRIPTION
## What

Emit verification success event from the passkey assertion service when the finish assertion completes successfully.

Emit verification failed event in one of the failure cases - a subsequent PR will cover off the remaining cases.

Note that we have compromised here and emitted events from the service rather than the handler which would be more standard - this is because emitting the events from the handler would require a significant rewrite of the service to return all the information needed to emit the events, a lot of which is private to the finish assertion method.

Future work may improve this.