### PR TITLE
BAU: Detect unsigned requests

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidAuthorizeRequestException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidAuthorizeRequestException.java
@@ -2,11 +2,12 @@ package uk.gov.di.authentication.oidc.exceptions;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public class InvalidAuthenticationRequestException extends Exception {
+public class InvalidAuthorizeRequestException extends Exception {
 
     private final ErrorObject error;
 
-    public InvalidAuthenticationRequestException(ErrorObject error) {
+    public InvalidAuthorizeRequestException(ErrorObject error) {
+        super(error != null ? error.getDescription() : null);
         this.error = error;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -29,7 +29,7 @@ import uk.gov.di.authentication.oidc.entity.ClientRateLimitConfig;
 import uk.gov.di.authentication.oidc.entity.SlidingWindowAlgorithm;
 import uk.gov.di.authentication.oidc.exceptions.AuthenticationAuthorisationRequestException;
 import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
-import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidHttpMethodException;
 import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
 import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
@@ -51,9 +51,7 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
-import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.DocAppSubjectIdHelper;
@@ -330,7 +328,7 @@ public class AuthorisationHandler
                 LOG.info("Validating request object");
                 authRequestError = requestObjectAuthorizeValidator.validate(authRequest);
             }
-        } catch (ClientRedirectUriValidationException | InvalidResponseModeException e) {
+        } catch (InvalidAuthorizeRequestException e) {
             return generateBadRequestResponse(user, e.getMessage(), client.getClientID());
         } catch (ClientSignatureValidationException e) {
             return generateApiGatewayProxyResponse(
@@ -937,7 +935,7 @@ public class AuthorisationHandler
                     error.getClientID() != null ? error.getClientID().getValue() : null);
         } catch (IncorrectRedirectUriException | ClientNotFoundException e) {
             return generateBadRequestResponse(user, e.getMessage(), error.getClientID().getValue());
-        } catch (InvalidAuthenticationRequestException e) {
+        } catch (InvalidAuthorizeRequestException e) {
             return generateErrorResponse(
                     error.getRedirectionURI(),
                     error.getState(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorisationService.java
@@ -4,7 +4,7 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
-import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
 import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
@@ -28,7 +28,7 @@ public class AuthorisationService {
             throws MissingClientIDException,
                     IncorrectRedirectUriException,
                     ClientNotFoundException,
-                    InvalidAuthenticationRequestException,
+                    InvalidAuthorizeRequestException,
                     MissingRedirectUriException {
         if (error.getClientID() == null) {
             throw new MissingClientIDException(error.getErrorObject());
@@ -44,11 +44,11 @@ public class AuthorisationService {
                         .orElseThrow(
                                 () -> new ClientNotFoundException(error.getClientID().getValue()));
 
-        if (client.getRedirectUrls().contains(error.getRedirectionURI().toString())) {
-            throw new InvalidAuthenticationRequestException(error.getErrorObject());
+        if (!client.getRedirectUrls().contains(error.getRedirectionURI().toString())) {
+            LOG.warn("Redirect URI {} is invalid for client", error.getRedirectionURI());
+            throw new IncorrectRedirectUriException(error.getErrorObject());
         }
 
-        LOG.warn("Redirect URI {} is invalid for client", error.getRedirectionURI());
-        throw new IncorrectRedirectUriException(error.getErrorObject());
+        throw new InvalidAuthorizeRequestException(error.getErrorObject());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -233,7 +233,7 @@ public abstract class BaseAuthorizeValidator {
 
             logErrorInProdElseWarn(errorMessage);
             throw new InvalidAuthorizeRequestException(
-                    OAuth2Error.INVALID_REQUEST.setDescription(errorMessage));
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, errorMessage));
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -10,6 +10,7 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.Channel;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
@@ -17,7 +18,6 @@ import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
-import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
@@ -45,7 +45,9 @@ public abstract class BaseAuthorizeValidator {
     }
 
     public abstract Optional<AuthRequestError> validate(AuthenticationRequest authRequest)
-            throws ClientSignatureValidationException, JwksException;
+            throws ClientSignatureValidationException,
+                    InvalidAuthorizeRequestException,
+                    JwksException;
 
     ClientRegistry getClientFromDynamo(String clientId) {
         var client = dynamoClientService.getClient(clientId).orElse(null);
@@ -222,14 +224,16 @@ public abstract class BaseAuthorizeValidator {
         return Optional.empty();
     }
 
-    protected void validateResponseMode(String responseMode) throws InvalidResponseModeException {
+    protected void validateResponseMode(String responseMode)
+            throws InvalidAuthorizeRequestException {
         if (!responseMode.equals(ResponseMode.QUERY.getValue())
                 && !responseMode.equals(ResponseMode.FRAGMENT.getValue())) {
             var errorMessage =
                     String.format("Invalid response mode included in request: %s", responseMode);
 
             logErrorInProdElseWarn(errorMessage);
-            throw new InvalidResponseModeException(errorMessage);
+            throw new InvalidAuthorizeRequestException(
+                    OAuth2Error.INVALID_REQUEST.setDescription(errorMessage));
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -49,7 +49,7 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                     String.format(
                             "Invalid Redirect URI in request %s", authRequest.getRedirectionURI()));
             throw new InvalidAuthorizeRequestException(
-                    OAuth2Error.INVALID_REQUEST.setDescription("Invalid redirect URI"));
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid redirect URI"));
         }
         var redirectURI = authRequest.getRedirectionURI();
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -6,11 +6,10 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.Identifier;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
-import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
-import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 
@@ -18,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
@@ -40,7 +38,7 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
 
     @Override
     public Optional<AuthRequestError> validate(AuthenticationRequest authRequest)
-            throws InvalidResponseModeException {
+            throws InvalidAuthorizeRequestException {
 
         var clientId = authRequest.getClientID().toString();
         attachLogFieldToLogs(CLIENT_ID, clientId);
@@ -50,15 +48,15 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
             logErrorInProdElseWarn(
                     String.format(
                             "Invalid Redirect URI in request %s", authRequest.getRedirectionURI()));
-            throw new ClientRedirectUriValidationException(
-                    format(
-                            "Invalid Redirect in request %s",
-                            authRequest.getRedirectionURI().toString()));
+            throw new InvalidAuthorizeRequestException(
+                    OAuth2Error.INVALID_REQUEST.setDescription("Invalid redirect URI"));
         }
         var redirectURI = authRequest.getRedirectionURI();
 
-        var responseMode = Optional.ofNullable(authRequest.getResponseMode());
-        responseMode.ifPresent(mode -> validateResponseMode(mode.getValue()));
+        var responseMode = authRequest.getResponseMode();
+        if (responseMode != null) {
+            validateResponseMode(responseMode.getValue());
+        }
 
         if (authRequest.getState() == null) {
             logErrorInProdElseWarn("State is missing from authRequest");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -80,7 +80,8 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         } else {
             logErrorInProdElseWarn("Request object JWT was unsigned");
             throw new InvalidAuthorizeRequestException(
-                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_OBJECT_CODE,
                             "Request object JWT must be signed"));
         }
 
@@ -111,7 +112,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                                 "Invalid Redirect URI in request %s",
                                 jwtClaimsSet.getStringClaim("redirect_uri")));
                 throw new InvalidAuthorizeRequestException(
-                        OAuth2Error.INVALID_REQUEST.setDescription("Invalid redirect URI"));
+                        new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid redirect URI"));
             }
 
             var redirectURI = URI.create(jwtClaimsSet.getStringClaim("redirect_uri"));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -10,12 +10,12 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
-import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.serialization.Json;
@@ -32,7 +32,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.ResponseType.CODE;
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static uk.gov.di.authentication.oidc.helpers.RequestObjectToAuthRequestHelper.parseOidcClaims;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
@@ -68,17 +67,25 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
 
     @Override
     public Optional<AuthRequestError> validate(AuthenticationRequest authRequest)
-            throws ClientSignatureValidationException, JwksException {
+            throws ClientSignatureValidationException,
+                    InvalidAuthorizeRequestException,
+                    JwksException {
 
         var clientId = authRequest.getClientID().toString();
         attachLogFieldToLogs(CLIENT_ID, clientId);
         ClientRegistry client = getClientFromDynamo(clientId);
 
-        var signedJWT = (SignedJWT) authRequest.getRequestObject();
-        clientSignatureValidationService.validate(signedJWT, client);
+        if (authRequest.getRequestObject() instanceof SignedJWT signedJWT) {
+            clientSignatureValidationService.validate(signedJWT, client);
+        } else {
+            logErrorInProdElseWarn("Request object JWT was unsigned");
+            throw new InvalidAuthorizeRequestException(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                            "Request object JWT must be signed"));
+        }
 
         try {
-            var jwtClaimsSet = signedJWT.getJWTClaimsSet();
+            var jwtClaimsSet = authRequest.getRequestObject().getJWTClaimsSet();
 
             var expiration = jwtClaimsSet.getExpirationTime();
             if (Objects.isNull(expiration)) {
@@ -103,13 +110,11 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                         String.format(
                                 "Invalid Redirect URI in request %s",
                                 jwtClaimsSet.getStringClaim("redirect_uri")));
-                throw new ClientRedirectUriValidationException(
-                        format(
-                                "Invalid Redirect in request %s",
-                                jwtClaimsSet.getStringClaim("redirect_uri")));
+                throw new InvalidAuthorizeRequestException(
+                        OAuth2Error.INVALID_REQUEST.setDescription("Invalid redirect URI"));
             }
 
-            var redirectURI = URI.create((String) jwtClaimsSet.getClaim("redirect_uri"));
+            var redirectURI = URI.create(jwtClaimsSet.getStringClaim("redirect_uri"));
 
             var responseMode = jwtClaimsSet.getStringClaim("response_mode");
 
@@ -225,7 +230,7 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("ui_locales"))) {
                 try {
-                    String uiLocales = (String) jwtClaimsSet.getClaim("ui_locales");
+                    var uiLocales = jwtClaimsSet.getStringClaim("ui_locales");
                     LangTagUtils.parseLangTagList(uiLocales.split(" "));
                 } catch (ClassCastException | LangTagException e) {
                     logErrorInProdElseWarn(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -56,7 +56,7 @@ import uk.gov.di.authentication.oidc.entity.ClientRateLimitConfig;
 import uk.gov.di.authentication.oidc.entity.RateLimitDecision;
 import uk.gov.di.authentication.oidc.exceptions.AuthenticationAuthorisationRequestException;
 import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
-import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidHttpMethodException;
 import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
 import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
@@ -79,7 +79,6 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.helpers.DocAppSubjectIdHelper;
@@ -644,13 +643,13 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldCallClassifyParseExceptionWhenAuthorisationRequestCannotBeParsed()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
                         MissingRedirectUriException {
             doThrow(
-                            new InvalidAuthenticationRequestException(
+                            new InvalidAuthorizeRequestException(
                                     new com.nimbusds.oauth2.sdk.ParseException(
                                                     "Missing response_type parameter")
                                             .getErrorObject()))
@@ -711,13 +710,13 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldCallClassifyParseExceptionWhenUnrecognisedPromptValue()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
                         MissingRedirectUriException {
             doThrow(
-                            new InvalidAuthenticationRequestException(
+                            new InvalidAuthorizeRequestException(
                                     new com.nimbusds.oauth2.sdk.ParseException(
                                                     "Invalid prompt parameter: Unknown prompt type: unrecognised")
                                             .getErrorObject()))
@@ -739,8 +738,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldValidateRequestObjectWhenJARValidationIsRequired()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldValidateRequestObjectWhenJARValidationIsRequired() throws Exception {
             when(orchestrationAuthorizationService.isJarValidationRequired(any())).thenReturn(true);
 
             var jwtClaimsSet = buildjwtClaimsSet("https://localhost/authorize", null, null);
@@ -761,8 +759,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldValidateRequestObjectWhenJARValidationIsNotRequired()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldValidateRequestObjectWhenJARValidationIsNotRequired() throws Exception {
             when(orchestrationAuthorizationService.isJarValidationRequired(any()))
                     .thenReturn(false);
 
@@ -784,8 +781,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToLoginWhenRequestObjectIsValid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldRedirectToLoginWhenRequestObjectIsValid() throws Exception {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
 
@@ -838,8 +834,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldReturnValidationFailedWhenSignatureIsInvalid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnValidationFailedWhenSignatureIsInvalid() throws Exception {
             when(requestObjectAuthorizeValidator.validate(any()))
                     .thenThrow(ClientSignatureValidationException.class);
 
@@ -862,8 +857,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToLoginWhenMissingNonce()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldRedirectToLoginWhenMissingNonce() throws Exception {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(Optional.empty());
             var jwtClaimsSet =
@@ -925,8 +919,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldReturnServerErrorOnJwksException()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnServerErrorOnJwksException() throws Exception {
             when(requestObjectAuthorizeValidator.validate(any())).thenThrow(JwksException.class);
 
             var jwtClaimsSet = buildjwtClaimsSet("https://localhost/authorize", null, null);
@@ -1706,9 +1699,9 @@ class AuthorisationHandlerTest {
     @Nested
     class InvalidRequestNonRedirecting {
         @Test
-        void shouldReturn400WhenAuthorisationRequestContainsInvalidRedirectUri() {
+        void shouldReturn400WhenAuthorisationRequestContainsInvalidRedirectUri() throws Exception {
             when(queryParamsAuthorizeValidator.validate(any(AuthenticationRequest.class)))
-                    .thenThrow(ClientRedirectUriValidationException.class);
+                    .thenThrow(InvalidAuthorizeRequestException.class);
 
             APIGatewayProxyRequestEvent event =
                     withRequestEvent(
@@ -1746,7 +1739,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldReturn400ForOpenRedirect()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
@@ -1777,7 +1770,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldReturn400WhenMissingClientId()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
@@ -1801,7 +1794,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldReturn400WhenMissingRedirectUri()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
@@ -1826,7 +1819,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldReturn400WhenIncorrectRedirectUri()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
@@ -1857,7 +1850,7 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldReturn400WhenClientNotFound()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
@@ -1945,7 +1938,8 @@ class AuthorisationHandlerTest {
     @Nested
     class InvalidRequestRedirectingErrors {
         @Test
-        void shouldReturn302WithErrorQueryParamsWhenAuthorisationRequestContainsInvalidScope() {
+        void shouldReturn302WithErrorQueryParamsWhenAuthorisationRequestContainsInvalidScope()
+                throws Exception {
             when(queryParamsAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(
                             Optional.of(
@@ -1980,12 +1974,12 @@ class AuthorisationHandlerTest {
 
         @Test
         void shouldReturnRedirectWithErrorWhenInvalidAuthParameters()
-                throws InvalidAuthenticationRequestException,
+                throws InvalidAuthorizeRequestException,
                         ClientNotFoundException,
                         MissingClientIDException,
                         IncorrectRedirectUriException,
                         MissingRedirectUriException {
-            doThrow(new InvalidAuthenticationRequestException(INVALID_REQUEST))
+            doThrow(new InvalidAuthorizeRequestException(INVALID_REQUEST))
                     .when(authorisationService)
                     .classifyParseException(any());
 
@@ -2014,8 +2008,7 @@ class AuthorisationHandlerTest {
         }
 
         @Test
-        void shouldRedirectToRPWhenRequestObjectIsNotValid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldRedirectToRPWhenRequestObjectIsNotValid() throws Exception {
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(
                             Optional.of(
@@ -2163,8 +2156,7 @@ class AuthorisationHandlerTest {
 
         @ParameterizedTest
         @MethodSource("expectedErrorObjects")
-        void shouldReturnErrorWhenRequestObjectIsInvalid(ErrorObject errorObject)
-                throws JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenRequestObjectIsInvalid(ErrorObject errorObject) throws Exception {
             when(orchestrationAuthorizationService.isJarValidationRequired(any())).thenReturn(true);
             when(requestObjectAuthorizeValidator.validate(any(AuthenticationRequest.class)))
                     .thenReturn(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorisationServiceTest.java
@@ -6,7 +6,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.exceptions.IncorrectRedirectUriException;
-import uk.gov.di.authentication.oidc.exceptions.InvalidAuthenticationRequestException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.exceptions.MissingClientIDException;
 import uk.gov.di.authentication.oidc.exceptions.MissingRedirectUriException;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
@@ -94,7 +94,7 @@ class AuthorisationServiceTest {
     void
             classifyParseExceptionShouldReturnInvalidAuthenticationRequestExceptionWhenRedirectUrlIsCorrect() {
         assertThrows(
-                InvalidAuthenticationRequestException.class,
+                InvalidAuthorizeRequestException.class,
                 () ->
                         authorisationService.classifyParseException(
                                 new ParseException(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.oidc.services;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
-import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -23,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.validators.BaseAuthorizeValidator;
 import uk.gov.di.authentication.oidc.validators.QueryParamsAuthorizeValidator;
 import uk.gov.di.orchestration.shared.entity.Channel;
@@ -30,8 +30,6 @@ import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
-import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
-import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
@@ -42,7 +40,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -110,7 +107,8 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateAuthRequestWhenIdentityValuesAreIncludedInVtrAttribute() {
+    void shouldSuccessfullyValidateAuthRequestWhenIdentityValuesAreIncludedInVtrAttribute()
+            throws Exception {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         AuthenticationRequest authRequest =
                 generateAuthRequest(
@@ -135,7 +133,8 @@ class QueryParamsAuthorizeValidatorTest {
 
     @ParameterizedTest
     @MethodSource("invalidVtrAttributes")
-    void shouldReturnErrorWhenInvalidVtrAttributeIsSentInRequest(String invalidVtrAttribute) {
+    void shouldReturnErrorWhenInvalidVtrAttributeIsSentInRequest(String invalidVtrAttribute)
+            throws Exception {
         AuthenticationRequest authRequest =
                 generateAuthRequest(
                         REDIRECT_URI.toString(),
@@ -164,7 +163,8 @@ class QueryParamsAuthorizeValidatorTest {
 
     @ParameterizedTest
     @MethodSource("invalidChannelAttributes")
-    void shouldReturnErrorWhenInvalidChannelIsSentInRequest(String invalidChannel) {
+    void shouldReturnErrorWhenInvalidChannelIsSentInRequest(String invalidChannel)
+            throws Exception {
         AuthenticationRequest authRequest =
                 generateAuthRequest(
                         REDIRECT_URI.toString(),
@@ -193,7 +193,8 @@ class QueryParamsAuthorizeValidatorTest {
 
     @ParameterizedTest
     @MethodSource("validChannelAttributes")
-    void shouldSuccessfullyValidateWhenValidChannelIsSentInRequest(String validChannel) {
+    void shouldSuccessfullyValidateWhenValidChannelIsSentInRequest(String validChannel)
+            throws Exception {
         AuthenticationRequest authRequest =
                 generateAuthRequest(
                         REDIRECT_URI.toString(),
@@ -208,7 +209,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateWhenNoChannelIsSentInRequest() {
+    void shouldSuccessfullyValidateWhenNoChannelIsSentInRequest() throws Exception {
         AuthenticationRequest authRequest =
                 generateAuthRequest(
                         REDIRECT_URI.toString(),
@@ -223,7 +224,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateAuthRequest() {
+    void shouldSuccessfullyValidateAuthRequest() throws Exception {
         var errorObject =
                 queryParamsAuthorizeValidator.validate(
                         generateAuthRequest(
@@ -238,7 +239,8 @@ class QueryParamsAuthorizeValidatorTest {
 
     @ParameterizedTest
     @MethodSource("validClaims")
-    void shouldSuccessfullyValidateAuthRequestWhenValidClaimsArePresent(String validClaim) {
+    void shouldSuccessfullyValidateAuthRequestWhenValidClaimsArePresent(String validClaim)
+            throws Exception {
         var clientRegistry =
                 new ClientRegistry()
                         .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
@@ -262,7 +264,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenValidatingAuthRequestWhichContainsInvalidClaims() {
+    void shouldReturnErrorWhenValidatingAuthRequestWhichContainsInvalidClaims() throws Exception {
         var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         AuthenticationRequest authRequest =
@@ -285,7 +287,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldAcceptEmptyClaimsObject() throws ParseException {
+    void shouldAcceptEmptyClaimsObject() throws Exception {
         var authRequest =
                 AuthenticationRequest.parse(
                         "client_id="
@@ -298,7 +300,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateAccountManagementAuthRequest() {
+    void shouldSuccessfullyValidateAccountManagementAuthRequest() throws Exception {
         Scope accountManagementScope =
                 new Scope(OIDCScopeValue.OPENID, CustomScopeValue.ACCOUNT_MANAGEMENT);
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
@@ -319,7 +321,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorForAccountManagementAuthRequestWhenScopeNotInClient() {
+    void shouldReturnErrorForAccountManagementAuthRequestWhenScopeNotInClient() throws Exception {
         Scope accountManagementScope =
                 new Scope(OIDCScopeValue.OPENID, CustomScopeValue.ACCOUNT_MANAGEMENT);
         var errorObject =
@@ -335,7 +337,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenClientIdIsNotValidInAuthRequest() {
+    void shouldReturnErrorWhenClientIdIsNotValidInAuthRequest() throws Exception {
         when(dynamoClientService.getClient(CLIENT_ID.toString())).thenReturn(Optional.empty());
         var runtimeException =
                 assertThrows(
@@ -352,7 +354,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenResponseTypeIsNotValidInAuthRequest() {
+    void shouldReturnErrorWhenResponseTypeIsNotValidInAuthRequest() throws Exception {
         ResponseType invalidResponseType =
                 new ResponseType(ResponseType.Value.TOKEN, ResponseType.Value.CODE);
         var errorObject =
@@ -366,7 +368,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenScopeIsNotValidInAuthRequest() {
+    void shouldReturnErrorWhenScopeIsNotValidInAuthRequest() throws Exception {
         Scope invalidScopes = new Scope();
         invalidScopes.add(OIDCScopeValue.OPENID);
         invalidScopes.add(OIDCScopeValue.EMAIL);
@@ -381,7 +383,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenStateIsNotIncludedInAuthRequest() {
+    void shouldReturnErrorWhenStateIsNotIncludedInAuthRequest() throws Exception {
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 VALID_RESPONSE_TYPE,
@@ -403,7 +405,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateWhenNonceNotExpectedAndMissing() {
+    void shouldSuccessfullyValidateWhenNonceNotExpectedAndMissing() throws Exception {
         var clientRegitry =
                 generateClientRegistry(REDIRECT_URI.toString(), CLIENT_ID.toString())
                         .withPermitMissingNonce(true)
@@ -424,7 +426,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenNonceIsExpectedAndMissing() {
+    void shouldReturnErrorWhenNonceIsExpectedAndMissing() throws Exception {
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 VALID_RESPONSE_TYPE,
@@ -468,7 +470,7 @@ class QueryParamsAuthorizeValidatorTest {
     @ParameterizedTest
     @MethodSource("requestVtrsNotPermitted")
     void shouldReturnErrorWhenVtrInAuthRequestIsNotPermittedForGivenClient(
-            List<String> clientLoCs, String vtr) {
+            List<String> clientLoCs, String vtr) throws Exception {
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
                 .thenReturn(
                         Optional.of(
@@ -496,7 +498,8 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void validatorReturnsErrorWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse() {
+    void validatorReturnsErrorWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse()
+            throws Exception {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         List<String> clientLoCs = List.of("P0", "P2");
         var vtr = jsonArrayOf("Cl.Cm.P2");
@@ -531,7 +534,8 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void validatorErrorsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod() {
+    void validatorErrorsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod()
+            throws Exception {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         List<String> clientLoCs = List.of("P0", "P2");
         var vtr = jsonArrayOf("Cl.Cm.P2");
@@ -567,7 +571,8 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldNotReturnErrorWhenPkceIsNotEnforcedAndCodeChallengeAndMethodAreMissing() {
+    void shouldNotReturnErrorWhenPkceIsNotEnforcedAndCodeChallengeAndMethodAreMissing()
+            throws Exception {
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
                                 VALID_RESPONSE_TYPE,
@@ -584,7 +589,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenPkceIsEnforcedAndCodeChallengeMissing() {
+    void shouldReturnErrorWhenPkceIsEnforcedAndCodeChallengeMissing() throws Exception {
         var clientRegistry = generateClientRegistry(REDIRECT_URI.toString(), CLIENT_ID.toString());
         clientRegistry.setPKCEEnforced(true);
         when(dynamoClientService.getClient(CLIENT_ID.getValue()))
@@ -615,8 +620,7 @@ class QueryParamsAuthorizeValidatorTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsMissing()
-            throws ParseException {
+    void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsMissing() throws Exception {
 
         var codeChallenge = CodeChallenge.parse("aCodeChallenge");
 
@@ -646,8 +650,7 @@ class QueryParamsAuthorizeValidatorTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsInvalid()
-            throws ParseException {
+    void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsInvalid() throws Exception {
 
         var codeChallenge = CodeChallenge.parse("aCodeChallenge");
         var codeChallengeMethod = CodeChallengeMethod.PLAIN;
@@ -678,7 +681,7 @@ class QueryParamsAuthorizeValidatorTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void shouldNotReturnErrorWhenPkceCodeChallengeAndMethodAreValid() throws ParseException {
+    void shouldNotReturnErrorWhenPkceCodeChallengeAndMethodAreValid() throws Exception {
         var codeChallenge = CodeChallenge.parse("aCodeChallenge");
         var codeChallengeMethod = CodeChallengeMethod.S256;
 
@@ -699,7 +702,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenIdentityIsRequiredButNoIPVCapacityIsAvailable() {
+    void shouldReturnErrorWhenIdentityIsRequiredButNoIPVCapacityIsAvailable() throws Exception {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(false);
         var authRequest =
                 new AuthenticationRequest.Builder(
@@ -717,7 +720,8 @@ class QueryParamsAuthorizeValidatorTest {
 
     @Test
     void
-            shouldNotReturnErrorWhenIdentityIsRequiredButNoIPVCapacityIsAvailableAndTheClientIsATestClient() {
+            shouldNotReturnErrorWhenIdentityIsRequiredButNoIPVCapacityIsAvailableAndTheClientIsATestClient()
+                    throws Exception {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(false);
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
                 .thenReturn(
@@ -752,19 +756,17 @@ class QueryParamsAuthorizeValidatorTest {
 
         var exception =
                 assertThrows(
-                        ClientRedirectUriValidationException.class,
+                        InvalidAuthorizeRequestException.class,
                         () ->
                                 queryParamsAuthorizeValidator.validate(
                                         generateAuthRequest(
                                                 redirectUri, VALID_RESPONSE_TYPE, VALID_SCOPES)),
                         "Expected to throw exception");
-        assertThat(
-                exception.getMessage(),
-                equalTo(format("Invalid Redirect in request %s", redirectUri)));
+        assertThat(exception.getMessage(), equalTo("Invalid redirect URI"));
     }
 
     @Test
-    void shouldReturnErrorWhenRequestURIIsPresent() {
+    void shouldReturnErrorWhenRequestURIIsPresent() throws Exception {
         var authenticationRequest =
                 new AuthenticationRequest.Builder(
                                 VALID_RESPONSE_TYPE, VALID_SCOPES, CLIENT_ID, REDIRECT_URI)
@@ -782,7 +784,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenMaxAgeIsInvalid() {
+    void shouldReturnErrorWhenMaxAgeIsInvalid() throws Exception {
         AuthenticationRequest.Builder authRequestBuilder =
                 new AuthenticationRequest.Builder(
                                 VALID_RESPONSE_TYPE, VALID_SCOPES, CLIENT_ID, REDIRECT_URI)
@@ -811,7 +813,7 @@ class QueryParamsAuthorizeValidatorTest {
                         .responseMode(new ResponseMode("code"));
 
         assertThrows(
-                InvalidResponseModeException.class,
+                InvalidAuthorizeRequestException.class,
                 () -> queryParamsAuthorizeValidator.validate(authRequestBuilder.build()));
     }
 
@@ -825,13 +827,13 @@ class QueryParamsAuthorizeValidatorTest {
                         .responseMode(new ResponseMode("code"));
 
         assertThrows(
-                InvalidResponseModeException.class,
+                InvalidAuthorizeRequestException.class,
                 () -> queryParamsAuthorizeValidator.validate(authRequestBuilder.build()));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"query", "fragment"})
-    void shouldAllowValidResponseModes(String responseMode) {
+    void shouldAllowValidResponseModes(String responseMode) throws Exception {
         AuthenticationRequest.Builder authRequestBuilder =
                 new AuthenticationRequest.Builder(
                                 VALID_RESPONSE_TYPE, VALID_SCOPES, CLIENT_ID, REDIRECT_URI)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.oidc.exceptions.InvalidAuthorizeRequestException;
 import uk.gov.di.authentication.oidc.validators.BaseAuthorizeValidator;
 import uk.gov.di.authentication.oidc.validators.RequestObjectAuthorizeValidator;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
@@ -33,9 +34,7 @@ import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.PublicKeySource;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
-import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
-import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
 import uk.gov.di.orchestration.shared.services.ClientSignatureValidationService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -111,8 +110,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateWithDefaultClaimSet()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldSuccessfullyValidateWithDefaultClaimSet() throws Exception {
         var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
@@ -130,7 +128,7 @@ class RequestObjectAuthorizeValidatorTest {
 
         @Test
         void shouldSuccessfullyValidateWhenVtrIsPresentAndVtrIsPermittedForClient()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+                throws Exception {
             when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("vtr", List.of("P2.Cl.Cm")).build();
@@ -142,8 +140,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenVtrIsPresentAndVtrIsNotPermittedForClient()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenVtrIsPresentAndVtrIsNotPermittedForClient() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("vtr", jsonArrayOf("Cl.Cm.P3")).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -161,8 +158,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void validatorReturnsErrorWhenCannotParseVtr()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void validatorReturnsErrorWhenCannotParseVtr() throws Exception {
             var invalidVtr = false;
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().claim("vtr", invalidVtr).build();
 
@@ -182,7 +178,7 @@ class RequestObjectAuthorizeValidatorTest {
 
         @Test
         void validatorReturnsErrorWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+                throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("vtr", jsonArrayOf("Cl.Cm.P2")).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -215,7 +211,7 @@ class RequestObjectAuthorizeValidatorTest {
 
         @Test
         void validatorErrorsWhenIdentityJourneyRequestedWithInsufficientlySecureTokenAuthMethod()
-                throws ClientSignatureValidationException, JwksException, JOSEException {
+                throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("vtr", jsonArrayOf("Cl.Cm.P2")).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -252,8 +248,7 @@ class RequestObjectAuthorizeValidatorTest {
     @Nested
     class MaxAgeClaim {
         @Test
-        void shouldSuccessfullyValidateWhenMaxAgeIsNumerical()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldSuccessfullyValidateWhenMaxAgeIsNumerical() throws Exception {
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().claim("max_age", 1800).build();
             var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
@@ -263,8 +258,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenMaxAgeIsString()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenMaxAgeIsString() throws Exception {
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().claim("max_age", "-5").build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
             var requestObjectError = validator.validate(authRequest);
@@ -277,8 +271,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenMaxAgeIsInvalidString()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenMaxAgeIsInvalidString() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("max_age", "NotANumber").build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -292,8 +285,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenMaxAgeIsNegativeInteger()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenMaxAgeIsNegativeInteger() throws Exception {
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().claim("max_age", -5).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
             var requestObjectError = validator.validate(authRequest);
@@ -316,7 +308,7 @@ class RequestObjectAuthorizeValidatorTest {
                             .build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
             assertThrows(
-                    ClientRedirectUriValidationException.class,
+                    InvalidAuthorizeRequestException.class,
                     () -> validator.validate(authRequest),
                     "Expected to throw exception");
         }
@@ -335,7 +327,7 @@ class RequestObjectAuthorizeValidatorTest {
                             .build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
             assertThrows(
-                    ClientRedirectUriValidationException.class,
+                    InvalidAuthorizeRequestException.class,
                     () -> validator.validate(authRequest),
                     "Expected to throw exception");
         }
@@ -356,8 +348,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenClientTypeIsNotAppOrWeb()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenClientTypeIsNotAppOrWeb() throws Exception {
             var clientRegistry =
                     generateClientRegistry(
                             "not-app-or-web",
@@ -380,8 +371,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenClientIDIsInvalid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenClientIDIsInvalid() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("client_id", "invalid-client-id").build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -399,8 +389,7 @@ class RequestObjectAuthorizeValidatorTest {
     @Nested
     class ResponseTypeClaim {
         @Test
-        void shouldReturnErrorWhenResponseTypeIsInvalidInJWTClaimSet()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenResponseTypeIsInvalidInJWTClaimSet() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder()
                             .claim("response_type", ResponseType.CODE_IDTOKEN.toString())
@@ -417,8 +406,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenResponseTypeIsInvalidInQueryParams()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenResponseTypeIsInvalidInQueryParams() throws Exception {
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().build();
             var authRequest =
                     new AuthenticationRequest.Builder(
@@ -445,8 +433,7 @@ class RequestObjectAuthorizeValidatorTest {
     class ScopeClaim {
 
         @Test
-        void shouldReturnErrorWhenScopeIsUnsupported()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenScopeIsUnsupported() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("scope", "openid profile").build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -459,8 +446,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenClientHasNotRegisteredDocAppScope()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenClientHasNotRegisteredDocAppScope() throws Exception {
             var clientRegistry =
                     generateClientRegistry(
                             ClientType.APP.getValue(), new Scope(OIDCScopeValue.OPENID.getValue()));
@@ -479,8 +465,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenAuthRequestContainsInvalidScope()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenAuthRequestContainsInvalidScope() throws Exception {
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().build();
             var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
@@ -497,8 +482,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenUnregisteredScope()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenUnregisteredScope() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("scope", "openid email").build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -518,7 +502,8 @@ class RequestObjectAuthorizeValidatorTest {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("response_mode", "code").build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
-            assertThrows(InvalidResponseModeException.class, () -> validator.validate(authRequest));
+            assertThrows(
+                    InvalidAuthorizeRequestException.class, () -> validator.validate(authRequest));
         }
 
         @Test
@@ -537,13 +522,14 @@ class RequestObjectAuthorizeValidatorTest {
                             .issuer(CLIENT_ID.getValue())
                             .build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
-            assertThrows(InvalidResponseModeException.class, () -> validator.validate(authRequest));
+            assertThrows(
+                    InvalidAuthorizeRequestException.class, () -> validator.validate(authRequest));
         }
 
         @ParameterizedTest
         @ValueSource(strings = {"query", "fragment"})
         void shouldValidateSuccessfullyWhenResponseModeIsValid(String responseMode)
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+                throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("response_mode", responseMode).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -557,7 +543,7 @@ class RequestObjectAuthorizeValidatorTest {
     class Pkce {
         @Test
         void shouldNotReturnErrorWhenPkceIsNotEnforcedAndCodeChallengeAndMethodAreMissing()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+                throws Exception {
 
             var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -568,8 +554,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenPkceIsEnforcedAndCodeChallengeMissing()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenPkceIsEnforcedAndCodeChallengeMissing() throws Exception {
             var clientRegistry =
                     generateClientRegistry(
                             ClientType.APP.getValue(),
@@ -596,8 +581,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsMissing()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsMissing() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder()
                             .claim("code_challenge", PKCE_CODE_CHALLENGE)
@@ -619,8 +603,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsInvalid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenPkceCodeChallengeMethodIsExpectedAndIsInvalid() throws Exception {
             var invalidCodeChallengeMethod = CodeChallengeMethod.PLAIN.getValue();
 
             var jwtClaimsSet =
@@ -646,8 +629,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldValidateSuccessfullyWhenPkceCodeChallengeAndMethodAreValid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldValidateSuccessfullyWhenPkceCodeChallengeAndMethodAreValid() throws Exception {
             var codeChallengeMethod = CodeChallengeMethod.S256.getValue();
 
             var jwtClaimsSet =
@@ -666,8 +648,7 @@ class RequestObjectAuthorizeValidatorTest {
     @Nested
     class LoginHintClaim {
         @Test
-        void shouldValidateSuccessfullyWhenLoginHintIsValid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldValidateSuccessfullyWhenLoginHintIsValid() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("login_hint", VALID_LOGIN_HINT).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -678,8 +659,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenLoginHintIsInvalid()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenLoginHintIsInvalid() throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("login_hint", INVALID_LOGIN_HINT).build();
             var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -702,8 +682,7 @@ class RequestObjectAuthorizeValidatorTest {
     @Nested
     class ClaimsJson {
         @Test
-        void shouldReturnErrorWhenUnknownClaimsInJsonString()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenUnknownClaimsInJsonString() throws Exception {
             var claimSet =
                     new OIDCClaimsRequest()
                             .withUserInfoClaimsRequest(
@@ -728,8 +707,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenClaimsNotSupportedByClientInJsonString()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenClaimsNotSupportedByClientInJsonString() throws Exception {
             var claimSet =
                     new OIDCClaimsRequest()
                             .withUserInfoClaimsRequest(
@@ -754,8 +732,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenUnknownClaimsInJsonObject()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenUnknownClaimsInJsonObject() throws Exception {
             var claimSet =
                     new OIDCClaimsRequest()
                             .withUserInfoClaimsRequest(
@@ -780,8 +757,7 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void shouldReturnErrorWhenClaimsNotSupportedByClientInJsonObject()
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenClaimsNotSupportedByClientInJsonObject() throws Exception {
             var claimSet =
                     new OIDCClaimsRequest()
                             .withUserInfoClaimsRequest(
@@ -817,8 +793,7 @@ class RequestObjectAuthorizeValidatorTest {
 
         @ParameterizedTest
         @MethodSource("invalidChannelAttributes")
-        void shouldReturnErrorWhenChannelIsInvalid(String invalidChannel)
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldReturnErrorWhenChannelIsInvalid(String invalidChannel) throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("channel", invalidChannel).build();
             var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -841,8 +816,7 @@ class RequestObjectAuthorizeValidatorTest {
 
         @ParameterizedTest
         @MethodSource("validChannelAttributes")
-        void shouldSuccessfullyValidateWhenChannelIsValid(String validChannel)
-                throws JOSEException, JwksException, ClientSignatureValidationException {
+        void shouldSuccessfullyValidateWhenChannelIsValid(String validChannel) throws Exception {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("channel", validChannel).build();
             var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -853,8 +827,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenAudienceIsInvalid()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenAudienceIsInvalid() throws Exception {
         var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().audience("invalid-audience").build();
 
         var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
@@ -867,8 +840,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenIssuerIsInvalid()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenIssuerIsInvalid() throws Exception {
         var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().issuer("invalid-client").build();
         var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = validator.validate(authRequest);
@@ -881,8 +853,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenRequestClaimIsPresentInJwt()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenRequestClaimIsPresentInJwt() throws Exception {
         var jwtClaimsSet =
                 getDefaultJWTClaimsSetBuilder()
                         .claim("request", "some-random-request-value")
@@ -898,8 +869,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenRequestUriClaimIsPresentInJwt()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenRequestUriClaimIsPresentInJwt() throws Exception {
         var jwtClaimsSet =
                 getDefaultJWTClaimsSetBuilder()
                         .claim("request_uri", URI.create("https://localhost/request_uri"))
@@ -929,8 +899,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenStateIsMissing()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenStateIsMissing() throws Exception {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -955,8 +924,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldSuccessfullyValidateWhenNonceNotExpectedAndMissing()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldSuccessfullyValidateWhenNonceNotExpectedAndMissing() throws Exception {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         var clientRegistry =
                 generateClientRegistry(
@@ -998,8 +966,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenNonceIsExpectedAndMissing()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenNonceIsExpectedAndMissing() throws Exception {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(OIDC_BASE_AUTHORIZE_URI.toString())
@@ -1024,8 +991,7 @@ class RequestObjectAuthorizeValidatorTest {
     }
 
     @Test
-    void shouldReturnErrorWhenUILocalesIsInvalid()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
+    void shouldReturnErrorWhenUILocalesIsInvalid() throws Exception {
         var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().claim("ui_locales", "123456").build();
         var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = validator.validate(authRequest);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.oidc.services;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -1000,6 +1001,22 @@ class RequestObjectAuthorizeValidatorTest {
         assertThat(requestObjectError.get().errorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
         assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
         assertEquals(STATE, requestObjectError.get().state());
+    }
+
+    @Test
+    void shouldThrowErrorWhenPassedPlainJWT() {
+        var authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                new Scope(OIDCScopeValue.OPENID),
+                                CLIENT_ID,
+                                URI.create(REDIRECT_URI))
+                        .state(STATE)
+                        .nonce(new Nonce())
+                        .requestObject(new PlainJWT(getDefaultJWTClaimsSetBuilder().build()))
+                        .build();
+
+        assertThrows(InvalidAuthorizeRequestException.class, () -> validator.validate(authRequest));
     }
 
     private ClientRegistry generateClientRegistry(String clientType, Scope scope) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientRedirectUriValidationException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/ClientRedirectUriValidationException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.orchestration.shared.exceptions;
-
-public class ClientRedirectUriValidationException extends RuntimeException {
-    public ClientRedirectUriValidationException(String message) {
-        super(message);
-    }
-}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidResponseModeException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidResponseModeException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.orchestration.shared.exceptions;
-
-public class InvalidResponseModeException extends RuntimeException {
-    public InvalidResponseModeException(String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
### Wider context of change

Today, unsigned requests cause a `ClassCastException` when the code assumes a `SignedJWT`.

### What’s changed

- Consolidate fatal request validation exceptions into `InvalidAuthorizeRequestException`s
- Add a check for the JWT type and throw an `InvalidAuthorizeRequestException` if unsigned.
