### PR TITLE
ATO-2593: Send some anomaly alerts to 2nd line

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -8240,7 +8240,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8285,7 +8285,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8374,7 +8374,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8417,7 +8417,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8460,7 +8460,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8503,7 +8503,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8547,7 +8547,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8591,7 +8591,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8635,7 +8635,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8679,7 +8679,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8809,7 +8809,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8854,7 +8854,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8898,7 +8898,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8941,7 +8941,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1
@@ -8984,7 +8984,7 @@ Resources:
         - !If
           - IsNotProduction
           - !Ref SlackEvents
-          - !Ref OrchProdSlackEvents
+          - !Ref SecondLineSlackEvents
       ComparisonOperator: GreaterThanUpperThreshold
       EvaluationPeriods: 3
       ThresholdMetricId: ad1


### PR DESCRIPTION
### What’s changed

This PR updates the following error anomaly alarms to notify 2nd line instead of the orch prod alerts channel:
- `FetchJwksErrorAnomalyAlarm`
- `OpenIdConfigurationErrorAnomalyAlarm`
- `DocAppCallbackErrorAnomalyAlarm`
- `TokenFunctionErrorAnomalyAlarm`
- `LogoutFunctionErrorAnomalyAlarm`
- `AuthenticationCallbackFunctionErrorAnomalyAlarm`
- `JwksFunctionErrorAnomalyAlarm`
- `AuthorisationFunctionErrorAnomalyAlarm`
- `UserInfoFunctionErrorAnomalyAlarm`
- `AuthCodeFunctionErrorAnomalyAlarm`
- `IpvCallbackFunctionErrorAnomalyAlarm`
- `SpotResponseFunctionErrorAnomalyAlarm`
- `StorageTokenJwkFunctionErrorAnomalyAlarm`
- `IpvJwksFunctionErrorAnomalyAlarm`
- `AuthJwksFunctionErrorAnomalyAlarm`

### Testing

We already have alarms sent to 2nd line using the SecondLineSlackEvents SNS topic so this should be fine!

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

