### PR TITLE
AUT-5522: Stop sending mfaRequired login handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 public record LoginResponse(
         @SerializedName("redactedPhoneNumber") @Expose String redactedPhoneNumber,
-        @SerializedName("mfaRequired") @Expose @Required boolean mfaRequired,
         @SerializedName(value = "latestTermsAndConditionsAccepted") @Expose @Required
                 boolean latestTermsAndConditionsAccepted,
         @SerializedName("mfaMethodType") @Expose @Required MFAMethodType mfaMethodType,
@@ -28,7 +27,6 @@ public record LoginResponse(
             boolean passwordChangeRequired) {
         this(
                 redactedPhoneNumber,
-                mfaDetail.isMfaRequired(),
                 latestTermsAndConditionsAccepted,
                 mfaDetail.mfaMethodType(),
                 mfaDetail.mfaMethodVerified(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -197,11 +197,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 authSession.setInternalCommonSubjectId(internalCommonSubjectId);
                 var userCredentials =
                         authenticationService.getUserCredentialsFromEmail(emailAddress);
-                userMfaDetail =
-                        getUserMFADetail(
-                                authSession.getRequestedCredentialStrength(),
-                                userCredentials,
-                                userProfile.get());
+                userMfaDetail = getUserMFADetail(userCredentials, userProfile.get());
                 auditContext = auditContext.withSubjectId(internalCommonSubjectId);
 
                 needsForcedMFAResetAfterMFACheck =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.frontendapi.errormapper.DecisionErrorMapper;
 import uk.gov.di.authentication.frontendapi.errormapper.ForbiddenReasonErrorMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ReauthMetadataBuilder;
 import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
+import uk.gov.di.authentication.shared.conditions.MfaHelper;
 import uk.gov.di.authentication.shared.conditions.TermsAndConditionsHelper;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.domain.CloudwatchMetrics;
@@ -303,11 +304,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             JourneyType journeyType,
             PermissionContext permissionContext) {
 
-        var userMfaDetail =
-                getUserMFADetail(
-                        authSessionItem.getRequestedCredentialStrength(),
-                        userCredentials,
-                        userProfile);
+        var userMfaDetail = getUserMFADetail(userCredentials, userProfile);
+        var isMfaRequired = MfaHelper.mfaRequired(authSessionItem.getRequestedCredentialStrength());
 
         boolean isPasswordChangeRequired = isPasswordResetRequired(request.getPassword());
 
@@ -327,7 +325,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         auditService.submitAuditEvent(
                 AUTH_LOG_IN_SUCCESS, auditContext, pairs.toArray(AuditService.MetadataPair[]::new));
         var clientId = userContext.getAuthSession().getClientId();
-        if (!userMfaDetail.isMfaRequired()) {
+        if (!isMfaRequired) {
             cloudwatchMetricsService.incrementAuthenticationSuccessWithoutMfa(
                     AuthSessionItem.AccountState.EXISTING,
                     clientId,
@@ -381,7 +379,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         var defaultMfaMethodMaybe =
                 MFAMethodsService.getMfaMethodOrDefaultMfaMethod(retrievedMfaMethods, null, null);
 
-        if (userMfaDetail.isMfaRequired()) {
+        if (isMfaRequired) {
             if (defaultMfaMethodMaybe.isPresent()) {
                 var permissionContextBuilder = PermissionContext.builder().from(permissionContext);
                 permissionContextBuilder.withE164FormattedPhoneNumber(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelperTest.java
@@ -25,12 +25,10 @@ class FrontendApiPhoneNumberHelperTest {
     private static Stream<Arguments> userMfaDetail() {
         return Stream.of(
                 Arguments.of(UserMfaDetail.noMfa(), null),
-                Arguments.of(new UserMfaDetail(false, false, MFAMethodType.SMS, ""), null),
-                Arguments.of(
-                        new UserMfaDetail(false, false, MFAMethodType.AUTH_APP, "123456789"), null),
-                Arguments.of(
-                        new UserMfaDetail(false, false, MFAMethodType.SMS, "123456789"), "789"),
-                Arguments.of(new UserMfaDetail(false, false, MFAMethodType.SMS, "12"), null));
+                Arguments.of(new UserMfaDetail(false, MFAMethodType.SMS, ""), null),
+                Arguments.of(new UserMfaDetail(false, MFAMethodType.AUTH_APP, "123456789"), null),
+                Arguments.of(new UserMfaDetail(false, MFAMethodType.SMS, "123456789"), "789"),
+                Arguments.of(new UserMfaDetail(false, MFAMethodType.SMS, "12"), null));
     }
 
     @ParameterizedTest

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -533,7 +533,6 @@ class LoginHandlerTest {
                         new LoginResponse(
                                 expectedRedactedPhoneNumber,
                                 true,
-                                true,
                                 SMS,
                                 true,
                                 List.of(
@@ -547,7 +546,6 @@ class LoginHandlerTest {
                         DEFAULT_AUTH_APP_MFA_METHOD,
                         new LoginResponse(
                                 null,
-                                true,
                                 true,
                                 AUTH_APP,
                                 true,
@@ -601,7 +599,6 @@ class LoginHandlerTest {
                         new LoginResponse(
                                 expectedRedactedPhoneNumber,
                                 true,
-                                true,
                                 SMS,
                                 true,
                                 List.of(
@@ -617,7 +614,6 @@ class LoginHandlerTest {
                         new LoginResponse(
                                 null,
                                 true,
-                                true,
                                 AUTH_APP,
                                 true,
                                 List.of(
@@ -631,7 +627,6 @@ class LoginHandlerTest {
                         List.of(DEFAULT_SMS_MFA_METHOD),
                         new LoginResponse(
                                 expectedRedactedPhoneNumber,
-                                true,
                                 true,
                                 SMS,
                                 true,
@@ -647,7 +642,6 @@ class LoginHandlerTest {
                         List.of(DEFAULT_AUTH_APP_MFA_METHOD),
                         new LoginResponse(
                                 null,
-                                true,
                                 true,
                                 AUTH_APP,
                                 true,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -177,7 +177,6 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
             var loginResponse = objectMapper.readValue(response.getBody(), LoginResponse.class);
 
-            assertThat(loginResponse.mfaRequired(), equalTo(level != LOW_LEVEL));
             assertThat(
                     loginResponse.latestTermsAndConditionsAccepted(),
                     equalTo(termsAndConditionsVersion.equals(CURRENT_TERMS_AND_CONDITIONS)));
@@ -266,7 +265,6 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
             var loginResponse = objectMapper.readValue(response.getBody(), LoginResponse.class);
 
-            assertThat(loginResponse.mfaRequired(), equalTo(level != LOW_LEVEL));
             assertThat(
                     loginResponse.latestTermsAndConditionsAccepted(),
                     equalTo(termsAndConditionsVersion.equals(CURRENT_TERMS_AND_CONDITIONS)));
@@ -373,7 +371,6 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             assertThat(response, hasStatus(200));
 
             var loginResponse = objectMapper.readValue(response.getBody(), LoginResponse.class);
-            assertThat(loginResponse.mfaRequired(), equalTo(true));
             assertThat(loginResponse.mfaMethodType(), equalTo(SMS));
             assertThat(loginResponse.mfaMethodVerified(), equalTo(true));
             assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_LOG_IN_SUCCESS));

--- a/shared/src/main/java/uk/gov/di/authentication/entity/UserMfaDetail.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/UserMfaDetail.java
@@ -3,11 +3,8 @@ package uk.gov.di.authentication.entity;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 
 public record UserMfaDetail(
-        boolean isMfaRequired,
-        boolean mfaMethodVerified,
-        MFAMethodType mfaMethodType,
-        String phoneNumber) {
+        boolean mfaMethodVerified, MFAMethodType mfaMethodType, String phoneNumber) {
     public static UserMfaDetail noMfa() {
-        return new UserMfaDetail(false, false, MFAMethodType.NONE, null);
+        return new UserMfaDetail(false, MFAMethodType.NONE, null);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -41,45 +41,37 @@ public class MfaHelper {
     }
 
     public static UserMfaDetail getUserMFADetail(
-            CredentialTrustLevel credentialTrustLevel,
-            UserCredentials userCredentials,
-            UserProfile userProfile) {
-        var isMfaRequired = mfaRequired(credentialTrustLevel);
+            UserCredentials userCredentials, UserProfile userProfile) {
         if (userProfile.isMfaMethodsMigrated()) {
-            return getMfaDetailForMigratedUser(userCredentials, isMfaRequired);
+            return getMfaDetailForMigratedUser(userCredentials);
         } else {
             return getMfaDetailForNonMigratedUser(
                     userCredentials,
                     userProfile.getPhoneNumber(),
-                    userProfile.isPhoneNumberVerified(),
-                    isMfaRequired);
+                    userProfile.isPhoneNumberVerified());
         }
     }
 
     private static UserMfaDetail getMfaDetailForNonMigratedUser(
-            UserCredentials userCredentials,
-            String phoneNumber,
-            boolean isPhoneVerified,
-            boolean isMfaRequired) {
+            UserCredentials userCredentials, String phoneNumber, boolean isPhoneVerified) {
         var enabledMethod = getPrimaryMFAMethod(userCredentials);
 
         if (enabledMethod.filter(MFAMethod::isMethodVerified).isPresent()) {
             LOG.info("User has verified method from user credentials");
             var mfaMethodType = MFAMethodType.valueOf(enabledMethod.get().getMfaMethodType());
-            return new UserMfaDetail(isMfaRequired, true, mfaMethodType, phoneNumber);
+            return new UserMfaDetail(true, mfaMethodType, phoneNumber);
         } else if (!isPhoneVerified && enabledMethod.isPresent()) {
             LOG.info("Unverified auth app mfa method present and no verified phone number");
             var mfaMethodType = MFAMethodType.valueOf(enabledMethod.get().getMfaMethodType());
-            return new UserMfaDetail(isMfaRequired, false, mfaMethodType, phoneNumber);
+            return new UserMfaDetail(false, mfaMethodType, phoneNumber);
         } else {
             var mfaMethodType = isPhoneVerified ? MFAMethodType.SMS : MFAMethodType.NONE;
             LOG.info("User has mfa method {}", mfaMethodType);
-            return new UserMfaDetail(isMfaRequired, isPhoneVerified, mfaMethodType, phoneNumber);
+            return new UserMfaDetail(isPhoneVerified, mfaMethodType, phoneNumber);
         }
     }
 
-    private static UserMfaDetail getMfaDetailForMigratedUser(
-            UserCredentials userCredentials, boolean isMfaRequired) {
+    private static UserMfaDetail getMfaDetailForMigratedUser(UserCredentials userCredentials) {
         var maybeDefaultMethod = MfaHelper.getDefaultMfaMethodForMigratedUser(userCredentials);
         if (maybeDefaultMethod.isPresent()) {
             var defaultMethod = maybeDefaultMethod.get();
@@ -90,14 +82,13 @@ public class MfaHelper {
                 phoneNumberForMigratedMethod = null;
             }
             return new UserMfaDetail(
-                    isMfaRequired,
                     defaultMethod.isMethodVerified(),
                     MFAMethodType.valueOf(defaultMethod.getMfaMethodType()),
                     phoneNumberForMigratedMethod);
         } else {
             logNoDefaultMfaMethodDebug(userCredentials.getMfaMethods(), true);
 
-            return new UserMfaDetail(isMfaRequired, false, MFAMethodType.NONE, null);
+            return new UserMfaDetail(false, MFAMethodType.NONE, null);
         }
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/MfaHelperTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADetail;
+import static uk.gov.di.authentication.shared.conditions.MfaHelper.mfaRequired;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.NONE;
 import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
@@ -75,7 +76,8 @@ class MfaHelperTest {
             new CaptureLoggingExtension(NoDefaultMfaMethodLogHelper.class);
 
     @Nested
-    class GetUserMFADetail {
+    class MfaRequired {
+
         private static Stream<Arguments> trustLevelsToMfaRequired() {
             return Stream.of(
                     Arguments.of(CredentialTrustLevel.LOW_LEVEL, false),
@@ -84,13 +86,14 @@ class MfaHelperTest {
 
         @ParameterizedTest
         @MethodSource("trustLevelsToMfaRequired")
-        void isMfaRequiredShouldReflectLevelOfTrustRequested(
+        void shouldReturnCorrectMfaRequiredDependingOnCredentialTrustLevel(
                 CredentialTrustLevel trustLevel, boolean expectedMfaRequired) {
-            setupUserProfile(userProfile, PHONE_NUMBER, true, false);
-            var result = getUserMFADetail(trustLevel, userCredentials, userProfile);
-
-            assertEquals(expectedMfaRequired, result.isMfaRequired());
+            assertEquals(mfaRequired(trustLevel), expectedMfaRequired);
         }
+    }
+
+    @Nested
+    class GetUserMFADetail {
 
         @Test
         void shouldReturnAVerifiedSmsMethodWhenNoAuthAppExists() {
@@ -99,10 +102,8 @@ class MfaHelperTest {
 
             when(userCredentials.getMfaMethods()).thenReturn(List.of());
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
 
@@ -120,10 +121,8 @@ class MfaHelperTest {
             var authApp = authAppMfaMethod(true, isAuthAppEnabled);
             when(userCredentials.getMfaMethods()).thenReturn(List.of(authApp));
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
         }
@@ -135,10 +134,8 @@ class MfaHelperTest {
 
             when(userCredentials.getMfaMethods()).thenReturn(List.of());
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, false, NONE, PHONE_NUMBER);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(false, NONE, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
 
@@ -159,11 +156,8 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(isAuthAppVerified, true)));
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult =
-                    new UserMfaDetail(true, true, MFAMethodType.AUTH_APP, PHONE_NUMBER);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(true, MFAMethodType.AUTH_APP, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
 
@@ -182,10 +176,8 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(false, true)));
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, isPhoneNumberVerified, SMS, PHONE_NUMBER);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(isPhoneNumberVerified, SMS, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
         }
@@ -199,10 +191,8 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(authAppMfaMethod(isAuthAppVerified, true)));
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, false, AUTH_APP, PHONE_NUMBER);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(false, AUTH_APP, PHONE_NUMBER);
 
             assertEquals(expectedResult, result);
 
@@ -240,10 +230,8 @@ class MfaHelperTest {
             when(userCredentials.getMfaMethods())
                     .thenReturn(List.of(defaultSmsMethod, backupAuthAppMethod));
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, true, SMS, phoneNumberOfMigratedMethod);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(true, SMS, phoneNumberOfMigratedMethod);
 
             assertEquals(expectedResult, result);
         }
@@ -264,10 +252,8 @@ class MfaHelperTest {
                             "auth-app-mfa-id");
             when(userCredentials.getMfaMethods()).thenReturn(List.of(backupAuthAppMethod));
 
-            var result =
-                    getUserMFADetail(
-                            CredentialTrustLevel.MEDIUM_LEVEL, userCredentials, userProfile);
-            var expectedResult = new UserMfaDetail(true, false, NONE, null);
+            var result = getUserMFADetail(userCredentials, userProfile);
+            var expectedResult = new UserMfaDetail(false, NONE, null);
 
             assertEquals(expectedResult, result);
 


### PR DESCRIPTION
## What

Now that we are setting the `isMfaRequired` in the authorize-controller (see this [PR](https://github.com/govuk-one-login/authentication-frontend/pull/3459)) and no longer setting it in /enter-password (see this [PR](https://github.com/govuk-one-login/authentication-frontend/pull/3462)) we can stop sending `mfaRequired` in the `/login` response

## How to review

1. Code review

