### PR TITLE
Aut 5466/more verification failed events

### DIFF
--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
@@ -9,8 +9,8 @@ public record PasskeyDetail(
         String passkeyVerificationFailureReason) {
     public static PasskeyDetail verificationFailed(
             String userVerification,
-            long passkeyCounter,
-            boolean passkeyCredentialBackedUp,
+            Long passkeyCounter,
+            Boolean passkeyCredentialBackedUp,
             String passkeyCredentialDeviceType,
             String verificationFailureReason) {
         var userVerified = false;

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
@@ -2,8 +2,8 @@ package uk.gov.di.authentication.auditevents.entity.shared.passkeys;
 
 public record PasskeyDetail(
         PasskeyAuthenticationRequest passkeyAuthenticationRequest,
-        long passkeyCounter,
-        boolean passkeyCredentialBackedUp,
+        Long passkeyCounter,
+        Boolean passkeyCredentialBackedUp,
         String passkeyCredentialDeviceType,
         boolean passkeyUserVerified,
         String passkeyAuthenticationFailureReason) {
@@ -21,6 +21,11 @@ public record PasskeyDetail(
                 passkeyCredentialDeviceType,
                 userVerified,
                 authenticationFailureReason);
+    }
+
+    public static PasskeyDetail verificationCouldNotProceed(String authenticationFailureReason) {
+        var userVerified = false;
+        return new PasskeyDetail(null, null, null, null, userVerified, authenticationFailureReason);
     }
 
     public static PasskeyDetail verificationSuccessful(

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/passkeys/PasskeyDetail.java
@@ -6,13 +6,13 @@ public record PasskeyDetail(
         Boolean passkeyCredentialBackedUp,
         String passkeyCredentialDeviceType,
         boolean passkeyUserVerified,
-        String passkeyAuthenticationFailureReason) {
+        String passkeyVerificationFailureReason) {
     public static PasskeyDetail verificationFailed(
             String userVerification,
             long passkeyCounter,
             boolean passkeyCredentialBackedUp,
             String passkeyCredentialDeviceType,
-            String authenticationFailureReason) {
+            String verificationFailureReason) {
         var userVerified = false;
         return new PasskeyDetail(
                 new PasskeyAuthenticationRequest(userVerification),
@@ -20,12 +20,12 @@ public record PasskeyDetail(
                 passkeyCredentialBackedUp,
                 passkeyCredentialDeviceType,
                 userVerified,
-                authenticationFailureReason);
+                verificationFailureReason);
     }
 
-    public static PasskeyDetail verificationCouldNotProceed(String authenticationFailureReason) {
+    public static PasskeyDetail verificationCouldNotProceed(String verificationFailureReason) {
         var userVerified = false;
-        return new PasskeyDetail(null, null, null, null, userVerified, authenticationFailureReason);
+        return new PasskeyDetail(null, null, null, null, userVerified, verificationFailureReason);
     }
 
     public static PasskeyDetail verificationSuccessful(

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
@@ -39,7 +39,7 @@ class AuthPasskeyVerificationFailedTest {
 
         var passkeyVerificationFailed =
                 PasskeyDetail.verificationFailed(
-                        "required", 0, true, "multi-device", "Verification failed");
+                        "required", 0L, true, "multi-device", "Verification failed");
 
         var event =
                 AuthPasskeyVerificationFailed.create(

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
@@ -39,7 +39,7 @@ class AuthPasskeyVerificationFailedTest {
 
         var passkeyVerificationFailed =
                 PasskeyDetail.verificationFailed(
-                        "required", 0, true, "multi-device", "UserVerificationError");
+                        "required", 0, true, "multi-device", "Verification failed");
 
         var event =
                 AuthPasskeyVerificationFailed.create(
@@ -97,7 +97,7 @@ class AuthPasskeyVerificationFailedTest {
                               "passkey_credential_backed_up": true,
                               "passkey_credential_device_type": "multi-device",
                               "passkey_user_verified": false,
-                              "passkey_verification_failure_reason": "UserVerificationError"
+                              "passkey_verification_failure_reason": "Verification failed"
                             }
                           }
                         }

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.auditevents.entity;
 
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
@@ -15,23 +16,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
 
 class AuthPasskeyVerificationFailedTest {
+    private static final AuditContext AUDIT_CONTEXT =
+            AuditContext.emptyAuditContext()
+                    .withClientId("client-id")
+                    .withEmail("test@example.com")
+                    .withSubjectId("internal-common-subject-id")
+                    .withPersistentSessionId("persistent-session-id")
+                    .withSessionId("session-id")
+                    .withClientSessionId("signin-journey-id")
+                    .withIpAddress("192.0.2.0/24")
+                    .withTxmaAuditEncoded("encoded-device-info");
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-06-10T13:13:04.730565Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
 
     @Test
     void shouldSerialiseAnAuthPasskeyVerificationFailedAuditEvent() {
-        var auditContext =
-                AuditContext.emptyAuditContext()
-                        .withClientId("client-id")
-                        .withEmail("test@example.com")
-                        .withSubjectId("internal-common-subject-id")
-                        .withPersistentSessionId("persistent-session-id")
-                        .withSessionId("session-id")
-                        .withClientSessionId("signin-journey-id")
-                        .withIpAddress("192.0.2.0/24")
-                        .withTxmaAuditEncoded("encoded-device-info");
-
-        var fixedInstant = Instant.parse("2026-06-10T13:13:04.730565Z");
-        var fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
-
         var passkeyAllowCredentials =
                 List.of(
                         new PasskeyAllowCredentials("credential-1", null),
@@ -43,66 +43,112 @@ class AuthPasskeyVerificationFailedTest {
 
         var event =
                 AuthPasskeyVerificationFailed.create(
-                        auditContext,
+                        AUDIT_CONTEXT,
                         JourneyType.SIGN_IN,
                         passkeyAllowCredentials,
                         "credential-1",
                         passkeyVerificationFailed,
-                        fixedClock);
+                        FIXED_CLOCK);
 
         var actualEvent = event.serialize();
 
         var expectedEvent =
                 """
-                {
-                  "event_name": "AUTH_PASSKEY_VERIFICATION_FAILED",
-                  "timestamp": 1781097184,
-                  "event_timestamp_ms": 1781097184730,
-                  "client_id": "client-id",
-                  "component_id": "AUTH",
-                  "user": {
-                    "email": "test@example.com",
-                    "govuk_signin_journey_id": "signin-journey-id",
-                    "ip_address": "192.0.2.0/24",
-                    "persistent_session_id": "persistent-session-id",
-                    "session_id": "session-id",
-                    "user_id": "internal-common-subject-id"
-                  },
-                  "restricted": {
-                    "device_information": {
-                      "encoded": "encoded-device-info"
-                    },
-                    "passkey": {
-                      "passkey_allowed_credentials": [
                         {
-                          "passkey_credential_id": "credential-1"
-                        },
-                        {
-                          "passkey_credential_id": "credential-2",
-                          "passkey_credential_transports": [
-                            "ble"
-                          ]
+                          "event_name": "AUTH_PASSKEY_VERIFICATION_FAILED",
+                          "timestamp": 1781097184,
+                          "event_timestamp_ms": 1781097184730,
+                          "client_id": "client-id",
+                          "component_id": "AUTH",
+                          "user": {
+                            "email": "test@example.com",
+                            "govuk_signin_journey_id": "signin-journey-id",
+                            "ip_address": "192.0.2.0/24",
+                            "persistent_session_id": "persistent-session-id",
+                            "session_id": "session-id",
+                            "user_id": "internal-common-subject-id"
+                          },
+                          "restricted": {
+                            "device_information": {
+                              "encoded": "encoded-device-info"
+                            },
+                            "passkey": {
+                              "passkey_allowed_credentials": [
+                                {
+                                  "passkey_credential_id": "credential-1"
+                                },
+                                {
+                                  "passkey_credential_id": "credential-2",
+                                  "passkey_credential_transports": [
+                                    "ble"
+                                  ]
+                                }
+                              ],
+                              "passkey_credential_id": "credential-1"
+                            }
+                          },
+                          "extensions": {
+                            "journey-type": "SIGN_IN",
+                            "passkey": {
+                              "passkey_authentication_request": {
+                                "passkey_request_user_verification": "required"
+                              },
+                              "passkey_counter": 0,
+                              "passkey_credential_backed_up": true,
+                              "passkey_credential_device_type": "multi-device",
+                              "passkey_user_verified": false,
+                              "passkey_authentication_failure_reason": "UserVerificationError"
+                            }
+                          }
                         }
-                      ],
-                      "passkey_credential_id": "credential-1"
-                    }
-                  },
-                  "extensions": {
-                    "journey-type": "SIGN_IN",
-                    "passkey": {
-                      "passkey_authentication_request": {
-                        "passkey_request_user_verification": "required"
-                      },
-                      "passkey_counter": 0,
-                      "passkey_credential_backed_up": true,
-                      "passkey_credential_device_type": "multi-device",
-                      "passkey_user_verified": false,
-                      "passkey_authentication_failure_reason": "UserVerificationError"
-                    }
-                  }
-                }
-                """;
+                        """;
 
         assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+
+    @Test
+    void shouldSerialiseAnAuthPasskeyVerificationFailedAuditEventWhenVerificationCouldNotProceed() {
+        var passkeyVerificationFailed =
+                PasskeyDetail.verificationCouldNotProceed(
+                        "Stored assertion request failed to parse");
+
+        var event =
+                AuthPasskeyVerificationFailed.create(
+                        AUDIT_CONTEXT,
+                        JourneyType.SIGN_IN,
+                        null,
+                        null,
+                        passkeyVerificationFailed,
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+        var actualEventAsJsonObject = JsonParser.parseString(actualEvent).getAsJsonObject();
+
+        var expectedRestrictedSection =
+                """
+                        {
+                          "device_information": {
+                            "encoded": "encoded-device-info"
+                          },
+                          "passkey": {}
+                        }
+                        """;
+        var actualRestrictedSection = actualEventAsJsonObject.get("restricted");
+
+        assertEquals(asJson(expectedRestrictedSection), actualRestrictedSection);
+
+        var expectedExtensions =
+                """
+                        {
+                            "journey-type": "SIGN_IN",
+                            "passkey": {
+                              "passkey_user_verified": false,
+                              "passkey_authentication_failure_reason": "Stored assertion request failed to parse"
+                            }
+                          }
+                        """;
+
+        var actualExtensionsSection = actualEventAsJsonObject.get("extensions");
+        assertEquals(asJson(expectedExtensions), actualExtensionsSection);
     }
 }

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationFailedTest.java
@@ -97,7 +97,7 @@ class AuthPasskeyVerificationFailedTest {
                               "passkey_credential_backed_up": true,
                               "passkey_credential_device_type": "multi-device",
                               "passkey_user_verified": false,
-                              "passkey_authentication_failure_reason": "UserVerificationError"
+                              "passkey_verification_failure_reason": "UserVerificationError"
                             }
                           }
                         }
@@ -143,7 +143,7 @@ class AuthPasskeyVerificationFailedTest {
                             "journey-type": "SIGN_IN",
                             "passkey": {
                               "passkey_user_verified": false,
-                              "passkey_authentication_failure_reason": "Stored assertion request failed to parse"
+                              "passkey_verification_failure_reason": "Stored assertion request failed to parse"
                             }
                           }
                         """;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -114,7 +114,7 @@ public class PasskeyAssertionService {
                         assertionResult.getSignatureCount(),
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceTypeFrom(assertionResult),
-                        "UnknownError");
+                        "Passkey assertion result was not successful");
         var event =
                 AuthPasskeyVerificationFailed.create(
                         auditContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -63,7 +63,8 @@ public class PasskeyAssertionService {
         try {
             credential = jsonParser.parsePublicKeyCredential(publicKeyCredentialJson);
         } catch (Exception e) {
-            emitAuthPasskeyVerificationFailedEvent(auditContext);
+            var failureReason = "Public key credential in request failed to parse";
+            emitAuthPasskeyVerificationFailedEvent(auditContext, failureReason, Optional.empty());
             return Result.failure(FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR);
         }
 
@@ -71,6 +72,9 @@ public class PasskeyAssertionService {
         try {
             assertionRequest = jsonParser.parseAssertionRequest(assertionRequestJson);
         } catch (Exception e) {
+            var failureReason = "Assertion request stored in session failed to parse";
+            emitAuthPasskeyVerificationFailedEvent(
+                    auditContext, failureReason, Optional.of(credential));
             return Result.failure(
                     FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR);
         }
@@ -101,16 +105,22 @@ public class PasskeyAssertionService {
         return Result.success(assertionResult);
     }
 
-    private void emitAuthPasskeyVerificationFailedEvent(AuditContext auditContext) {
-        var passkeyDetail =
-                PasskeyDetail.verificationCouldNotProceed(
-                        "Public key credential in request failed to parse");
+    private void emitAuthPasskeyVerificationFailedEvent(
+            AuditContext auditContext,
+            String failureReason,
+            Optional<
+                            PublicKeyCredential<
+                                    AuthenticatorAssertionResponse,
+                                    ClientAssertionExtensionOutputs>>
+                    maybePublicKeyCredential) {
+        var passkeyDetail = PasskeyDetail.verificationCouldNotProceed(failureReason);
+        var credentialId = maybePublicKeyCredential.map(c -> c.getId().getBase64Url()).orElse(null);
         var event =
                 AuthPasskeyVerificationFailed.create(
                         auditContext,
                         JourneyType.SIGN_IN,
                         null,
-                        null,
+                        credentialId,
                         passkeyDetail,
                         Clock.systemUTC());
         structuredAuditService.submitAuditEvent(event);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationFailed;
 import uk.gov.di.authentication.auditevents.entity.AuthPasskeyVerificationSuccessful;
+import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyAllowCredentials;
 import uk.gov.di.authentication.auditevents.entity.shared.passkeys.PasskeyDetail;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
@@ -24,6 +25,7 @@ import uk.gov.di.authentication.shared.entity.Result;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.frontendapi.helpers.PasskeyAuditExtensionsHelper.passkeyAllowedCredentialsFrom;
@@ -89,6 +91,8 @@ public class PasskeyAssertionService {
                                     .build());
         } catch (AssertionFailedException e) {
             LOG.error("Passkey assertion unexpectedly failed with error: {}", e.getMessage());
+            emitAuthPasskeyVerificationFailedEventForAssertionError(
+                    auditContext, assertionRequest, credential, e);
             return Result.failure(FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR);
         }
 
@@ -115,15 +119,26 @@ public class PasskeyAssertionService {
                     maybePublicKeyCredential) {
         var passkeyDetail = PasskeyDetail.verificationCouldNotProceed(failureReason);
         var credentialId = maybePublicKeyCredential.map(c -> c.getId().getBase64Url()).orElse(null);
-        var event =
-                AuthPasskeyVerificationFailed.create(
-                        auditContext,
-                        JourneyType.SIGN_IN,
+        emitVerificationFailedEvent(auditContext, null, credentialId, passkeyDetail);
+    }
+
+    private void emitAuthPasskeyVerificationFailedEventForAssertionError(
+            AuditContext auditContext,
+            AssertionRequest assertionRequest,
+            PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
+                    publicKeyCredential,
+            AssertionFailedException error) {
+        var passkeyDetail =
+                PasskeyDetail.verificationFailed(
+                        userVerificationStringFrom(assertionRequest),
                         null,
-                        credentialId,
-                        passkeyDetail,
-                        Clock.systemUTC());
-        structuredAuditService.submitAuditEvent(event);
+                        null,
+                        null,
+                        String.format(
+                                "Passkey finish assertion threw error: %s", error.getClass()));
+        var alllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
+        var credentialId = publicKeyCredential.getId().getBase64Url();
+        emitVerificationFailedEvent(auditContext, alllowedCredentials, credentialId, passkeyDetail);
     }
 
     @SuppressWarnings("deprecation")
@@ -140,15 +155,9 @@ public class PasskeyAssertionService {
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceTypeFrom(assertionResult),
                         "Passkey assertion result was not successful");
-        var event =
-                AuthPasskeyVerificationFailed.create(
-                        auditContext,
-                        JourneyType.SIGN_IN,
-                        passkeyAllowedCredentialsFrom(assertionRequest),
-                        publicKeyCredential.getId().getBase64Url(),
-                        passkeyDetail,
-                        Clock.systemUTC());
-        structuredAuditService.submitAuditEvent(event);
+        var alllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
+        var credentialId = publicKeyCredential.getId().getBase64Url();
+        emitVerificationFailedEvent(auditContext, alllowedCredentials, credentialId, passkeyDetail);
     }
 
     @SuppressWarnings("deprecation")
@@ -171,6 +180,22 @@ public class PasskeyAssertionService {
                         passkeyAllowedCredentialsFrom(assertionRequest),
                         passkeyDetail,
                         publicKeyCredential.getId().getBase64Url(),
+                        Clock.systemUTC());
+        structuredAuditService.submitAuditEvent(event);
+    }
+
+    private void emitVerificationFailedEvent(
+            AuditContext auditContext,
+            List<PasskeyAllowCredentials> allowedCredentials,
+            String credentialId,
+            PasskeyDetail passkeyDetail) {
+        var event =
+                AuthPasskeyVerificationFailed.create(
+                        auditContext,
+                        JourneyType.SIGN_IN,
+                        allowedCredentials,
+                        credentialId,
+                        passkeyDetail,
                         Clock.systemUTC());
         structuredAuditService.submitAuditEvent(event);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -58,15 +58,6 @@ public class PasskeyAssertionService {
             String assertionRequestJson,
             String publicKeyCredentialJson,
             AuditContext auditContext) {
-
-        AssertionRequest assertionRequest;
-        try {
-            assertionRequest = jsonParser.parseAssertionRequest(assertionRequestJson);
-        } catch (Exception e) {
-            return Result.failure(
-                    FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR);
-        }
-
         PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
                 credential;
         try {
@@ -74,6 +65,14 @@ public class PasskeyAssertionService {
         } catch (Exception e) {
             emitAuthPasskeyVerificationFailedEvent(auditContext);
             return Result.failure(FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR);
+        }
+
+        AssertionRequest assertionRequest;
+        try {
+            assertionRequest = jsonParser.parseAssertionRequest(assertionRequestJson);
+        } catch (Exception e) {
+            return Result.failure(
+                    FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR);
         }
 
         AssertionResult assertionResult;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -72,6 +72,7 @@ public class PasskeyAssertionService {
         try {
             credential = jsonParser.parsePublicKeyCredential(publicKeyCredentialJson);
         } catch (Exception e) {
+            emitAuthPasskeyVerificationFailedEvent(auditContext);
             return Result.failure(FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR);
         }
 
@@ -99,6 +100,21 @@ public class PasskeyAssertionService {
                 auditContext, assertionRequest, assertionResult, credential);
 
         return Result.success(assertionResult);
+    }
+
+    private void emitAuthPasskeyVerificationFailedEvent(AuditContext auditContext) {
+        var passkeyDetail =
+                PasskeyDetail.verificationCouldNotProceed(
+                        "Public key credential in request failed to parse");
+        var event =
+                AuthPasskeyVerificationFailed.create(
+                        auditContext,
+                        JourneyType.SIGN_IN,
+                        null,
+                        null,
+                        passkeyDetail,
+                        Clock.systemUTC());
+        structuredAuditService.submitAuditEvent(event);
     }
 
     @SuppressWarnings("deprecation")

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -42,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -207,12 +206,7 @@ class PasskeyAssertionServiceTest {
                         FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR,
                         actualFailureReason);
 
-                verify(structuredAuditService)
-                        .submitAuditEvent(
-                                argThat(
-                                        event ->
-                                                event.eventName()
-                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
+                verifyAuditEventEmittedWithName(VERIFICATION_FAILED_EVENT_NAME);
             }
 
             @Test
@@ -230,31 +224,13 @@ class PasskeyAssertionServiceTest {
                         .getFailure();
 
                 // Then
-                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
-
-                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
-                var capturedAuditEvent = argCaptor.getValue();
-
-                assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
-
-                var authPasskeyVerificationFailed =
-                        (AuthPasskeyVerificationFailed) capturedAuditEvent;
-
-                assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
-
                 var expectedPasskeyDetail =
                         PasskeyDetail.verificationCouldNotProceed(
                                 "Assertion request stored in session failed to parse");
-                assertEquals(
-                        expectedPasskeyDetail,
-                        authPasskeyVerificationFailed.extensions().passkey());
-
                 var expectedRestrictedPasskeySection =
                         new RestrictedPasskeySection(null, CREDENTIAL_ID);
-
-                assertEquals(
-                        expectedRestrictedPasskeySection,
-                        authPasskeyVerificationFailed.restricted().passkey());
+                verifyVerificationFailedAuditEventEmitted(
+                        expectedPasskeyDetail, expectedRestrictedPasskeySection);
             }
 
             @Test
@@ -273,12 +249,7 @@ class PasskeyAssertionServiceTest {
                 // Then
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR, actualFailureReason);
-                verify(structuredAuditService)
-                        .submitAuditEvent(
-                                argThat(
-                                        event ->
-                                                event.eventName()
-                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
+                verifyAuditEventEmittedWithName(VERIFICATION_FAILED_EVENT_NAME);
             }
 
             @Test
@@ -294,41 +265,23 @@ class PasskeyAssertionServiceTest {
                         .getFailure();
 
                 // Then
-                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
-
-                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
-                var capturedAuditEvent = argCaptor.getValue();
-
-                assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
-
-                var authPasskeyVerificationFailed =
-                        (AuthPasskeyVerificationFailed) capturedAuditEvent;
-
-                assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
-
                 var expectedPasskeyDetail =
                         PasskeyDetail.verificationCouldNotProceed(
                                 "Public key credential in request failed to parse");
-                assertEquals(
-                        expectedPasskeyDetail,
-                        authPasskeyVerificationFailed.extensions().passkey());
-
                 var expectedRestrictedPasskeySection = new RestrictedPasskeySection(null, null);
-
-                assertEquals(
-                        expectedRestrictedPasskeySection,
-                        authPasskeyVerificationFailed.restricted().passkey());
+                verifyVerificationFailedAuditEventEmitted(
+                        expectedPasskeyDetail, expectedRestrictedPasskeySection);
             }
 
             @Test
             @SuppressWarnings("unchecked")
             void shouldFailWithAssertionFailedErrorWhenAssertionFails()
-                    throws IOException, AssertionFailedException {
+                    throws IOException, AssertionFailedException, Base64UrlException {
                 // Given
-                when(jsonParser.parseAssertionRequest(any()))
-                        .thenReturn(mock(AssertionRequest.class));
-                when(jsonParser.parsePublicKeyCredential(any()))
-                        .thenReturn(mock(PublicKeyCredential.class));
+                var assertionRequest = setupAssertionRequest();
+                var credential = setupPublicKeyCredential(CREDENTIAL_ID);
+                when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(credential);
                 when(relyingParty.finishAssertion(any())).thenThrow(AssertionFailedException.class);
 
                 // When
@@ -341,7 +294,46 @@ class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR,
                         actualFailureReason);
-                verify(structuredAuditService, never()).submitAuditEvent(any());
+                verifyAuditEventEmittedWithName(VERIFICATION_FAILED_EVENT_NAME);
+            }
+
+            @Test
+            void shouldEmitAnAuditEventWhenAssertionThrowsError()
+                    throws IOException, AssertionFailedException, Base64UrlException {
+                // Given
+                var userVerification = UserVerificationRequirement.PREFERRED;
+                var allowedCredentialsMap = Map.of(CREDENTIAL_ID, "BLE");
+
+                var assertionRequest =
+                        setupAssertionRequest(allowedCredentialsMap, userVerification);
+                var publicKeyCredential = setupPublicKeyCredential(CREDENTIAL_ID);
+                when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
+                when(relyingParty.finishAssertion(any())).thenThrow(AssertionFailedException.class);
+
+                // When
+                passkeyAssertionService
+                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
+                        .getFailure();
+
+                // Then
+                var expectedFailureReason =
+                        "Passkey finish assertion threw error: class com.yubico.webauthn.exception.AssertionFailedException";
+                var expectedPasskeyDetail =
+                        PasskeyDetail.verificationFailed(
+                                userVerification.getValue(),
+                                null,
+                                null,
+                                null,
+                                expectedFailureReason);
+
+                var expectedRestrictedPasskeySection =
+                        new RestrictedPasskeySection(
+                                List.of(new PasskeyAllowCredentials(CREDENTIAL_ID, List.of("BLE"))),
+                                CREDENTIAL_ID);
+
+                verifyVerificationFailedAuditEventEmitted(
+                        expectedPasskeyDetail, expectedRestrictedPasskeySection);
             }
 
             @Test
@@ -366,12 +358,7 @@ class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR,
                         actualFailureReason);
-                verify(structuredAuditService)
-                        .submitAuditEvent(
-                                argThat(
-                                        event ->
-                                                event.eventName()
-                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
+                verifyAuditEventEmittedWithName(VERIFICATION_FAILED_EVENT_NAME);
             }
 
             @Test
@@ -381,7 +368,7 @@ class PasskeyAssertionServiceTest {
                 // Given
 
                 var assertionIsSuccess = false;
-                var signCount = 10;
+                var signCount = 10L;
                 var isBackedUp = false;
                 var isBackupEligible = false;
                 var userVerification = UserVerificationRequirement.PREFERRED;
@@ -402,18 +389,6 @@ class PasskeyAssertionServiceTest {
                 passkeyAssertionService.finishAssertion("", "", auditContext).getFailure();
 
                 // Then
-                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
-
-                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
-                var capturedAuditEvent = argCaptor.getValue();
-
-                assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
-
-                var authPasskeyVerificationFailed =
-                        (AuthPasskeyVerificationFailed) capturedAuditEvent;
-
-                assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
-
                 var expectedPasskeyDetail =
                         PasskeyDetail.verificationFailed(
                                 userVerification.getValue(),
@@ -421,18 +396,36 @@ class PasskeyAssertionServiceTest {
                                 isBackedUp,
                                 "single-device",
                                 "Passkey assertion result was not successful");
-                assertEquals(
-                        expectedPasskeyDetail,
-                        authPasskeyVerificationFailed.extensions().passkey());
 
-                var restrictedPasskeySection =
+                var expectedRestrictedPasskeySection =
                         new RestrictedPasskeySection(
                                 List.of(new PasskeyAllowCredentials(CREDENTIAL_ID, List.of("BLE"))),
                                 CREDENTIAL_ID);
-                assertEquals(
-                        restrictedPasskeySection,
-                        authPasskeyVerificationFailed.restricted().passkey());
+                verifyVerificationFailedAuditEventEmitted(
+                        expectedPasskeyDetail, expectedRestrictedPasskeySection);
             }
+        }
+
+        private void verifyVerificationFailedAuditEventEmitted(
+                PasskeyDetail expectedPasskeyDetail,
+                RestrictedPasskeySection expectedRestrictedPasskeySection) {
+            var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
+
+            verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+            var capturedAuditEvent = argCaptor.getValue();
+
+            assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
+
+            var authPasskeyVerificationFailed = (AuthPasskeyVerificationFailed) capturedAuditEvent;
+
+            assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
+
+            assertEquals(
+                    expectedPasskeyDetail, authPasskeyVerificationFailed.extensions().passkey());
+
+            assertEquals(
+                    expectedRestrictedPasskeySection,
+                    authPasskeyVerificationFailed.restricted().passkey());
         }
     }
 
@@ -442,6 +435,11 @@ class PasskeyAssertionServiceTest {
 
     private static AssertionResult setupAnyFailureMockAssertionResult() {
         return setupMockAssertionResult(10, false, false, false);
+    }
+
+    private void verifyAuditEventEmittedWithName(String expectedName) {
+        verify(structuredAuditService)
+                .submitAuditEvent(argThat(event -> event.eventName().equals(expectedName)));
     }
 
     @SuppressWarnings("deprecation")

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -327,7 +327,7 @@ class PasskeyAssertionServiceTest {
                                 signCount,
                                 isBackedUp,
                                 "single-device",
-                                "UnknownError");
+                                "Passkey assertion result was not successful");
                 assertEquals(
                         expectedPasskeyDetail,
                         authPasskeyVerificationFailed.extensions().passkey());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -56,6 +56,7 @@ class PasskeyAssertionServiceTest {
     private static final String CREDENTIAL_ID = "Q6pkKSucKCqDzOuFky3pQAA";
     private static final StructuredAuditService structuredAuditService =
             mock(StructuredAuditService.class);
+    private static final String VERIFICATION_FAILED_EVENT_NAME = "AUTH_PASSKEY_VERIFICATION_FAILED";
 
     @BeforeEach
     void setup() {
@@ -188,8 +189,10 @@ class PasskeyAssertionServiceTest {
         class Error {
             @Test
             void shouldFailWithParsingAssertionRequestErrorWhenAssertionRequestJsonParsingFails()
-                    throws JsonProcessingException {
+                    throws IOException, Base64UrlException {
                 // Given
+                var pkc = setupPublicKeyCredential(CREDENTIAL_ID);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(pkc);
                 when(jsonParser.parseAssertionRequest(any()))
                         .thenThrow(JsonProcessingException.class);
 
@@ -204,7 +207,54 @@ class PasskeyAssertionServiceTest {
                         FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR,
                         actualFailureReason);
 
-                verify(structuredAuditService, never()).submitAuditEvent(any());
+                verify(structuredAuditService)
+                        .submitAuditEvent(
+                                argThat(
+                                        event ->
+                                                event.eventName()
+                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
+            }
+
+            @Test
+            void shouldEmitAuditEventWhenAssertionRequestParsingFails()
+                    throws IOException, Base64UrlException {
+                // Given
+                var pkc = setupPublicKeyCredential(CREDENTIAL_ID);
+                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(pkc);
+                when(jsonParser.parseAssertionRequest(any()))
+                        .thenThrow(JsonProcessingException.class);
+
+                // When
+                passkeyAssertionService
+                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
+                        .getFailure();
+
+                // Then
+                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
+
+                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+                var capturedAuditEvent = argCaptor.getValue();
+
+                assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
+
+                var authPasskeyVerificationFailed =
+                        (AuthPasskeyVerificationFailed) capturedAuditEvent;
+
+                assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
+
+                var expectedPasskeyDetail =
+                        PasskeyDetail.verificationCouldNotProceed(
+                                "Assertion request stored in session failed to parse");
+                assertEquals(
+                        expectedPasskeyDetail,
+                        authPasskeyVerificationFailed.extensions().passkey());
+
+                var expectedRestrictedPasskeySection =
+                        new RestrictedPasskeySection(null, CREDENTIAL_ID);
+
+                assertEquals(
+                        expectedRestrictedPasskeySection,
+                        authPasskeyVerificationFailed.restricted().passkey());
             }
 
             @Test
@@ -228,8 +278,7 @@ class PasskeyAssertionServiceTest {
                                 argThat(
                                         event ->
                                                 event.eventName()
-                                                        .equals(
-                                                                "AUTH_PASSKEY_VERIFICATION_FAILED")));
+                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
             }
 
             @Test
@@ -250,7 +299,7 @@ class PasskeyAssertionServiceTest {
                 verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
                 var capturedAuditEvent = argCaptor.getValue();
 
-                assertEquals("AUTH_PASSKEY_VERIFICATION_FAILED", capturedAuditEvent.eventName());
+                assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
 
                 var authPasskeyVerificationFailed =
                         (AuthPasskeyVerificationFailed) capturedAuditEvent;
@@ -322,8 +371,7 @@ class PasskeyAssertionServiceTest {
                                 argThat(
                                         event ->
                                                 event.eventName()
-                                                        .equals(
-                                                                "AUTH_PASSKEY_VERIFICATION_FAILED")));
+                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
             }
 
             @Test
@@ -359,7 +407,7 @@ class PasskeyAssertionServiceTest {
                 verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
                 var capturedAuditEvent = argCaptor.getValue();
 
-                assertEquals("AUTH_PASSKEY_VERIFICATION_FAILED", capturedAuditEvent.eventName());
+                assertEquals(VERIFICATION_FAILED_EVENT_NAME, capturedAuditEvent.eventName());
 
                 var authPasskeyVerificationFailed =
                         (AuthPasskeyVerificationFailed) capturedAuditEvent;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -56,6 +56,8 @@ class PasskeyAssertionServiceTest {
     private static final StructuredAuditService structuredAuditService =
             mock(StructuredAuditService.class);
     private static final String VERIFICATION_FAILED_EVENT_NAME = "AUTH_PASSKEY_VERIFICATION_FAILED";
+    private static final AuditContext AUDIT_CONTEXT =
+            AuditContext.emptyAuditContext().withEmail(EMAIL);
 
     @BeforeEach
     void setup() {
@@ -118,9 +120,7 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 AssertionResult actualAssertionResult =
-                        passkeyAssertionService
-                                .finishAssertion("", "", AuditContext.emptyAuditContext())
-                                .getSuccess();
+                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getSuccess();
 
                 // Then
                 assertEquals(actualAssertionResult, mockAssertionResult);
@@ -149,9 +149,7 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
 
                 // When
-                passkeyAssertionService
-                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
-                        .getSuccess();
+                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getSuccess();
 
                 // Then
                 var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
@@ -197,9 +195,7 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService
-                                .finishAssertion("", "", AuditContext.emptyAuditContext())
-                                .getFailure();
+                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 assertEquals(
@@ -219,9 +215,7 @@ class PasskeyAssertionServiceTest {
                         .thenThrow(JsonProcessingException.class);
 
                 // When
-                passkeyAssertionService
-                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
-                        .getFailure();
+                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 var expectedPasskeyDetail =
@@ -242,9 +236,7 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService
-                                .finishAssertion("", "", AuditContext.emptyAuditContext())
-                                .getFailure();
+                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 assertEquals(
@@ -260,9 +252,7 @@ class PasskeyAssertionServiceTest {
                 when(jsonParser.parsePublicKeyCredential(any())).thenThrow(IOException.class);
 
                 // When
-                passkeyAssertionService
-                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
-                        .getFailure();
+                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 var expectedPasskeyDetail =
@@ -286,9 +276,7 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService
-                                .finishAssertion("", "", AuditContext.emptyAuditContext())
-                                .getFailure();
+                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 assertEquals(
@@ -312,9 +300,7 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenThrow(AssertionFailedException.class);
 
                 // When
-                passkeyAssertionService
-                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
-                        .getFailure();
+                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 var expectedFailureReason =
@@ -350,9 +336,7 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService
-                                .finishAssertion("", "", AuditContext.emptyAuditContext())
-                                .getFailure();
+                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 assertEquals(
@@ -383,10 +367,9 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
                 when(jsonParser.parseAssertionRequest(any())).thenReturn(assertionRequest);
                 when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
-                var auditContext = AuditContext.emptyAuditContext().withEmail(EMAIL);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "", auditContext).getFailure();
+                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
 
                 // Then
                 var expectedPasskeyDetail =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -223,7 +223,52 @@ class PasskeyAssertionServiceTest {
                 // Then
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR, actualFailureReason);
-                verify(structuredAuditService, never()).submitAuditEvent(any());
+                verify(structuredAuditService)
+                        .submitAuditEvent(
+                                argThat(
+                                        event ->
+                                                event.eventName()
+                                                        .equals(
+                                                                "AUTH_PASSKEY_VERIFICATION_FAILED")));
+            }
+
+            @Test
+            void shouldEmitRelevantAuditEventWhenPKCParsingFails() throws IOException {
+                // Given
+                when(jsonParser.parseAssertionRequest(any()))
+                        .thenReturn(mock(AssertionRequest.class));
+                when(jsonParser.parsePublicKeyCredential(any())).thenThrow(IOException.class);
+
+                // When
+                passkeyAssertionService
+                        .finishAssertion("", "", AuditContext.emptyAuditContext().withEmail(EMAIL))
+                        .getFailure();
+
+                // Then
+                var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
+
+                verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+                var capturedAuditEvent = argCaptor.getValue();
+
+                assertEquals("AUTH_PASSKEY_VERIFICATION_FAILED", capturedAuditEvent.eventName());
+
+                var authPasskeyVerificationFailed =
+                        (AuthPasskeyVerificationFailed) capturedAuditEvent;
+
+                assertEquals(EMAIL, authPasskeyVerificationFailed.user().email());
+
+                var expectedPasskeyDetail =
+                        PasskeyDetail.verificationCouldNotProceed(
+                                "Public key credential in request failed to parse");
+                assertEquals(
+                        expectedPasskeyDetail,
+                        authPasskeyVerificationFailed.extensions().passkey());
+
+                var expectedRestrictedPasskeySection = new RestrictedPasskeySection(null, null);
+
+                assertEquals(
+                        expectedRestrictedPasskeySection,
+                        authPasskeyVerificationFailed.restricted().passkey());
             }
 
             @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -65,7 +65,7 @@ class PasskeyAssertionServiceTest {
 
     @AfterEach
     void tearDown() {
-        reset(structuredAuditService);
+        reset(structuredAuditService, jsonParser, relyingParty);
     }
 
     @Nested


### PR DESCRIPTION
Emit verification failure audit events in the case of any failure within the finish passkey assertion.

These events don't have all the data the existing failure event has (which is emitted in the case of the yubico library returning an unsuccessful assertion result). Various fields are nulled which means they won't appear on the audit event. This is because, depending on when the failure occurs, we won't have all the data required to populate the full event.

## Related PRs

In [this previous PR](https://github.com/govuk-one-login/authentication-api/pull/8489) we started emitting the failure event in one of the failure cases. The current PR implements the event for all failure cases.
