### PR TITLE
Aut 5529/suppress passkey setup for new accounts

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -15,4 +15,6 @@ public record CheckUserExistsResponse(
         @SerializedName("lockoutInformation") @Expose List<LockoutInformation> lockoutInformation,
         @SerializedName("hasActivePasskey") @Expose Boolean hasActivePasskey,
         @SerializedName("needsForcedMFAResetAfterMFACheck") @Expose
-                boolean needsForcedMFAResetAfterMFACheck) {}
+                boolean needsForcedMFAResetAfterMFACheck,
+        @SerializedName("shouldSuppressPasskeyRegistrationPrompt") @Expose
+                boolean shouldSuppressPasskeyRegistrationPrompt) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelper.java
@@ -1,0 +1,44 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+public class PasskeyRegistrationPromptHelper {
+    private static final Logger LOG = LogManager.getLogger(PasskeyRegistrationPromptHelper.class);
+
+    private PasskeyRegistrationPromptHelper() {
+        /* This utility class should not be instantiated */
+    }
+
+    public static boolean shouldSuppressPasskeyRegistrationPrompt(UserProfile userProfile) {
+        return accountIsLessThanTwoHoursOld(userProfile);
+    }
+
+    private static boolean accountIsLessThanTwoHoursOld(UserProfile userProfile) {
+        if (Objects.isNull(userProfile.getCreated()) || userProfile.getCreated().isEmpty()) {
+            LOG.warn(
+                    "created at date on user profile is null or empty, not suppressing create passkey prompt");
+            return false;
+        }
+        try {
+            var createdDate = LocalDateTime.parse(userProfile.getCreated());
+            var nowMinusTwoHours = LocalDateTime.now(ZoneId.of("UTC")).minusHours(2);
+            var shouldSuppressBasedOnAccountCreation = createdDate.isAfter(nowMinusTwoHours);
+            if (shouldSuppressBasedOnAccountCreation) {
+                LOG.info(
+                        "suppressing passkey registration prompt as account is less than two hours old");
+            }
+            return shouldSuppressBasedOnAccountCreation;
+        } catch (DateTimeParseException e) {
+            LOG.warn(
+                    "created at date on user profile could not be parsed as local date time, not suppressing create passkey prompt");
+            return false;
+        }
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.errormapper.DecisionErrorHttpMapper;
+import uk.gov.di.authentication.frontendapi.helpers.PasskeyRegistrationPromptHelper;
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
@@ -180,6 +181,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             var userMfaDetail = UserMfaDetail.noMfa();
             Optional<Boolean> hasActivePasskey = Optional.empty();
             var needsForcedMFAResetAfterMFACheck = false;
+            var shouldSuppressPasskeyRegistrationPrompt = false;
 
             AuthSessionItem authSession = userContext.getAuthSession();
 
@@ -206,6 +208,9 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                 && requiresMfaResetForInternationalNumber(
                                         authSession, userCredentials, userProfile);
                 hasActivePasskey = hasActivePasskey(userProfile.getPublicSubjectID(), authSession);
+                shouldSuppressPasskeyRegistrationPrompt =
+                        PasskeyRegistrationPromptHelper.shouldSuppressPasskeyRegistrationPrompt(
+                                userProfile);
                 metadataPairs.add(
                         pair(
                                 AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY,
@@ -242,7 +247,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             lockoutInformation,
                             hasActivePasskey.orElse(null),
                             needsForcedMFAResetAfterMFACheck,
-                            false);
+                            shouldSuppressPasskeyRegistrationPrompt);
 
             authSessionService.updateSession(authSession);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -241,7 +241,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                             getLastDigitsOfPhoneNumber(userMfaDetail),
                             lockoutInformation,
                             hasActivePasskey.orElse(null),
-                            needsForcedMFAResetAfterMFACheck);
+                            needsForcedMFAResetAfterMFACheck,
+                            false);
 
             authSessionService.updateSession(authSession);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -133,12 +133,12 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
 
-            var userProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
-            var userExists = userProfile.isPresent();
+            var maybeUserProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
+            var userExists = maybeUserProfile.isPresent();
             var internalCommonSubjectId =
                     userExists
                             ? ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                            userProfile.get(),
+                                            maybeUserProfile.get(),
                                             configurationService.getInternalSectorUri(),
                                             authenticationService)
                                     .getValue()
@@ -184,10 +184,11 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             AuthSessionItem authSession = userContext.getAuthSession();
 
             if (userExists) {
+                var userProfile = maybeUserProfile.get();
                 auditableEvent = FrontendAuditableEvent.AUTH_CHECK_USER_KNOWN_EMAIL;
                 rpPairwiseId =
                         ClientSubjectHelper.getSubject(
-                                        userProfile.get(),
+                                        userProfile,
                                         userContext.getAuthSession(),
                                         authenticationService)
                                 .getValue();
@@ -197,15 +198,14 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 authSession.setInternalCommonSubjectId(internalCommonSubjectId);
                 var userCredentials =
                         authenticationService.getUserCredentialsFromEmail(emailAddress);
-                userMfaDetail = getUserMFADetail(userCredentials, userProfile.get());
+                userMfaDetail = getUserMFADetail(userCredentials, userProfile);
                 auditContext = auditContext.withSubjectId(internalCommonSubjectId);
 
                 needsForcedMFAResetAfterMFACheck =
                         configurationService.isForcedMFAResetAfterMFACheckEnabled()
                                 && requiresMfaResetForInternationalNumber(
-                                        authSession, userCredentials, userProfile.get());
-                hasActivePasskey =
-                        hasActivePasskey(userProfile.get().getPublicSubjectID(), authSession);
+                                        authSession, userCredentials, userProfile);
+                hasActivePasskey = hasActivePasskey(userProfile.getPublicSubjectID(), authSession);
                 metadataPairs.add(
                         pair(
                                 AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelperTest.java
@@ -1,0 +1,61 @@
+package uk.gov.di.authentication.frontendapi.helpers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static uk.gov.di.authentication.frontendapi.helpers.PasskeyRegistrationPromptHelper.shouldSuppressPasskeyRegistrationPrompt;
+
+class PasskeyRegistrationPromptHelperTest {
+    private static final String YESTERDAY = LocalDateTime.now().minusDays(1).toString();
+    private static final String TWO_HOURS_ONE_MINUTE_AGO =
+            LocalDateTime.now().minusMinutes(121).toString();
+    private static final String ONE_HOUR_59_AGO = LocalDateTime.now().minusMinutes(119).toString();
+    private static final String THIRTY_MINUTES_AGO =
+            LocalDateTime.now().minusMinutes(30).toString();
+
+    private static Stream<Arguments> dateTimesToExpectedShouldSuppressPrompts() {
+        return Stream.of(
+                Arguments.of(YESTERDAY, false),
+                Arguments.of(TWO_HOURS_ONE_MINUTE_AGO, false),
+                Arguments.of(ONE_HOUR_59_AGO, true),
+                Arguments.of(THIRTY_MINUTES_AGO, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateTimesToExpectedShouldSuppressPrompts")
+    void shouldSuppressPasskeyRegistrationPromptShouldReturnTrueIfAccountLessThan2HoursOld(
+            String createdAtTimestamp, boolean expectedResult) {
+        var userProfile = new UserProfile().withCreated(createdAtTimestamp);
+
+        assertEquals(expectedResult, shouldSuppressPasskeyRegistrationPrompt(userProfile));
+    }
+
+    @Test
+    void shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfAccountTimestampIsNull() {
+        var userProfile = new UserProfile();
+
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile));
+    }
+
+    @Test
+    void shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfAccountTimestampIsEmpty() {
+        var userProfile = new UserProfile().withCreated("");
+
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile));
+    }
+
+    @Test
+    void shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfAccountTimestampDoesNotParse() {
+        var userProfile = new UserProfile().withCreated("not a parseable local date time");
+
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile));
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -199,7 +199,8 @@ class CheckUserExistsHandlerTest {
                     "phoneNumberLastThree":"%s",
                     "lockoutInformation":[],
                     "hasActivePasskey":null,
-                    "needsForcedMFAResetAfterMFACheck":false}
+                    "needsForcedMFAResetAfterMFACheck":false,
+                    "shouldSuppressPasskeyRegistrationPrompt":false}
                     """,
                             EMAIL_ADDRESS, phoneNumber.substring(phoneNumber.length() - 3));
             assertEquals(
@@ -256,7 +257,8 @@ class CheckUserExistsHandlerTest {
                     "phoneNumberLastThree": %s,
                     "lockoutInformation":[],
                     "hasActivePasskey":null,
-                    "needsForcedMFAResetAfterMFACheck":false}
+                    "needsForcedMFAResetAfterMFACheck":false,
+                    "shouldSuppressPasskeyRegistrationPrompt":false}
                     """,
                             EMAIL_ADDRESS,
                             expectedMfaMethodType,
@@ -376,6 +378,7 @@ class CheckUserExistsHandlerTest {
                                             lockoutExpiry.getEpochSecond(),
                                             JourneyType.PASSWORD_RESET_MFA)),
                             null,
+                            false,
                             false);
             assertThat(result, hasJsonBody(expectedResponse));
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -50,6 +50,7 @@ import uk.gov.di.authentication.userpermissions.entity.LockoutInformation;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -116,6 +117,8 @@ class CheckUserExistsHandlerTest {
             ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
     private static final BearerAccessToken ADAPI_BEARER_ACCESS_TOKEN =
             new BearerAccessToken("adapi_bearer");
+    private static final String YESTERDAY = LocalDateTime.now().minusDays(1).toString();
+    private static final String ONE_HOUR_AGO = LocalDateTime.now().minusHours(1).toString();
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
@@ -662,6 +665,30 @@ class CheckUserExistsHandlerTest {
             assertEquals(hasActivePasskey, checkUserExistsResponse.hasActivePasskey());
         }
 
+        private static Stream<Arguments> dateTimesToExpectedShouldSuppressPrompts() {
+            return Stream.of(Arguments.of(YESTERDAY, false), Arguments.of(ONE_HOUR_AGO, true));
+        }
+
+        @ParameterizedTest
+        @MethodSource("dateTimesToExpectedShouldSuppressPrompts")
+        void shouldIndicateThatPasskeyPromptShouldBeSuppressedWhenAccountIsLessThanTwoHoursOld(
+                String createdAtTimestamp, boolean expectedShouldSuppressPasskeyPrompt)
+                throws Json.JsonException {
+            var userProfile = generateUserProfile().withCreated(createdAtTimestamp);
+            setupUserProfileAndClient(Optional.of(userProfile));
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+
+            assertThat(result, hasStatus(200));
+            var checkUserExistsResponse =
+                    objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+            assertEquals(
+                    expectedShouldSuppressPasskeyPrompt,
+                    checkUserExistsResponse.shouldSuppressPasskeyRegistrationPrompt());
+        }
+
         @Test
         void shouldReturnNullForHasActivePasskeyIfPasskeysServiceReturnsFailure()
                 throws Json.JsonException {
@@ -794,6 +821,7 @@ class CheckUserExistsHandlerTest {
                 .withEmailVerified(true)
                 .withPublicSubjectID(new Subject().getValue())
                 .withSubjectID(SUBJECT.getValue())
+                .withCreated(YESTERDAY)
                 .withTermsAndConditions(
                         new TermsAndConditions("1.0", NowHelper.now().toInstant().toString()));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -111,6 +111,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             assertThat(checkUserExistsResponse.email(), equalTo(TEST_EMAIL_1));
             assertThat(checkUserExistsResponse.mfaMethodType(), equalTo(mfaMethodType));
             assertTrue(checkUserExistsResponse.doesUserExist());
+            assertTrue(checkUserExistsResponse.shouldSuppressPasskeyRegistrationPrompt());
 
             if (MFAMethodType.SMS.equals(mfaMethodType)) {
                 assertThat(checkUserExistsResponse.phoneNumberLastThree(), equalTo("321"));


### PR DESCRIPTION
Introduces a new field on the check user exists response, which indicates whether the backend knows of any reason the passkey registration prompt should be suppressed. 

For now, the only rule it applies is whether the account is less than 2 hours old or not - if so, it will return a response indicating the passkey registration prompt should be skipped by the frontend. This is so that users who are signing into the OL app to prove their identity (after creating their account) are not prompted to set up a passkey during an ID proving journey.

In future, we will add more rules into this logic as appropriate.

This can be merged before the relevant change on the frontend to start responding to this new field is in place - currently without that this change is a no-op in terms of journeys. The frontend does not perform strict validation on the shape of response so an extra field is just ignored.