### PR TITLE
ATO-2686: Repoint origin DNS at new API Gateway

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -134,7 +134,10 @@ Conditions:
       !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]],
     ]
   SwapOriginToApiGateway:
-    !And [!Condition CreateApiGwCustomDomain, !Equals [dev, !Ref Environment]]
+    !And [
+      !Condition CreateApiGwCustomDomain,
+      !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]],
+    ]
   #endregion
 
 Mappings:


### PR DESCRIPTION
### Wider context of change

Now that we've created the custom domain, we can repoint the DNS for the origin subdomain at the API Gateway, readying it up for us to re-point the Cloudfront at this DNS for the origin. This is [step 4.3 in our rollout plan](https://govukverify.atlassian.net/wiki/x/UpHujQE)

### What’s changed

- Enables the `SwapOriginToApiGateway` feature flag, which swaps our `origin.` alias record from the old API Gateway custom domain to the new one

### Manual testing
- N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
