### PR TITLE
AUT-5503: Remove reference to @old-mfa-reset-with-ipv in acceptance tests for backend

### DIFF
--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -12,18 +12,18 @@ Mappings:
   AcceptanceTestTags:
     dev:
       tags: >-
-        @UI and not (@AccountInterventions or @Reauth or @old-mfa-without-ipv or
+        @UI and not (@AccountInterventions or @Reauth or
         @AccountRecovery or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-
         @UI and not (@under-development or @AccountInterventions or @Reauth or
-        @old-mfa-without-ipv or @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
+        @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
         or @PasskeysEnabled or @PasskeyUsageEnabled)
     staging:
       tags: >-
         @UI and not (@under-development or @AccountInterventions or @Reauth or
-        @old-mfa-without-ipv or @new-mfa-reset-with-ipv or @AcceptInternationalNumbers
+        @new-mfa-reset-with-ipv or @AcceptInternationalNumbers
         or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled or @EnvironmentWithAMCStubDeployed)
 
 Resources:


### PR DESCRIPTION
All the tests tagged with this tag have been removed from the acceptance test repo, as the feature flag has been removed from code so we have no way of toggling back to this old way of resetting mfa. Therefore, reference to this tag can now safely be removed from the tags for each environment

## Related PRs

Depends on https://github.com/govuk-one-login/authentication-acceptance-tests/pull/934
