### PR TITLE
ATO-2686: fixups after running in build 

### DIFF
--- a/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/alternative-with-live-cert-parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/alternative-with-live-cert-parameters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc-orch.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:767397776536:certificate/d7f6e974-d9e5-4c42-ba24-551f64d14494"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "ApiGatewayOriginDomain",
+    "ParameterValue": "w2kildk4ee.execute-api.eu-west-2.amazonaws.com"
+  },
+  {
+    "ParameterKey": "OriginPath",
+    "ParameterValue": "/build"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/live-with-rollback-parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/live-with-rollback-parameters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:767397776536:certificate/d7f6e974-d9e5-4c42-ba24-551f64d14494"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "ApiGatewayOriginDomain",
+    "ParameterValue": "w2kildk4ee.execute-api.eu-west-2.amazonaws.com"
+  },
+  {
+    "ParameterKey": "OriginPath",
+    "ParameterValue": "/build"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/parameters.json
+++ b/ci/stack-orchestration/configuration/build/build-oidc-cloudfront/parameters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:767397776536:certificate/d7f6e974-d9e5-4c42-ba24-551f64d14494"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "ApiGatewayOriginDomain",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginPath",
+    "ParameterValue": "none"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/cloudfront-tls-certificate/parameters.json
+++ b/ci/stack-orchestration/configuration/build/cloudfront-tls-certificate/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "HostedZoneID",
+    "ParameterValue": "Z10153513B1NLWHFQ9WTW"
+  },
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "oidc.build.account.gov.uk"
+  }
+]

--- a/ci/stack-orchestration/configuration/build/hosted-zone/live-no-cert-parameters.json
+++ b/ci/stack-orchestration/configuration/build/hosted-zone/live-no-cert-parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": ""
+  }
+]

--- a/ci/stack-orchestration/configuration/build/hosted-zone/parameters.json
+++ b/ci/stack-orchestration/configuration/build/hosted-zone/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": ""
+  }
+]

--- a/ci/stack-orchestration/deploy-build.sh
+++ b/ci/stack-orchestration/deploy-build.sh
@@ -106,7 +106,7 @@ while [[ $# -gt 0 ]]; do
       PROVISION_HOSTED_ZONE=true
       DOMAIN_TO_PROVISION=${2}
 
-      PERMITTED_VALUES="live alternative"
+      PERMITTED_VALUES="live alternative live-no-cert"
 
       if ! [[ ${PERMITTED_VALUES} =~ ( |^)${DOMAIN_TO_PROVISION}( |$) ]]; then
         echo "Hosted zone arg provided: ${DOMAIN_TO_PROVISION} is not one of ${PERMITTED_VALUES}"
@@ -201,8 +201,9 @@ function provision_hosted_zone_stack() {
 
   if [ "${DOMAIN_TO_PROVISION}" == "alternative" ]; then
     parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/alternative-domain-parameters.json"
+  elif [ "${DOMAIN_TO_PROVISION}" == "live-no-cert" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/live-no-cert-parameters.json"
   fi
-
   PARAMETERS_FILE="${parameters_file}" ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
   echo "Provisioned hosted zone stack"
 }

--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -80,7 +80,7 @@ while [[ $# -gt 0 ]]; do
       PROVISION_CLOUDFRONT=true
       CLOUDFRONT_PARAMS_TO_USE="${2}"
 
-      PERMITTED_VALUES="live alternative"
+      PERMITTED_VALUES="live alternative alt-with-live-cert live-with-rollback"
 
       if ! [[ ${PERMITTED_VALUES} =~ ( |^)${CLOUDFRONT_PARAMS_TO_USE}( |$) ]]; then
         echo "Cloudfront distribution arg provided: ${CLOUDFRONT_PARAMS_TO_USE} is not one of ${PERMITTED_VALUES}"
@@ -160,6 +160,10 @@ function provision_cloudfront_distribution() {
 
   if [ "${CLOUDFRONT_PARAMS_TO_USE}" == "alternative" ]; then
     params_file="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-oidc-cloudfront/alternative-parameters.json"
+  elif [ "${CLOUDFRONT_PARAMS_TO_USE}" == "alt-with-live-cert" ]; then
+    params_file="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-oidc-cloudfront/alternative-with-live-cert-parameters.json"
+  elif [ "${CLOUDFRONT_PARAMS_TO_USE}" == "live-with-rollback" ]; then
+    params_file="$(pwd)/configuration/${ENVIRONMENT}/${ENVIRONMENT}-oidc-cloudfront/live-with-rollback-parameters.json"
   fi
 
   if [ "${SYNC_SECRETS}" == "true" ]; then

--- a/ci/stack-orchestration/deploy-cloudfront.sh
+++ b/ci/stack-orchestration/deploy-cloudfront.sh
@@ -122,7 +122,7 @@ function sync_secret_from_auth_account() {
   echo "Logged into account ${account_id}"
 
   local secret_value=""
-  secret_value=$(AWS_PROFILE="${PROFILE_TO_SYNC_SECRET_WITH}" aws secrets-manager get-secret-value --secret-id "${expected_managed_secret_name}" | jq -r ".SecretString" || exit 1)
+  secret_value=$(AWS_PROFILE="${PROFILE_TO_SYNC_SECRET_WITH}" aws secretsmanager get-secret-value --secret-id "${expected_managed_secret_name}" | jq -r ".SecretString" || exit 1)
 
   if [ -z "${secret_value}" ]; then
     echo "Failed to get previous origin cloaking secret"

--- a/ci/stack-orchestration/get-set-ssm-params.sh
+++ b/ci/stack-orchestration/get-set-ssm-params.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="/deploy/api-migration"
+GET_PARAMS=false
+SET_PARAMS=false
+
+function usage() {
+  cat << USAGE
+  Script to get/set the necessary SSM params for the API Gateway/Cloudfront migration
+
+  Usage:
+    ex: ./get-set-ssm-params.sh -e dev -d <DISTRIBUTION-ID> --get
+
+  Options:
+    -e, --environment   The environment to get/set SSM params in
+    -d, --distribution-id The old cloudfront distribution ID to fetch the ssm parameter
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    -e | --environment)
+      ENVIRONMENT="${2}"
+
+      PERMITTED_ENVIRONMENTS="dev build staging integration production"
+      if ! [[ ${PERMITTED_ENVIRONMENTS} =~ ( |^)${ENVIRONMENT}( |$) ]]; then
+        echo "Environment provided: ${ENVIRONMENT} is not one of ${PERMITTED_ENVIRONMENTS}"
+        exit 1
+      fi
+
+      echo "Selected environment: ${ENVIRONMENT}"
+      shift
+      ;;
+    -d | --distribution-id)
+      OLD_CLOUDFRONT_DISTRIBUTION_ID="${2}"
+      shift
+      ;;
+    --get)
+      GET_PARAMS=true
+      ;;
+    --set)
+      SET_PARAMS=true
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ ${GET_PARAMS} == "true" ]] && [[ ${SET_PARAMS} == "true" ]]; then
+  echo "Cannot both get and set params in one action!"
+  exit 1
+fi
+
+function get_ssm_params() {
+
+  local expected_api_custom_domain="oidc.${ENVIRONMENT}.account.gov.uk"
+
+  if [[ ${ENVIRONMENT} == "production" ]]; then
+    expected_api_custom_domain="oidc.account.gov.uk"
+  fi
+
+  local get_domains_response=""
+  get_domains_response=$(aws apigateway get-domain-names --query "items[? (domainName == '${expected_api_custom_domain}')]") || exit 1
+
+  # shellcheck disable=SC2128
+  if [ -z "${get_domains_response}" ] || [ "${get_domains_response}" == "[]" ]; then
+    echo "Error: Could not record set for hosted zone ID: ${HOSTED_ZONE_ID}."
+    exit 1
+  fi
+
+  local regional_hosted_zone_id=""
+  regional_hosted_zone_id=$(jq -r ".[].regionalHostedZoneId" <<< "${get_domains_response}") || exit 1
+
+  local regional_domain_name=""
+  regional_domain_name=$(jq -r ".[].regionalDomainName" <<< "${get_domains_response}") || exit 1
+
+  local cloudfront_distribution_domain=""
+  cloudfront_distribution_domain=$(aws cloudfront list-distributions --query "DistributionList.Items[? (Id == '${OLD_CLOUDFRONT_DISTRIBUTION_ID}')].DomainName" --output text) || exit 1
+
+  local output="${PREFIX}/old-api-gateway-regional-hosted-zone-id=${regional_hosted_zone_id}\n${PREFIX}/old-api-gateway-regional-domain-name=${regional_domain_name}\n${PREFIX}/old-cloudfront-distribution-domain=${cloudfront_distribution_domain}"
+
+  echo -e "${output}" >> "${ENVIRONMENT}-migration-ssm-params"
+}
+
+function put_ssm_parameters() {
+  while IFS='=' read -r name val; do
+    echo "Putting SSM param: ${name} with value: ${val}"
+    # shellcheck disable=SC2086
+    aws ssm put-parameter --name ${name} --value ${val} --type "String" || exit 1
+  done < "${ENVIRONMENT}-migration-ssm-params"
+}
+
+[ "${GET_PARAMS}" == "true" ] && get_ssm_params && exit 0
+
+[ "${SET_PARAMS}" == "true" ] && put_ssm_parameters && exit 0

--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -44,12 +44,6 @@ Parameters:
     AllowedValues:
       - "Yes"
       - "No"
-  CloudfrontTxtRecordValue:
-    # See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-create-target.html
-    Description: >
-      (Optional) A value to provide to create a TXT record of the format "_oidc.account.gov.uk TXT 'CloudfrontTxtRecordValue' "
-    Type: String
-    Default: "none"
 
 Conditions:
   DeployDevSubDomains:
@@ -58,8 +52,6 @@ Conditions:
       !Equals [!Ref DeploySubEnvDomains, "Yes"],
     ]
   DeployCertificate: !Equals [!Ref DeployCertificate, "Yes"]
-  CreateCloudFrontTxtRecord:
-    !Not [!Equals [!Ref CloudfrontTxtRecordValue, "none"]]
 
 Mappings:
   EnvironmentConfiguration:
@@ -176,16 +168,6 @@ Resources:
       Name: !Sub "/deploy/hosted-zone/oidc${EndpointSuffix}/certificate-Arn"
       Type: String
       Value: !Ref OidcHostedZoneRootCertificate
-
-  OidcDomainValidationTxtRecord:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      Name: !Sub "_oidc.${DomainSuffix}" # See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-create-target.html
-      Type: TXT
-      HostedZoneId: !Ref OidcHostedZone
-      ResourceRecords:
-        - !Sub '"${CloudfrontTxtRecordValue}"' # Needs quotes as it's YAML and we need the record to be "d111111abcdef8.cloudfront.net"
-      TTL: 900
 
   Orchdev1HostedZone:
     Condition: DeployDevSubDomains

--- a/ci/stack-orchestration/test-origin.sh
+++ b/ci/stack-orchestration/test-origin.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function usage() {
+  cat << USAGE
+  Script to test the "origin." domain integration with the API Gateway.
+
+  Usage:
+    ex: ./test-origin.sh -e dev
+
+  Options:
+    -e, --environment   The environment you wish to test the origin for.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    -e | --environment)
+      ENVIRONMENT="${2}"
+
+      PERMITTED_ENVIRONMENTS="dev build staging integration production"
+      if ! [[ ${PERMITTED_ENVIRONMENTS} =~ ( |^)${ENVIRONMENT}( |$) ]]; then
+        echo "Environment provided: ${ENVIRONMENT} is not one of ${PERMITTED_ENVIRONMENTS}"
+        exit 1
+      fi
+
+      echo "Selected environment: ${ENVIRONMENT}"
+      shift
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+function curl_origin_with_header() {
+  local expected_managed_secret_name="${ENVIRONMENT}-oidc-cloudfront-origin-cloaking-header-managed"
+  local secret_value=""
+  secret_value=$(aws secretsmanager get-secret-value --secret-id "${expected_managed_secret_name}" | jq -r ".SecretString" || exit 1)
+
+  if [ -z "${secret_value}" ]; then
+    echo "Failed to get origin cloaking secret"
+    exit 1
+  fi
+
+  local expected_origin_domain="origin.oidc.${ENVIRONMENT}.account.gov.uk"
+  local expected_fqdn="oidc.${ENVIRONMENT}.account.gov.uk"
+
+  if [[ ${ENVIRONMENT} == "production" ]]; then
+    expected_origin_domain="origin.oidc.account.gov.uk"
+    expected_fqdn="oidc.account.gov.uk"
+  fi
+
+  # needs -k flag
+  curl -H "origin-cloaking-secret: ${secret_value}" -H "Host: ${expected_fqdn}" -k "https://${expected_origin_domain}/trustmark"
+}
+
+curl_origin_with_header


### PR DESCRIPTION
### Wider context of change

After running the migration in build, there are a couple of things that needed minor tweaks, fixes or scripts that needed to be written to ease the process. This add these things.

### What’s changed
- Adds a load of parameter files to represent our intermediate states for the hosted zone and cloudfront distribution stacks
- Updates the scripts to support these intermediate states
- Adds a script to automate the getting/setting of SSM params needed for the migration
- Adds a script to test the origin configuration for step 4.4 of the migration plan
- fixes typos in the any existing scripts

### Manual testing

- N/A these were ran against build

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
