### PR TITLE
ATO-2671: Create SIS token signing key

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3676,6 +3676,9 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
+          SIS_TOKEN_SIGNING_KEY_ALIAS: !Ref OrchSISTokenSigningKmsKeyAlias
+      Policies:
+        - !Ref SISTokenSigningKmsAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -6885,6 +6888,20 @@ Resources:
             Resource:
               - !GetAtt OrchIPVTokenSigningKmsKey.Arn
 
+  SISTokenSigningKmsAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSISTokenSigningKms
+            Effect: Allow
+            Action:
+              - kms:Sign
+              - kms:GetPublicKey
+            Resource:
+              - !GetAtt OrchSISTokenSigningKmsKey.Arn
+
   OrchToAuthSigningKmsAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -8178,6 +8195,33 @@ Resources:
     Type: AWS::KMS::Key
     Properties:
       Description: KMS signing key for authentication to the IPV token endpoint
+      PendingWindowInDays: 30
+      KeyUsage: SIGN_VERIFY
+      KeySpec: ECC_NIST_P256
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+
+  #endregion
+
+  #region SIS token signing key pair
+
+  OrchSISTokenSigningKmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${Environment}-orch-sis-token-auth-kms-key-alias"
+      TargetKeyId: !Ref OrchSISTokenSigningKmsKey
+
+  OrchSISTokenSigningKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS signing key for authentication to the SIS token endpoint
       PendingWindowInDays: 30
       KeyUsage: SIGN_VERIFY
       KeySpec: ECC_NIST_P256


### PR DESCRIPTION
### What’s changed

This PR creates a signing key to be used by SIS. It also adds an alias, access policy, and attaches the alias and policy to the `SISJwksFunction` 

### Manual testing

Deployed to dev, saw the new infra existed.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
