### PR TITLE
ATO-2701: deploy new Cloudfront and API Gateway staging

### DIFF
--- a/ci/stack-orchestration/configuration/staging/cloudfront-monitoring-alarm/parameters.json
+++ b/ci/stack-orchestration/configuration/staging/cloudfront-monitoring-alarm/parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "staging"
+  },
+  {
+    "ParameterKey": "CloudFrontAdditionaldMetricsEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmSNSTopicARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:590183975515:staging-CloudFrontCacheHitSlackAlerts"
+  },
+  {
+    "ParameterKey": "CloudfrontDistribution",
+    "ParameterValue": "EQP7H7MNHRVB6"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmDescription",
+    "ParameterValue": "Cache Hit detected for staging OIDC Cloudfront. Runbook: https://govukverify.atlassian.net/wiki/x/AYC0gwE"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/cloudfront-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/staging/cloudfront-notifications/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "staging"
+  },
+  {
+    "ParameterKey": "DeploySlackNotificationTopic",
+    "ParameterValue": "Yes"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/cloudfront-tls-certificate/alternative-parameters.json
+++ b/ci/stack-orchestration/configuration/staging/cloudfront-tls-certificate/alternative-parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "HostedZoneID",
+    "ParameterValue": "Z09233603LNC809VH7WBA"
+  },
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "oidc-orch.staging.account.gov.uk"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/hosted-zone/alternative-domain-parameters.json
+++ b/ci/stack-orchestration/configuration/staging/hosted-zone/alternative-domain-parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "staging"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": "-orch"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/staging-oidc-cloudfront/alternative-parameters.json
+++ b/ci/stack-orchestration/configuration/staging/staging-oidc-cloudfront/alternative-parameters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc-orch.staging.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:590183975515:certificate/eab2ec2f-75b0-4070-a32b-62b5023ab0ba"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "ApiGatewayOriginDomain",
+    "ParameterValue": "u76vrv46ld.execute-api.eu-west-2.amazonaws.com"
+  },
+  {
+    "ParameterKey": "OriginPath",
+    "ParameterValue": "/staging"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/staging-oidc-cloudfront/tags.json
+++ b/ci/stack-orchestration/configuration/staging/staging-oidc-cloudfront/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "FMSGlobalCustomPolicy",
+    "Value": "true"
+  },
+  {
+    "Key": "FMSGlobalCustomPolicyName",
+    "Value": "cloudfrontoidc"
+  }
+]

--- a/ci/stack-orchestration/configuration/staging/staging-oidc-cloudfront/tags.json
+++ b/ci/stack-orchestration/configuration/staging/staging-oidc-cloudfront/tags.json
@@ -1,10 +1,6 @@
 [
   {
     "Key": "FMSGlobalCustomPolicy",
-    "Value": "true"
-  },
-  {
-    "Key": "FMSGlobalCustomPolicyName",
     "Value": "cloudfrontoidc"
   }
 ]

--- a/ci/stack-orchestration/deploy-integration.sh
+++ b/ci/stack-orchestration/deploy-integration.sh
@@ -14,6 +14,8 @@ PROVISION_BASE_STACKS=false
 PROVISION_VPC_STACK=false
 PROVISION_PIPELINE_STACK=false
 PROVISION_TXMA_STACK=false
+PROVISION_HOSTED_ZONE=false
+DOMAIN_TO_PROVISION="live"
 
 ENVIRONMENT=integration
 
@@ -53,6 +55,7 @@ function usage() {
     -p, --pipelines                        Provision secure pipelines
     -v, --vpc                              Provision VPC stack
     -t, --txma                             Provision the manual TxMA stack for auditing.
+    -h, --hosted-zone                      Provisions the hosted zone stack for the OIDC domain.
 USAGE
 }
 
@@ -92,6 +95,19 @@ while [[ $# -gt 0 ]]; do
       ;;
     -t | --txma)
       PROVISION_TXMA_STACK=true
+      ;;
+    -h | --hosted-zone)
+      PROVISION_HOSTED_ZONE=true
+      DOMAIN_TO_PROVISION=${2}
+
+      PERMITTED_VALUES="live alternative live-no-cert"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${DOMAIN_TO_PROVISION}( |$) ]]; then
+        echo "Hosted zone arg provided: ${DOMAIN_TO_PROVISION} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
+      shift
       ;;
     *)
       usage
@@ -155,6 +171,28 @@ function provision_pipeline_stack() {
   echo "Provisioned secure pipeline stack"
 }
 
+function provision_hosted_zone_stack() {
+  export AWS_REGION="eu-west-2"
+
+  # shellcheck disable=SC2155
+  local parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/parameters.json"
+
+  echo "Provisioning hosted zone stack"
+  TEMPLATE_FILE="$(pwd)/manual-stacks/domains/template.yaml"
+  if [ ! -f "${TEMPLATE_FILE}" ]; then
+    echo "Could not find the hosted zone stack template at path: ${TEMPLATE_FILE}"
+    exit 1
+  fi
+
+  if [ "${DOMAIN_TO_PROVISION}" == "alternative" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/alternative-domain-parameters.json"
+  elif [ "${DOMAIN_TO_PROVISION}" == "live-no-cert" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/live-no-cert-parameters.json"
+  fi
+  PARAMETERS_FILE="${parameters_file}" ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
+  echo "Provisioned hosted zone stack"
+}
+
 # --------------------
 # Run provision commands
 # --------------------
@@ -163,6 +201,7 @@ function provision_pipeline_stack() {
 
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_VPC_STACK}" == "true" ] && provision_vpc_stack
+[ "${PROVISION_HOSTED_ZONE}" == "true" ] && provision_hosted_zone_stack
 
 # Now we can deploy the pipeline stack
 

--- a/ci/stack-orchestration/deploy-production.sh
+++ b/ci/stack-orchestration/deploy-production.sh
@@ -14,6 +14,8 @@ PROVISION_BASE_STACKS=false
 PROVISION_VPC_STACK=false
 PROVISION_PIPELINE_STACK=false
 PROVISION_TXMA_STACK=false
+PROVISION_HOSTED_ZONE=false
+DOMAIN_TO_PROVISION="live"
 
 ENVIRONMENT=production
 
@@ -93,6 +95,19 @@ while [[ $# -gt 0 ]]; do
     -t | --txma)
       PROVISION_TXMA_STACK=true
       ;;
+    -h | --hosted-zone)
+      PROVISION_HOSTED_ZONE=true
+      DOMAIN_TO_PROVISION=${2}
+
+      PERMITTED_VALUES="live alternative live-no-cert"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${DOMAIN_TO_PROVISION}( |$) ]]; then
+        echo "Hosted zone arg provided: ${DOMAIN_TO_PROVISION} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
+      shift
+      ;;
     *)
       usage
       exit 1
@@ -155,6 +170,28 @@ function provision_pipeline_stack() {
   echo "Provisioned secure pipeline stack"
 }
 
+function provision_hosted_zone_stack() {
+  export AWS_REGION="eu-west-2"
+
+  # shellcheck disable=SC2155
+  local parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/parameters.json"
+
+  echo "Provisioning hosted zone stack"
+  TEMPLATE_FILE="$(pwd)/manual-stacks/domains/template.yaml"
+  if [ ! -f "${TEMPLATE_FILE}" ]; then
+    echo "Could not find the hosted zone stack template at path: ${TEMPLATE_FILE}"
+    exit 1
+  fi
+
+  if [ "${DOMAIN_TO_PROVISION}" == "alternative" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/alternative-domain-parameters.json"
+  elif [ "${DOMAIN_TO_PROVISION}" == "live-no-cert" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/live-no-cert-parameters.json"
+  fi
+  PARAMETERS_FILE="${parameters_file}" ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
+  echo "Provisioned hosted zone stack"
+}
+
 # --------------------
 # Run provision commands
 # --------------------
@@ -163,6 +200,7 @@ function provision_pipeline_stack() {
 
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_VPC_STACK}" == "true" ] && provision_vpc_stack
+[ "${PROVISION_HOSTED_ZONE}" == "true" ] && provision_hosted_zone_stack
 
 # Now we can deploy the pipeline stack
 

--- a/ci/stack-orchestration/deploy-staging.sh
+++ b/ci/stack-orchestration/deploy-staging.sh
@@ -16,6 +16,8 @@ PROVISION_VPC_STACK=false
 PROVISION_PIPELINE_STACK=false
 PROVISION_CLOUDWATCH_ALARM_STACK=false
 PROVISION_TXMA_STACK=false
+PROVISION_HOSTED_ZONE=false
+DOMAIN_TO_PROVISION="live"
 
 ENVIRONMENT=staging
 
@@ -58,6 +60,7 @@ function usage() {
     -c, --cloudwatch-alarm                 Provisions the cloudwatch alarm stack: A stack for deploying an alarm which
                                                monitors the lambda code storage and sends an alert when a threshold is reached.
                                                See confluence page: https://govukverify.atlassian.net/wiki/x/AwCc3Q
+    -h, --hosted-zone                      Provisions the hosted zone stack for the OIDC domain.
 USAGE
 }
 
@@ -100,6 +103,19 @@ while [[ $# -gt 0 ]]; do
       ;;
     -c | --cloudwatch-alarm)
       PROVISION_CLOUDWATCH_ALARM_STACK=true
+      ;;
+    -h | --hosted-zone)
+      PROVISION_HOSTED_ZONE=true
+      DOMAIN_TO_PROVISION=${2}
+
+      PERMITTED_VALUES="live alternative live-no-cert"
+
+      if ! [[ ${PERMITTED_VALUES} =~ ( |^)${DOMAIN_TO_PROVISION}( |$) ]]; then
+        echo "Hosted zone arg provided: ${DOMAIN_TO_PROVISION} is not one of ${PERMITTED_VALUES}"
+        exit 1
+      fi
+
+      shift
       ;;
     *)
       usage
@@ -171,6 +187,28 @@ function provision_pipeline_stack() {
   echo "Provisioned secure pipeline stack"
 }
 
+function provision_hosted_zone_stack() {
+  export AWS_REGION="eu-west-2"
+
+  # shellcheck disable=SC2155
+  local parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/parameters.json"
+
+  echo "Provisioning hosted zone stack"
+  TEMPLATE_FILE="$(pwd)/manual-stacks/domains/template.yaml"
+  if [ ! -f "${TEMPLATE_FILE}" ]; then
+    echo "Could not find the hosted zone stack template at path: ${TEMPLATE_FILE}"
+    exit 1
+  fi
+
+  if [ "${DOMAIN_TO_PROVISION}" == "alternative" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/alternative-domain-parameters.json"
+  elif [ "${DOMAIN_TO_PROVISION}" == "live-no-cert" ]; then
+    parameters_file="$(pwd)/configuration/${ENVIRONMENT}/hosted-zone/live-no-cert-parameters.json"
+  fi
+  PARAMETERS_FILE="${parameters_file}" ${LOCAL_PROVISION_COMMAND} "${ENVIRONMENT}" "hosted-zone" "${TEMPLATE_FILE}"
+  echo "Provisioned hosted zone stack"
+}
+
 # --------------------
 # Run provision commands
 # --------------------
@@ -179,6 +217,7 @@ function provision_pipeline_stack() {
 
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_VPC_STACK}" == "true" ] && provision_vpc_stack
+[ "${PROVISION_HOSTED_ZONE}" == "true" ] && provision_hosted_zone_stack
 
 # Now we can deploy the pipeline stack
 


### PR DESCRIPTION
### Wider context of change

As part of the migration, we need to setup the new infrastructure on an alternate domain. This PR documents the parameters used.

### What’s changed

- Adds alternate domain parameters for Cloudfront/API Gateway setup

### Manual testing

- N/A 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
