### PR TITLE
ATO-2011: Bump nimbus OIDC package to 11.22.2

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -173,7 +173,7 @@ public class TokenHandler
                 var tokenErrorResponse =
                         tokenUtilityService.generateTokenErrorResponse(OAuth2Error.INVALID_REQUEST);
                 return generateApiGatewayProxyResponse(
-                        tokenErrorResponse.getStatusCode(), tokenErrorResponse.getContent());
+                        tokenErrorResponse.getStatusCode(), tokenErrorResponse.getBody());
             }
 
             LOG.info(
@@ -223,12 +223,12 @@ public class TokenHandler
             var tokenErrorResponse =
                     tokenUtilityService.generateTokenErrorResponse(e.getErrorObject());
             return generateApiGatewayProxyResponse(
-                    tokenErrorResponse.getStatusCode(), tokenErrorResponse.getContent());
+                    tokenErrorResponse.getStatusCode(), tokenErrorResponse.getBody());
         } catch (AuthCodeStoreRetreivalException e) {
             var tokenErrorResponse =
                     tokenUtilityService.generateTokenErrorResponse(e.getOAuth2Error());
             return generateApiGatewayProxyResponse(
-                    tokenErrorResponse.getStatusCode(), tokenErrorResponse.getContent());
+                    tokenErrorResponse.getStatusCode(), tokenErrorResponse.getBody());
         }
     }
 

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/validators/TokenRequestValidator.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/validators/TokenRequestValidator.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
 import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.auth.verifier.JWTAudienceCheck;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,7 +78,8 @@ public class TokenRequestValidator {
             ClientAuthenticationVerifier<?> signatureVerifier =
                     new ClientAuthenticationVerifier<>(
                             new PrivateKeyJwtAuthPublicKeySelector(publicKeys, KeyType.EC),
-                            expectedAudience);
+                            expectedAudience,
+                            JWTAudienceCheck.LEGACY);
             signatureVerifier.verify(privateKeyJWT, null, null);
         } catch (InvalidClientException e) {
             LOG.warn("Invalid client in private_key_jwt", e);

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/TokenServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/TokenServiceTest.java
@@ -41,7 +41,7 @@ class TokenServiceTest {
 
         assertNotNull(httpResponse);
         assertEquals(400, httpResponse.getStatusCode());
-        assertTrue(httpResponse.getContent().contains("invalid_request"));
-        assertTrue(httpResponse.getContent().contains("Invalid request parameters"));
+        assertTrue(httpResponse.getBody().contains("invalid_request"));
+        assertTrue(httpResponse.getBody().contains("Invalid request parameters"));
     }
 }

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -158,7 +158,7 @@ public class DocAppCriService {
                         response.getStatusCode());
             }
 
-            if (!response.getContentAsJSONObject().get("sub").equals(docAppSubjectId)
+            if (!response.getBodyAsJSONObject().get("sub").equals(docAppSubjectId)
                     && !configurationService.getEnvironment().equals("dev")
                     && !configurationService.getEnvironment().equals("build")) {
                 throw new UnsuccessfulCredentialResponseException(
@@ -179,7 +179,7 @@ public class DocAppCriService {
     private List<SignedJWT> parseResponse(HTTPResponse response)
             throws UnsuccessfulCredentialResponseException {
         try {
-            var contentAsJSONObject = response.getContentAsJSONObject();
+            var contentAsJSONObject = response.getBodyAsJSONObject();
             if (Objects.isNull(contentAsJSONObject.get(CREDENTIAL_JWT.getValue()))) {
                 throw new UnsuccessfulCredentialResponseException(
                         "No Credential JWT claim present");

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -81,7 +81,7 @@ public class DocAppCriService {
                         "Unsuccessful {} response from DocApp token endpoint on attempt {}: {} ",
                         response.getStatusCode(),
                         count,
-                        response.getContent());
+                        response.getBody());
             }
         } while (!tokenResponse.indicatesSuccess() && count < maxTries);
 
@@ -146,7 +146,7 @@ public class DocAppCriService {
                     LOG.warn(
                             format(
                                     "Unsuccessful %s response from DocApp userinfo endpoint on attempt %d: %s ",
-                                    response.getStatusCode(), count, response.getContent()));
+                                    response.getStatusCode(), count, response.getBody()));
                 }
             } while (!response.indicatesSuccess() && count < maxTries);
 
@@ -154,7 +154,7 @@ public class DocAppCriService {
                 throw new UnsuccessfulCredentialResponseException(
                         format(
                                 "Error %s when attempting to call CRI data endpoint: %s",
-                                response.getStatusCode(), response.getContent()),
+                                response.getStatusCode(), response.getBody()),
                         response.getStatusCode());
             }
 

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -107,15 +106,11 @@ public class DocAppCriService {
                         NowHelper.now(),
                         NowHelper.now(),
                         new JWTID());
-        return new TokenRequest(
-                tokenURI,
-                generatePrivateKeyJwt(claimsSet),
-                codeGrant,
-                null,
-                singletonList(tokenURI),
-                Map.of(
-                        "client_id",
-                        singletonList(configurationService.getDocAppAuthorisationClientId())));
+
+        return new TokenRequest.Builder(tokenURI, generatePrivateKeyJwt(claimsSet), codeGrant)
+                .resource(tokenURI)
+                .customParameter("client_id", configurationService.getDocAppAuthorisationClientId())
+                .build();
     }
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawTokenTest.java
@@ -20,7 +20,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.kms.model.*;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.app.services.DocAppCriService;
 import uk.gov.di.orchestration.shared.api.DocAppCriAPI;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
@@ -36,7 +40,10 @@ import java.util.Date;
 import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 
 @PactConsumerTest
 @MockServerConfig(hostInterface = "localHost", port = "1234")
@@ -151,8 +158,7 @@ public class DcmawTokenTest {
         TokenResponse response = docAppCriService.sendTokenRequest(tokenRequest);
 
         assertThat(response.indicatesSuccess(), equalTo(true));
-        assertThat(
-                response.toHTTPResponse().getContent(), equalTo(getSuccessfulTokenHttpResponse()));
+        assertThat(response.toHTTPResponse().getBody(), equalTo(getSuccessfulTokenHttpResponse()));
     }
 
     @Pact(consumer = "OrchTokenConsumer")

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
@@ -174,7 +174,7 @@ public class DcmawUserInfoTest {
                         + "\""
                         + "]"
                         + "}");
-        var contentAsJSONObject = userInfoHTTPResponse.getContentAsJSONObject();
+        var contentAsJSONObject = userInfoHTTPResponse.getBodyAsJSONObject();
         var serializedSignedJWTs =
                 (List<String>) contentAsJSONObject.get(CREDENTIAL_JWT.getValue());
         List<SignedJWT> signedJWTs = new ArrayList<>();

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/contract/DcmawUserInfoTest.java
@@ -159,7 +159,7 @@ public class DcmawUserInfoTest {
             throws ParseException, java.text.ParseException {
         var userInfoHTTPResponse = new HTTPResponse(200);
         userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(
+        userInfoHTTPResponse.setBody(
                 "{"
                         + " \""
                         + SUB_FIELD

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -90,7 +90,7 @@ class DocAppCriServiceTest {
     @Nested
     class TokenTests {
         @Test
-        void shouldConstructTokenRequest() throws JOSEException {
+        void shouldConstructTokenRequest() throws Exception {
             signJWTWithKMS();
             TokenRequest tokenRequest =
                     docAppCriService.constructTokenRequest(AUTH_CODE.getValue());
@@ -99,13 +99,17 @@ class DocAppCriServiceTest {
                     tokenRequest.getClientAuthentication().getMethod().getValue(),
                     equalTo("private_key_jwt"));
             assertThat(
-                    tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
+                    tokenRequest
+                            .toHTTPRequest()
+                            .getBodyAsFormParameters()
+                            .get("redirect_uri")
+                            .get(0),
                     equalTo(REDIRECT_URI.toString()));
             assertThat(
-                    tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
+                    tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("grant_type").get(0),
                     equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
             assertThat(
-                    tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
+                    tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("client_id").get(0),
                     equalTo(CLIENT_ID.getValue()));
         }
 

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -224,7 +224,7 @@ class DocAppCriServiceTest {
                             + "}";
             var tokenHTTPResponse = new HTTPResponse(200);
             tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            tokenHTTPResponse.setContent(tokenResponseContent);
+            tokenHTTPResponse.setBody(tokenResponseContent);
 
             return tokenHTTPResponse;
         }
@@ -258,7 +258,7 @@ class DocAppCriServiceTest {
                 throws IOException, UnsuccessfulCredentialResponseException {
             var userInfoHTTPResponse = new HTTPResponse(200);
             userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
+            userInfoHTTPResponse.setBody(userInfoHTTPResponseContent);
             when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
 
             var response = docAppCriService.sendCriDataRequest(httpRequest, DOC_APP_SUBJECT_ID);
@@ -273,7 +273,7 @@ class DocAppCriServiceTest {
                 throws IOException, UnsuccessfulCredentialResponseException {
             var userInfoHTTPResponse = new HTTPResponse(200);
             userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
+            userInfoHTTPResponse.setBody(userInfoHTTPResponseContent);
             when(httpRequest.send())
                     .thenReturn(new HTTPResponse(500))
                     .thenReturn(userInfoHTTPResponse);
@@ -291,7 +291,7 @@ class DocAppCriServiceTest {
                 throws IOException {
             var userInfoHTTPResponse = new HTTPResponse(200);
             userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            userInfoHTTPResponse.setContent(userInfoHTTPResponseContent);
+            userInfoHTTPResponse.setBody(userInfoHTTPResponseContent);
             when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
 
             UnsuccessfulCredentialResponseException thrown =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
@@ -178,7 +178,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
                                 journeyOutcome =
                                         SerializationService.getInstance()
                                                 .readValue(
-                                                        response.getContent(),
+                                                        response.getBody(),
                                                         JourneyOutcomeResponse.class);
                             } catch (JsonException e) {
                                 LOG.error("Failed to parse journey outcome response", e);
@@ -189,7 +189,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
                             emitAuthorisationReceivedAuditEvent(journeyOutcome, userContext, input);
 
                             LOG.info("Journey outcome received successfully");
-                            return generateApiGatewayProxyResponse(200, response.getContent());
+                            return generateApiGatewayProxyResponse(200, response.getBody());
                         });
     }
 
@@ -268,7 +268,7 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
                 LOG.warn(
                         "Error {} when attempting to call AMC token endpoint: {}",
                         response.getStatusCode(),
-                        response.getContent());
+                        response.getBody());
                 return Result.failure(TokenResponseError.ERROR_RESPONSE_FROM_TOKEN_REQUEST);
             }
             return Result.success(TokenResponse.parse(response));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -179,7 +179,7 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
                 return generateApiGatewayProxyErrorResponse(400, REVERIFICATION_RESULT_GET_ERROR);
             }
 
-            return generateApiGatewayProxyResponse(200, reverificationResult.getContent());
+            return generateApiGatewayProxyResponse(200, reverificationResult.getBody());
         } catch (UnsuccessfulReverificationResponseException | ParseException e) {
             LOG.error("Error getting reverification result", e);
             return generateApiGatewayProxyErrorResponse(400, REVERIFICATION_RESULT_GET_ERROR);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -156,7 +156,7 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
 
             LOG.info("ReverificationResult response received from IPV");
 
-            var reverificationResultJson = reverificationResult.getContentAsJSONObject();
+            var reverificationResultJson = reverificationResult.getBodyAsJSONObject();
 
             var validMetadata =
                     extractValidMetadata(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -115,12 +115,13 @@ public class AMCService {
                 .mapFailure(this::mapJwtFailureReason)
                 .map(
                         signedJWT ->
-                                new TokenRequest(
-                                        configurationService.getAMCTokenEndpointURI(),
-                                        new PrivateKeyJWT(signedJWT),
-                                        new AuthorizationCodeGrant(
-                                                new AuthorizationCode(authCode),
-                                                URI.create(usedRedirectUrl))));
+                                new TokenRequest.Builder(
+                                                configurationService.getAMCTokenEndpointURI(),
+                                                new PrivateKeyJWT(signedJWT),
+                                                new AuthorizationCodeGrant(
+                                                        new AuthorizationCode(authCode),
+                                                        URI.create(usedRedirectUrl)))
+                                        .build());
     }
 
     public Result<JourneyOutcomeError, HTTPResponse> requestJourneyOutcome(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultService.java
@@ -6,7 +6,10 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.*;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
@@ -123,7 +126,7 @@ public class ReverificationResultService {
                             "Unsuccessful {} response from IPV token endpoint on attempt: {}; error: {}",
                             response.toHTTPResponse().getStatusCode(),
                             count,
-                            httpResponse.getContent());
+                            httpResponse.getBody());
                 }
             } catch (IOException e) {
                 LOG.error("Error whilst sending TokenRequest", e);
@@ -154,14 +157,14 @@ public class ReverificationResultService {
                             "Unsuccessful {} response from IPV reverification endpoint on attempt{}: {} ",
                             response.getStatusCode(),
                             count,
-                            response.getContent());
+                            response.getBody());
                 }
             } while (!response.indicatesSuccess() && count < maxTries);
             if (!response.indicatesSuccess()) {
                 throw new UnsuccessfulReverificationResponseException(
                         String.format(
                                 "Error %s when attempting to call IPV reverification endpoint: %s",
-                                response.getStatusCode(), response.getContent()));
+                                response.getStatusCode(), response.getBody()));
             }
             LOG.info("Received successful reverification response");
             return response;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultService.java
@@ -32,7 +32,6 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
@@ -77,15 +76,9 @@ public class ReverificationResultService {
                         NowHelper.now(),
                         NowHelper.now(),
                         new JWTID());
-        return new TokenRequest(
-                ipvTokenURI,
-                generatePrivateKeyJwt(claimsSet),
-                codeGrant,
-                null,
-                null,
-                Map.of(
-                        "client_id",
-                        singletonList(configurationService.getIPVAuthorisationClientId())));
+        return new TokenRequest.Builder(ipvTokenURI, generatePrivateKeyJwt(claimsSet), codeGrant)
+                .customParameter("client_id", configurationService.getIPVAuthorisationClientId())
+                .build();
     }
 
     private TokenResponse sendTokenRequest(TokenRequest tokenRequest) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/ReverificationTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/ReverificationTest.java
@@ -91,7 +91,7 @@ class ReverificationTest {
                                 tokens.getBearerAccessToken()));
 
         assertThat(
-                reverificationResponse.getContentAsJSONObject(),
+                reverificationResponse.getBodyAsJSONObject(),
                 equalTo(getResponseFromSuccessfulReverification()));
     }
 
@@ -200,7 +200,7 @@ class ReverificationTest {
                         + SUCCESS_FIELD
                         + "\":true"
                         + "}");
-        return reverificationHTTPResponse.getContentAsJSONObject();
+        return reverificationHTTPResponse.getBodyAsJSONObject();
     }
 
     private String getResponseFromUnsuccessfulReverification() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/ReverificationTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/ReverificationTest.java
@@ -189,7 +189,7 @@ class ReverificationTest {
     private JSONObject getResponseFromSuccessfulReverification() throws ParseException {
         var reverificationHTTPResponse = new HTTPResponse(200);
         reverificationHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        reverificationHTTPResponse.setContent(
+        reverificationHTTPResponse.setBody(
                 "{"
                         + "\""
                         + SUB_FIELD
@@ -206,7 +206,7 @@ class ReverificationTest {
     private String getResponseFromUnsuccessfulReverification() {
         var reverificationHTTPResponse = new HTTPResponse(400);
         reverificationHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        reverificationHTTPResponse.setContent(
+        reverificationHTTPResponse.setBody(
                 "{"
                         + "\""
                         + ERROR_CODE_FIELD

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/ReverificationTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/ReverificationTest.java
@@ -227,6 +227,6 @@ class ReverificationTest {
                         + SUCCESS_FIELD
                         + "\":false"
                         + "}\n");
-        return reverificationHTTPResponse.getContent();
+        return reverificationHTTPResponse.getBody();
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
@@ -469,7 +469,7 @@ class AMCCallbackHandlerTest {
 
     private void setupJourneyOutcomeResponse(String journeyOutcomeContent) {
         var journeyOutcomeHttpResponse = new HTTPResponse(200);
-        journeyOutcomeHttpResponse.setContent(journeyOutcomeContent);
+        journeyOutcomeHttpResponse.setBody(journeyOutcomeContent);
 
         when(AMC_SERVICE.requestJourneyOutcome(
                         argThat(
@@ -487,7 +487,7 @@ class AMCCallbackHandlerTest {
             throws ParseException, IOException {
         var httpResponse = new HTTPResponse(tokenResponseCode);
         httpResponse.setContentType("application/json");
-        httpResponse.setContent(tokenResponseBody);
+        httpResponse.setBody(tokenResponseBody);
         when(httpRequest.send()).thenReturn(httpResponse);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -527,7 +527,7 @@ class ReverificationResultHandlerTest {
                 throws ParseException, UnsuccessfulReverificationResponseException {
             HTTPResponse userInfo = new HTTPResponse(200);
             userInfo.setContentType("application/json");
-            userInfo.setContent(responseContent);
+            userInfo.setBody(responseContent);
 
             when(idReverificationStateService.get(anyString()))
                     .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));
@@ -554,7 +554,7 @@ class ReverificationResultHandlerTest {
                         + "}";
         var tokenHTTPResponse = new HTTPResponse(200);
         tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        tokenHTTPResponse.setContent(tokenResponseContent);
+        tokenHTTPResponse.setBody(tokenResponseContent);
 
         return TokenResponse.parse(tokenHTTPResponse);
     }
@@ -562,7 +562,7 @@ class ReverificationResultHandlerTest {
     private HTTPResponse successfulResponseWithBody(String body) throws ParseException {
         HTTPResponse userInfo = new HTTPResponse(200);
         userInfo.setContentType("application/json");
-        userInfo.setContent(body);
+        userInfo.setBody(body);
         return userInfo;
     }
 
@@ -575,7 +575,7 @@ class ReverificationResultHandlerTest {
 
         var tokenHTTPResponse = new HTTPResponse(400);
         tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        tokenHTTPResponse.setContent(tokenResponseContent);
+        tokenHTTPResponse.setBody(tokenResponseContent);
 
         return TokenErrorResponse.parse(tokenHTTPResponse);
     }
@@ -597,7 +597,7 @@ class ReverificationResultHandlerTest {
 
         HTTPResponse userInfo = new HTTPResponse(200);
         userInfo.setContentType("application/json");
-        userInfo.setContent(responseContent);
+        userInfo.setBody(responseContent);
 
         when(idReverificationStateService.get(anyString()))
                 .thenReturn(Optional.ofNullable(ID_REVERIFICATION_STATE));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -190,7 +190,7 @@ class ReverificationResultHandlerTest {
                     logging.events(),
                     hasItem(withMessageContaining(format("Received reverification success code"))));
             assertThat(result, hasStatus(200));
-            assertThat(result, hasBody(userInfo.getContent()));
+            assertThat(result, hasBody(userInfo.getBody()));
 
             verify(auditService)
                     .submitAuditEvent(
@@ -228,7 +228,7 @@ class ReverificationResultHandlerTest {
                             USER_CONTEXT);
 
             assertThat(result, hasStatus(200));
-            assertThat(result, hasBody(userInfo.getContent()));
+            assertThat(result, hasBody(userInfo.getBody()));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultServiceTest.java
@@ -50,9 +50,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
 import static java.util.Collections.singletonList;
@@ -351,8 +354,7 @@ class ReverificationResultServiceTest {
 
             var reverificationResult =
                     reverificationResultService.sendIpvReverificationRequest(userInfoRequest);
-            assertThat(
-                    reverificationResult.getContent(), equalTo(userInfoHTTPResponse.getContent()));
+            assertThat(reverificationResult.getBody(), equalTo(userInfoHTTPResponse.getBody()));
         }
 
         @Test
@@ -369,8 +371,7 @@ class ReverificationResultServiceTest {
 
             var reverificationResult =
                     reverificationResultService.sendIpvReverificationRequest(userInfoRequest);
-            assertThat(
-                    reverificationResult.getContent(), equalTo(userInfoHTTPResponse.getContent()));
+            assertThat(reverificationResult.getBody(), equalTo(userInfoHTTPResponse.getBody()));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ReverificationResultServiceTest.java
@@ -348,7 +348,7 @@ class ReverificationResultServiceTest {
                 throws IOException, UnsuccessfulReverificationResponseException {
             var userInfoHTTPResponse = new HTTPResponse(200);
             userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            userInfoHTTPResponse.setContent(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+            userInfoHTTPResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
             when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
             when(userInfoRequest.toHTTPRequest()).thenReturn(httpRequest);
 
@@ -362,7 +362,7 @@ class ReverificationResultServiceTest {
                 throws IOException, UnsuccessfulReverificationResponseException {
             var userInfoHTTPResponse = new HTTPResponse(200);
             userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            userInfoHTTPResponse.setContent(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+            userInfoHTTPResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
             when(userInfoRequest.toHTTPRequest()).thenReturn(httpRequest);
 
             when(httpRequest.send())
@@ -378,7 +378,7 @@ class ReverificationResultServiceTest {
         void shouldReturnUnsuccessfulResponseIfTwoCallsToIPVUserIdentityFail() throws IOException {
             var userInfoHTTPResponse = new HTTPResponse(200);
             userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-            userInfoHTTPResponse.setContent(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+            userInfoHTTPResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
             when(userInfoRequest.toHTTPRequest()).thenReturn(httpRequest);
 
             when(httpRequest.send()).thenReturn(new HTTPResponse(500));

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ libphonenumber = "com.googlecode.libphonenumber:libphonenumber:9.0.32"
 log4jJsonTemplate = "org.apache.logging.log4j:log4j-layout-template-json:2.25.4"
 mockitoCore = "org.mockito:mockito-core:5.23.0"
 nimbusJwt = "com.nimbusds:nimbus-jose-jwt:10.9.1"
-nimbusOidc = "com.nimbusds:oauth2-oidc-sdk:10.13.2"
+nimbusOidc = "com.nimbusds:oauth2-oidc-sdk:11.22.2"
 openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.28.1-alpha"
 openTelemetryAwsSdk = { module = "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure" }
 openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -154,7 +154,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
         String responseBody = response.getBody();
         HTTPResponse httpResponse = new HTTPResponse(200);
-        httpResponse.setContent(responseBody);
+        httpResponse.setBody(responseBody);
         httpResponse.setContentType(response.getHeaders().get("Content-Type"));
         TokenResponse tokenResponse = TokenResponse.parse(httpResponse);
         assertFalse(
@@ -201,7 +201,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
 
         String responseBody = response.getBody();
         HTTPResponse httpResponse = new HTTPResponse(200);
-        httpResponse.setContent(responseBody);
+        httpResponse.setBody(responseBody);
         httpResponse.setContentType(response.getHeaders().get("Content-Type"));
         TokenResponse tokenResponse = TokenResponse.parse(httpResponse);
         assertFalse(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -35,7 +35,6 @@ import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -103,15 +102,9 @@ public class IPVTokenService {
                         NowHelper.now(),
                         NowHelper.now(),
                         new JWTID());
-        return new TokenRequest(
-                ipvTokenURI,
-                generatePrivateKeyJwt(claimsSet),
-                codeGrant,
-                null,
-                null,
-                Map.of(
-                        "client_id",
-                        singletonList(configurationService.getIPVAuthorisationClientId())));
+        return new TokenRequest.Builder(ipvTokenURI, generatePrivateKeyJwt(claimsSet), codeGrant)
+                .customParameter("client_id", configurationService.getIPVAuthorisationClientId())
+                .build();
     }
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -80,7 +80,7 @@ public class IPVTokenService {
                         "Unsuccessful {} response from IPV token endpoint on attempt {}: {} ",
                         response.getStatusCode(),
                         count,
-                        response.getContent());
+                        response.getBody());
             }
         } while (!tokenResponse.indicatesSuccess() && count < maxTries);
 
@@ -143,9 +143,7 @@ public class IPVTokenService {
                     LOG.warn(
                             format(
                                     "Unsuccessful %s response from IPV user identity endpoint on attempt %d: %s ",
-                                    httpResponse.getStatusCode(),
-                                    count,
-                                    httpResponse.getContent()));
+                                    httpResponse.getStatusCode(), count, httpResponse.getBody()));
                 }
             } while (!userIdentityResponse.indicatesSuccess() && count < maxTries);
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvUserIdentityTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/contract/IpvUserIdentityTest.java
@@ -7,25 +7,27 @@ import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
-import com.nimbusds.oauth2.sdk.*;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
-import com.nimbusds.openid.connect.sdk.*;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
-import uk.gov.di.orchestration.shared.helpers.*;
-import uk.gov.di.orchestration.shared.services.*;
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 
 import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
 import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @PactConsumerTest
 public class IpvUserIdentityTest {
@@ -172,7 +174,7 @@ public class IpvUserIdentityTest {
     private UserInfo getUserInfoFromSuccessfulUserIdentityHttpResponse() throws ParseException {
         var userInfoHTTPResponse = new HTTPResponse(200);
         userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(
+        userInfoHTTPResponse.setBody(
                 "{"
                         + " \""
                         + SUB_FIELD

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -110,7 +110,7 @@ class IPVTokenServiceTest {
     }
 
     @Test
-    void shouldConstructTokenRequest() throws JOSEException, ParseException {
+    void shouldConstructTokenRequest() throws Exception {
         mockKmsSigningJwt();
         TokenRequest tokenRequest = ipvTokenService.constructTokenRequest(AUTH_CODE.getValue());
         assertThat(tokenRequest.getEndpointURI().toString(), equalTo(IPV_URI + "token"));
@@ -118,16 +118,17 @@ class IPVTokenServiceTest {
                 tokenRequest.getClientAuthentication().getMethod().getValue(),
                 equalTo("private_key_jwt"));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("redirect_uri").get(0),
                 equalTo(REDIRECT_URI.toString()));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("grant_type").get(0),
                 equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("client_id").get(0),
                 equalTo(CLIENT_ID.getValue()));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("resource"), equalTo(null));
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("resource"),
+                equalTo(null));
         assertSignRequestHeaderEquals(
                 new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(KEY_ID).build());
     }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -176,7 +176,7 @@ class IPVTokenServiceTest {
             throws IOException, UnsuccessfulCredentialResponseException {
         var userInfoHTTPResponse = new HTTPResponse(200);
         userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+        userInfoHTTPResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
         when(httpRequest.send()).thenReturn(userInfoHTTPResponse);
         when(userInfoRequest.toHTTPRequest()).thenReturn(httpRequest);
 
@@ -209,7 +209,7 @@ class IPVTokenServiceTest {
             throws IOException, UnsuccessfulCredentialResponseException {
         var userInfoHTTPResponse = new HTTPResponse(200);
         userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+        userInfoHTTPResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
         when(userInfoRequest.toHTTPRequest()).thenReturn(httpRequest);
 
         when(httpRequest.send()).thenReturn(new HTTPResponse(500)).thenReturn(userInfoHTTPResponse);
@@ -224,7 +224,7 @@ class IPVTokenServiceTest {
     void shouldReturnUnsuccessfulResponseIfTwoCallsToIPVUserIdentityFail() throws IOException {
         var userInfoHTTPResponse = new HTTPResponse(200);
         userInfoHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        userInfoHTTPResponse.setContent(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+        userInfoHTTPResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
         when(userInfoRequest.toHTTPRequest()).thenReturn(httpRequest);
 
         when(httpRequest.send()).thenReturn(new HTTPResponse(500));
@@ -288,7 +288,7 @@ class IPVTokenServiceTest {
                         + "}";
         var tokenHTTPResponse = new HTTPResponse(200);
         tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        tokenHTTPResponse.setContent(tokenResponseContent);
+        tokenHTTPResponse.setBody(tokenResponseContent);
 
         return tokenHTTPResponse;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -74,7 +74,7 @@ public class AuthenticationTokenService {
                         "Unsuccessful {} response from Authentication token endpoint on attempt {}: {} ",
                         response.getStatusCode(),
                         count,
-                        response.getContent());
+                        response.getBody());
             }
         } while (!tokenResponse.indicatesSuccess() && count < maxTries);
 
@@ -136,18 +136,18 @@ public class AuthenticationTokenService {
                     LOG.warn(
                             format(
                                     "Unsuccessful %s response from Authentication userinfo endpoint on attempt %d: %s ",
-                                    response.getStatusCode(), count, response.getContent()));
+                                    response.getStatusCode(), count, response.getBody()));
                 }
             } while (!response.indicatesSuccess() && count < maxTries);
             if (!response.indicatesSuccess()) {
                 LOG.error(
                         format(
                                 "Error %s when attempting to call Authentication userinfo endpoint: %s",
-                                response.getStatusCode(), response.getContent()));
+                                response.getStatusCode(), response.getBody()));
                 throw new UnsuccessfulCredentialResponseException(
                         format(
                                 "Error %s when attempting to call Authentication userinfo endpoint: %s",
-                                response.getStatusCode(), response.getContent()));
+                                response.getStatusCode(), response.getBody()));
             }
 
             LOG.info("Received successful userinfo response");
@@ -162,7 +162,7 @@ public class AuthenticationTokenService {
     UserInfo parseUserInfoFromResponse(HTTPResponse response)
             throws UnsuccessfulCredentialResponseException {
         try {
-            String content = response.getContent();
+            String content = response.getBody();
             if (content == null) {
                 LOG.error("No content in HTTP response");
                 throw new UnsuccessfulCredentialResponseException("No content in HTTP response");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -97,15 +96,10 @@ public class AuthenticationTokenService {
                         NowHelper.now(),
                         NowHelper.now(),
                         new JWTID());
-        return new TokenRequest(
-                tokenURI,
-                generatePrivateKeyJwt(claimsSet),
-                codeGrant,
-                null,
-                singletonList(tokenURI),
-                Map.of(
-                        "client_id",
-                        singletonList(configurationService.getOrchestrationClientId())));
+        return new TokenRequest.Builder(tokenURI, generatePrivateKeyJwt(claimsSet), codeGrant)
+                .resource(tokenURI)
+                .customParameter("client_id", configurationService.getOrchestrationClientId())
+                .build();
     }
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
@@ -165,7 +165,7 @@ class AuthenticationTokenServiceTest {
         HTTPResponse httpResponse = mock(HTTPResponse.class);
         when(httpRequest.send()).thenReturn(httpResponse);
         when(httpResponse.indicatesSuccess()).thenReturn(true);
-        when(httpResponse.getContent()).thenReturn(userInfoJson);
+        when(httpResponse.getBody()).thenReturn(userInfoJson);
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("Content-Type", Collections.singletonList("application/json"));
@@ -185,7 +185,7 @@ class AuthenticationTokenServiceTest {
         int failureStatusCode = 503;
         String failureErrorMessage = "Error content";
         when(httpResponse.getStatusCode()).thenReturn(failureStatusCode);
-        when(httpResponse.getContent()).thenReturn(failureErrorMessage);
+        when(httpResponse.getBody()).thenReturn(failureErrorMessage);
 
         UnsuccessfulCredentialResponseException exception =
                 assertThrows(
@@ -206,7 +206,7 @@ class AuthenticationTokenServiceTest {
     @Test
     void shouldThrowUnsuccessfulCredentialResponseExceptionWhenHttpContentIsNull() {
         HTTPResponse httpResponse = mock(HTTPResponse.class);
-        when(httpResponse.getContent()).thenReturn(null);
+        when(httpResponse.getBody()).thenReturn(null);
 
         UnsuccessfulCredentialResponseException thrown =
                 assertThrows(
@@ -221,7 +221,7 @@ class AuthenticationTokenServiceTest {
     @Test
     void shouldThrowUnsuccessfulCredentialResponseExceptionWhenObjectMapperThrowsException() {
         HTTPResponse httpResponse = mock(HTTPResponse.class);
-        when(httpResponse.getContent()).thenReturn("{}");
+        when(httpResponse.getBody()).thenReturn("{}");
 
         UnsuccessfulCredentialResponseException thrown =
                 assertThrows(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
@@ -89,7 +89,7 @@ class AuthenticationTokenServiceTest {
     }
 
     @Test
-    void shouldConstructTokenRequest() throws JOSEException {
+    void shouldConstructTokenRequest() throws Exception {
         signJWTWithKMS(KEY_ID);
         TokenRequest tokenRequest =
                 authenticationTokenService.constructTokenRequest(AUTH_CODE.getValue());
@@ -98,13 +98,13 @@ class AuthenticationTokenServiceTest {
                 tokenRequest.getClientAuthentication().getMethod().getValue(),
                 equalTo("private_key_jwt"));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("redirect_uri").get(0),
                 equalTo(ORCH_CALLBACK_URI.toString()));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("grant_type").get(0),
                 equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
         assertThat(
-                tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("client_id").get(0),
                 equalTo(CLIENT_ID.getValue()));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
@@ -286,7 +286,7 @@ class AuthenticationTokenServiceTest {
                         + "}";
         var tokenHTTPResponse = new HTTPResponse(200);
         tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
-        tokenHTTPResponse.setContent(tokenResponseContent);
+        tokenHTTPResponse.setBody(tokenResponseContent);
 
         return tokenHTTPResponse;
     }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/TokenGeneratorHelper.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/helper/TokenGeneratorHelper.java
@@ -70,7 +70,7 @@ public class TokenGeneratorHelper {
                         subject,
                         List.of(new Audience(clientId)),
                         expiryDate,
-                        new Date());
+                        Date.from(expiryDate.toInstant().minus(1, ChronoUnit.DAYS)));
         if (Objects.nonNull(clientSessionId)) idTokenClaims.setClaim("sid", clientSessionId);
         if (Objects.nonNull(vot)) idTokenClaims.setClaim("vot", vot);
 
@@ -140,7 +140,7 @@ public class TokenGeneratorHelper {
                         .claim("scope", scopes)
                         .issuer(issuerUrl)
                         .expirationTime(expiryDate)
-                        .issueTime(NowHelper.now())
+                        .issueTime(Date.from(expiryDate.toInstant().minus(1, ChronoUnit.DAYS)))
                         .claim("client_id", clientId)
                         .subject(subject.getValue())
                         .jwtID(UUID.randomUUID().toString());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java
@@ -10,6 +10,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
 import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.auth.verifier.JWTAudienceCheck;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -110,7 +111,8 @@ public class ClientSignatureValidationService {
                             new PrivateKeyJwtAuthPublicKeySelector(publicKey),
                             Set.of(
                                     new Audience(oidcAPI.tokenURI().toString()),
-                                    new Audience(oidcAPI.getIssuerURI().toString())));
+                                    new Audience(oidcAPI.getIssuerURI().toString())),
+                            JWTAudienceCheck.LEGACY);
             authenticationVerifier.verify(privateKeyJWT, null, null);
         } catch (InvalidClientException
                 | NoSuchAlgorithmException


### PR DESCRIPTION
### Wider context of change

We have previously analysed the changes from our previous version of `com.nimbusds:oauth2-oidc-sdk` to `11.21` and have ensured that RPs are not sending invalid auth requests.

### What’s changed

Unfortunately, due to `11.7.1` introducing a dependency with a vulnerability, we have had to update to `11.22.2` instead, where the vulnerable dependency was updated to a non-vulnerable version. This PR also replaces all the now-deprecated methods and constructors, and replaces them with their equivalent in `11.22.2`.

### Manual testing

Deployed to dev, ran through an auth only journey, an identity journey, and a docapp journey. All 3 journeys were successful.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

