### PR TITLE
AUT-5524: Turn on account intervention tests

### DIFF
--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -12,12 +12,12 @@ Mappings:
   AcceptanceTestTags:
     dev:
       tags: >-
-        @UI and not (@AccountInterventions or @Reauth or
+        @UI and not (@Reauth or
         @AccountRecovery or @InternationalSmsSendingDisabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-
-        @UI and not (@under-development or @AccountInterventions or @Reauth or
+        @UI and not (@under-development or @Reauth or
         @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
         or @PasskeysEnabled or @PasskeyUsageEnabled)
     staging:


### PR DESCRIPTION
## What

- The tests were turned off as they started failing due to auth using the orch stub
- The failing tests have been removed from the acceptance tests entirely as they test orchestration behaviour, not authentication behaviour
- The remaining succeeding tests that test authentication behaviour have been reinstated
- Account interventions tests should not be run in staging at all as there is currently no way to set up a test user
## How to review

1. Code Review
2. Deploy to dev alongside AT changes and see tests pass

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/937