### PR TITLE
BAU: Enable @PasskeyUsageEnabled tests in Dev and Staging

### DIFF
--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -13,7 +13,7 @@ Mappings:
     dev:
       tags: >-
         @UI and not (@AccountInterventions or @Reauth or
-        @AccountRecovery or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled)
+        @AccountRecovery or @InternationalSmsSendingDisabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-
@@ -24,7 +24,7 @@ Mappings:
       tags: >-
         @UI and not (@under-development or @AccountInterventions or @Reauth or
         @new-mfa-reset-with-ipv or @AcceptInternationalNumbers
-        or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled or @EnvironmentWithAMCStubDeployed)
+        or @InternationalSmsSendingDisabled or @EnvironmentWithAMCStubDeployed)
 
 Resources:
   AcceptanceTestAPICucumberFilterTags:


### PR DESCRIPTION
## What

Removes `@PasskeyUsageEnabled` from the `not` section of the acceptance test filter flags for Dev and Staging, so that these tests now run. We'll continue to keep it disabled in Build until we go-live.

## How to review

1. Code Review