### PR TITLE
AUT-5368: Rehash existing passwords on successful sign in (dev and staging)

### DIFF
--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -32,6 +32,13 @@ Resources:
               argon2Parallelism,
               DefaultValue: "1",
             ]
+          PASSWORD_REHASH_ON_LOGIN_ENABLED:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              passwordRehashOnLoginEnabled,
+              DefaultValue: "false",
+            ]
           AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -277,6 +277,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "true"
       relyingPartyId: authdev1.dev.account.gov.uk
     authdev2:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ff8d97e6-69d6-4ea1-81c0-0de8d8bcac85
@@ -334,6 +335,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "true"
       relyingPartyId: authdev2.dev.account.gov.uk
     authdev3:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/8a67ba56-4eb2-4bfb-8254-5cc1c92a5db5
@@ -395,6 +397,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "true"
       relyingPartyId: authdev3.dev.account.gov.uk
     dev:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f5e5d059-1581-4c5c-8d60-e168fd8a9a84
@@ -461,6 +464,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "true"
       relyingPartyId: dev.account.gov.uk
     build:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/e8fdebb6-2d33-4d0c-825c-2b5c874522d8
@@ -532,6 +536,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "false"
       relyingPartyId: build.account.gov.uk
     staging:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
@@ -605,6 +610,7 @@ Mappings:
       argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "true"
       relyingPartyId: staging.account.gov.uk
     integration:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
@@ -678,6 +684,7 @@ Mappings:
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "false"
       relyingPartyId: integration.account.gov.uk
     production:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/730472f0-c7ba-4bda-a411-08cdaa65fe8a
@@ -751,6 +758,7 @@ Mappings:
       argon2MemoryInKibibytes: "15360"
       argon2Iterations: "2"
       argon2Parallelism: "1"
+      passwordRehashOnLoginEnabled: "false"
       relyingPartyId: account.gov.uk
   LambdaConfiguration:
     account-recovery:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -29,6 +29,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -304,6 +305,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             JourneyType journeyType,
             PermissionContext permissionContext) {
 
+        rehashPasswordIfRequired(request.getEmail(), request.getPassword(), userCredentials);
+
         var userMfaDetail = getUserMFADetail(userCredentials, userProfile);
         var isMfaRequired = MfaHelper.mfaRequired(authSessionItem.getRequestedCredentialStrength());
 
@@ -576,5 +579,24 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             return formatPhoneNumber(mfaMethod.getDestination());
         }
         return null;
+    }
+
+    private void rehashPasswordIfRequired(
+            String email, String password, UserCredentials userCredentials) {
+        try {
+            if (!configurationService.isPasswordRehashOnLoginEnabled()) {
+                return;
+            }
+            boolean needsRehash =
+                    Argon2MatcherHelper.needsRehash(
+                            userCredentials.getPassword(), configurationService);
+            LOG.info("Password rehash check: needsRehash={}", needsRehash);
+            if (needsRehash) {
+                authenticationService.updatePassword(email, password);
+                LOG.info("Password rehash completed for user");
+            }
+        } catch (Exception e) {
+            LOG.error("Error during password rehash", e);
+        }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -76,6 +76,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -1502,5 +1503,104 @@ class LoginHandlerTest {
         handler.handleRequest(event, context);
 
         verify(authSessionService).updateSession(argThat(s -> !s.getIsPartiallyCreatedAccount()));
+    }
+
+    @Test
+    void shouldRehashPasswordWhenFlagEnabledAndParamsDiffer() {
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(configurationService.isPasswordRehashOnLoginEnabled()).thenReturn(true);
+        when(configurationService.getArgon2MemoryInKibibytes()).thenReturn(32768);
+        when(configurationService.getArgon2Iterations()).thenReturn(2);
+        when(configurationService.getArgon2Parallelism()).thenReturn(1);
+        var userCredentials =
+                new UserCredentials()
+                        .withEmail(EMAIL)
+                        .withPassword(
+                                "$argon2id$v=19$m=15360,t=2,p=1$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw");
+        when(authenticationService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
+        when(authenticationService.login(userCredentials, CommonTestVariables.PASSWORD))
+                .thenReturn(true);
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_MFA_METHOD)));
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        handler.handleRequest(event, context);
+
+        verify(authenticationService).updatePassword(EMAIL, CommonTestVariables.PASSWORD);
+    }
+
+    @Test
+    void shouldNotRehashPasswordWhenFlagDisabled() {
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(configurationService.isPasswordRehashOnLoginEnabled()).thenReturn(false);
+        usingApplicableUserCredentialsWithLogin(SMS, true);
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        handler.handleRequest(event, context);
+
+        verify(authenticationService, never()).updatePassword(anyString(), anyString());
+    }
+
+    @Test
+    void shouldNotRehashPasswordWhenFlagEnabledButParamsMatch() {
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(configurationService.isPasswordRehashOnLoginEnabled()).thenReturn(true);
+        when(configurationService.getArgon2MemoryInKibibytes()).thenReturn(15360);
+        when(configurationService.getArgon2Iterations()).thenReturn(2);
+        when(configurationService.getArgon2Parallelism()).thenReturn(1);
+        var userCredentials =
+                new UserCredentials()
+                        .withEmail(EMAIL)
+                        .withPassword(
+                                "$argon2id$v=19$m=15360,t=2,p=1$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw");
+        when(authenticationService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
+        when(authenticationService.login(userCredentials, CommonTestVariables.PASSWORD))
+                .thenReturn(true);
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_MFA_METHOD)));
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        handler.handleRequest(event, context);
+
+        verify(authenticationService, never()).updatePassword(anyString(), anyString());
+    }
+
+    @Test
+    void shouldStillLoginSuccessfullyWhenRehashThrowsException() {
+        UserProfile userProfile = generateUserProfile(null);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(configurationService.isPasswordRehashOnLoginEnabled()).thenReturn(true);
+        when(configurationService.getArgon2MemoryInKibibytes()).thenReturn(32768);
+        when(configurationService.getArgon2Iterations()).thenReturn(2);
+        when(configurationService.getArgon2Parallelism()).thenReturn(1);
+        var userCredentials =
+                new UserCredentials()
+                        .withEmail(EMAIL)
+                        .withPassword(
+                                "$argon2id$v=19$m=15360,t=2,p=1$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw");
+        when(authenticationService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
+        when(authenticationService.login(userCredentials, CommonTestVariables.PASSWORD))
+                .thenReturn(true);
+        when(mfaMethodsService.getMfaMethods(EMAIL))
+                .thenReturn(Result.success(List.of(DEFAULT_SMS_MFA_METHOD)));
+        usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
+        doThrow(new RuntimeException("DynamoDB error"))
+                .when(authenticationService)
+                .updatePassword(anyString(), anyString());
+
+        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelper.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.bouncycastle.crypto.params.Argon2Parameters;
 import org.bouncycastle.util.Arrays;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Base64;
 
@@ -26,6 +27,21 @@ public class Argon2MatcherHelper {
         generator.init(decoded.getParameters());
         generator.generateBytes(rawPassword.toCharArray(), hashBytes);
         return constantTimeArrayEquals(decoded.getHash(), hashBytes);
+    }
+
+    public static boolean needsRehash(
+            String encodedPassword, ConfigurationService configurationService) {
+        try {
+            Argon2Hash decoded = decode(encodedPassword);
+            Argon2Parameters params = decoded.getParameters();
+            return params.getVersion() != Argon2Parameters.ARGON2_VERSION_13
+                    || params.getMemory() != configurationService.getArgon2MemoryInKibibytes()
+                    || params.getIterations() != configurationService.getArgon2Iterations()
+                    || params.getLanes() != configurationService.getArgon2Parallelism();
+        } catch (IllegalArgumentException ex) {
+            LOG.warn("Unable to parse password hash for rehash check");
+            return false;
+        }
     }
 
     private static boolean constantTimeArrayEquals(byte[] expected, byte[] actual) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -785,6 +785,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
+    public boolean isPasswordRehashOnLoginEnabled() {
+        return System.getenv()
+                .getOrDefault("PASSWORD_REHASH_ON_LOGIN_ENABLED", FEATURE_SWITCH_OFF)
+                .equals(FEATURE_SWITCH_ON);
+    }
+
     public boolean isAuthenticationAttemptsServiceEnabled() {
         return System.getenv()
                 .getOrDefault("AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED", FEATURE_SWITCH_OFF)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelperNeedsRehashTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelperNeedsRehashTest.java
@@ -1,0 +1,67 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Argon2MatcherHelperNeedsRehashTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    private static final String HASH_M15360_T2_P1 =
+            "$argon2id$v=19$m=15360,t=2,p=1$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw";
+
+    @Test
+    void shouldReturnFalseWhenAllParamsMatchConfig() {
+        setupConfig(15360, 2, 1);
+        assertFalse(Argon2MatcherHelper.needsRehash(HASH_M15360_T2_P1, configurationService));
+    }
+
+    @Test
+    void shouldReturnTrueWhenMemoryDiffers() {
+        setupConfig(7777, 2, 1);
+        assertTrue(Argon2MatcherHelper.needsRehash(HASH_M15360_T2_P1, configurationService));
+    }
+
+    @Test
+    void shouldReturnTrueWhenIterationsDiffer() {
+        setupConfig(15360, 7, 1);
+        assertTrue(Argon2MatcherHelper.needsRehash(HASH_M15360_T2_P1, configurationService));
+    }
+
+    @Test
+    void shouldReturnTrueWhenParallelismDiffers() {
+        setupConfig(15360, 2, 7);
+        assertTrue(Argon2MatcherHelper.needsRehash(HASH_M15360_T2_P1, configurationService));
+    }
+
+    @Test
+    void shouldReturnTrueWhenVersionDiffers() {
+        String hashWithOldVersion =
+                "$argon2id$v=16$m=15360,t=2,p=1$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw";
+        setupConfig(15360, 2, 1);
+        assertTrue(Argon2MatcherHelper.needsRehash(hashWithOldVersion, configurationService));
+    }
+
+    @Test
+    void shouldReturnFalseForMalformedHash() {
+        setupConfig(15360, 2, 1);
+        assertFalse(Argon2MatcherHelper.needsRehash("not-a-valid-hash", configurationService));
+    }
+
+    @Test
+    void shouldReturnFalseForEmptyString() {
+        setupConfig(15360, 2, 1);
+        assertFalse(Argon2MatcherHelper.needsRehash("", configurationService));
+    }
+
+    private void setupConfig(int memory, int iterations, int parallelism) {
+        when(configurationService.getArgon2MemoryInKibibytes()).thenReturn(memory);
+        when(configurationService.getArgon2Iterations()).thenReturn(iterations);
+        when(configurationService.getArgon2Parallelism()).thenReturn(parallelism);
+    }
+}


### PR DESCRIPTION
## What

* Added `PASSWORD_REHASH_ON_LOGIN_ENABLED` infrastructure config and feature toggle.
* Added `Argon2MatcherHelper.needsRehash()` to check for outdated password hashes.
* Updated `LoginHandler` to silently rehash and update passwords on successful sign in if parameters differ.
* Wrapped the rehash logic in a try-catch block to prevent sign in failures on error.

NOTE: This PR only enables the new flag for the dev and staging environments. Build is excluded to replicate the production environment.

Other info: The user should not receive an email notifying them of a "password change" as the rehashing is a transparent upgrade to the hashing algorithm parameters and the underlying plaintext password has not changed (only the stored hash).

## How to review

1. Code review
1. Deploy to a dev environment using the GitHub dev deployment workflows.
1. Verify the `PASSWORD_REHASH_ON_LOGIN_ENABLED` environment variable is correctly applied to the login Lambda.
1. Sign in using test credentials that have an outdated Argon2 hash (e.g., different memory, iterations, or parallelism).
1. Check the dev database to confirm the user's password hash has been updated to match the current configuration parameters.
1. Observe the logs to ensure the `Password rehash completed for user` message is emitted.
1. Sign in again using the same test credentials to check that these are still valid after the rehashing operation.
1. Confirm no "password changed" email was received.

## Testing

Ran through the above steps, confirmed password was rehashed (reviewed dev DB item and the lambda logs), confirmed could sign in again. Confirmed no "password changed" email was received.

## Checklist

- [x] Deployment of this PR will not break active user journeys **- Rehashing should occur silently on sign in, with any exception caught.**

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**

- [ ] A UCD review has been performed. **- N/A, backend only.**