### PR TITLE
ATO-2710: Add signing key to SISJwksHandler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/orchestration/sis/lambda/SISJwksHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/sis/lambda/SISJwksHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+package uk.gov.di.orchestration.sis.lambda;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.text.ParseException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class SISJwksHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    @Test
+    void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
+        handler = new SISJwksHandler(TEST_CONFIGURATION_SERVICE);
+
+        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+
+        assertThat(response, hasStatus(200));
+        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
+    }
+}

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -92,6 +92,10 @@ public class IntegrationTest {
             new TokenSigningExtension("ipv-token-auth-key");
 
     @RegisterExtension
+    protected static final TokenSigningExtension sisPrivateKeyJwtSigner =
+            new TokenSigningExtension("sis-token-auth-key");
+
+    @RegisterExtension
     protected static final TokenSigningExtension docAppPrivateKeyJwtSigner =
             new TokenSigningExtension("doc-app-token-auth-key");
 
@@ -233,6 +237,11 @@ public class IntegrationTest {
         @Override
         public String getIPVTokenSigningKeyAlias() {
             return ipvPrivateKeyJwtSigner.getKeyAlias();
+        }
+
+        @Override
+        public String getSISTokenSigningKeyAlias() {
+            return sisPrivateKeyJwtSigner.getKeyAlias();
         }
 
         @Override

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -288,6 +288,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 System.getenv().getOrDefault("JWK_CACHE_EXPIRATION_IN_SECONDS", "300"));
     }
 
+    public String getSISTokenSigningKeyAlias() {
+        return System.getenv("SIS_TOKEN_SIGNING_KEY_ALIAS");
+    }
+
     public String getInternalSectorURI() {
         return System.getenv("INTERNAl_SECTOR_URI");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -95,6 +95,11 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getIPVTokenSigningKeyAlias());
     }
 
+    public JWK getPublicSisTokenJwkWithOpaqueId() {
+        LOG.info("Retrieving SIS token public key");
+        return getPublicJWKWithKeyId(configurationService.getSISTokenSigningKeyAlias());
+    }
+
     public JWK getPublicAuthSigningJwkWithOpaqueId() {
         LOG.info("Retrieving Auth public signing key");
         return getPublicJWKWithKeyId(configurationService.getAuthSigningKeyAlias());

--- a/sis-api/src/main/java/uk/gov/di/orchestration/sis/lambda/SISJwksHandler.java
+++ b/sis-api/src/main/java/uk/gov/di/orchestration/sis/lambda/SISJwksHandler.java
@@ -4,14 +4,41 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.JwksService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachTraceId;
 
 public class SISJwksHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final JwksService jwksService;
+    private static final Logger LOG = LogManager.getLogger(SISJwksHandler.class);
+
+    public SISJwksHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
+    }
+
+    public SISJwksHandler(ConfigurationService configurationService) {
+        this.jwksService =
+                new JwksService(
+                        configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public SISJwksHandler() {
+        this(ConfigurationService.getInstance());
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
@@ -21,7 +48,26 @@ public class SISJwksHandler
     }
 
     public APIGatewayProxyResponseEvent sisJwksRequestHandler() {
-        return generateApiGatewayProxyResponse(
-                200, "Test lambda", Map.of("Cache-Control", "max-age=86400"), null);
+        try {
+            attachTraceId();
+            LOG.info("SISJwks request received");
+
+            List<JWK> signingKeys = new ArrayList<>();
+
+            signingKeys.add(jwksService.getPublicSisTokenJwkWithOpaqueId());
+
+            JWKSet jwkSet = new JWKSet(signingKeys);
+
+            LOG.info("Generating SISJwks successful response");
+
+            return generateApiGatewayProxyResponse(
+                    200,
+                    segmentedFunctionCall("serialiseJWKSet", () -> jwkSet.toString(true)),
+                    Map.of("Cache-Control", "max-age=86400"),
+                    null);
+        } catch (Exception e) {
+            LOG.error("Error in SISJwks lambda", e);
+            return generateApiGatewayProxyResponse(500, "Error providing SISJwks data");
+        }
     }
 }

--- a/sis-api/src/test/java/uk/gov/di/orchestration/sis/lambda/SISJwksHandlerTest.java
+++ b/sis-api/src/test/java/uk/gov/di/orchestration/sis/lambda/SISJwksHandlerTest.java
@@ -2,21 +2,60 @@ package uk.gov.di.orchestration.sis.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.services.JwksService;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasHeader;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-public class SISJwksHandlerTest {
+class SISJwksHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final JwksService jwksService = mock(JwksService.class);
+    private SISJwksHandler handler;
+    private ECKey sisTokenSigningKey;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        sisTokenSigningKey =
+                new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+        handler = new SISJwksHandler(jwksService);
+
+        when(jwksService.getPublicSisTokenJwkWithOpaqueId()).thenReturn(sisTokenSigningKey);
+    }
+
     @Test
-    void shouldCheckLambdaReturnsExpectedValue() {
-        var sisJwksHandler = new SISJwksHandler();
+    void shouldReturnASingleJwk() {
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
 
-        var response =
-                sisJwksHandler.handleRequest(
-                        new APIGatewayProxyRequestEvent(), mock(Context.class));
+        var expectedJWKSet = new JWKSet(List.of(sisTokenSigningKey));
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals("Test lambda", response.getBody());
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
+        assertThat(result, hasHeader("Cache-Control", "max-age=86400"));
+    }
+
+    @Test
+    void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(jwksService.getPublicSisTokenJwkWithOpaqueId()).thenReturn(null);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody("Error providing SISJwks data"));
     }
 }


### PR DESCRIPTION
### Wider context of change

We have added a new signing key for SIS, and have a SISJwksHandler which is doing nothing at the moment. We would like to make the handler serve this signing key.

### What’s changed

This PR passes the key alias for our SIS signing key to SISJwksHandler and serves it, much like our other JWKS endpoints. I've also added unit and integration tests for this.

### Manual testing

Tested by deploying to dev and manually invoking the lambda in the AWS console. Saw the response was a JWKS response and had 1 key in it.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

