### PR TITLE
BAU: Refactor IntegrationTestConfigurationService

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/orchestration/app/lambda/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/app/lambda/DocAppCallbackHandlerIntegrationTest.java
@@ -27,7 +27,6 @@ import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.orchestration.shared.helpers.SaltHelper;
-import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.CriStubExtension;
@@ -130,7 +129,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldRedirectToRpWhenSuccessfullyProcessedDocAppResponse() throws Json.JsonException {
+    void shouldRedirectToRpWhenSuccessfullyProcessedDocAppResponse() {
         setupSession();
 
         var response =
@@ -165,8 +164,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldRedirectToRpWhenSuccessfullyProcessedDocAppResponseUsingUserinfoV2Endpoint()
-            throws Json.JsonException {
+    void shouldRedirectToRpWhenSuccessfullyProcessedDocAppResponseUsingUserinfoV2Endpoint() {
         handler = new DocAppCallbackHandler(configurationService);
         setupSession();
 
@@ -202,8 +200,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldThrowIfClientSessionAndUserInfoEndpointDocAppIdDoesNotMatch()
-            throws Json.JsonException {
+    void shouldThrowIfClientSessionAndUserInfoEndpointDocAppIdDoesNotMatch() {
         setupSession();
 
         criStub.register(
@@ -234,7 +231,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldThrowIfInvalidResponseReceivedFromCriProtectedEndpoint() throws Json.JsonException {
+    void shouldThrowIfInvalidResponseReceivedFromCriProtectedEndpoint() {
         setupSession();
 
         criStub.register("/userinfo/v2", 200, "application/jwt", "invalid-response");
@@ -261,8 +258,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldSendAuthenticationErrorResponseToRPWhenCRIRequestReturns404()
-            throws Json.JsonException {
+    void shouldSendAuthenticationErrorResponseToRPWhenCRIRequestReturns404() {
         setupSession();
         handler = new DocAppCallbackHandler(configurationService);
 
@@ -293,7 +289,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldThrowIfErrorReceivedFromCriProtectedEndpoint() throws Json.JsonException {
+    void shouldThrowIfErrorReceivedFromCriProtectedEndpoint() {
         setupSession();
 
         criStub.register("/userinfo/v2", 400, "application/jwt", "error");
@@ -320,8 +316,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     }
 
     @Test
-    void shouldRedirectToRPWhenNoSessionCookieAndAccessDeniedErrorIsPresent()
-            throws Json.JsonException {
+    void shouldRedirectToRPWhenNoSessionCookieAndAccessDeniedErrorIsPresent() {
         setupSession();
         crossBrowserStorageExtension.store(DOC_APP_STATE, CLIENT_SESSION_ID);
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/app/lambda/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/app/lambda/DocAppCallbackHandlerIntegrationTest.java
@@ -36,9 +36,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.DocumentAppCredentialStoreE
 import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -110,12 +108,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
             new CrossBrowserStorageExtension();
 
     protected static final ConfigurationService configurationService =
-            new DocAppCallbackHandlerIntegrationTest.TestConfigurationService(
-                    criStub,
-                    externalTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner);
+            new TestConfigurationService(criStub);
 
     private static final String CLIENT_ID = "test-client-id";
     private static final String CLIENT_NAME = "test-client-name";
@@ -357,7 +350,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), equalTo(expectedURI));
     }
 
-    private void setupSession() throws Json.JsonException {
+    private void setupSession() {
         var authRequestBuilder =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE,
@@ -399,19 +392,8 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
         private final CriStubExtension criStubExtension;
 
-        public TestConfigurationService(
-                CriStubExtension criStubExtension,
-                TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotRequestQueue,
-                TokenSigningExtension docAppPrivateKeyJwtSigner) {
-            super(
-                    tokenSigningKey,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+        public TestConfigurationService(CriStubExtension criStubExtension) {
+            super();
             this.criStubExtension = criStubExtension;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCallbackHandlerIntegrationTest.java
@@ -48,9 +48,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.IPVStubExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.orchestration.testsupport.helpers.SpotQueueAssertionHelper;
 
 import java.net.URI;
@@ -138,9 +136,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     @BeforeEach
     void setup() {
         ipvStub.init();
-        configurationService =
-                new IPVCallbackHandlerIntegrationTest.TestConfigurationService(
-                        ipvStub, externalTokenSigner, ipvPrivateKeyJwtSigner, spotRequestQueue);
+        configurationService = new TestConfigurationService(ipvStub);
         handler = new IPVCallbackHandler(configurationService);
         txmaAuditQueue.clear();
         spotRequestQueue.clear();
@@ -351,13 +347,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     }
 
     private void enableSyncWaitForSPOT() {
-        configurationService =
-                new TestConfigurationService(
-                        ipvStub,
-                        externalTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        true);
+        configurationService = new TestConfigurationService(ipvStub, true);
         handler = new IPVCallbackHandler(configurationService);
     }
 
@@ -706,27 +696,13 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         private final IPVStubExtension ipvStubExtension;
         private final boolean isSyncWaitForSPOTEnabled;
 
-        public TestConfigurationService(
-                IPVStubExtension ipvStub,
-                TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotRequestQueue) {
-            this(ipvStub, tokenSigningKey, ipvPrivateKeyJwtSigner, spotRequestQueue, false);
+        public TestConfigurationService(IPVStubExtension ipvStub) {
+            this(ipvStub, false);
         }
 
         public TestConfigurationService(
-                IPVStubExtension ipvStub,
-                TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotRequestQueue,
-                boolean isSyncWaitForSPOTEnabled) {
-            super(
-                    tokenSigningKey,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+                IPVStubExtension ipvStub, boolean isSyncWaitForSPOTEnabled) {
+            super();
             this.ipvStubExtension = ipvStub;
             this.isSyncWaitForSPOTEnabled = isSyncWaitForSPOTEnabled;
         }

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCapacityHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IPVCapacityHandlerIntegrationTest.java
@@ -41,13 +41,7 @@ class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     }
 
     public ConfigurationService capacityAwareConfiguration(String value) {
-        return new IntegrationTestConfigurationService(
-                externalTokenSigner,
-                storageTokenSigner,
-                ipvPrivateKeyJwtSigner,
-                spotRequestQueue,
-                docAppPrivateKeyJwtSigner,
-                configurationParameters) {
+        return new IntegrationTestConfigurationService() {
 
             @Override
             public String getTxmaAuditQueueUrl() {

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IpvJwksHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IpvJwksHandlerIntegrationTest.java
@@ -17,9 +17,7 @@ import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyRespons
 class IpvJwksHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService = new IntegrationTestConfigurationService();
-
-        handler = new IpvJwksHandler(configurationService);
+        handler = new IpvJwksHandler(TEST_CONFIGURATION_SERVICE);
 
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IpvJwksHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/ipv/lambda/IpvJwksHandlerIntegrationTest.java
@@ -17,14 +17,7 @@ import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyRespons
 class IpvJwksHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService =
-                new IntegrationTestConfigurationService(
-                        externalTokenSigner,
-                        storageTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters);
+        var configurationService = new IntegrationTestConfigurationService();
 
         handler = new IpvJwksHandler(configurationService);
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthJwksHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthJwksHandlerIntegrationTest.java
@@ -16,9 +16,7 @@ import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyRespons
 class AuthJwksHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200WithAuthPublicSigningKey() throws ParseException {
-        var configurationService = new IntegrationTestConfigurationService();
-
-        handler = new AuthJwksHandler(configurationService);
+        handler = new AuthJwksHandler(TEST_CONFIGURATION_SERVICE);
 
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthJwksHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthJwksHandlerIntegrationTest.java
@@ -4,7 +4,6 @@ import com.nimbusds.jose.jwk.JWKSet;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.AuthJwksHandler;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.orchestration.sharedtest.basetest.IntegrationTest;
 
 import java.text.ParseException;
 import java.util.Map;
@@ -17,14 +16,7 @@ import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyRespons
 class AuthJwksHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn200WithAuthPublicSigningKey() throws ParseException {
-        var configurationService =
-                new IntegrationTest.IntegrationTestConfigurationService(
-                        externalTokenSigner,
-                        storageTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters);
+        var configurationService = new IntegrationTestConfigurationService();
 
         handler = new AuthJwksHandler(configurationService);
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthenticationCallbackHandlerIntegrationTest.java
@@ -57,7 +57,6 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
-import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -166,14 +165,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
     @BeforeAll
     static void beforeAll() {
         configurationService =
-                new AuthenticationCallbackHandlerIntegrationTest.TestConfigurationService(
-                        authExternalApiStub,
-                        externalTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        docAppPrivateKeyJwtSigner,
-                        accountInterventionApiStub,
-                        false);
+                new TestConfigurationService(
+                        authExternalApiStub, accountInterventionApiStub, false);
         var rsaKey =
                 new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
                         .keyUse(KeyUse.ENCRYPTION)
@@ -1054,14 +1047,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
     private void setupTest(boolean abortOnAisErrorResponse) {
         configurationService =
-                new AuthenticationCallbackHandlerIntegrationTest.TestConfigurationService(
-                        authExternalApiStub,
-                        externalTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        docAppPrivateKeyJwtSigner,
-                        accountInterventionApiStub,
-                        abortOnAisErrorResponse);
+                new TestConfigurationService(
+                        authExternalApiStub, accountInterventionApiStub, abortOnAisErrorResponse);
         handler = new AuthenticationCallbackHandler(configurationService);
         authExternalApiStub.init(SUBJECT_ID);
         txmaAuditQueue.clear();
@@ -1093,19 +1080,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
         public TestConfigurationService(
                 AuthExternalApiStubExtension authExternalApiStub,
-                TokenSigningExtension tokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotRequestQueue,
-                TokenSigningExtension docAppPrivateKeyJwtSigner,
                 AccountInterventionsStubExtension accountInterventionsStubExtension,
                 boolean abortOnAisErrorResponse) {
-            super(
-                    tokenSigningKey,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super();
             this.authExternalApiStub = authExternalApiStub;
             this.accountInterventionApiStub = accountInterventionsStubExtension;
             this.abortOnAisErrorResponse = abortOnAisErrorResponse;

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
@@ -46,6 +46,7 @@ import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.CrossBrowserStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.JwksCacheExtension;
@@ -153,14 +154,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String CLAIMS =
             "{\"userinfo\":{\"https://vocab.account.gov.uk/v1/coreIdentityJWT\":{\"essential\":true},\"https://vocab.account.gov.uk/v1/address\":{\"essential\":true}}}";
 
-    private static final IntegrationTestConfigurationService configuration =
-            new IntegrationTestConfigurationService(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+    private static final ConfigurationService configuration =
+            new IntegrationTestConfigurationService() {
                 @Override
                 public String getTxmaAuditQueueUrl() {
                     return txmaAuditQueue.getQueueUrl();

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/JwksIntegrationTest.java
@@ -18,14 +18,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService =
-                new IntegrationTestConfigurationService(
-                        externalTokenSigner,
-                        storageTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters);
+        var configurationService = new IntegrationTestConfigurationService();
         handler = new JwksHandler(configurationService);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/JwksIntegrationTest.java
@@ -18,8 +18,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService = new IntegrationTestConfigurationService();
-        handler = new JwksHandler(configurationService);
+        handler = new JwksHandler(TEST_CONFIGURATION_SERVICE);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
         assertThat(response, hasStatus(200));

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -70,8 +70,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
                     + Base64.getMimeEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded())
                     + "\n-----END PUBLIC KEY-----\n";
 
-    private static final ConfigurationService configurationService =
-            new OrchestrationToAuthenticationAuthorizeIntegrationTest.TestConfigurationService();
+    private static final ConfigurationService configurationService = new TestConfigurationService();
 
     @RegisterExtension
     public static final OrchSessionExtension orchSessionExtension = new OrchSessionExtension();
@@ -403,13 +402,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
     private static class TestConfigurationService extends IntegrationTestConfigurationService {
 
         public TestConfigurationService() {
-            super(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super();
         }
 
         @Override

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/StorageTokenJwkIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/StorageTokenJwkIntegrationTest.java
@@ -18,8 +18,7 @@ class StorageTokenJwkIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService = new IntegrationTestConfigurationService();
-        handler = new StorageTokenJwkHandler(configurationService);
+        handler = new StorageTokenJwkHandler(TEST_CONFIGURATION_SERVICE);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
         assertThat(response, hasStatus(200));

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/StorageTokenJwkIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/StorageTokenJwkIntegrationTest.java
@@ -18,14 +18,7 @@ class StorageTokenJwkIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        var configurationService =
-                new IntegrationTestConfigurationService(
-                        externalTokenSigner,
-                        storageTokenSigner,
-                        ipvPrivateKeyJwtSigner,
-                        spotRequestQueue,
-                        docAppPrivateKeyJwtSigner,
-                        configurationParameters);
+        var configurationService = new IntegrationTestConfigurationService();
         handler = new StorageTokenJwkHandler(configurationService);
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/TokenIntegrationTest.java
@@ -112,13 +112,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
 
     protected static final ConfigurationService configuration =
-            new IntegrationTestConfigurationService(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+            new IntegrationTestConfigurationService() {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/TokenIntegrationTest.java
@@ -111,14 +111,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private final String CODE_CHALLENGE_STRING = createCodeChallengeFromCodeVerifier(CODE_VERIFIER);
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
 
-    protected static final ConfigurationService configuration =
-            new IntegrationTestConfigurationService() {
-
-                @Override
-                public String getTxmaAuditQueueUrl() {
-                    return txmaAuditQueue.getQueueUrl();
-                }
-            };
+    protected static final ConfigurationService configuration = TXMA_ENABLED_CONFIGURATION_SERVICE;
 
     @RegisterExtension
     public static final RpPublicKeyCacheExtension rpPublicKeyCacheExtension =

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
@@ -27,6 +27,7 @@ import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
 import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.orchestration.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.DocumentAppCredentialStoreExtension;
@@ -105,14 +106,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     protected static final OrchAccessTokenExtension orchAccessTokenExtension =
             new OrchAccessTokenExtension();
 
-    private static final IntegrationTestConfigurationService configuration =
-            new IntegrationTestConfigurationService() {
-
-                @Override
-                public String getTxmaAuditQueueUrl() {
-                    return txmaAuditQueue.getQueueUrl();
-                }
-            };
+    private static final ConfigurationService configuration = TXMA_ENABLED_CONFIGURATION_SERVICE;
 
     @BeforeEach
     void setup() throws JOSEException, NoSuchAlgorithmException {
@@ -334,7 +328,9 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
             throws JOSEException, NoSuchAlgorithmException {
         var jwsHeader =
-                new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(configuration.getKeyId()).build();
+                new JWSHeader.Builder(JWSAlgorithm.ES256)
+                        .keyID(externalTokenSigner.getKeyId())
+                        .build();
         var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
 
         var keyPairGenerator = KeyPairGenerator.getInstance("EC");

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/UserInfoIntegrationTest.java
@@ -106,13 +106,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             new OrchAccessTokenExtension();
 
     private static final IntegrationTestConfigurationService configuration =
-            new IntegrationTestConfigurationService(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+            new IntegrationTestConfigurationService() {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {
@@ -464,13 +458,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static class UserInfoConfigurationService extends IntegrationTestConfigurationService {
 
         public UserInfoConfigurationService() {
-            super(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            super();
         }
 
         @Override

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -112,22 +112,10 @@ public class IntegrationTest {
                             Map.entry("local-notify-callback-bearer-token", BEARER_TOKEN)));
 
     protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
-            new IntegrationTestConfigurationService(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters);
+            new IntegrationTestConfigurationService();
 
     protected static final ConfigurationService TXMA_ENABLED_CONFIGURATION_SERVICE =
-            new IntegrationTestConfigurationService(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+            new IntegrationTestConfigurationService() {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {
@@ -136,13 +124,7 @@ public class IntegrationTest {
             };
 
     protected static final ConfigurationService TXMA_AND_AIS_ENABLED_CONFIGURATION_SERVICE =
-            new IntegrationTestConfigurationService(
-                    externalTokenSigner,
-                    storageTokenSigner,
-                    ipvPrivateKeyJwtSigner,
-                    spotRequestQueue,
-                    docAppPrivateKeyJwtSigner,
-                    configurationParameters) {
+            new IntegrationTestConfigurationService() {
 
                 @Override
                 public String getTxmaAuditQueueUrl() {
@@ -220,61 +202,32 @@ public class IntegrationTest {
 
     public static class IntegrationTestConfigurationService extends ConfigurationService {
 
-        private final TokenSigningExtension externalTokenSigningKey;
-        private final TokenSigningExtension storageTokenSigningKey;
-        private final TokenSigningExtension ipvPrivateKeyJwtSigner;
-        private final SqsQueueExtension spotRequestQueue;
-        private final TokenSigningExtension docAppPrivateKeyJwtSigner;
-
-        public IntegrationTestConfigurationService(
-                TokenSigningExtension externalTokenSigningKey,
-                TokenSigningExtension storageTokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotRequestQueue,
-                TokenSigningExtension docAppPrivateKeyJwtSigner,
-                ParameterStoreExtension parameterStoreExtension) {
-            super(parameterStoreExtension.getClient());
-            this.externalTokenSigningKey = externalTokenSigningKey;
-            this.storageTokenSigningKey = storageTokenSigningKey;
-            this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
-            this.spotRequestQueue = spotRequestQueue;
-            this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
+        public IntegrationTestConfigurationService() {
+            super(configurationParameters.getClient());
         }
 
-        public IntegrationTestConfigurationService(
-                TokenSigningExtension externalTokenSigningKey,
-                TokenSigningExtension storageTokenSigningKey,
-                TokenSigningExtension ipvPrivateKeyJwtSigner,
-                SqsQueueExtension spotRequestQueue,
-                TokenSigningExtension docAppPrivateKeyJwtSigner,
-                ParameterStoreExtension parameterStoreExtension,
-                SystemService systemService) {
-            super(parameterStoreExtension.getClient());
-            this.externalTokenSigningKey = externalTokenSigningKey;
-            this.storageTokenSigningKey = storageTokenSigningKey;
-            this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
-            this.spotRequestQueue = spotRequestQueue;
-            this.docAppPrivateKeyJwtSigner = docAppPrivateKeyJwtSigner;
+        public IntegrationTestConfigurationService(SystemService systemService) {
+            super(configurationParameters.getClient());
             super.systemService = systemService;
         }
 
         public String getKeyId() {
-            return externalTokenSigningKey.getKeyId();
+            return externalTokenSigner.getKeyId();
         }
 
         @Override
         public String getExternalTokenSigningKeyAlias() {
-            return externalTokenSigningKey.getKeyAlias();
+            return externalTokenSigner.getKeyAlias();
         }
 
         @Override
         public String getNextExternalTokenSigningKeyAliasV2() {
-            return externalTokenSigningKey.getNewKeyAliasV2();
+            return externalTokenSigner.getNewKeyAliasV2();
         }
 
         @Override
         public String getStorageTokenSigningKeyAlias() {
-            return storageTokenSigningKey.getKeyAlias();
+            return storageTokenSigner.getKeyAlias();
         }
 
         @Override


### PR DESCRIPTION
### Wider context of change

Previously, this static class took several extensions as parameters, stored them locally, and overrode some ConfigurationService methods to use these extensions. However, in all cases where this constructor was used, the test were passing in the protected extensions defined in `IntegrationTest` (as the integration tests inherit from this class). This was kind of pointless, as these protected extensions were available to the `IntegrationTestConfgurationService`, so we were passing these extensions around for no reason.

### What’s changed

This PR removes the parameters for extensions in the static class `IntegrationTestConfigurationService`, instead using the protected extensions defined in the `IntegrationTest` class (which is where `IntegrationTestConfigurationService` resides). 

There were also some constants for common `IntegrationTestConfigurationService` instances, like `TEST_CONFIGURATION_SERVICE` and `TXMA_ENABLED_CONFIGURATION_SERVICE`, which i've used in some places instead of instantiating `IntegrationTestConfigurationService` again.

I've also tidied up some class references, removing any unnecessary class prefixes when the static class was already in the class.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

