### PR TITLE
AUT-5394: Update new password hashing params (integration)

### DIFF
--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -570,7 +570,7 @@ Mappings:
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
       accountDataApiId: hoidt6wujb
-      argon2MemoryInKibibytes: "15360"
+      argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
     production:

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -675,7 +675,7 @@ Mappings:
       amcCreatePasskeyRedirectUri: https://signin.integration.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"
       amcJwksUrl: https://votf1tvl36.execute-api.eu-west-2.amazonaws.com/v1/.well-known/jwks.json
-      argon2MemoryInKibibytes: "15360"
+      argon2MemoryInKibibytes: "32768"
       argon2Iterations: "2"
       argon2Parallelism: "1"
       relyingPartyId: integration.account.gov.uk


### PR DESCRIPTION
## What

* Updates the integration environment password hashing parameters to the new values, both for the internal API and the AM API.

See [the ticket](https://govukverify.atlassian.net/browse/AUT-5394) and [the prior ticket](https://govukverify.atlassian.net/browse/AUT-5367) for more details.

These parameter values have been in place on staging for the past 7 weeks and have been through multiple performance tests.

## How to review

1. Code review.
1. Check the values for the production environment (in the same files) are unchanged.

## Checklist

- [x] Deployment of this PR will not break active user journeys

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**

- [ ] A UCD review has been performed. **- N/A.**