### PR TITLE
BAU: Extract OrchJwtService

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -38,6 +38,7 @@ import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.Metrics;
 import uk.gov.di.orchestration.shared.services.OrchAuthCodeService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -118,9 +119,9 @@ public class DocAppCallbackHandler
         this.authorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
-                        kmsConnectionService,
                         new JwksCacheService(configurationService),
-                        new StateStorageService(configurationService));
+                        new StateStorageService(configurationService),
+                        new OrchJwtService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);

--- a/doc-checking-app-api/src/main/resources/LambdaJsonLayout.json
+++ b/doc-checking-app-api/src/main/resources/LambdaJsonLayout.json
@@ -87,5 +87,9 @@
   "trace-id": {
     "$resolver": "mdc",
     "key": "dt.trace_id"
+  },
+  "jwt-id": {
+    "$resolver": "mdc",
+    "key": "jti"
   }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -137,8 +137,7 @@ public class IPVCallbackHandler
     public IPVCallbackHandler(ConfigurationService configurationService) {
         var kmsConnectionService = new KmsConnectionService(configurationService);
         this.configurationService = configurationService;
-        this.ipvAuthorisationService =
-                new IPVAuthorisationService(configurationService, kmsConnectionService);
+        this.ipvAuthorisationService = new IPVAuthorisationService(configurationService);
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.orchSessionService = new OrchSessionService(configurationService);
         this.authUserInfoStorageService =

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -1,19 +1,7 @@
 package uk.gov.di.authentication.ipv.services;
 
-import com.nimbusds.jose.EncryptionMethod;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.crypto.RSAEncrypter;
-import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -23,9 +11,6 @@ import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.kms.model.SignRequest;
-import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.ipv.entity.IpvCallbackValidationError;
 import uk.gov.di.orchestration.shared.entity.JwksCacheItem;
 import uk.gov.di.orchestration.shared.entity.StateItem;
@@ -34,13 +19,10 @@ import uk.gov.di.orchestration.shared.helpers.NowHelper.NowClock;
 import uk.gov.di.orchestration.shared.helpers.RsaKeyHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
-import uk.gov.di.orchestration.shared.services.JwksService;
-import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 
-import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
-import java.text.ParseException;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -51,38 +33,32 @@ public class IPVAuthorisationService {
 
     private static final Logger LOG = LogManager.getLogger(IPVAuthorisationService.class);
     private final ConfigurationService configurationService;
-    private final KmsConnectionService kmsConnectionService;
-    private final JwksService jwksService;
     private final JwksCacheService jwksCacheService;
     private final StateStorageService stateStorageService;
+    private final OrchJwtService orchJwtService;
     private final NowClock nowClock;
     public static final String STATE_STORAGE_PREFIX = "state:";
-    private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
     public static final String SESSION_INVALIDATED_ERROR_CODE = "session_invalidated";
 
-    public IPVAuthorisationService(
-            ConfigurationService configurationService, KmsConnectionService kmsConnectionService) {
+    public IPVAuthorisationService(ConfigurationService configurationService) {
         this(
                 configurationService,
-                kmsConnectionService,
-                new JwksService(configurationService, kmsConnectionService),
                 new JwksCacheService(configurationService),
                 new StateStorageService(configurationService),
+                new OrchJwtService(configurationService),
                 new NowClock(Clock.systemUTC()));
     }
 
     public IPVAuthorisationService(
             ConfigurationService configurationService,
-            KmsConnectionService kmsConnectionService,
-            JwksService jwksService,
             JwksCacheService jwksCacheService,
             StateStorageService stateStorageService,
+            OrchJwtService orchJwtService,
             NowClock nowClock) {
         this.configurationService = configurationService;
-        this.kmsConnectionService = kmsConnectionService;
-        this.jwksService = jwksService;
         this.jwksCacheService = jwksCacheService;
         this.stateStorageService = stateStorageService;
+        this.orchJwtService = orchJwtService;
         this.nowClock = nowClock;
     }
 
@@ -162,9 +138,6 @@ public class IPVAuthorisationService {
             List<String> vtr,
             Boolean reproveIdentity) {
         LOG.info("Generating request JWT");
-        var signingKeyJwt = jwksService.getPublicIpvTokenJwkWithOpaqueId();
-        var jwsHeader =
-                new JWSHeader.Builder(SIGNING_ALGORITHM).keyID(signingKeyJwt.getKeyID()).build();
         var jwtID = IdGenerator.generate();
         var expiryDate = nowClock.nowPlus(3, ChronoUnit.MINUTES);
         var claimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claims);
@@ -192,62 +165,13 @@ public class IPVAuthorisationService {
             claimsBuilder.claim("reprove_identity", reproveIdentity);
         }
         claimsBuilder.claim("claims", claimsRequest.toJSONObject());
-
-        var encodedHeader = jwsHeader.toBase64URL();
-        var encodedClaims = Base64URL.encode(claimsBuilder.build().toString());
-        var message = encodedHeader + "." + encodedClaims;
-        var signRequest =
-                SignRequest.builder()
-                        .message(SdkBytes.fromByteArray(message.getBytes(StandardCharsets.UTF_8)))
-                        .keyId(configurationService.getIPVTokenSigningKeyAlias())
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
-                        .build();
-        try {
-            LOG.info("Signing request JWT");
-            var signResult = kmsConnectionService.sign(signRequest);
-            LOG.info("Request JWT has been signed successfully");
-            var signature =
-                    Base64URL.encode(
-                                    ECDSA.transcodeSignatureToConcat(
-                                            signResult.signature().asByteArray(),
-                                            ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
-                            .toString();
-            var signedJWT = SignedJWT.parse(message + "." + signature);
-            var encryptedJWT = encryptJWT(signedJWT);
-            LOG.info("Encrypted request JWT has been generated");
-            return encryptedJWT;
-        } catch (ParseException | JOSEException e) {
-            LOG.error("Error when generating SignedJWT", e);
-            throw new RuntimeException(e);
-        }
-    }
-
-    private EncryptedJWT encryptJWT(SignedJWT signedJWT) {
-        try {
-            LOG.info("Encrypting SignedJWT");
-            JwksCacheItem jwksCacheItem = getJwksCacheItemFromJwksEndpoint();
-            String keyId = jwksCacheItem.getKeyId();
-            RSAPublicKey publicEncryptionKey =
-                    RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem(jwksCacheItem);
-
-            var jweObject =
-                    new JWEObject(
-                            new JWEHeader.Builder(
-                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
-                                    .contentType("JWT")
-                                    .keyID(keyId)
-                                    .build(),
-                            new Payload(signedJWT));
-            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
-            LOG.info("SignedJWT has been successfully encrypted");
-            return EncryptedJWT.parse(jweObject.serialize());
-        } catch (JOSEException e) {
-            LOG.error("Error when encrypting SignedJWT", e);
-            throw new RuntimeException(e);
-        } catch (ParseException e) {
-            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
-            throw new RuntimeException(e);
-        }
+        LOG.info("Encrypted request JWT has been generated");
+        RSAPublicKey publicEncryptionKey =
+                RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem(getJwksCacheItemFromJwksEndpoint());
+        return orchJwtService.signAndEncryptJWT(
+                claimsBuilder.build(),
+                configurationService.getIPVTokenSigningKeyAlias(),
+                publicEncryptionKey);
     }
 
     private JwksCacheItem getJwksCacheItemFromJwksEndpoint() {

--- a/ipv-api/src/main/resources/LambdaJsonLayout.json
+++ b/ipv-api/src/main/resources/LambdaJsonLayout.json
@@ -87,5 +87,9 @@
   "trace-id": {
     "$resolver": "mdc",
     "key": "dt.trace_id"
+  },
+  "jwt-id": {
+    "$resolver": "mdc",
+    "key": "jti"
   }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -5,13 +5,11 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -28,6 +26,7 @@ import org.approvaltests.JsonApprovals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
@@ -41,6 +40,7 @@ import uk.gov.di.orchestration.shared.services.DocAppAuthorisationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.helper.TestClockHelper;
 
@@ -61,8 +61,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -91,15 +92,16 @@ class IPVAuthorisationServiceTest {
     private final JwksService jwksService = mock(JwksService.class);
     private final JwksCacheService jwksCacheService = mock(JwksCacheService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
+    private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
     private final IPVAuthorisationService authorisationService =
             new IPVAuthorisationService(
                     configurationService,
-                    kmsConnectionService,
-                    jwksService,
                     jwksCacheService,
                     stateStorageService,
+                    orchJwtService,
                     TestClockHelper.getInstance());
     private PrivateKey privateKey;
+    private RSAKey publicEncKey;
 
     @BeforeEach
     void setUp() throws MalformedURLException {
@@ -115,7 +117,7 @@ class IPVAuthorisationServiceTest {
         when(configurationService.getIPVAudience()).thenReturn(IPV_URI.toString());
         var keyPair = generateRsaKeyPair();
         privateKey = keyPair.getPrivate();
-        var rsaKey =
+        publicEncKey =
                 new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
                         .keyUse(KeyUse.ENCRYPTION)
                         .keyID(KEY_ID)
@@ -123,7 +125,7 @@ class IPVAuthorisationServiceTest {
         var jwksUrl = new URL("http://localhost/.well-known/jwks.json");
         when(configurationService.getIPVJwksUrl()).thenReturn(jwksUrl);
         when(jwksCacheService.getOrGenerateIpvJwksCacheItem())
-                .thenReturn(new JwksCacheItem(jwksUrl.toString(), rsaKey, 300));
+                .thenReturn(new JwksCacheItem(jwksUrl.toString(), publicEncKey, 300));
         when(configurationService.getIPVTokenSigningKeyAlias()).thenReturn(IPV_SIGNING_KEY_ID);
         when(jwksService.getPublicIpvTokenJwkWithOpaqueId())
                 .thenReturn(
@@ -285,7 +287,7 @@ class IPVAuthorisationServiceTest {
         }
 
         @Test
-        void shouldConstructASignedRequestJWT() throws JOSEException, ParseException {
+        void shouldConstructASignedRequestJWT() throws JOSEException {
             var state = new State("test-state");
             var scope = new Scope(OIDCScopeValue.OPENID);
             var pairwise = new Subject("pairwise-identifier");
@@ -307,151 +309,117 @@ class IPVAuthorisationServiceTest {
                                                     "https://vocab.account.gov.uk/v1/storageAccessToken")
                                             .withValues(List.of(SERIALIZED_JWT)));
 
-            EncryptedJWT encryptedJWT;
             try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
                 mockIdGenerator.when(IdGenerator::generate).thenReturn("test-jti");
-                encryptedJWT =
-                        authorisationService.constructRequestJWT(
-                                state,
-                                scope,
-                                pairwise,
-                                claims,
-                                "journey-id",
-                                "test@test.com",
-                                List.of("P2", "P1"),
-                                true);
+                authorisationService.constructRequestJWT(
+                        state,
+                        scope,
+                        pairwise,
+                        claims,
+                        "journey-id",
+                        "test@test.com",
+                        List.of("P2", "P1"),
+                        true);
             }
-            assertThat(encryptedJWT.getHeader().getKeyID(), equalTo(KEY_ID));
+            var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+            verify(orchJwtService)
+                    .signAndEncryptJWT(
+                            captor.capture(),
+                            eq(IPV_SIGNING_KEY_ID),
+                            eq(publicEncKey.toRSAPublicKey()));
+            var actualClaims = captor.getValue();
 
-            var signedJWTResponse = decryptJWT(encryptedJWT);
+            JsonApprovals.verifyAsJson(actualClaims.toJSONObject(), GsonBuilder::serializeNulls);
 
-            JsonApprovals.verifyAsJson(
-                    signedJWTResponse.getJWTClaimsSet().toJSONObject(),
-                    GsonBuilder::serializeNulls);
-
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("client_id"),
-                    equalTo(IPV_CLIENT_ID));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("state"),
-                    equalTo(state.getValue()));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getSubject(), equalTo(pairwise.getValue()));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("scope"),
-                    equalTo(scope.toString()));
-            assertThat(signedJWTResponse.getJWTClaimsSet().getIssuer(), equalTo(IPV_CLIENT_ID));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getAudience(),
-                    equalTo(singletonList(IPV_URI.toString())));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("response_type"), equalTo("code"));
+            assertThat(actualClaims.getClaim("client_id"), equalTo(IPV_CLIENT_ID));
+            assertThat(actualClaims.getClaim("state"), equalTo(state.getValue()));
+            assertThat(actualClaims.getSubject(), equalTo(pairwise.getValue()));
+            assertThat(actualClaims.getClaim("scope"), equalTo(scope.toString()));
+            assertThat(actualClaims.getIssuer(), equalTo(IPV_CLIENT_ID));
+            assertThat(actualClaims.getAudience(), equalTo(singletonList(IPV_URI.toString())));
+            assertThat(actualClaims.getClaim("response_type"), equalTo("code"));
             var expectedClaimsRequest =
                     new OIDCClaimsRequest().withUserInfoClaimsRequest(claims).toJSONObject();
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("claims"),
-                    equalTo(expectedClaimsRequest));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("email_address"),
-                    equalTo("test@test.com"));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("govuk_signin_journey_id"),
-                    equalTo("journey-id"));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("vtr"),
-                    equalTo(List.of("P2", "P1")));
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("reprove_identity"),
-                    equalTo(true));
-            assertThat(
-                    signedJWTResponse.getHeader().getKeyID(),
-                    equalTo(hashSha256String(IPV_SIGNING_KEY_ID)));
+            assertThat(actualClaims.getClaim("claims"), equalTo(expectedClaimsRequest));
+            assertThat(actualClaims.getClaim("email_address"), equalTo("test@test.com"));
+            assertThat(actualClaims.getClaim("govuk_signin_journey_id"), equalTo("journey-id"));
+            assertThat(actualClaims.getClaim("vtr"), equalTo(List.of("P2", "P1")));
+            assertThat(actualClaims.getClaim("reprove_identity"), equalTo(true));
         }
 
         @Test
-        void shouldConstructJWTWithCorrectReproveIdentityClaimFromFlag()
-                throws JOSEException, ParseException {
-            EncryptedJWT encryptedJWT;
+        void shouldConstructJWTWithCorrectReproveIdentityClaimFromFlag() throws JOSEException {
             try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
                 mockIdGenerator.when(IdGenerator::generate).thenReturn("test-jti");
-                encryptedJWT =
-                        authorisationService.constructRequestJWT(
-                                new State("state"),
-                                new Scope(OIDCScopeValue.OPENID),
-                                new Subject("subject"),
-                                new ClaimsSetRequest(),
-                                "",
-                                "",
-                                emptyList(),
-                                false);
+                authorisationService.constructRequestJWT(
+                        new State("state"),
+                        new Scope(OIDCScopeValue.OPENID),
+                        new Subject("subject"),
+                        new ClaimsSetRequest(),
+                        "",
+                        "",
+                        emptyList(),
+                        false);
             }
-
-            var signedJWTResponse = decryptJWT(encryptedJWT);
-
-            assertThat(
-                    signedJWTResponse.getJWTClaimsSet().getClaim("reprove_identity"),
-                    equalTo(false));
+            verify(orchJwtService)
+                    .signAndEncryptJWT(
+                            argThat(
+                                    claims -> {
+                                        try {
+                                            return !claims.getBooleanClaim("reprove_identity");
+                                        } catch (ParseException e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }),
+                            eq(IPV_SIGNING_KEY_ID),
+                            eq(publicEncKey.toRSAPublicKey()));
         }
 
         @Test
         void shouldNotConstructJWTWithReproveIdentityClaimIfAccountInterventionsActionFlagDisabled()
-                throws JOSEException, ParseException {
+                throws JOSEException {
             when(configurationService.isAccountInterventionServiceActionEnabled())
                     .thenReturn(false);
-            EncryptedJWT encryptedJWT;
 
             try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
                 mockIdGenerator.when(IdGenerator::generate).thenReturn("test-jti");
-                encryptedJWT =
-                        authorisationService.constructRequestJWT(
-                                new State("state"),
-                                new Scope(OIDCScopeValue.OPENID),
-                                new Subject("subject"),
-                                new ClaimsSetRequest(),
-                                "",
-                                "",
-                                emptyList(),
-                                false);
+                authorisationService.constructRequestJWT(
+                        new State("state"),
+                        new Scope(OIDCScopeValue.OPENID),
+                        new Subject("subject"),
+                        new ClaimsSetRequest(),
+                        "",
+                        "",
+                        emptyList(),
+                        false);
             }
-            var signedJWTResponse = decryptJWT(encryptedJWT);
-
-            assertFalse(
-                    signedJWTResponse
-                            .getJWTClaimsSet()
-                            .getClaims()
-                            .containsKey("reprove_identity"));
+            verify(orchJwtService)
+                    .signAndEncryptJWT(
+                            argThat(claims -> !claims.getClaims().containsKey("reprove_identity")),
+                            eq(IPV_SIGNING_KEY_ID),
+                            eq(publicEncKey.toRSAPublicKey()));
         }
 
         @Test
         void shouldNotConstructJWTWithReproveIdentityClaimIfReproveIdentityIsNull()
-                throws JOSEException, ParseException {
-            EncryptedJWT encryptedJWT;
-
+                throws Exception {
             try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
                 mockIdGenerator.when(IdGenerator::generate).thenReturn("test-jti");
-                encryptedJWT =
-                        authorisationService.constructRequestJWT(
-                                new State("state"),
-                                new Scope(OIDCScopeValue.OPENID),
-                                new Subject("subject"),
-                                new ClaimsSetRequest(),
-                                "",
-                                "",
-                                emptyList(),
-                                null);
+                authorisationService.constructRequestJWT(
+                        new State("state"),
+                        new Scope(OIDCScopeValue.OPENID),
+                        new Subject("subject"),
+                        new ClaimsSetRequest(),
+                        "",
+                        "",
+                        emptyList(),
+                        null);
             }
-            var signedJWTResponse = decryptJWT(encryptedJWT);
-
-            assertFalse(
-                    signedJWTResponse
-                            .getJWTClaimsSet()
-                            .getClaims()
-                            .containsKey("reprove_identity"));
+            verify(orchJwtService)
+                    .signAndEncryptJWT(
+                            argThat(claims -> !claims.getClaims().containsKey("reprove_identity")),
+                            eq(IPV_SIGNING_KEY_ID),
+                            eq(publicEncKey.toRSAPublicKey()));
         }
-    }
-
-    private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
-        encryptedJWT.decrypt(new RSADecrypter(privateKey));
-        return encryptedJWT.getPayload().toSignedJWT();
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidJWEException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidJWEException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.authentication.oidc.exceptions;
-
-public class InvalidJWEException extends RuntimeException {
-    public InvalidJWEException(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -153,7 +153,7 @@ public class AuthenticationCallbackHandler
                 new InitiateIPVAuthorisationService(
                         configurationService,
                         auditService,
-                        new IPVAuthorisationService(configurationService, kmsConnectionService),
+                        new IPVAuthorisationService(configurationService),
                         metrics,
                         new CrossBrowserOrchestrationService(configurationService),
                         new TokenService(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -69,6 +69,7 @@ import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.Metrics;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
@@ -175,6 +176,7 @@ public class AuthorisationHandler
         var jwksService = new JwksService(configurationService, kmsConnectionService);
         var jwksCacheService = new JwksCacheService(configurationService);
         var stateStorageService = new StateStorageService(configurationService);
+        var orchJwtService = new OrchJwtService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
         this.crossBrowserOrchestrationService =
                 new CrossBrowserOrchestrationService(configurationService);
@@ -205,9 +207,9 @@ public class AuthorisationHandler
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
                         configurationService,
-                        kmsConnectionService,
                         jwksCacheService,
-                        stateStorageService);
+                        stateStorageService,
+                        orchJwtService);
         var cloudwatchMetricService = new Metrics(configurationService);
         this.metrics = cloudwatchMetricService;
         this.authorisationService = new AuthorisationService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationService.java
@@ -1,21 +1,10 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.crypto.RSAEncrypter;
-import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.ResponseMode;
@@ -26,11 +15,6 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.kms.model.MessageType;
-import software.amazon.awssdk.services.kms.model.SignRequest;
-import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.authentication.oidc.exceptions.InvalidJWEException;
 import uk.gov.di.authentication.oidc.exceptions.InvalidPublicKeyException;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CustomScopeValue;
@@ -42,14 +26,11 @@ import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,39 +38,33 @@ import java.util.Optional;
 public class OrchestrationAuthorizationService {
     public static final String VTR_PARAM = "vtr";
     public static final String AUTHENTICATION_STATE_STORAGE_PREFIX = "auth-state:";
-    private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
     private final ConfigurationService configurationService;
     private final DynamoClientService dynamoClientService;
-    private final KmsConnectionService kmsConnectionService;
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final StateStorageService stateStorageService;
-    private final JwksService jwksService;
+    private final OrchJwtService orchJwtService;
     private static final Logger LOG = LogManager.getLogger(OrchestrationAuthorizationService.class);
 
     public OrchestrationAuthorizationService(
             ConfigurationService configurationService,
             DynamoClientService dynamoClientService,
-            KmsConnectionService kmsConnectionService,
             CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             StateStorageService stateStorageService,
-            JwksService jwksService) {
+            OrchJwtService orchJwtService) {
         this.configurationService = configurationService;
         this.dynamoClientService = dynamoClientService;
-        this.kmsConnectionService = kmsConnectionService;
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.stateStorageService = stateStorageService;
-        this.jwksService = jwksService;
+        this.orchJwtService = orchJwtService;
     }
 
     public OrchestrationAuthorizationService(ConfigurationService configurationService) {
         this(
                 configurationService,
                 new DynamoClientService(configurationService),
-                new KmsConnectionService(configurationService),
                 new CrossBrowserOrchestrationService(configurationService),
                 new StateStorageService(configurationService),
-                new JwksService(
-                        configurationService, new KmsConnectionService(configurationService)));
+                new OrchJwtService(configurationService));
     }
 
     public OrchestrationAuthorizationService(
@@ -100,10 +75,11 @@ public class OrchestrationAuthorizationService {
         this(
                 configurationService,
                 new DynamoClientService(configurationService),
-                kmsConnectionService,
                 crossBrowserOrchestrationService,
                 stateStorageService,
-                new JwksService(configurationService, kmsConnectionService));
+                new OrchJwtService(
+                        kmsConnectionService,
+                        new JwksService(configurationService, kmsConnectionService)));
     }
 
     public boolean isClientRedirectUriValid(ClientID clientID, URI redirectURI)
@@ -137,76 +113,8 @@ public class OrchestrationAuthorizationService {
     }
 
     public EncryptedJWT getSignedAndEncryptedJWT(JWTClaimsSet jwtClaimsSet) {
-        var signedJwt = getSignedJWT(jwtClaimsSet);
-        return encryptJWT(signedJwt);
-    }
-
-    public SignedJWT getSignedJWT(JWTClaimsSet jwtClaimsSet) {
-        LOG.info("Generating signed and encrypted JWT");
-        var signingKey = jwksService.getPublicAuthSigningJwkWithOpaqueId();
-        var signingKeyAlias = configurationService.getAuthSigningKeyAlias();
-        var jwsHeader =
-                new JWSHeader.Builder(SIGNING_ALGORITHM).keyID(signingKey.getKeyID()).build();
-
-        var encodedHeader = jwsHeader.toBase64URL();
-        var encodedClaims = Base64URL.encode(jwtClaimsSet.toString());
-        var message = encodedHeader + "." + encodedClaims;
-
-        var signRequestBuilder =
-                SignRequest.builder()
-                        .keyId(signingKeyAlias)
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256);
-
-        SignRequest signRequest =
-                isMessageHashSignRequired(message)
-                        ? signRequestBuilder
-                                .message(SdkBytes.fromByteArray(getMessageHashDigest(message)))
-                                .messageType(MessageType.DIGEST)
-                                .build()
-                        : signRequestBuilder
-                                .message(
-                                        SdkBytes.fromByteArray(
-                                                message.getBytes(StandardCharsets.UTF_8)))
-                                .messageType(MessageType.RAW)
-                                .build();
-        try {
-            LOG.info("Signing request JWT");
-            var signResult = kmsConnectionService.sign(signRequest);
-            LOG.info("Request JWT has been signed successfully");
-            var signature =
-                    Base64URL.encode(
-                                    ECDSA.transcodeSignatureToConcat(
-                                            signResult.signature().asByteArray(),
-                                            ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
-                            .toString();
-            return SignedJWT.parse(message + "." + signature);
-        } catch (ParseException | JOSEException e) {
-            LOG.error("Error when generating SignedJWT", e);
-            throw new InvalidJWEException("Error when generating SignedJWT", e);
-        }
-    }
-
-    private EncryptedJWT encryptJWT(SignedJWT signedJWT) {
-        try {
-            LOG.info("Encrypting SignedJWT");
-            var publicEncryptionKey = getPublicKey();
-            var jweObject =
-                    new JWEObject(
-                            new JWEHeader.Builder(
-                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
-                                    .contentType("JWT")
-                                    .build(),
-                            new Payload(signedJWT));
-            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
-            LOG.info("SignedJWT has been successfully encrypted");
-            return EncryptedJWT.parse(jweObject.serialize());
-        } catch (JOSEException e) {
-            LOG.error("Error when encrypting SignedJWT", e);
-            throw new InvalidJWEException("Error when encrypting SignedJWT", e);
-        } catch (ParseException e) {
-            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
-            throw new InvalidJWEException("Error when parsing JWE object to EncryptedJWT", e);
-        }
+        return orchJwtService.signAndEncryptJWT(
+                jwtClaimsSet, configurationService.getAuthSigningKeyAlias(), getPublicKey());
     }
 
     private RSAPublicKey getPublicKey() {
@@ -259,21 +167,5 @@ public class OrchestrationAuthorizationService {
     public boolean isJarValidationRequired(ClientRegistry client) {
         return client.getScopes().contains(CustomScopeValue.DOC_CHECKING_APP.getValue())
                 || client.isJarValidationRequired();
-    }
-
-    private boolean isMessageHashSignRequired(String jwtMessage) {
-        return jwtMessage.getBytes(StandardCharsets.UTF_8).length >= 4096;
-    }
-
-    private byte[] getMessageHashDigest(String jwtMessage) {
-        byte[] signingInputHash;
-        try {
-            signingInputHash =
-                    MessageDigest.getInstance("SHA-256")
-                            .digest(jwtMessage.getBytes(StandardCharsets.UTF_8));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e.getMessage());
-        }
-        return signingInputHash;
     }
 }

--- a/oidc-api/src/main/resources/LambdaJsonLayout.json
+++ b/oidc-api/src/main/resources/LambdaJsonLayout.json
@@ -87,5 +87,9 @@
   "trace-id": {
     "$resolver": "mdc",
     "key": "dt.trace_id"
+  },
+  "jwt-id": {
+    "$resolver": "mdc",
+    "key": "jti"
   }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/OrchestrationAuthorizationServiceTest.java
@@ -1,18 +1,8 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.ECDSAVerifier;
-import com.nimbusds.jose.crypto.RSADecrypter;
-import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import com.nimbusds.jose.util.Base64URL;
-import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -30,29 +20,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.kms.model.MessageType;
-import software.amazon.awssdk.services.kms.model.SignRequest;
-import software.amazon.awssdk.services.kms.model.SignResponse;
-import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
-import uk.gov.di.orchestration.shared.services.JwksService;
-import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
 import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.text.ParseException;
+import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +45,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,43 +59,41 @@ class OrchestrationAuthorizationServiceTest {
     private static final ClientID CLIENT_ID = new ClientID();
     private static final State STATE = new State();
     private static final Nonce NONCE = new Nonce();
-    private static final String KEY_ID = "14342354354353";
-    // 5000 Chars long
-    private static final String LONG_CLAIM =
-            "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+    private static final String SIGNING_KEY_ALIAS = "test-signing-key";
     private OrchestrationAuthorizationService orchestrationAuthorizationService;
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
-    private final IPVCapacityService ipvCapacityService = mock(IPVCapacityService.class);
-    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
             mock(CrossBrowserOrchestrationService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
-    private final JwksService jwksService = mock(JwksService.class);
-    private PrivateKey privateKey;
+    private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
+    private RSAPublicKey publicEncryptionKey;
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(OrchestrationAuthorizationService.class);
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         orchestrationAuthorizationService =
                 new OrchestrationAuthorizationService(
                         configurationService,
                         dynamoClientService,
-                        kmsConnectionService,
                         crossBrowserOrchestrationService,
                         stateStorageService,
-                        jwksService);
+                        orchJwtService);
         var keyPair = generateRsaKeyPair();
-        privateKey = keyPair.getPrivate();
-        String publicCertificateAsPem =
+        var publicCertificateAsPem =
                 "-----BEGIN PUBLIC KEY-----\n"
                         + Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded())
                         + "\n-----END PUBLIC KEY-----\n";
         when(configurationService.getOrchestrationToAuthenticationEncryptionPublicKey())
                 .thenReturn(publicCertificateAsPem);
+        publicEncryptionKey =
+                new RSAKey.Builder((RSAKey) JWK.parseFromPEMEncodedObjects(publicCertificateAsPem))
+                        .build()
+                        .toRSAPublicKey();
+        when(configurationService.getAuthSigningKeyAlias()).thenReturn(SIGNING_KEY_ALIAS);
     }
 
     @AfterEach
@@ -212,84 +188,14 @@ class OrchestrationAuthorizationServiceTest {
     }
 
     @Test
-    void shouldConstructASignedAndEncryptedRequestJWT() throws JOSEException, ParseException {
+    void shouldConstructASignedAndEncryptedRequestJWT() {
         var claim1Value = "JWT claim 1";
-        var ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID(KEY_ID)
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        when(jwksService.getPublicAuthSigningJwkWithOpaqueId())
-                .thenReturn(ecSigningKey.toPublicJWK());
-        var ecdsaSigner = new ECDSASigner(ecSigningKey);
         var jwtClaimsSet = new JWTClaimsSet.Builder().claim("claim1", claim1Value).build();
-        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(KEY_ID).build();
-        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
-        signedJWT.sign(ecdsaSigner);
-        byte[] signatureToDER = ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
-        var expectedMessage =
-                jwsHeader.toBase64URL() + "." + Base64URL.encode(jwtClaimsSet.toString());
-        var signResult =
-                SignResponse.builder()
-                        .signature(SdkBytes.fromByteArray(signatureToDER))
-                        .keyId(KEY_ID)
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
-                        .build();
-        when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
 
-        var encryptedJWT = orchestrationAuthorizationService.getSignedAndEncryptedJWT(jwtClaimsSet);
+        orchestrationAuthorizationService.getSignedAndEncryptedJWT(jwtClaimsSet);
 
-        var signedJWTResponse = decryptJWT(encryptedJWT);
-        var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
-        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claim1"), equalTo(claim1Value));
-        verify(kmsConnectionService).sign(signRequestCaptor.capture());
-        assertThat(
-                SdkBytes.fromByteArray(expectedMessage.getBytes(StandardCharsets.UTF_8)),
-                equalTo(signRequestCaptor.getValue().message()));
-        assertThat(MessageType.RAW, equalTo(signRequestCaptor.getValue().messageType()));
-    }
-
-    @Test
-    void shouldUseAHashDigestWhenMessageSizeIsMoreThan4095() throws JOSEException, ParseException {
-        var claim1Value = "JWT claim 1";
-        var ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID(KEY_ID)
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        when(jwksService.getPublicAuthSigningJwkWithOpaqueId())
-                .thenReturn(ecSigningKey.toPublicJWK());
-        var ecdsaSigner = new ECDSASigner(ecSigningKey);
-        var jwtClaimsSet =
-                new JWTClaimsSet.Builder()
-                        .claim("claim1", claim1Value)
-                        .claim("state", LONG_CLAIM)
-                        .build();
-        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(KEY_ID).build();
-        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
-        var expectedMessage =
-                jwsHeader.toBase64URL() + "." + Base64URL.encode(jwtClaimsSet.toString());
-        signedJWT.sign(ecdsaSigner);
-        byte[] signatureToDER = ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
-        var signResult =
-                SignResponse.builder()
-                        .signature(SdkBytes.fromByteArray(signatureToDER))
-                        .keyId(KEY_ID)
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
-                        .build();
-        when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
-
-        var encryptedJWT = orchestrationAuthorizationService.getSignedAndEncryptedJWT(jwtClaimsSet);
-
-        var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
-        var signedJWTResponse = decryptJWT(encryptedJWT);
-        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claim1"), equalTo(claim1Value));
-        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("state"), equalTo(LONG_CLAIM));
-        signedJWTResponse.verify(new ECDSAVerifier(ecSigningKey.toECPublicKey()));
-        verify(kmsConnectionService).sign(signRequestCaptor.capture());
-        assertThat(
-                getHashSdkBytes(expectedMessage), equalTo(signRequestCaptor.getValue().message()));
-        assertThat(MessageType.DIGEST, equalTo(signRequestCaptor.getValue().messageType()));
+        verify(orchJwtService)
+                .signAndEncryptJWT(jwtClaimsSet, SIGNING_KEY_ALIAS, publicEncryptionKey);
     }
 
     @Test
@@ -356,22 +262,5 @@ class OrchestrationAuthorizationServiceTest {
         claimsRequest.ifPresent(authRequestBuilder::claims);
 
         return authRequestBuilder.build();
-    }
-
-    private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
-        encryptedJWT.decrypt(new RSADecrypter(privateKey));
-        return encryptedJWT.getPayload().toSignedJWT();
-    }
-
-    private SdkBytes getHashSdkBytes(String jwtMessage) {
-        byte[] signingInputHash;
-        try {
-            signingInputHash =
-                    MessageDigest.getInstance("SHA-256")
-                            .digest(jwtMessage.getBytes(StandardCharsets.UTF_8));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e.getMessage());
-        }
-        return SdkBytes.fromByteArray(signingInputHash);
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidJWEException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidJWEException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class InvalidJWEException extends RuntimeException {
+    public InvalidJWEException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/helpers/LogLineHelper.java
@@ -21,7 +21,8 @@ public class LogLineHelper {
         AWS_REQUEST_ID("awsRequestId", false),
         CLIENT_ID("clientId", true),
         CLIENT_NAME("clientName", false),
-        TRACE_ID("dt.trace_id", false);
+        TRACE_ID("dt.trace_id", false),
+        JWT_ID("jti", false);
 
         private final String logFieldName;
         private boolean isBase64;

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -1,19 +1,7 @@
 package uk.gov.di.orchestration.shared.services;
 
-import com.nimbusds.jose.EncryptionMethod;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.crypto.RSAEncrypter;
-import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
@@ -21,63 +9,52 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.State;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
-import software.amazon.awssdk.services.kms.model.SignRequest;
-import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.JwksCacheItem;
 import uk.gov.di.orchestration.shared.entity.StateItem;
-import uk.gov.di.orchestration.shared.exceptions.DocAppAuthorisationServiceException;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.helpers.RsaKeyHelper;
 
-import java.nio.charset.StandardCharsets;
-import java.security.interfaces.RSAPublicKey;
-import java.text.ParseException;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.di.orchestration.shared.helpers.HashHelper.hashSha256String;
-
 public class DocAppAuthorisationService {
 
     private static final Logger LOG = LogManager.getLogger(DocAppAuthorisationService.class);
     private final ConfigurationService configurationService;
-    private final KmsConnectionService kmsConnectionService;
     private final JwksCacheService jwksCacheService;
     private final StateStorageService stateStorageService;
+    private final OrchJwtService orchJwtService;
     private final NowHelper.NowClock nowClock;
     public static final String STATE_STORAGE_PREFIX = "state:";
 
     public static final String STATE_PARAM = "state";
-    private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
 
     public DocAppAuthorisationService(
             ConfigurationService configurationService,
-            KmsConnectionService kmsConnectionService,
             JwksCacheService jwksCacheService,
             StateStorageService stateStorageService,
+            OrchJwtService orchJwtService,
             Clock clock) {
         this.configurationService = configurationService;
-        this.kmsConnectionService = kmsConnectionService;
         this.jwksCacheService = jwksCacheService;
         this.stateStorageService = stateStorageService;
+        this.orchJwtService = orchJwtService;
         this.nowClock = new NowHelper.NowClock(clock);
     }
 
     public DocAppAuthorisationService(
             ConfigurationService configurationService,
-            KmsConnectionService kmsConnectionService,
             JwksCacheService jwksCacheService,
-            StateStorageService stateStorageService) {
+            StateStorageService stateStorageService,
+            OrchJwtService orchJwtService) {
         this.configurationService = configurationService;
-        this.kmsConnectionService = kmsConnectionService;
         this.jwksCacheService = jwksCacheService;
         this.stateStorageService = stateStorageService;
+        this.orchJwtService = orchJwtService;
         this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
     }
 
@@ -146,20 +123,6 @@ public class DocAppAuthorisationService {
             ClientRegistry clientRegistry,
             String clientSessionId) {
         LOG.info("Generating request JWT");
-
-        var docAppTokenSigningKeyAlias = configurationService.getDocAppTokenSigningKeyAlias();
-
-        var signingKeyId =
-                kmsConnectionService
-                        .getPublicKey(
-                                GetPublicKeyRequest.builder()
-                                        .keyId(docAppTokenSigningKeyAlias)
-                                        .build())
-                        .keyId();
-        var jwsHeader =
-                new JWSHeader.Builder(SIGNING_ALGORITHM)
-                        .keyID(hashSha256String(signingKeyId))
-                        .build();
         var jwtID = IdGenerator.generate();
         var expiryDate =
                 clientRegistry.isTestClient()
@@ -188,60 +151,12 @@ public class DocAppAuthorisationService {
         if (clientRegistry.isTestClient()) {
             claimsBuilder.claim("test_client", true);
         }
-        var encodedHeader = jwsHeader.toBase64URL();
-        var encodedClaims = Base64URL.encode(claimsBuilder.build().toString());
-        var message = encodedHeader + "." + encodedClaims;
-        var signRequest =
-                SignRequest.builder()
-                        .message(SdkBytes.fromByteArray(message.getBytes(StandardCharsets.UTF_8)))
-                        .keyId(docAppTokenSigningKeyAlias)
-                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
-                        .build();
-        try {
-            LOG.info("Signing request JWT");
-            var signResponse = kmsConnectionService.sign(signRequest);
-            LOG.info("Request JWT has been signed successfully");
-            var signature =
-                    Base64URL.encode(
-                                    ECDSA.transcodeSignatureToConcat(
-                                            signResponse.signature().asByteArray(),
-                                            ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
-                            .toString();
-            var signedJWT = SignedJWT.parse(message + "." + signature);
-            var encryptedJWT = encryptJWT(signedJWT);
-            LOG.info("Encrypted request JWT has been generated");
-            return encryptedJWT;
-        } catch (ParseException | JOSEException e) {
-            LOG.error("Error when generating SignedJWT", e);
-            throw new DocAppAuthorisationServiceException(e);
-        }
-    }
-
-    private EncryptedJWT encryptJWT(SignedJWT signedJWT) {
-        try {
-            LOG.info("Encrypting SignedJWT");
-            JwksCacheItem jwksCacheItem = getPublicEncryptionKey();
-            RSAPublicKey publicEncryptionKey =
-                    RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem(jwksCacheItem);
-
-            var jweObject =
-                    new JWEObject(
-                            new JWEHeader.Builder(
-                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
-                                    .contentType("JWT")
-                                    .keyID(jwksCacheItem.getKeyId())
-                                    .build(),
-                            new Payload(signedJWT));
-            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
-            LOG.info("SignedJWT has been successfully encrypted");
-            return EncryptedJWT.parse(jweObject.serialize());
-        } catch (JOSEException e) {
-            LOG.error("Error when encrypting SignedJWT", e);
-            throw new DocAppAuthorisationServiceException(e);
-        } catch (ParseException e) {
-            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
-            throw new DocAppAuthorisationServiceException(e);
-        }
+        var publicEncryptionKey =
+                RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem(getPublicEncryptionKey());
+        return orchJwtService.signAndEncryptJWT(
+                claimsBuilder.build(),
+                configurationService.getDocAppTokenSigningKeyAlias(),
+                publicEncryptionKey);
     }
 
     private JwksCacheItem getPublicEncryptionKey() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -104,7 +104,7 @@ public class JwksService {
         return JwksUtils.retrieveJwkFromURLWithKeyId(url, keyId);
     }
 
-    private JWK getPublicJWKWithKeyId(String keyId) {
+    JWK getPublicJWKWithKeyId(String keyId) {
         var jwk =
                 segmentedFunctionCall(
                         "createJwk", () -> KEY_CACHE.computeIfAbsent(keyId, this::createJwk));

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchJwtService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchJwtService.java
@@ -1,0 +1,138 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.MessageType;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.orchestration.shared.exceptions.InvalidJWEException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.JWT_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class OrchJwtService {
+    private static final Logger LOG = LogManager.getLogger(OrchJwtService.class);
+    private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
+
+    private final KmsConnectionService kmsConnectionService;
+    private final JwksService jwksService;
+
+    public OrchJwtService(ConfigurationService configurationService) {
+        this(
+                new KmsConnectionService(configurationService),
+                new JwksService(
+                        configurationService, new KmsConnectionService(configurationService)));
+    }
+
+    public OrchJwtService(KmsConnectionService kmsConnectionService, JwksService jwksService) {
+        this.kmsConnectionService = kmsConnectionService;
+        this.jwksService = jwksService;
+    }
+
+    public EncryptedJWT signAndEncryptJWT(
+            JWTClaimsSet jwtClaimsSet, String signingKeyAlias, RSAPublicKey publicEncryptionKey) {
+        if (jwtClaimsSet.getJWTID() != null) {
+            attachLogFieldToLogs(JWT_ID, jwtClaimsSet.getJWTID());
+        }
+        LOG.info("Generating signed and encrypted JWT");
+        var signingKey = jwksService.getPublicJWKWithKeyId(signingKeyAlias);
+        var jwsHeader =
+                new JWSHeader.Builder(SIGNING_ALGORITHM).keyID(signingKey.getKeyID()).build();
+
+        var encodedHeader = jwsHeader.toBase64URL();
+        var encodedClaims = Base64URL.encode(jwtClaimsSet.toString());
+        var message = encodedHeader + "." + encodedClaims;
+
+        var signRequestBuilder =
+                SignRequest.builder()
+                        .keyId(signingKeyAlias)
+                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256);
+
+        SignRequest signRequest =
+                isMessageHashSignRequired(message)
+                        ? signRequestBuilder
+                                .message(SdkBytes.fromByteArray(getMessageHashDigest(message)))
+                                .messageType(MessageType.DIGEST)
+                                .build()
+                        : signRequestBuilder
+                                .message(
+                                        SdkBytes.fromByteArray(
+                                                message.getBytes(StandardCharsets.UTF_8)))
+                                .messageType(MessageType.RAW)
+                                .build();
+        try {
+            LOG.info("Signing request JWT");
+            var signResult = kmsConnectionService.sign(signRequest);
+            LOG.info("Request JWT has been signed successfully");
+            var signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.signature().asByteArray(),
+                                            ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
+                            .toString();
+            return encryptJWT(SignedJWT.parse(message + "." + signature), publicEncryptionKey);
+        } catch (ParseException | JOSEException e) {
+            LOG.error("Error when generating SignedJWT", e);
+            throw new InvalidJWEException("Error when generating SignedJWT", e);
+        }
+    }
+
+    private EncryptedJWT encryptJWT(SignedJWT signedJWT, RSAPublicKey publicEncryptionKey) {
+        try {
+            LOG.info("Encrypting SignedJWT");
+            var jweObject =
+                    new JWEObject(
+                            new JWEHeader.Builder(
+                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                                    .contentType("JWT")
+                                    .build(),
+                            new Payload(signedJWT));
+            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
+            LOG.info("SignedJWT has been successfully encrypted");
+            return EncryptedJWT.parse(jweObject.serialize());
+        } catch (JOSEException e) {
+            LOG.error("Error when encrypting SignedJWT", e);
+            throw new InvalidJWEException("Error when encrypting SignedJWT", e);
+        } catch (ParseException e) {
+            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
+            throw new InvalidJWEException("Error when parsing JWE object to EncryptedJWT", e);
+        }
+    }
+
+    private boolean isMessageHashSignRequired(String jwtMessage) {
+        return jwtMessage.getBytes(StandardCharsets.UTF_8).length >= 4096;
+    }
+
+    private byte[] getMessageHashDigest(String jwtMessage) {
+        byte[] signingInputHash;
+        try {
+            signingInputHash =
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(jwtMessage.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        return signingInputHash;
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -4,13 +4,11 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -25,6 +23,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.SdkBytes;
@@ -59,10 +58,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.orchestration.shared.helpers.HashHelper.hashSha256String;
 import static uk.gov.di.orchestration.shared.services.DocAppAuthorisationService.STATE_STORAGE_PREFIX;
 import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
@@ -91,12 +90,13 @@ class DocAppAuthorisationServiceTest {
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final JwksCacheService jwksCacheService = mock(JwksCacheService.class);
     private final StateStorageService stateStorageService = mock(StateStorageService.class);
+    private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
     private final DocAppAuthorisationService authorisationService =
             new DocAppAuthorisationService(
                     configurationService,
-                    kmsConnectionService,
                     jwksCacheService,
                     stateStorageService,
+                    orchJwtService,
                     FIXED_CLOCK);
     private PrivateKey privateEncryptionKey;
     private RSAKey publicEncryptionRsaKey;
@@ -243,43 +243,40 @@ class DocAppAuthorisationServiceTest {
         when(jwksCacheService.getOrGenerateDocAppJwksCacheItem())
                 .thenReturn(new JwksCacheItem(JWKS_URL.toString(), publicEncryptionRsaKey, 300));
 
-        var encryptedJWT =
-                authorisationService.constructRequestJWT(
-                        state, pairwise.getValue(), clientRegistry, "client-session-id");
+        authorisationService.constructRequestJWT(
+                state, pairwise.getValue(), clientRegistry, "client-session-id");
 
-        var signedJWTResponse = decryptJWT(encryptedJWT);
+        var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+        verify(orchJwtService)
+                .signAndEncryptJWT(
+                        captor.capture(),
+                        eq(KEY_ALIAS),
+                        eq(publicEncryptionRsaKey.toRSAPublicKey()));
+        var actualClaims = captor.getValue();
 
+        assertThat(actualClaims.getClaim("client_id"), equalTo(DOC_APP_CLIENT_ID));
+        assertThat(actualClaims.getClaim("state"), equalTo(state.getValue()));
+        assertThat(actualClaims.getSubject(), equalTo(pairwise.getValue()));
+        assertThat(actualClaims.getIssuer(), equalTo(DOC_APP_CLIENT_ID));
         assertThat(
-                signedJWTResponse.getJWTClaimsSet().getClaim("client_id"),
-                equalTo(DOC_APP_CLIENT_ID));
-        assertThat(
-                signedJWTResponse.getJWTClaimsSet().getClaim("state"), equalTo(state.getValue()));
-        assertThat(signedJWTResponse.getJWTClaimsSet().getSubject(), equalTo(pairwise.getValue()));
-        assertThat(signedJWTResponse.getJWTClaimsSet().getIssuer(), equalTo(DOC_APP_CLIENT_ID));
-        assertThat(
-                signedJWTResponse.getJWTClaimsSet().getAudience(),
+                actualClaims.getAudience(),
                 equalTo(singletonList(DOC_APP_AUTHORISATION_URI.toString())));
-        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("response_type"), equalTo("code"));
+        assertThat(actualClaims.getClaim("response_type"), equalTo("code"));
 
         assertThat(
-                signedJWTResponse.getJWTClaimsSet().getStringClaim("govuk_signin_journey_id"),
+                actualClaims.getStringClaim("govuk_signin_journey_id"),
                 equalTo("client-session-id"));
-        assertThat(
-                signedJWTResponse.getHeader().getKeyID(),
-                equalTo(hashSha256String("789789789789789")));
         if (isTestClient) {
-            assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("test_client"), equalTo(true));
+            assertThat(actualClaims.getClaim("test_client"), equalTo(true));
             assertThat(
-                    signedJWTResponse
-                            .getJWTClaimsSet()
+                    actualClaims
                             .getExpirationTime()
                             .after(FIXED_NOW_HELPER.nowPlus(3, ChronoUnit.MINUTES)),
                     equalTo(true));
         } else {
-            assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("test_client"), equalTo(null));
+            assertThat(actualClaims.getClaim("test_client"), equalTo(null));
             assertThat(
-                    signedJWTResponse
-                            .getJWTClaimsSet()
+                    actualClaims
                             .getExpirationTime()
                             .before(NowHelper.nowPlus(3, ChronoUnit.MINUTES)),
                     equalTo(true));
@@ -290,8 +287,7 @@ class DocAppAuthorisationServiceTest {
     class Approvals {
         @ParameterizedTest
         @ValueSource(booleans = {true, false})
-        void shouldCreateRequestJWTWithExpectedClaims(boolean isTestClient)
-                throws JOSEException, ParseException {
+        void shouldCreateRequestJWTWithExpectedClaims(boolean isTestClient) throws JOSEException {
             setupSigning();
             var state = new State("state");
             var pairwise = new Subject("pairwise-identifier");
@@ -300,27 +296,29 @@ class DocAppAuthorisationServiceTest {
                     .thenReturn(
                             new JwksCacheItem(JWKS_URL.toString(), publicEncryptionRsaKey, 300));
 
-            EncryptedJWT requestJWT;
-
             try (MockedStatic<IdGenerator> mockIdGenerator =
                     Mockito.mockStatic(IdGenerator.class)) {
                 mockIdGenerator.when(IdGenerator::generate).thenReturn("jti");
-                requestJWT =
-                        authorisationService.constructRequestJWT(
-                                state, pairwise.getValue(), clientRegistry, "client-session-id");
+                authorisationService.constructRequestJWT(
+                        state, pairwise.getValue(), clientRegistry, "client-session-id");
             }
-
-            var signedJWTResponse = decryptJWT(requestJWT);
+            var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+            verify(orchJwtService)
+                    .signAndEncryptJWT(
+                            captor.capture(),
+                            eq(KEY_ALIAS),
+                            eq(publicEncryptionRsaKey.toRSAPublicKey()));
+            var actualClaims = captor.getValue();
 
             JsonApprovals.verifyAsJson(
-                    signedJWTResponse.getJWTClaimsSet().toJSONObject(),
+                    actualClaims.toJSONObject(),
                     org.approvaltests.Approvals.NAMES.withParameters(
                             isTestClient ? "forTestClient" : "forNonTestClient"));
         }
     }
 
     @Test
-    void usesNewDocAppAudClaim() throws JOSEException, ParseException {
+    void usesNewDocAppAudClaim() throws JOSEException {
         when(configurationService.isDocAppNewAudClaimEnabled()).thenReturn(true);
         String newAudience = "https://www.review-b.test.account.gov.uk";
         when(configurationService.getDocAppAudClaim()).thenReturn(new Audience(newAudience));
@@ -331,13 +329,17 @@ class DocAppAuthorisationServiceTest {
 
         when(jwksCacheService.getOrGenerateDocAppJwksCacheItem())
                 .thenReturn(new JwksCacheItem(JWKS_URL.toString(), publicEncryptionRsaKey, 300));
-        var encryptedJWT =
-                authorisationService.constructRequestJWT(
-                        state, pairwise.getValue(), clientRegistry, "client-session-id");
 
-        assertThat(encryptedJWT.getHeader().getKeyID(), equalTo(ENCRYPTION_KID));
-        var signedJwt = decryptJWT(encryptedJWT);
-        assertThat(signedJwt.getJWTClaimsSet().getAudience(), contains(newAudience));
+        authorisationService.constructRequestJWT(
+                state, pairwise.getValue(), clientRegistry, "client-session-id");
+        var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+        verify(orchJwtService)
+                .signAndEncryptJWT(
+                        captor.capture(),
+                        eq(KEY_ALIAS),
+                        eq(publicEncryptionRsaKey.toRSAPublicKey()));
+        var actualClaims = captor.getValue();
+        assertThat(actualClaims.getAudience(), contains(newAudience));
     }
 
     private void setupSigning() throws JOSEException {
@@ -369,10 +371,5 @@ class DocAppAuthorisationServiceTest {
                         .keyId(KEY_ID)
                         .build();
         when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
-    }
-
-    private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
-        encryptedJWT.decrypt(new RSADecrypter(privateEncryptionKey));
-        return encryptedJWT.getPayload().toSignedJWT();
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchJwtServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchJwtServiceTest.java
@@ -1,0 +1,147 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.MessageType;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
+
+class OrchJwtServiceTest {
+    private static final String SIGNING_KEY_ID = "test-key-id";
+    private static final String SIGNING_KEY_ALIAS = "test-key-alias";
+    private static final String LONG_CLAIM = "1".repeat(5000);
+    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private final JwksService jwksService = mock(JwksService.class);
+    private OrchJwtService orchJwtService;
+    private ECKey ecSigningKey;
+    private PrivateKey privateEncKey;
+    private RSAPublicKey publicEncKey;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(SIGNING_KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        when(jwksService.getPublicJWKWithKeyId(SIGNING_KEY_ALIAS))
+                .thenReturn(ecSigningKey.toPublicJWK());
+        var keyPair = generateRsaKeyPair();
+        privateEncKey = keyPair.getPrivate();
+        publicEncKey = (RSAPublicKey) keyPair.getPublic();
+
+        orchJwtService = new OrchJwtService(kmsConnectionService, jwksService);
+    }
+
+    @Test
+    void shouldConstructASignedAndEncryptedRequestJWT() throws Exception {
+        var claim1Value = "JWT claim 1";
+        var jwtClaimsSet = new JWTClaimsSet.Builder().claim("claim1", claim1Value).build();
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(SIGNING_KEY_ID).build();
+        var expectedMessage =
+                jwsHeader.toBase64URL() + "." + Base64URL.encode(jwtClaimsSet.toString());
+        mockKmsSigning(ecSigningKey, jwtClaimsSet);
+
+        var encryptedJWT =
+                orchJwtService.signAndEncryptJWT(jwtClaimsSet, SIGNING_KEY_ALIAS, publicEncKey);
+
+        var signedJWTResponse = decryptJWT(encryptedJWT);
+        var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
+        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claim1"), equalTo(claim1Value));
+        verify(kmsConnectionService).sign(signRequestCaptor.capture());
+        assertThat(
+                SdkBytes.fromByteArray(expectedMessage.getBytes(StandardCharsets.UTF_8)),
+                equalTo(signRequestCaptor.getValue().message()));
+        assertThat(MessageType.RAW, equalTo(signRequestCaptor.getValue().messageType()));
+    }
+
+    @Test
+    void shouldUseAHashDigestWhenMessageSizeIsMoreThan4095() throws Exception {
+        var claim1Value = "JWT claim 1";
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .claim("claim1", claim1Value)
+                        .claim("state", LONG_CLAIM)
+                        .build();
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(SIGNING_KEY_ID).build();
+        var expectedMessage =
+                jwsHeader.toBase64URL() + "." + Base64URL.encode(jwtClaimsSet.toString());
+        mockKmsSigning(ecSigningKey, jwtClaimsSet);
+
+        var encryptedJWT =
+                orchJwtService.signAndEncryptJWT(jwtClaimsSet, SIGNING_KEY_ALIAS, publicEncKey);
+
+        var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
+        var signedJWTResponse = decryptJWT(encryptedJWT);
+        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claim1"), equalTo(claim1Value));
+        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("state"), equalTo(LONG_CLAIM));
+        signedJWTResponse.verify(new ECDSAVerifier(ecSigningKey.toECPublicKey()));
+        verify(kmsConnectionService).sign(signRequestCaptor.capture());
+        assertThat(
+                getHashSdkBytes(expectedMessage), equalTo(signRequestCaptor.getValue().message()));
+        assertThat(MessageType.DIGEST, equalTo(signRequestCaptor.getValue().messageType()));
+    }
+
+    private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {
+        encryptedJWT.decrypt(new RSADecrypter(privateEncKey));
+        return encryptedJWT.getPayload().toSignedJWT();
+    }
+
+    private SdkBytes getHashSdkBytes(String jwtMessage) {
+        byte[] signingInputHash;
+        try {
+            signingInputHash =
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(jwtMessage.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        return SdkBytes.fromByteArray(signingInputHash);
+    }
+
+    private void mockKmsSigning(ECKey ecSigningKey, JWTClaimsSet jwtClaimsSet) throws Exception {
+        var ecdsaSigner = new ECDSASigner(ecSigningKey);
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(SIGNING_KEY_ID).build();
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        signedJWT.sign(ecdsaSigner);
+        byte[] signatureToDER = ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
+        var signResult =
+                SignResponse.builder()
+                        .signature(SdkBytes.fromByteArray(signatureToDER))
+                        .keyId(SIGNING_KEY_ID)
+                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                        .build();
+        when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
+    }
+}


### PR DESCRIPTION
### Wider context of change

We have multiple places where we are signing and encrypting a JWT, and we are about to add another (for SIS). The signing and encrypting parts of the code are the same across all the places we are constructing JWTs (apart from the signing and encryption keys). It would be nice if we could have a service that handles the signing and encrypting for us, so we don't need to copy big chunks of code around.

### What’s changed

This PR extracts the signing and encryption of a JWT to a new service called `OrchJwtService`. This service has a method which takes a `JWTClaimSet`, a signing key alias, and an encryption key. It then signs and encrypts the JWT.

I've started to use this in `OrchestrationAuthorizationService`,`DocAppAuthorisationService` and `IPVAuthorisationService`. I have had to change the tests a bit to assert on the claims that we pass into the OrchJwtService, instead of decrypting the JWT we get back from it.

`OrchestrationAuthorizationService` is quite small now so we might be able to move the use of `OrchJwtService` into `AuthenticationAuthorisationService`. I've left it as is for now though

### Manual testing

Deployed to dev, ran through an auth only journey, an identity journey, and a docapp journey. All 3 journeys were successful.

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

