### PR TITLE
BAU: Fix deployment in subenvs

### DIFF
--- a/ci/cloudformation/account-management/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/account-management/parameters/acceptance-test-tags.yaml
@@ -3,7 +3,9 @@ AWSTemplateFormatVersion: "2010-09-09"
 Conditions:
   HasAcceptanceTests:
     Fn::Or:
-      - Fn::Equals: [!Ref Environment, dev]
+      - Fn::And:
+          - Fn::Equals: [!Ref Environment, dev]
+          - Fn::Equals: [!Ref SubEnvironment, none]
       - Fn::Equals: [!Ref Environment, build]
       - Fn::Equals: [!Ref Environment, staging]
 

--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -3,7 +3,9 @@ AWSTemplateFormatVersion: "2010-09-09"
 Conditions:
   HasAcceptanceTests:
     Fn::Or:
-      - Fn::Equals: [!Ref Environment, dev]
+      - Fn::And:
+          - Fn::Equals: [!Ref Environment, dev]
+          - Fn::Equals: [!Ref SubEnvironment, none]
       - Fn::Equals: [!Ref Environment, build]
       - Fn::Equals: [!Ref Environment, staging]
 


### PR DESCRIPTION
We need to take into account whether an environment is a subenv or not when deploying acceptance test tags, otherwise the subenvs (authdev1 / 2) will fail to deploy as they will attempt to write to the dev param and cloudformation will complain about state that it thinks is weird. The subenvs do not run acceptance tests as part of their pipeline so should not write to any cucumber param.


