### PR TITLE
ATO-2712: Create SISAuthorisationService

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -283,13 +283,29 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getURLOrThrow("IPV_JWKS_URL");
     }
 
-    public int getJwkCacheExpirationInSeconds() {
-        return Integer.parseInt(
-                System.getenv().getOrDefault("JWK_CACHE_EXPIRATION_IN_SECONDS", "300"));
+    public String getSISAudience() {
+        return System.getenv().getOrDefault("SIS_AUDIENCE", "");
+    }
+
+    public URI getSISAuthorisationCallbackURI() {
+        return getURIOrEmpty("SIS_AUTHORISATION_CALLBACK_URI");
+    }
+
+    public String getSISAuthorisationClientId() {
+        return System.getenv().getOrDefault("SIS_AUTHORISATION_CLIENT_ID", "");
     }
 
     public String getSISTokenSigningKeyAlias() {
         return System.getenv("SIS_TOKEN_SIGNING_KEY_ALIAS");
+    }
+
+    public URL getSISJwksUrl() {
+        return getURLOrThrow("SIS_JWKS_URL");
+    }
+
+    public int getJwkCacheExpirationInSeconds() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("JWK_CACHE_EXPIRATION_IN_SECONDS", "300"));
     }
 
     public String getInternalSectorURI() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksCacheService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksCacheService.java
@@ -62,6 +62,11 @@ public class JwksCacheService extends BaseDynamoService<JwksCacheItem> {
         return getOrGenerateJwksCacheItem(docAppsUrl);
     }
 
+    public JwksCacheItem getOrGenerateSISJwksCacheItem() {
+        URL docAppsUrl = configurationService.getSISJwksUrl();
+        return getOrGenerateJwksCacheItem(docAppsUrl);
+    }
+
     private JwksCacheItem getOrGenerateJwksCacheItem(URL url) {
         Optional<JwksCacheItem> jwkCacheItem = getEncryptionKey(url.toString());
         if (jwkCacheItem.isEmpty()) {

--- a/sis-api/src/main/java/uk/gov/di/orchestration/sis/service/SISAuthorisationService.java
+++ b/sis-api/src/main/java/uk/gov/di/orchestration/sis/service/SISAuthorisationService.java
@@ -1,0 +1,91 @@
+package uk.gov.di.orchestration.sis.service;
+
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.JwksCacheService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
+
+import java.security.interfaces.RSAPublicKey;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static uk.gov.di.orchestration.shared.helpers.RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem;
+
+public class SISAuthorisationService {
+    private static final Logger LOG = LogManager.getLogger(SISAuthorisationService.class);
+    private final ConfigurationService configurationService;
+    private final JwksCacheService jwksCacheService;
+    private final OrchJwtService orchJwtService;
+    private final NowHelper.NowClock nowClock;
+
+    public SISAuthorisationService(
+            ConfigurationService configurationService,
+            JwksCacheService jwksCacheService,
+            OrchJwtService orchJwtService,
+            NowHelper.NowClock nowClock) {
+        this.configurationService = configurationService;
+        this.jwksCacheService = jwksCacheService;
+        this.orchJwtService = orchJwtService;
+        this.nowClock = nowClock;
+    }
+
+    public EncryptedJWT constructRequestJWT(
+            State state,
+            Scope scope,
+            Subject subject,
+            ClaimsSetRequest claims,
+            String clientSessionId,
+            String emailAddress,
+            List<String> vtr,
+            Boolean reproveIdentity) {
+        LOG.info("Generating request JWT");
+        var jwtID = IdGenerator.generate();
+        var expiryDate = nowClock.nowPlus(3, ChronoUnit.MINUTES);
+        var claimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claims);
+        var claimsBuilder =
+                new JWTClaimsSet.Builder()
+                        .issuer(configurationService.getSISAuthorisationClientId())
+                        .audience(configurationService.getSISAudience())
+                        .expirationTime(expiryDate)
+                        .subject(subject.getValue())
+                        .issueTime(nowClock.now())
+                        .jwtID(jwtID)
+                        .notBeforeTime(nowClock.now())
+                        .claim("state", state.getValue())
+                        .claim("govuk_signin_journey_id", clientSessionId)
+                        .claim("email_address", emailAddress)
+                        .claim(
+                                "redirect_uri",
+                                configurationService.getSISAuthorisationCallbackURI().toString())
+                        .claim("client_id", configurationService.getSISAuthorisationClientId())
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", scope.toString())
+                        .claim("vtr", vtr);
+        if (configurationService.isAccountInterventionServiceActionEnabled()
+                && reproveIdentity != null) {
+            claimsBuilder.claim("reprove_identity", reproveIdentity);
+        }
+        claimsBuilder.claim("claims", claimsRequest.toJSONObject());
+        LOG.info("Encrypted request JWT has been generated");
+        return orchJwtService.signAndEncryptJWT(
+                claimsBuilder.build(),
+                configurationService.getSISTokenSigningKeyAlias(),
+                getPublicEncryptionKey());
+    }
+
+    private RSAPublicKey getPublicEncryptionKey() {
+        LOG.info("Getting SIS Encryption JWK via JWKS endpoint");
+        return getRsaPublicKeyFromJwksCacheItem(jwksCacheService.getOrGenerateSISJwksCacheItem());
+    }
+}

--- a/sis-api/src/test/java/uk/gov/di/orchestration/sis/PackageSettings.java
+++ b/sis-api/src/test/java/uk/gov/di/orchestration/sis/PackageSettings.java
@@ -1,0 +1,14 @@
+package uk.gov.di.orchestration.sis;
+
+import org.approvaltests.core.ApprovalFailureReporter;
+import org.approvaltests.reporters.AutoApproveWhenEmptyReporter;
+import org.approvaltests.reporters.JunitReporter;
+
+public class PackageSettings {
+    public static ApprovalFailureReporter UseReporter =
+            new AutoApproveWhenEmptyReporter(new JunitReporter());
+    public static ApprovalFailureReporter FrontloadedReporter =
+            new AutoApproveWhenEmptyReporter(new JunitReporter());
+    public static String UseApprovalSubdirectory = "approvals";
+    public static String ApprovalBaseDirectory = "../resources";
+}

--- a/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
+++ b/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
@@ -1,0 +1,137 @@
+package uk.gov.di.orchestration.sis.service;
+
+import com.google.gson.GsonBuilder;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.ClaimRequirement;
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import org.approvaltests.JsonApprovals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import uk.gov.di.orchestration.shared.entity.JwksCacheItem;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.JwksCacheService;
+import uk.gov.di.orchestration.shared.services.OrchJwtService;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
+
+class SISAuthorisationServiceTest {
+    private static final String KEY_ID = "14342354354353";
+    private static final String SIS_CLIENT_ID = "sis-client-id";
+    private static final URI SIS_URI = URI.create("http://sis/");
+    private static final URI SIS_CALLBACK_URI = URI.create("http://localhost/oidc/sis/callback");
+    private static final String SIS_SIGNING_KEY_ALIAS = "test-signing-key-id";
+    private static final Instant NOW = Instant.parse("2026-06-29T15:00:00Z");
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final JwksCacheService jwksCacheService = mock(JwksCacheService.class);
+    private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
+    private SISAuthorisationService authorisationService;
+
+    private RSAPublicKey publicEncKey;
+
+    @BeforeEach
+    void setup() throws Exception {
+        when(configurationService.getSISAuthorisationClientId()).thenReturn(SIS_CLIENT_ID);
+        when(configurationService.getSISAuthorisationCallbackURI()).thenReturn(SIS_CALLBACK_URI);
+        when(configurationService.getSISAudience()).thenReturn(SIS_URI.toString());
+        var keyPair = generateRsaKeyPair();
+        var publicEncJwk =
+                new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                        .keyUse(KeyUse.ENCRYPTION)
+                        .keyID(KEY_ID)
+                        .build();
+        publicEncKey = publicEncJwk.toRSAPublicKey();
+        var jwksUrl = new URL("http://localhost/.well-known/jwks.json");
+        when(configurationService.getSISJwksUrl()).thenReturn(jwksUrl);
+        when(jwksCacheService.getOrGenerateSISJwksCacheItem())
+                .thenReturn(new JwksCacheItem(jwksUrl.toString(), publicEncJwk, 300));
+        when(configurationService.getSISTokenSigningKeyAlias()).thenReturn(SIS_SIGNING_KEY_ALIAS);
+
+        authorisationService =
+                new SISAuthorisationService(
+                        configurationService,
+                        jwksCacheService,
+                        orchJwtService,
+                        new NowHelper.NowClock(Clock.fixed(NOW, ZoneOffset.UTC)));
+    }
+
+    @Test
+    void shouldCreateASignedAndEncryptedJwt() {
+        var state = new State("test-state");
+        var scope = new Scope(OIDCScopeValue.OPENID);
+        var pairwise = new Subject("pairwise-identifier");
+        var claims =
+                new ClaimsSetRequest()
+                        .add(
+                                new ClaimsSetRequest.Entry(
+                                                "https://vocab.account.gov.uk/v1/coreIdentityJWT")
+                                        .withClaimRequirement(ClaimRequirement.ESSENTIAL));
+        var clientSessionId = "test-csid";
+        var email = "test@email.com";
+        var vtrList = List.of("P2");
+        var jwtId = "test-jwt-id";
+        try (MockedStatic<IdGenerator> mockedIdGenerator = mockStatic(IdGenerator.class)) {
+            mockedIdGenerator.when(IdGenerator::generate).thenReturn(jwtId);
+            authorisationService.constructRequestJWT(
+                    state, scope, pairwise, claims, clientSessionId, email, vtrList, null);
+        }
+        var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
+
+        verify(orchJwtService)
+                .signAndEncryptJWT(captor.capture(), eq(SIS_SIGNING_KEY_ALIAS), eq(publicEncKey));
+        var actualClaims = captor.getValue();
+        assertThat(actualClaims.getJWTID(), equalTo(jwtId));
+        assertThat(actualClaims.getClaim("client_id"), equalTo(SIS_CLIENT_ID));
+        assertThat(actualClaims.getClaim("state"), equalTo(state.getValue()));
+        assertThat(actualClaims.getSubject(), equalTo(pairwise.getValue()));
+        assertThat(actualClaims.getClaim("scope"), equalTo(scope.toString()));
+        assertThat(actualClaims.getIssuer(), equalTo(SIS_CLIENT_ID));
+        assertThat(actualClaims.getAudience(), equalTo(singletonList(SIS_URI.toString())));
+        assertThat(actualClaims.getClaim("response_type"), equalTo("code"));
+        var expectedClaimsRequest =
+                new OIDCClaimsRequest().withUserInfoClaimsRequest(claims).toJSONObject();
+        assertThat(actualClaims.getClaim("claims"), equalTo(expectedClaimsRequest));
+        assertThat(actualClaims.getClaim("email_address"), equalTo(email));
+        assertThat(actualClaims.getClaim("govuk_signin_journey_id"), equalTo(clientSessionId));
+        assertThat(actualClaims.getClaim("vtr"), equalTo(vtrList));
+        assertNull(actualClaims.getClaim("reprove_identity"));
+        assertThat(actualClaims.getClaim("redirect_uri"), equalTo(SIS_CALLBACK_URI.toString()));
+        assertThat(actualClaims.getIssueTime(), equalTo(Date.from(NOW)));
+        assertThat(actualClaims.getNotBeforeTime(), equalTo(Date.from(NOW)));
+        assertThat(
+                actualClaims.getExpirationTime(),
+                equalTo(Date.from(NOW.plus(3, ChronoUnit.MINUTES))));
+
+        JsonApprovals.verifyAsJson(actualClaims.toJSONObject(), GsonBuilder::serializeNulls);
+    }
+}

--- a/sis-api/src/test/resources/uk/gov/di/orchestration/sis/service/approvals/SISAuthorisationServiceTest.shouldCreateASignedAndEncryptedJwt.approved.json
+++ b/sis-api/src/test/resources/uk/gov/di/orchestration/sis/service/approvals/SISAuthorisationServiceTest.shouldCreateASignedAndEncryptedJwt.approved.json
@@ -1,0 +1,26 @@
+{
+  "sub": "pairwise-identifier",
+  "iss": "sis-client-id",
+  "response_type": "code",
+  "client_id": "sis-client-id",
+  "govuk_signin_journey_id": "test-csid",
+  "aud": "http://sis/",
+  "nbf": 1782745200,
+  "email_address": "test@email.com",
+  "vtr": [
+    "P2"
+  ],
+  "scope": "openid",
+  "claims": {
+    "userinfo": {
+      "https://vocab.account.gov.uk/v1/coreIdentityJWT": {
+        "essential": true
+      }
+    }
+  },
+  "state": "test-state",
+  "redirect_uri": "http://localhost/oidc/sis/callback",
+  "exp": 1782745380,
+  "iat": 1782745200,
+  "jti": "test-jwt-id"
+}


### PR DESCRIPTION
### What’s changed

This PR creates the start of what will be the authorisation component that interacts with SIS. For now we are just creating the request JWT, and testing that it has been created with the correct claims.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
