### PR TITLE
Aut 5503: remove support reauth signout enabled flag

### DIFF
--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -305,7 +305,6 @@ Mappings:
       manuallyDeleteAccountReservedConcurrency: 1
       reauthEnterEmailCountTtl: 120
       reducedLockoutDuration: 300
-      supportReauthSignoutEnabled: true
       testClientsEnabled: true
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
@@ -342,7 +341,6 @@ Mappings:
       manuallyDeleteAccountReservedConcurrency: 1
       reauthEnterEmailCountTtl: 120
       reducedLockoutDuration: 300
-      supportReauthSignoutEnabled: true
       testClientsEnabled: true
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
@@ -379,7 +377,6 @@ Mappings:
       manuallyDeleteAccountReservedConcurrency: 1
       reauthEnterEmailCountTtl: 120
       reducedLockoutDuration: 300
-      supportReauthSignoutEnabled: true
       testClientsEnabled: true
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
@@ -423,7 +420,6 @@ Mappings:
       otpCodeTtlDuration: 120
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 30
-      supportReauthSignoutEnabled: false
       testClientsEnabled: true
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
@@ -469,7 +465,6 @@ Mappings:
       otpCodeTtlDuration: 900
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 30
-      supportReauthSignoutEnabled: true
       testClientsEnabled: true
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
@@ -514,7 +509,6 @@ Mappings:
       otpCodeTtlDuration: 900
       reauthEnterEmailCountTtl: 300
       reducedLockoutDuration: 900
-      supportReauthSignoutEnabled: true
       testClientsEnabled: true
       accountManagementInternationalSmsEnabled: false
       internationalSmsSendingEnabled: false
@@ -558,7 +552,6 @@ Mappings:
       pendingEmailCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/ac2fa7d3-5c80-4a78-905b-e22b2bf525d8
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 900
-      supportReauthSignoutEnabled: true
       testClientsEnabled: false
       UseAlarmActions: "Yes"
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2f7fd1cc-c0e1-40f5-a747-2ed29e02427d
@@ -606,7 +599,6 @@ Mappings:
       pendingEmailCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/3688b0a9-3ab1-4cc6-8d00-2f9d565a7d83
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 900
-      supportReauthSignoutEnabled: true
       testClientsEnabled: false
       UseAlarmActions: "Yes"
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/7f36e093-d4c1-4b18-8cf3-0c11a59e6d67

--- a/ci/cloudformation/auth/function/check-reauth-user.yaml
+++ b/ci/cloudformation/auth/function/check-reauth-user.yaml
@@ -46,12 +46,6 @@ Resources:
               reauthEnterEmailCountTtl,
             ]
           REDIS_KEY: "session"
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
           AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [

--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -77,12 +77,6 @@ Resources:
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           REDIS_KEY: "session"
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TERMS_CONDITIONS_VERSION:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/function/mfa.yaml
+++ b/ci/cloudformation/auth/function/mfa.yaml
@@ -52,12 +52,6 @@ Resources:
               lockoutDuration,
             ]
           REDIS_KEY: "session"
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TEST_CLIENTS_ENABLED:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/function/orch-auth-code.yaml
+++ b/ci/cloudformation/auth/function/orch-auth-code.yaml
@@ -27,12 +27,6 @@ Resources:
               - !Sub "https://identity.${Environment}.account.gov.uk"
             - "https://identity.account.gov.uk"
           REDIS_KEY: "session"
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
           ENHANCED_AUTH_CODE_PROTECTION_ENABLED:
             !FindInMap [

--- a/ci/cloudformation/auth/function/send-notification.yaml
+++ b/ci/cloudformation/auth/function/send-notification.yaml
@@ -68,12 +68,6 @@ Resources:
               Env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           REDIS_KEY: "session"
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TEST_CLIENTS_ENABLED:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/function/verify-code.yaml
+++ b/ci/cloudformation/auth/function/verify-code.yaml
@@ -62,12 +62,6 @@ Resources:
             - "{{resolve:ssm:/deploy/${env}/support_account_creation_count_ttl}}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TERMS_CONDITIONS_VERSION:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/function/verify-mfa-code.yaml
+++ b/ci/cloudformation/auth/function/verify-mfa-code.yaml
@@ -70,12 +70,6 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               reducedLockoutDuration,
             ]
-          SUPPORT_REAUTH_SIGNOUT_ENABLED:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
-              supportReauthSignoutEnabled,
-            ]
           TERMS_CONDITIONS_VERSION:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -14,8 +14,7 @@ Mappings:
   AcceptanceTestTags:
     dev:
       tags: >-
-        @UI and not (@Reauth or
-        @AccountRecovery or @InternationalSmsSendingDisabled)
+        @UI and not (@AccountRecovery or @InternationalSmsSendingDisabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -254,7 +254,6 @@ Mappings:
       lambdaMinConcurrency: 0
       reauthEnterEmailCountTtl: 120
       reducedLockoutDuration: 300
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
       authSessionUseStronglyConsistentReads: true
@@ -312,7 +311,6 @@ Mappings:
       lambdaMinConcurrency: 0
       reauthEnterEmailCountTtl: 120
       reducedLockoutDuration: 300
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
       authSessionUseStronglyConsistentReads: true
@@ -370,7 +368,6 @@ Mappings:
       lambdaMinConcurrency: 0
       reauthEnterEmailCountTtl: 120
       reducedLockoutDuration: 300
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
       authSessionUseStronglyConsistentReads: true
@@ -442,7 +439,6 @@ Mappings:
       otpCodeTtlDuration: 60
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 30
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
       authSessionUseStronglyConsistentReads: true
@@ -510,7 +506,6 @@ Mappings:
       otpCodeTtlDuration: 60
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 30
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
       authSessionUseStronglyConsistentReads: true
@@ -584,7 +579,6 @@ Mappings:
       otpCodeTtlDuration: 900
       reauthEnterEmailCountTtl: 300
       reducedLockoutDuration: 900
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: true
       authSessionUseStronglyConsistentReads: true
@@ -654,7 +648,6 @@ Mappings:
       pendingEmailCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/ac2fa7d3-5c80-4a78-905b-e22b2bf525d8
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 900
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: false
       UseAlarmActions: "Yes"
@@ -728,7 +721,6 @@ Mappings:
       pendingEmailCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/3688b0a9-3ab1-4cc6-8d00-2f9d565a7d83
       reauthEnterEmailCountTtl: 3600
       reducedLockoutDuration: 900
-      supportReauthSignoutEnabled: true
       termsConditionsVersion: 1.13
       testClientsEnabled: false
       UseAlarmActions: "Yes"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -132,8 +132,7 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                     new AuthorizationSuccessResponse(
                             redirectUri, authorisationCode, null, state, null);
 
-            if (configurationService.supportReauthSignoutEnabled()
-                    && Boolean.TRUE.equals(authCodeRequest.isReauthJourney())) {
+            if (Boolean.TRUE.equals(authCodeRequest.isReauthJourney())) {
                 var auditContext =
                         AuditContext.auditContextFromUserContext(
                                 userContext,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -588,7 +588,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuthSessionItem authSession,
             Optional<String> maybeRpPairwiseId) {
         if (journeyType == REAUTHENTICATION
-                && configurationService.supportReauthSignoutEnabled()
                 && configurationService.isAuthenticationAttemptsServiceEnabled()) {
             var counts =
                     maybeRpPairwiseId.isPresent()
@@ -647,8 +646,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             case TOO_MANY_INVALID_MFA_OTPS_ENTERED,
                     TOO_MANY_INVALID_PW_RESET_CODES_ENTERED,
                     TOO_MANY_EMAIL_CODES_FOR_MFA_RESET_ENTERED:
-                if (!configurationService.supportReauthSignoutEnabled()
-                        || journeyType != REAUTHENTICATION) {
+                if (journeyType != REAUTHENTICATION) {
                     blockCodeForSession(authSession, codeBlockedKeyPrefix);
                 }
                 resetIncorrectMfaCodeAttemptsCount(authSession);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -616,7 +616,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuthSessionItem authSession,
             Optional<String> maybeRpPairwiseId) {
         if (journeyType == REAUTHENTICATION
-                && configurationService.supportReauthSignoutEnabled()
                 && configurationService.isAuthenticationAttemptsServiceEnabled()) {
             var counts =
                     maybeRpPairwiseId.isPresent()
@@ -662,8 +661,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         ? configurationService.getReducedLockoutDuration()
                         : configurationService.getLockoutDuration();
 
-        if (!configurationService.supportReauthSignoutEnabled()
-                || journeyType != REAUTHENTICATION) {
+        if (journeyType != REAUTHENTICATION) {
             codeStorageService.saveBlockedForEmail(
                     emailAddress, codeBlockedKeyPrefix, blockDuration);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -257,7 +257,6 @@ class AuthenticationAuthCodeHandlerTest {
             var userProfile = new UserProfile().withEmail(EMAIL).withPhoneNumber(UK_MOBILE_NUMBER);
             userProfile.setSubjectID(TEST_SUBJECT_ID);
             when(configurationService.getAuthCodeExpiry()).thenReturn(Long.valueOf(12));
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
             when(authenticationService.getUserProfileFromEmail(CommonTestVariables.EMAIL))
                     .thenReturn(Optional.of(userProfile));
             mockedClientSubjectHelperClass
@@ -313,7 +312,6 @@ class AuthenticationAuthCodeHandlerTest {
             var userProfile = new UserProfile().withEmail(EMAIL).withPhoneNumber(UK_MOBILE_NUMBER);
             userProfile.setSubjectID(TEST_SUBJECT_ID);
             when(configurationService.getAuthCodeExpiry()).thenReturn(Long.valueOf(12));
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
             when(authenticationService.getUserProfileFromEmail(CommonTestVariables.EMAIL))
                     .thenReturn(Optional.of(userProfile));
             mockedClientSubjectHelperClass
@@ -353,7 +351,6 @@ class AuthenticationAuthCodeHandlerTest {
     @Test
     void shouldNotSubmitReauthSuccessEventForNonReauthJourney() {
         when(configurationService.getAuthCodeExpiry()).thenReturn(Long.valueOf(12));
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
         var userProfile = new UserProfile().withEmail(EMAIL).withPhoneNumber(UK_MOBILE_NUMBER);
         userProfile.setSubjectID(TEST_SUBJECT_ID);
         when(authenticationService.getUserProfileFromEmail(CommonTestVariables.EMAIL))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -145,7 +145,6 @@ class CheckReAuthUserHandlerTest {
         when(configurationService.getMaxEmailReAuthRetries()).thenReturn(MAX_RETRIES);
         when(configurationService.getMaxPasswordRetries()).thenReturn(MAX_RETRIES);
         when(configurationService.getCodeMaxRetries()).thenReturn(MAX_RETRIES);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
         when(permissionDecisionManager.canReceiveEmailAddress(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
@@ -191,8 +191,6 @@ class LoginHandlerReauthenticationRedisTest {
                                         Instant.now().plusSeconds(900),
                                         false)));
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -217,14 +215,12 @@ class LoginHandlerReauthenticationRedisTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"true, true", "false, true", "true, false", "false, false"})
-    void shouldIncrementRelevantCountWhenCredentialsAreInvalid(
-            boolean isReauthJourney, boolean isReauthEnabled) {
+    @ValueSource(booleans = {true, false})
+    void shouldIncrementRelevantCountWhenCredentialsAreInvalid(boolean isReauthJourney) {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         usingApplicableUserCredentialsWithLogin(SMS, false);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(isReauthEnabled);
 
         usingValidAuthSession();
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -221,8 +221,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                                             Map.of(ENTER_PASSWORD, MAX_ALLOWED_RETRIES - 1),
                                             java.util.List.of(ENTER_PASSWORD))));
 
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
             usingValidAuthSession();
             usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -344,8 +342,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
             setupConfigurationServiceCountForCountType(countType, MAX_ALLOWED_RETRIES);
 
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
             usingValidAuthSession();
             usingApplicableUserCredentialsWithLogin(SMS, true);
 
@@ -426,8 +422,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                                             detailedCounts,
                                             java.util.List.of(countType))));
 
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
             usingValidAuthSession();
             usingApplicableUserCredentialsWithLogin(SMS, true);
 
@@ -486,8 +480,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                                             detailedCounts,
                                             java.util.List.of(ENTER_PASSWORD))));
 
-            when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
             usingValidAuthSession();
             usingApplicableUserCredentialsWithLogin(SMS, false);
 
@@ -537,8 +529,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
         setupConfigurationServiceCountForCountType(ENTER_PASSWORD, MAX_ALLOWED_RETRIES);
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
@@ -583,8 +573,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
         setupConfigurationServiceCountForCountType(ENTER_PASSWORD, MAX_ALLOWED_RETRIES);
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
@@ -622,8 +610,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                 .thenReturn(Optional.of(userProfile));
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
         when(configurationService.getReauthEnterPasswordCountTTL()).thenReturn(120l);
 
         when(authenticationAttemptsService.getCount(any(), any(), any())).thenReturn(1);
@@ -645,7 +631,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                 .thenReturn(Optional.of(userProfile));
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
         when(configurationService.getReauthEnterPasswordCountTTL()).thenReturn(120l);
 
         when(authenticationAttemptsService.getCount(any(), any(), any()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -816,8 +816,6 @@ class LoginHandlerTest {
                                         Instant.now().plusSeconds(900),
                                         false)));
 
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
-
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -961,14 +959,12 @@ class LoginHandlerTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"true, true", "false, true", "true, false", "false, false"})
-    void shouldIncrementRelevantCountWhenCredentialsAreInvalid(
-            boolean isReauthJourney, boolean isReauthEnabled) {
+    @ValueSource(booleans = {true, false})
+    void shouldIncrementRelevantCountWhenCredentialsAreInvalid(boolean isReauthJourney) {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         usingApplicableUserCredentialsWithLogin(SMS, false);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(isReauthEnabled);
         when(permissionDecisionManager.canReceivePassword(any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -633,10 +633,8 @@ class MfaHandlerTest {
 
     @ParameterizedTest
     @MethodSource("smsJourneyTypes")
-    void shouldReturn400WhenUserHitsCodeRequestLimitAfterAction(
-            JourneyType journeyType, boolean reauthEnabled) {
+    void shouldReturn400WhenUserHitsCodeRequestLimitAfterAction(JourneyType journeyType) {
         usingValidSession();
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(reauthEnabled);
 
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(Result.success(new Decision.Permitted(0)))
@@ -665,10 +663,8 @@ class MfaHandlerTest {
 
     @ParameterizedTest
     @MethodSource("smsJourneyTypes")
-    void shouldReturn400IfUserIsBlockedFromRequestingAnyMoreMfaCodes(
-            JourneyType journeyType, boolean reauthEnabled) {
+    void shouldReturn400IfUserIsBlockedFromRequestingAnyMoreMfaCodes(JourneyType journeyType) {
         usingValidSession();
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(reauthEnabled);
         when(permissionDecisionManager.canSendSmsOtpNotification(any(), any(), any()))
                 .thenReturn(
                         Result.success(
@@ -727,10 +723,8 @@ class MfaHandlerTest {
 
     @ParameterizedTest
     @MethodSource("smsJourneyTypes")
-    void shouldReturn400IfUserIsBlockedFromAttemptingMfaCodes(
-            JourneyType journeyType, boolean reauthEnabled) {
+    void shouldReturn400IfUserIsBlockedFromAttemptingMfaCodes(JourneyType journeyType) {
         usingValidSession();
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(reauthEnabled);
         when(permissionDecisionManager.canVerifyMfaOtp(any(), any()))
                 .thenReturn(
                         Result.success(
@@ -975,14 +969,9 @@ class MfaHandlerTest {
                 .thenReturn(Optional.of(authSession));
     }
 
-    private static Stream<Arguments> smsJourneyTypes() {
+    private static Stream<JourneyType> smsJourneyTypes() {
         return Stream.of(
-                Arguments.of(JourneyType.PASSWORD_RESET_MFA, false),
-                Arguments.of(JourneyType.SIGN_IN, false),
-                Arguments.of(JourneyType.REAUTHENTICATION, false),
-                Arguments.of(JourneyType.PASSWORD_RESET_MFA, true),
-                Arguments.of(JourneyType.SIGN_IN, true),
-                Arguments.of(JourneyType.REAUTHENTICATION, true));
+                JourneyType.PASSWORD_RESET_MFA, JourneyType.SIGN_IN, JourneyType.REAUTHENTICATION);
     }
 
     private static Stream<Arguments> mfaJourneyTypes() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -1213,7 +1213,6 @@ class VerifyCodeHandlerTest {
 
     private void withReauthTurnedOn() {
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
     }
 
     @Nested

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -1490,7 +1490,6 @@ class VerifyMfaCodeHandlerTest {
 
     private void withReauthTurnedOn() {
         when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
-        when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -864,11 +864,6 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
             }
 
             @Override
-            public boolean supportReauthSignoutEnabled() {
-                return true;
-            }
-
-            @Override
             public boolean isAuthenticationAttemptsServiceEnabled() {
                 return true;
             }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -1571,11 +1571,6 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             }
 
             @Override
-            public boolean supportReauthSignoutEnabled() {
-                return true;
-            }
-
-            @Override
             public boolean isAuthenticationAttemptsServiceEnabled() {
                 return true;
             }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -180,11 +180,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
                         }
 
                         @Override
-                        public boolean supportReauthSignoutEnabled() {
-                            return true;
-                        }
-
-                        @Override
                         public boolean isAuthenticationAttemptsServiceEnabled() {
                             return true;
                         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -773,12 +773,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
-    public boolean supportReauthSignoutEnabled() {
-        return System.getenv()
-                .getOrDefault("SUPPORT_REAUTH_SIGNOUT_ENABLED", FEATURE_SWITCH_OFF)
-                .equals(FEATURE_SWITCH_ON);
-    }
-
     public boolean supportPasskeys() {
         return System.getenv()
                 .getOrDefault("SUPPORT_PASSKEYS", FEATURE_SWITCH_OFF)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -559,11 +559,6 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void supportReauthSignoutEnabledShouldEqualDefaultWhenEnvVarUnset() {
-        assertFalse(configurationService.supportReauthSignoutEnabled());
-    }
-
-    @Test
     void isAuthenticationAttemptsServiceEnabledShouldEqualDefaultWhenEnvVarUnset() {
         assertFalse(configurationService.isAuthenticationAttemptsServiceEnabled());
     }

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/UserActionsManager.java
@@ -245,9 +245,7 @@ public class UserActionsManager implements UserActions {
         if (codeRequestCount >= configurationService.getCodeMaxRetries()) {
             var blockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
 
-            boolean shouldRecordBlock =
-                    journeyType != JourneyType.REAUTHENTICATION
-                            || !configurationService.supportReauthSignoutEnabled();
+            boolean shouldRecordBlock = journeyType != JourneyType.REAUTHENTICATION;
 
             if (shouldRecordBlock) {
                 LOG.info("Setting block for email as user has requested too many SMS OTPs");

--- a/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/InMemoryLockoutStateHolder.java
+++ b/user-permissions/src/main/java/uk/gov/di/authentication/userpermissions/entity/InMemoryLockoutStateHolder.java
@@ -4,10 +4,10 @@ package uk.gov.di.authentication.userpermissions.entity;
  * In-memory state holder for communicating lockout status between UserActionsManager and
  * PermissionDecisionManager within a single Lambda invocation.
  *
- * <p>This exists as a workaround for reauth journeys when supportReauthSignoutEnabled is true. In
- * that scenario, sentSmsOtpNotification increments the count and resets it when the limit is
- * exceeded, but does NOT create a Redis block. The subsequent call to canSendSmsOtpNotification
- * checks Redis for blocks, but finds none because reauth users aren't blocked there.
+ * <p>This exists as a workaround for reauth journeys. In that scenario, sentSmsOtpNotification
+ * increments the count and resets it when the limit is exceeded, but does NOT create a Redis block.
+ * The subsequent call to canSendSmsOtpNotification checks Redis for blocks, but finds none because
+ * reauth users aren't blocked there.
  *
  * <p>We explicitly chose not to enable recording of the Redis block on reauth journeys because of
  * knock-on consequences to other places in the API that check these blocks. For example, if we

--- a/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
+++ b/user-permissions/src/test/java/uk/gov/di/authentication/userpermissions/UserActionsManagerTest.java
@@ -506,38 +506,7 @@ class UserActionsManagerTest {
             }
 
             @Test
-            void shouldBlockAndResetCountWhenReauthSignoutDisabled() {
-                when(configurationService.supportReauthSignoutEnabled()).thenReturn(false);
-                var codeRequestType =
-                        CodeRequestType.getCodeRequestType(
-                                SupportedCodeType.MFA, JourneyType.REAUTHENTICATION);
-                var sessionWithMaxCount = authSession;
-                for (int i = 0; i < 5; i++) {
-                    sessionWithMaxCount =
-                            sessionWithMaxCount.incrementCodeRequestCount(codeRequestType);
-                }
-                var contextWithMaxCount =
-                        PermissionContext.builder()
-                                .withEmailAddress(EMAIL)
-                                .withAuthSessionItem(sessionWithMaxCount)
-                                .build();
-
-                var result =
-                        userActionsManager.sentSmsOtpNotification(
-                                JourneyType.REAUTHENTICATION, contextWithMaxCount);
-
-                var expectedBlockedKey = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
-                verify(codeStorageService).saveBlockedForEmail(EMAIL, expectedBlockedKey, 900L);
-                ArgumentCaptor<AuthSessionItem> captor =
-                        ArgumentCaptor.forClass(AuthSessionItem.class);
-                verify(authSessionService, times(2)).updateSession(captor.capture());
-                assertEquals(0, captor.getAllValues().get(1).getCodeRequestCount(codeRequestType));
-                assertTrue(result.isSuccess());
-            }
-
-            @Test
-            void shouldSetInMemoryLockoutStateHolderAndResetCountWhenReauthSignoutEnabled() {
-                when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
+            void shouldSetInMemoryLockoutStateHolderAndResetCountWhenJourneyIsReauth() {
                 var codeRequestType =
                         CodeRequestType.getCodeRequestType(
                                 SupportedCodeType.MFA, JourneyType.REAUTHENTICATION);


### PR DESCRIPTION
## What

The supportReauthSignoutEnabled feature flag is redundant: it is enabled in all environments and we are not going to switch it off. 

This PR removes it from code and cloudformation templates as part of a general tidy up of feature flags.

## How to review

1. Code review, paying special attention to the production code changes and verifying that the behaviour retained is the same as feature flag on.

