### PR TITLE
ATO-2694: check AuthCode has not been used before updating

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -201,7 +201,7 @@ public class TokenHandler
         try {
             authCodeExchangeDataMaybe = orchAuthCodeService.getExchangeDataForCode(authCode);
         } catch (Exception e) {
-            LOG.error(
+            LOG.warn(
                     "Failed to retrieve authorisation code from orch auth code DynamoDB store. Error: {}",
                     e.getMessage());
             return generateApiGatewayProxyResponse(500, INTERNAL_SERVER_ERROR);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/BaseDynamoServiceTest.java
@@ -4,7 +4,9 @@ import org.mockito.ArgumentMatchers;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 
@@ -45,6 +47,21 @@ public abstract class BaseDynamoServiceTest<T> {
         doThrow(DynamoDbException.builder().message("Failed to update item in table").build())
                 .when(table)
                 .updateItem(ArgumentMatchers.<T>any());
+    }
+
+    protected void withFailedUpdateItemRequest() {
+        doThrow(DynamoDbException.builder().message("Failed to update item in table").build())
+                .when(table)
+                .updateItem(ArgumentMatchers.<UpdateItemEnhancedRequest<T>>any());
+    }
+
+    protected void withConditionalCheckFailedUpdateItemRequest() {
+        doThrow(
+                        ConditionalCheckFailedException.builder()
+                                .message("Conditional check has failed")
+                                .build())
+                .when(table)
+                .updateItem(ArgumentMatchers.<UpdateItemEnhancedRequest<T>>any());
     }
 
     protected void withFailedDelete() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BaseDynamoService.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
@@ -62,6 +63,10 @@ public class BaseDynamoService<T> {
 
     public void update(T item) {
         dynamoTable.updateItem(item);
+    }
+
+    public void update(UpdateItemEnhancedRequest<T> updateItemRequest) {
+        dynamoTable.updateItem(updateItemRequest);
     }
 
     public void put(T item) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeService.java
@@ -4,7 +4,11 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.OrchAuthCodeItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
@@ -14,6 +18,7 @@ import uk.gov.di.orchestration.shared.serialization.Json.JsonException;
 
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.Optional;
 
 public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
@@ -142,16 +147,33 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
                     e);
         }
 
-        markAuthCodeAsUsed(authCodeItem.get());
-
-        return authCodeExchangeData;
+        return markAuthCodeAsUsedIfAuthCodeUnused(authCodeItem.get())
+                ? authCodeExchangeData
+                : Optional.empty();
     }
 
-    private void markAuthCodeAsUsed(OrchAuthCodeItem authCodeItem) {
-        var item = authCodeItem.withIsUsed(true);
+    private boolean markAuthCodeAsUsedIfAuthCodeUnused(OrchAuthCodeItem authCodeItem) {
+        Expression conditionExpression =
+                Expression.builder()
+                        .expression("IsUsed = :false")
+                        .expressionValues(
+                                Collections.singletonMap(
+                                        ":false", AttributeValue.builder().bool(false).build()))
+                        .build();
+
+        UpdateItemEnhancedRequest<OrchAuthCodeItem> enhancedRequest =
+                UpdateItemEnhancedRequest.builder(OrchAuthCodeItem.class)
+                        .item(authCodeItem.withIsUsed(true))
+                        .conditionExpression(conditionExpression)
+                        .build();
 
         try {
-            update(item);
+            update(enhancedRequest);
+        } catch (ConditionalCheckFailedException e) {
+            LOG.warn(
+                    "Orch auth code item found with isUsed set to true. Code: {}",
+                    authCodeItem.getAuthCode());
+            return false;
         } catch (Exception e) {
             logAndThrowOrchAuthCodeException(
                     String.format(
@@ -159,6 +181,7 @@ public class OrchAuthCodeService extends BaseDynamoService<OrchAuthCodeItem> {
                             authCodeItem.getAuthCode()),
                     e);
         }
+        return true;
     }
 
     private void logAndThrowOrchAuthCodeException(String message, Exception e) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchAuthCodeServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.OrchAuthCodeItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchAuthCodeException;
@@ -123,11 +124,12 @@ class OrchAuthCodeServiceTest extends BaseDynamoServiceTest<OrchAuthCodeItem> {
 
         orchAuthCodeService.getExchangeDataForCode(AUTH_CODE);
 
-        var orchAuthCodeItemCaptor = ArgumentCaptor.forClass(OrchAuthCodeItem.class);
-        verify(table).updateItem(orchAuthCodeItemCaptor.capture());
-        var capturedRequest = orchAuthCodeItemCaptor.getValue();
+        ArgumentCaptor<UpdateItemEnhancedRequest<OrchAuthCodeItem>> updateItemEnhancedRequest =
+                ArgumentCaptor.forClass(UpdateItemEnhancedRequest.class);
+        verify(table).updateItem(updateItemEnhancedRequest.capture());
+        var capturedRequest = updateItemEnhancedRequest.getValue();
 
-        assertTrue(capturedRequest.getIsUsed());
+        assertTrue(capturedRequest.item().getIsUsed());
     }
 
     @Test
@@ -165,11 +167,25 @@ class OrchAuthCodeServiceTest extends BaseDynamoServiceTest<OrchAuthCodeItem> {
         var exchangeData = anAuthCodeExchangeDataEntity();
         withValidOrchAuthCode(exchangeData);
 
-        withFailedUpdate();
+        withFailedUpdateItemRequest();
 
         assertThrows(
                 OrchAuthCodeException.class,
                 () -> orchAuthCodeService.getExchangeDataForCode(AUTH_CODE));
+    }
+
+    @Test
+    void
+            shouldNotGetAuthCodeExchangeDataByAuthCodeWhenOrchAuthCodeItemExistsButIsMarkedAsUsedWhenMarkingAsUsed()
+                    throws Json.JsonException {
+        var exchangeData = anAuthCodeExchangeDataEntity();
+        withValidOrchAuthCode(exchangeData);
+
+        withConditionalCheckFailedUpdateItemRequest();
+
+        var actualExchangeData = orchAuthCodeService.getExchangeDataForCode(AUTH_CODE);
+
+        assertTrue(actualExchangeData.isEmpty());
     }
 
     private AuthCodeExchangeData anAuthCodeExchangeDataEntity() {


### PR DESCRIPTION
### Wider context of change

TokenHandler was sending two error logs for one error. And OrchAuthCodeService did not check if the auth code was used before updating which could allow concurrent requests.

### What’s changed

Updated TokenHandler to log a warn when an error log has already been logged.
Check whether auth code has been used before updating to has been used.

### Manual testing

Deployed to orch dev and ran through a journey.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required. **N/A**