### PR TITLE
Bau/remove account recovery tag

### DIFF
--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -14,8 +14,7 @@ Mappings:
   AcceptanceTestTags:
     dev:
       tags: >-
-        @UI and not (@ReauthMultiTabLogout or
-        @AccountRecovery or @InternationalSmsSendingDisabled)
+        @UI and not (ReauthMultiTabLogout or @InternationalSmsSendingDisabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-


### PR DESCRIPTION
No tests are tagged with @AccountRecovery any more so this tag is redundant and can be removed"

## Related PRs

This PR removed the tests tagged with @AccountRecovery and needs to be merged first https://github.com/govuk-one-login/authentication-acceptance-tests/pull/943
