### PR TITLE
ATO-2703: deploy new infra prod

### DIFF
--- a/ci/stack-orchestration/configuration/production/cloudfront-monitoring-alarm/parameters.json
+++ b/ci/stack-orchestration/configuration/production/cloudfront-monitoring-alarm/parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "production"
+  },
+  {
+    "ParameterKey": "CloudFrontAdditionaldMetricsEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmSNSTopicARN",
+    "ParameterValue": "arn:aws:sns:us-east-1:533266965190:production-CloudFrontCacheHitP1Alerts"
+  },
+  {
+    "ParameterKey": "CloudfrontDistribution",
+    "ParameterValue": "E2SO8Y0KNJ1D62"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmDescription",
+    "ParameterValue": "Cache Hit detected for production OIDC Cloudfront. Runbook: https://govukverify.atlassian.net/wiki/x/AYC0gwE"
+  }
+]

--- a/ci/stack-orchestration/configuration/production/cloudfront-notifications/parameters.json
+++ b/ci/stack-orchestration/configuration/production/cloudfront-notifications/parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "production"
+  },
+  {
+    "ParameterKey": "DeployPagerDutySnsTopic",
+    "ParameterValue": "Yes"
+  }
+]

--- a/ci/stack-orchestration/configuration/production/cloudfront-tls-certificate/alternative-parameters.json
+++ b/ci/stack-orchestration/configuration/production/cloudfront-tls-certificate/alternative-parameters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "HostedZoneID",
+    "ParameterValue": "Z05029003ROZP9M22DXP1"
+  },
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "oidc-orch.account.gov.uk"
+  }
+]

--- a/ci/stack-orchestration/configuration/production/hosted-zone/alternative-domain-parameters.json
+++ b/ci/stack-orchestration/configuration/production/hosted-zone/alternative-domain-parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "production"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": "-orch"
+  }
+]

--- a/ci/stack-orchestration/configuration/production/production-oidc-cloudfront/alternative-parameters.json
+++ b/ci/stack-orchestration/configuration/production/production-oidc-cloudfront/alternative-parameters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "oidc-orch.account.gov.uk"
+  },
+  {
+    "ParameterKey": "CloudFrontCertArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:533266965190:certificate/1db43f6a-bc1b-46ef-bc6c-fdd6022495d3"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeaderManagedSecretRotationMonthWeekDaySchedule",
+    "ParameterValue": "WED#3"
+  },
+  {
+    "ParameterKey": "OriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "PreviousOriginCloakingHeader",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "ApiGatewayOriginDomain",
+    "ParameterValue": "b8adb2uzol.execute-api.eu-west-2.amazonaws.com"
+  },
+  {
+    "ParameterKey": "OriginPath",
+    "ParameterValue": "/production"
+  }
+]

--- a/ci/stack-orchestration/configuration/production/production-oidc-cloudfront/tags.json
+++ b/ci/stack-orchestration/configuration/production/production-oidc-cloudfront/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "FMSGlobalCustomPolicy",
+    "Value": "true"
+  },
+  {
+    "Key": "FMSGlobalCustomPolicyName",
+    "Value": "cloudfrontoidc"
+  }
+]


### PR DESCRIPTION
### Wider context of change

We've now deployed our new infrastructure for the Cloudfront and API Gateway on an alternate domain, and this uses different configuration params for each stack. This adds these parameters, so that they are source controlled.

### What’s changed
- Adds the parameter and tags files for
   - New Cloudfront distribution 
   - Cloudfront monitoring stack
   - Cloudfront Notification stack
   - Cloudfront TLS certificate 


### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
