### PR TITLE
ATO-2695: check Refresh Token has not been used

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchRefreshTokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchRefreshTokenService.java
@@ -3,7 +3,11 @@ package uk.gov.di.orchestration.shared.services;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import uk.gov.di.orchestration.shared.entity.OrchRefreshTokenItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchRefreshTokenException;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
@@ -11,6 +15,7 @@ import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,8 +63,7 @@ public class OrchRefreshTokenService extends BaseDynamoService<OrchRefreshTokenI
             LOG.info("Orch refresh token item with Jwt ID: {} has isUsed = true", jwtId);
             return Optional.empty();
         }
-        var refreshToken = markTokenAsUsed(unusedOrchRefreshToken.get());
-        return Optional.of(refreshToken);
+        return markAuthCodeAsUsedIfAuthCodeUnused(unusedOrchRefreshToken.get());
     }
 
     public List<OrchRefreshTokenItem> getRefreshTokensForAuthCode(String authCode) {
@@ -100,17 +104,36 @@ public class OrchRefreshTokenService extends BaseDynamoService<OrchRefreshTokenI
         }
     }
 
-    private OrchRefreshTokenItem markTokenAsUsed(OrchRefreshTokenItem orchRefreshTokenItem) {
+    private Optional<OrchRefreshTokenItem> markAuthCodeAsUsedIfAuthCodeUnused(
+            OrchRefreshTokenItem orchRefreshTokenItem) {
         var item = orchRefreshTokenItem.withIsUsed(true);
+        Expression conditionExpression =
+                Expression.builder()
+                        .expression("IsUsed = :false")
+                        .expressionValues(
+                                Collections.singletonMap(
+                                        ":false", AttributeValue.builder().bool(false).build()))
+                        .build();
+
+        UpdateItemEnhancedRequest<OrchRefreshTokenItem> enhancedRequest =
+                UpdateItemEnhancedRequest.builder(OrchRefreshTokenItem.class)
+                        .item(item)
+                        .conditionExpression(conditionExpression)
+                        .build();
+
         try {
-            update(item);
+            update(enhancedRequest);
+        } catch (ConditionalCheckFailedException e) {
+            LOG.info("Orch refresh token item with Jwt ID: {} has isUsed = true", item.getJwtId());
+            return Optional.empty();
         } catch (Exception e) {
             logAndThrowOrchRefreshTokenException(
-                    "Failed to mark refresh token as used. Token jwt: "
-                            + orchRefreshTokenItem.getJwtId(),
+                    String.format(
+                            "Failed to mark refresh token as used. Token jwt: %s",
+                            orchRefreshTokenItem.getJwtId()),
                     e);
         }
-        return item;
+        return Optional.of(item);
     }
 
     private void logAndThrowOrchRefreshTokenException(String message, Exception e) {

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchRefreshTokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchRefreshTokenServiceTest.java
@@ -3,10 +3,8 @@ package uk.gov.di.orchestration.shared.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.orchestration.shared.entity.OrchRefreshTokenItem;
 import uk.gov.di.orchestration.shared.exceptions.OrchRefreshTokenException;
 import uk.gov.di.orchestration.sharedtest.basetest.BaseDynamoServiceTest;
@@ -20,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -38,7 +35,6 @@ class OrchRefreshTokenServiceTest extends BaseDynamoServiceTest<OrchRefreshToken
     private static final String AUTH_CODE_INDEX = "AuthCodeIndex";
     private static final Instant CREATION_INSTANT = Instant.parse("2025-02-01T03:04:05.678Z");
 
-    private final DynamoDbTable<OrchRefreshTokenItem> table = mock(DynamoDbTable.class);
     private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
     private OrchRefreshTokenService orchRefreshTokenService;
 
@@ -77,9 +73,7 @@ class OrchRefreshTokenServiceTest extends BaseDynamoServiceTest<OrchRefreshToken
 
     @Test
     void shouldThrowWhenFailsToStoreOrchRefreshToken() {
-        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
-                .when(table)
-                .putItem(any(OrchRefreshTokenItem.class));
+        withFailedPut();
 
         var exception =
                 assertThrows(
@@ -96,33 +90,28 @@ class OrchRefreshTokenServiceTest extends BaseDynamoServiceTest<OrchRefreshToken
 
     @Test
     void shouldGetOrchRefreshTokenForJwtId() {
-        var orchRefreshTokenItem =
-                new OrchRefreshTokenItem()
-                        .withJwtId(JWT_ID)
-                        .withInternalPairwiseSubjectId(INTERNAL_PAIRWISE_SUBJECT_ID)
-                        .withToken(TOKEN)
-                        .withAuthCode(AUTH_CODE);
+        withValidRefreshToken();
 
-        when(table.getItem(getRequestFor(JWT_ID))).thenReturn(orchRefreshTokenItem);
+        var actualOptionalOrchRefreshToken = orchRefreshTokenService.getRefreshToken(JWT_ID);
 
-        var actualOrchRefreshToken = orchRefreshTokenService.getRefreshToken(JWT_ID);
-
-        assertTrue(actualOrchRefreshToken.isPresent());
-        assertEquals(JWT_ID, orchRefreshTokenItem.getJwtId());
+        assertTrue(actualOptionalOrchRefreshToken.isPresent());
+        var actualOrchRefreshTokenItem = actualOptionalOrchRefreshToken.get();
+        assertEquals(JWT_ID, actualOrchRefreshTokenItem.getJwtId());
         assertEquals(
-                INTERNAL_PAIRWISE_SUBJECT_ID, orchRefreshTokenItem.getInternalPairwiseSubjectId());
-        assertEquals(TOKEN, orchRefreshTokenItem.getToken());
-        assertEquals(AUTH_CODE, orchRefreshTokenItem.getAuthCode());
-        assertTrue(orchRefreshTokenItem.getIsUsed());
+                INTERNAL_PAIRWISE_SUBJECT_ID,
+                actualOrchRefreshTokenItem.getInternalPairwiseSubjectId());
+        assertEquals(TOKEN, actualOrchRefreshTokenItem.getToken());
+        assertEquals(AUTH_CODE, actualOrchRefreshTokenItem.getAuthCode());
+        assertTrue(actualOrchRefreshTokenItem.getIsUsed());
     }
 
     @Test
     void shouldReturnEmptyWhenNoRefreshTokenForJwtId() {
-        when(table.getItem(any(GetItemEnhancedRequest.class))).thenReturn(null);
-
         var actualOrchRefreshToken = orchRefreshTokenService.getRefreshToken(JWT_ID);
 
         assertTrue(actualOrchRefreshToken.isEmpty());
+
+        verify(table).getItem(getRequestFor(JWT_ID));
     }
 
     @Test
@@ -143,16 +132,52 @@ class OrchRefreshTokenServiceTest extends BaseDynamoServiceTest<OrchRefreshToken
     }
 
     @Test
+    void shouldMarkRefreshTokenAsUsedAfterSuccessfullyGettingRefreshToken() {
+        withValidRefreshToken();
+
+        orchRefreshTokenService.getRefreshToken(JWT_ID);
+
+        ArgumentCaptor<UpdateItemEnhancedRequest<OrchRefreshTokenItem>> updateItemEnhancedRequest =
+                ArgumentCaptor.forClass(UpdateItemEnhancedRequest.class);
+        verify(table).updateItem(updateItemEnhancedRequest.capture());
+        var capturedRequest = updateItemEnhancedRequest.getValue();
+
+        assertTrue(capturedRequest.item().getIsUsed());
+    }
+
+    @Test
     void shouldThrowWhenFailsToGetOrchRefreshToken() {
-        doThrow(DynamoDbException.builder().message("Failed to get item from table").build())
-                .when(table)
-                .getItem(any(GetItemEnhancedRequest.class));
+        withFailedGet();
 
         var exception =
                 assertThrows(
                         OrchRefreshTokenException.class,
                         () -> orchRefreshTokenService.getRefreshToken(JWT_ID));
         assertEquals("Failed to get Orch refresh token from Dynamo", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenFailsToUpdateOrchRefreshToken() {
+        withValidRefreshToken();
+        withFailedUpdateItemRequest();
+
+        var exception =
+                assertThrows(
+                        OrchRefreshTokenException.class,
+                        () -> orchRefreshTokenService.getRefreshToken(JWT_ID));
+        assertEquals(
+                "Failed to mark refresh token as used. Token jwt: test-jwt-id",
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenRefreshTokenIsAlreadyUsedWhenMarkingAsUsed() {
+        withValidRefreshToken();
+        withConditionalCheckFailedUpdateItemRequest();
+
+        var actualOrchRefreshToken = orchRefreshTokenService.getRefreshToken(JWT_ID);
+
+        assertTrue(actualOrchRefreshToken.isEmpty());
     }
 
     @Test
@@ -216,5 +241,16 @@ class OrchRefreshTokenServiceTest extends BaseDynamoServiceTest<OrchRefreshToken
         assertEquals(
                 "Failed to get Orch refresh tokens from Dynamo for auth code",
                 exception.getMessage());
+    }
+
+    private void withValidRefreshToken() {
+        var orchRefreshTokenItem =
+                new OrchRefreshTokenItem()
+                        .withJwtId(JWT_ID)
+                        .withInternalPairwiseSubjectId(INTERNAL_PAIRWISE_SUBJECT_ID)
+                        .withToken(TOKEN)
+                        .withAuthCode(AUTH_CODE);
+
+        when(table.getItem(getRequestFor(JWT_ID))).thenReturn(orchRefreshTokenItem);
     }
 }


### PR DESCRIPTION
### Wider context of change

OrchRefreshTokenService did not check if token had been used before marking is used.

### What’s changed

OrchRefreshTokenService now checks if token has been used before marking as used.

### Manual testing

Tested OrchAuthCodeService change and copied code

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.