### PR TITLE
ATO-2669: Configure SIS JWKS API endpoint

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -111,7 +111,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       var.orch_storage_token_jwk_enabled,
       jsonencode(aws_api_gateway_integration.orch_ipv_jwks_integration),
       jsonencode(aws_api_gateway_method.orch_ipv_jwks_method),
-      jsonencode(aws_api_gateway_method.orch_auth_jwks_method)
+      jsonencode(aws_api_gateway_method.orch_auth_jwks_method),
+      jsonencode(aws_api_gateway_method.orch_sis_jwks_method)
     ]))
   }
 
@@ -1287,4 +1288,36 @@ resource "aws_api_gateway_integration" "orch_auth_jwks_integration" {
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
   uri                     = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:${var.orch_account_id}:function:${local.secure_pipelines_environment}-AuthJwksFunction:latest/invocations"
+}
+
+resource "aws_api_gateway_resource" "orch_sis_jwks_resource" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  parent_id   = aws_api_gateway_resource.wellknown_resource.id
+  path_part   = "sis-jwks.json"
+  depends_on = [
+    aws_api_gateway_resource.wellknown_resource
+  ]
+}
+
+resource "aws_api_gateway_method" "orch_sis_jwks_method" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  resource_id = aws_api_gateway_resource.orch_sis_jwks_resource.id
+  http_method = "GET"
+
+  depends_on = [
+    aws_api_gateway_resource.orch_sis_jwks_resource
+  ]
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "orch_sis_jwks_integration" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  resource_id = aws_api_gateway_resource.orch_sis_jwks_resource.id
+  http_method = aws_api_gateway_method.orch_sis_jwks_method.http_method
+  depends_on = [
+    aws_api_gateway_resource.orch_sis_jwks_resource
+  ]
+  type                    = "AWS_PROXY"
+  integration_http_method = "POST"
+  uri                     = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-2:${var.orch_account_id}:function:${local.secure_pipelines_environment}-SISJwksFunction:latest/invocations"
 }

--- a/orchestration-api-spec.yaml
+++ b/orchestration-api-spec.yaml
@@ -102,6 +102,15 @@ paths:
         passthroughBehavior: "when_no_match"
         timeoutInMillis: 29000
         type: "aws_proxy"
+  /.well-known/sis-jwks.json:
+    get:
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SISJwksFunction.Arn}:latest/invocations"
+        httpMethod: "POST"
+        passthroughBehavior: "when_no_match"
+        timeoutInMillis: 29000
+        type: "aws_proxy"
   /authorize:
     get:
       x-amazon-apigateway-integration:

--- a/template.yaml
+++ b/template.yaml
@@ -3718,6 +3718,17 @@ Resources:
           ApiId:
             !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
 
+  SISJwksFunctionOrchestrationApiPermission:
+    Type: AWS::Lambda::Permission
+    Condition: ProvisionNewApiGateway
+    Properties:
+      FunctionName: !Ref SISJwksFunction.Alias
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub
+        - "arn:aws:execute-api:eu-west-2:${AWS::AccountId}:${ApiId}/*/GET/.well-known/sis-jwks.json"
+        - ApiId: !Ref OrchestrationOidcApi
+
   SISJwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -3701,6 +3701,23 @@ Resources:
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
+  SISJwksFunctionCrossAccountPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref SISJwksFunction.Alias
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub
+        - "arn:aws:execute-api:eu-west-2:${AccountId}:${ApiId}/*/GET/.well-known/sis-jwks.json"
+        - AccountId:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              authAccountId,
+            ]
+          ApiId:
+            !FindInMap [EnvironmentConfiguration, !Ref Environment, authApiId]
+
   SISJwksFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
### What’s changed

This PR adds the `SISJwksFunction` to an API GW endpoint for the old API and new API. This involved configuring cross-account permissons for the old API GW, and also adding the endpoint to the api-spec for the new API (else it would not allow you to hit the new endpoint.

The path for both endpoints is `/.well-known/sis-jwks.json` 

### Manual testing

Deployed to dev and tested. Saw that the new endpoint worked in the old API and the new API

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
    ^ This will be done in another ticket! 

