### PR TITLE
ATO-2568: Create S3 bucket to hold JWKS files

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -198,6 +198,7 @@ Mappings:
         }]'
       oidcDomainName: "oidc.dev.account.gov.uk"
       oidcAlternateDomainName: "oidc-orch.dev.account.gov.uk"
+      serviceNameForKeyRotationStack: "orch"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -235,6 +236,7 @@ Mappings:
         }]'
       oidcDomainName: "oidc.build.account.gov.uk"
       oidcAlternateDomainName: "oidc-orch.build.account.gov.uk"
+      serviceNameForKeyRotationStack: "orch"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -274,6 +276,7 @@ Mappings:
         }]'
       oidcDomainName: "oidc.staging.account.gov.uk"
       oidcAlternateDomainName: "oidc-orch.staging.account.gov.uk"
+      serviceNameForKeyRotationStack: "orch"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -311,6 +314,7 @@ Mappings:
         }]'
       oidcDomainName: "oidc.integration.account.gov.uk"
       oidcAlternateDomainName: "oidc-orch.integration.account.gov.uk"
+      serviceNameForKeyRotationStack: "orch"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -348,6 +352,7 @@ Mappings:
         }]'
       oidcDomainName: "oidc.account.gov.uk"
       oidcAlternateDomainName: "oidc-orch.account.gov.uk"
+      serviceNameForKeyRotationStack: "orch"
 
 Globals:
   Function:
@@ -9601,6 +9606,34 @@ Resources:
       Statistic: Average
       Threshold: 10
       EvaluationPeriods: 1
+  #endregion
+
+  #region S3 bucket for JWKS files
+  WellKnownJwksBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub
+        - govuk-one-login-${ServiceName}-published-keys-${Environment}
+        - ServiceName:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              serviceNameForKeyRotationStack,
+            ]
+      LoggingConfiguration:
+        DestinationBucketName: !Sub di-s3-access-logs-${AWS::AccountId}-${AWS::Region}
+        LogFilePrefix: WellKnownJwksBucket/
+      VersioningConfiguration:
+        Status: "Enabled"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
   #endregion
 
 Outputs:


### PR DESCRIPTION
### Wider context of change

We would like to move away from creating JWKS responses in lambdas, and instead serve files in an S3 bucket. This should not only reduce response time, but also is a prerequesite to using the identity key rotation stacks, which will rotate keys for us. To start though, we need an S3 bucket to store JWKS json files.

### What’s changed

This PR creates a new S3 bucket for storing JWKS files. It's configured to use the new access logs bucket that has been set up for us by devplatform. 

### Manual testing

Deployed to dev, saw the bucket existed in S3 and saw it was configured with the correct access logs bucket.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

