### PR TITLE
AUT-5527: Add user identifiers to AUTH_DELETE_ACCOUNT audit event

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/BulkRemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/BulkRemoveAccountHandler.java
@@ -15,8 +15,8 @@ import uk.gov.di.accountmanagement.services.AwsSnsClient;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.accountmanagement.services.ManualAccountDeletionService;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -63,13 +63,13 @@ public class BulkRemoveAccountHandler
                         configurationService.getAwsRegion(),
                         configurationService.getLegacyAccountDeletionTopicArn(),
                         configurationService.getSnsEndpointUri());
-        var auditService = new AuditService(configurationService);
+        var structuredAuditService = new StructuredAuditService(configurationService);
         var dynamoDeleteService = new DynamoDeleteService(configurationService);
         var accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
                         emailSqsClient,
-                        auditService,
+                        structuredAuditService,
                         configurationService,
                         dynamoDeleteService);
         this.manualAccountDeletionService =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/ManuallyDeleteAccountHandler.java
@@ -8,7 +8,7 @@ import uk.gov.di.accountmanagement.services.AwsSnsClient;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.accountmanagement.services.ManualAccountDeletionService;
-import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -39,13 +39,13 @@ public class ManuallyDeleteAccountHandler implements RequestHandler<String, Stri
                 new AwsSnsClient(
                         configurationService.getAwsRegion(),
                         configurationService.getLegacyAccountDeletionTopicArn());
-        var auditService = new AuditService(configurationService);
+        var structuredAuditService = new StructuredAuditService(configurationService);
         var dynamoDeleteService = new DynamoDeleteService(configurationService);
         var accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
                         emailSqsClient,
-                        auditService,
+                        structuredAuditService,
                         configurationService,
                         dynamoDeleteService);
         this.manualAccountDeletionService =

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
@@ -21,7 +22,6 @@ import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -44,7 +44,7 @@ public class RemoveAccountHandler
 
     private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;
-    private final AuditService auditService;
+    private final StructuredAuditService structuredAuditService;
     private final ConfigurationService configurationService;
     private final DynamoDeleteService dynamoDeleteService;
     private final AccountDeletionService accountDeletionService;
@@ -53,13 +53,13 @@ public class RemoveAccountHandler
     public RemoveAccountHandler(
             AuthenticationService authenticationService,
             AwsSqsClient sqsClient,
-            AuditService auditService,
+            StructuredAuditService structuredAuditService,
             ConfigurationService configurationService,
             DynamoDeleteService dynamoDeleteService,
             AccountDeletionService accountDeletionService) {
         this.authenticationService = authenticationService;
         this.sqsClient = sqsClient;
-        this.auditService = auditService;
+        this.structuredAuditService = structuredAuditService;
         this.configurationService = configurationService;
         this.dynamoDeleteService = dynamoDeleteService;
         this.accountDeletionService = accountDeletionService;
@@ -72,14 +72,14 @@ public class RemoveAccountHandler
                         configurationService.getAwsRegion(),
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
-        this.auditService = new AuditService(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
         this.configurationService = configurationService;
         this.dynamoDeleteService = new DynamoDeleteService(configurationService);
         this.accountDeletionService =
                 new AccountDeletionService(
                         authenticationService,
                         sqsClient,
-                        auditService,
+                        structuredAuditService,
                         configurationService,
                         dynamoDeleteService);
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -7,6 +7,8 @@ import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -15,26 +17,23 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
+import java.time.Clock;
 import java.util.Optional;
 
-import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_AUTH;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_DELETE_ACCOUNT;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
-import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class AccountDeletionService {
     private static final Logger LOG = LogManager.getLogger(AccountDeletionService.class);
 
     private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;
-    private final AuditService auditService;
+    private final StructuredAuditService structuredAuditService;
     private final ConfigurationService configurationService;
     private final DynamoDeleteService dynamoDeleteService;
     private final Json objectMapper = SerializationService.getInstance();
@@ -42,12 +41,12 @@ public class AccountDeletionService {
     public AccountDeletionService(
             AuthenticationService authenticationService,
             AwsSqsClient sqsClient,
-            AuditService auditService,
+            StructuredAuditService structuredAuditService,
             ConfigurationService configurationService,
             DynamoDeleteService dynamoDeleteService) {
         this.authenticationService = authenticationService;
         this.sqsClient = sqsClient;
-        this.auditService = auditService;
+        this.structuredAuditService = structuredAuditService;
         this.configurationService = configurationService;
         this.dynamoDeleteService = dynamoDeleteService;
     }
@@ -94,8 +93,8 @@ public class AccountDeletionService {
             }
         }
 
-        String persistentSessionID = AuditService.UNKNOWN;
-        String ipAddress = AuditService.UNKNOWN;
+        String persistentSessionID = StructuredAuditService.UNKNOWN;
+        String ipAddress = StructuredAuditService.UNKNOWN;
         if (input.isPresent()) {
             persistentSessionID =
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.get().getHeaders());
@@ -109,21 +108,23 @@ public class AccountDeletionService {
                                     n ->
                                             n.getRequestContext()
                                                     .getAuthorizer()
-                                                    .getOrDefault("clientId", AuditService.UNKNOWN)
+                                                    .getOrDefault(
+                                                            "clientId",
+                                                            StructuredAuditService.UNKNOWN)
                                                     .toString())
-                            .orElse(AuditService.UNKNOWN);
+                            .orElse(StructuredAuditService.UNKNOWN);
             var clientSessionId =
                     input.map(
                                     n ->
                                             ClientSessionIdHelper.extractSessionIdFromHeaders(
                                                     n.getHeaders()))
-                            .orElse(AuditService.UNKNOWN);
+                            .orElse(StructuredAuditService.UNKNOWN);
             var sessionId =
                     input.map(
                                     n ->
                                             RequestHeaderHelper.getHeaderValueOrElse(
                                                     n.getHeaders(), SESSION_ID_HEADER, ""))
-                            .orElse(AuditService.UNKNOWN);
+                            .orElse(StructuredAuditService.UNKNOWN);
             var auditContext =
                     new AuditContext(
                             clientId,
@@ -135,11 +136,14 @@ public class AccountDeletionService {
                             userProfile.getPhoneNumber(),
                             persistentSessionID,
                             txmaAuditEncoded);
-            auditService.submitAuditEvent(
-                    AUTH_DELETE_ACCOUNT,
-                    auditContext,
-                    AUDIT_EVENT_COMPONENT_ID_AUTH,
-                    pair("account_deletion_reason", reason));
+            var auditEvent =
+                    AuthDeleteAccount.create(
+                            auditContext,
+                            userProfile.getPublicSubjectID(),
+                            userProfile.getLegacySubjectID(),
+                            reason.name(),
+                            Clock.systemUTC());
+            structuredAuditService.submitAuditEvent(auditEvent);
         } catch (Exception e) {
             LOG.error("Failed to audit account deletion: ", e);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
 import uk.gov.di.accountmanagement.services.AccountDeletionService;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.DynamoDeleteService;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -17,7 +18,6 @@ import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.helpers.TxmaAuditHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -54,7 +54,8 @@ class RemoveAccountHandlerTest {
     private final Context context = mock(Context.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDeleteService dynamoDeleteService = mock(DynamoDeleteService.class);
     private final AccountDeletionService accountDeletionService =
@@ -66,7 +67,7 @@ class RemoveAccountHandlerTest {
                 new RemoveAccountHandler(
                         authenticationService,
                         sqsClient,
-                        auditService,
+                        structuredAuditService,
                         configurationService,
                         dynamoDeleteService,
                         accountDeletionService);
@@ -114,7 +115,7 @@ class RemoveAccountHandlerTest {
                 .removeAccount(
                         Optional.of(event),
                         userProfile,
-                        AuditService.UNKNOWN,
+                        StructuredAuditService.UNKNOWN,
                         AccountDeletionReason.USER_INITIATED);
     }
 
@@ -139,7 +140,7 @@ class RemoveAccountHandlerTest {
 
         assertThat(expectedException.getMessage(), equalTo("Invalid Principal in request"));
         verifyNoInteractions(sqsClient);
-        verifyNoInteractions(auditService);
+        verifyNoInteractions(structuredAuditService);
     }
 
     @Test
@@ -150,7 +151,7 @@ class RemoveAccountHandlerTest {
         var result = handler.handleRequest(event, context);
 
         verifyNoInteractions(dynamoDeleteService);
-        verifyNoInteractions(auditService);
+        verifyNoInteractions(structuredAuditService);
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ACCT_DOES_NOT_EXIST));
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -12,12 +12,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import uk.gov.di.accountmanagement.entity.AccountDeletionReason;
+import uk.gov.di.authentication.auditevents.entity.AuthDeleteAccount;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSessionIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
-import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -25,7 +26,6 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,21 +34,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_AUTH;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_DELETE_ACCOUNT;
-import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class AccountDeletionServiceTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
-    private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDeleteService dynamoDeleteService = mock(DynamoDeleteService.class);
     private final UserProfile userProfile = mock(UserProfile.class);
@@ -65,7 +62,7 @@ class AccountDeletionServiceTest {
             new AccountDeletionService(
                     authenticationService,
                     sqsClient,
-                    auditService,
+                    structuredAuditService,
                     configurationService,
                     dynamoDeleteService);
     private static final String TEST_CLIENT_SESSION_ID = "test-client-session-id";
@@ -77,6 +74,8 @@ class AccountDeletionServiceTest {
     private static final String SUBJECT_ID = new Subject().getValue();
     private static final String TEST_PERSISTENT_SESSION_ID = "test-persistent-session-id";
     private static final String TEST_IP_ADDRESS = "test-ip-address";
+    private static final String TEST_PUBLIC_SUBJECT_ID = "public-subject-id";
+    private static final String TEST_LEGACY_SUBJECT_ID = "legacy-subject-id";
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -111,7 +110,7 @@ class AccountDeletionServiceTest {
         underTest.removeAccount(
                 Optional.of(input),
                 userProfile,
-                AuditService.UNKNOWN,
+                StructuredAuditService.UNKNOWN,
                 AccountDeletionReason.USER_INITIATED);
         // then
         verify(dynamoDeleteService).deleteAccount(eq(expectedEmail), any());
@@ -132,7 +131,7 @@ class AccountDeletionServiceTest {
                         underTest.removeAccount(
                                 Optional.of(input),
                                 userProfile,
-                                AuditService.UNKNOWN,
+                                StructuredAuditService.UNKNOWN,
                                 AccountDeletionReason.USER_INITIATED));
     }
 
@@ -147,7 +146,7 @@ class AccountDeletionServiceTest {
         underTest.removeAccount(
                 Optional.of(input),
                 userProfile,
-                AuditService.UNKNOWN,
+                StructuredAuditService.UNKNOWN,
                 AccountDeletionReason.USER_INITIATED);
 
         // then
@@ -173,7 +172,7 @@ class AccountDeletionServiceTest {
                         underTest.removeAccount(
                                 Optional.of(input),
                                 userProfile,
-                                AuditService.UNKNOWN,
+                                StructuredAuditService.UNKNOWN,
                                 AccountDeletionReason.USER_INITIATED));
         assertThat(
                 logging.events(),
@@ -183,12 +182,13 @@ class AccountDeletionServiceTest {
     @EnumSource()
     @ParameterizedTest
     void removeAccountAudits(AccountDeletionReason reason) throws Json.JsonException {
-        // given
         var expectedEmail = "test@example.com";
         var expectedPhoneNumber = "+44123456789";
         when(userProfile.getEmail()).thenReturn(expectedEmail);
         when(userProfile.getPhoneNumber()).thenReturn(expectedPhoneNumber);
         when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
+        when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
+        when(userProfile.getLegacySubjectID()).thenReturn(TEST_LEGACY_SUBJECT_ID);
         when(input.getHeaders()).thenReturn(TEST_HEADERS);
         clientSessionIdHelperMockedStatic
                 .when(() -> ClientSessionIdHelper.extractSessionIdFromHeaders(TEST_HEADERS))
@@ -203,31 +203,53 @@ class AccountDeletionServiceTest {
                 .when(() -> IpAddressHelper.extractIpAddress(input))
                 .thenReturn(TEST_IP_ADDRESS);
 
-        // when
-        underTest.removeAccount(Optional.of(input), userProfile, AuditService.UNKNOWN, reason);
+        underTest.removeAccount(
+                Optional.of(input), userProfile, StructuredAuditService.UNKNOWN, reason);
 
-        // then
-        verify(auditService)
-                .submitAuditEvent(
-                        eq(AUTH_DELETE_ACCOUNT),
-                        argThat(
-                                auditContext ->
-                                        Objects.equals(auditContext.clientId(), TEST_CLIENT_ID)
-                                                && Objects.equals(
-                                                        auditContext.clientSessionId(),
-                                                        TEST_CLIENT_SESSION_ID)
-                                                && Objects.equals(
-                                                        auditContext.email(), expectedEmail)
-                                                && Objects.equals(
-                                                        auditContext.phoneNumber(),
-                                                        expectedPhoneNumber)
-                                                && Objects.equals(
-                                                        auditContext.ipAddress(), TEST_IP_ADDRESS)
-                                                && Objects.equals(
-                                                        auditContext.persistentSessionId(),
-                                                        TEST_PERSISTENT_SESSION_ID)),
-                        eq(AUDIT_EVENT_COMPONENT_ID_AUTH),
-                        eq(pair("account_deletion_reason", reason)));
+        var captor = ArgumentCaptor.forClass(AuthDeleteAccount.class);
+        verify(structuredAuditService).submitAuditEvent(captor.capture());
+        var event = captor.getValue();
+
+        assertEquals("AUTH_DELETE_ACCOUNT", event.eventName());
+        assertEquals(TEST_CLIENT_ID, event.clientId());
+        assertEquals(TEST_PUBLIC_SUBJECT_ID, event.user().publicSubjectId());
+        assertEquals(TEST_LEGACY_SUBJECT_ID, event.user().legacySubjectId());
+        assertEquals(reason.name(), event.extensions().accountDeletionReason());
+    }
+
+    @Test
+    void removeAccountAuditsWithNullLegacySubjectId() throws Json.JsonException {
+        when(userProfile.getEmail()).thenReturn("test@example.com");
+        when(userProfile.getPhoneNumber()).thenReturn("+44123456789");
+        when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
+        when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
+        when(userProfile.getLegacySubjectID()).thenReturn(null);
+        when(input.getHeaders()).thenReturn(TEST_HEADERS);
+        clientSessionIdHelperMockedStatic
+                .when(() -> ClientSessionIdHelper.extractSessionIdFromHeaders(TEST_HEADERS))
+                .thenReturn(TEST_CLIENT_SESSION_ID);
+        when(input.getRequestContext()).thenReturn(proxyRequestContext);
+        when(proxyRequestContext.getAuthorizer()).thenReturn(TEST_AUTHORIZER);
+        when(testClientIdObject.toString()).thenReturn(TEST_CLIENT_ID);
+        persistentSessionIdHelperMockedStatic
+                .when(() -> PersistentIdHelper.extractPersistentIdFromHeaders(TEST_HEADERS))
+                .thenReturn(TEST_PERSISTENT_SESSION_ID);
+        ipAddressHelperMockedStatic
+                .when(() -> IpAddressHelper.extractIpAddress(input))
+                .thenReturn(TEST_IP_ADDRESS);
+
+        underTest.removeAccount(
+                Optional.of(input),
+                userProfile,
+                StructuredAuditService.UNKNOWN,
+                AccountDeletionReason.USER_INITIATED);
+
+        var captor = ArgumentCaptor.forClass(AuthDeleteAccount.class);
+        verify(structuredAuditService).submitAuditEvent(captor.capture());
+        var event = captor.getValue();
+
+        assertEquals(TEST_PUBLIC_SUBJECT_ID, event.user().publicSubjectId());
+        assertEquals(null, event.user().legacySubjectId());
     }
 
     @Test
@@ -235,14 +257,14 @@ class AccountDeletionServiceTest {
         // given
         when(userProfile.getEmail()).thenReturn("test@example.com");
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
-        doThrow(new RuntimeException()).when(auditService).submitAuditEvent(any(), any());
+        doThrow(new RuntimeException()).when(structuredAuditService).submitAuditEvent(any());
         // then
         assertDoesNotThrow(
                 () ->
                         underTest.removeAccount(
                                 Optional.of(input),
                                 userProfile,
-                                AuditService.UNKNOWN,
+                                StructuredAuditService.UNKNOWN,
                                 AccountDeletionReason.USER_INITIATED));
         assertThat(
                 logging.events(),

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthDeleteAccount.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthDeleteAccount.java
@@ -1,0 +1,66 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformation;
+import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public record AuthDeleteAccount(
+        String eventName,
+        long timestamp,
+        long eventTimestampMs,
+        String clientId,
+        String componentId,
+        User user,
+        Restricted restricted,
+        Extensions extensions)
+        implements StructuredAuditEvent {
+
+    private static final String EVENT_NAME = "AUTH_DELETE_ACCOUNT";
+
+    public static AuthDeleteAccount create(
+            AuditContext auditContext,
+            String publicSubjectId,
+            String legacySubjectId,
+            String reason,
+            Clock clock) {
+        Instant now = clock.instant();
+        var phoneNumberCountryCode =
+                PhoneNumberHelper.maybeGetCountry(auditContext.phoneNumber()).orElse(null);
+        return new AuthDeleteAccount(
+                EVENT_NAME,
+                now.getEpochSecond(),
+                now.toEpochMilli(),
+                auditContext.clientId(),
+                ComponentId.AUTH.getValue(),
+                new User(
+                        auditContext.email(),
+                        auditContext.clientSessionId(),
+                        auditContext.ipAddress(),
+                        legacySubjectId,
+                        auditContext.persistentSessionId(),
+                        auditContext.phoneNumber(),
+                        publicSubjectId,
+                        auditContext.sessionId(),
+                        auditContext.subjectId()),
+                new Restricted(EncodedDeviceInformation.from(auditContext)),
+                new Extensions(reason, phoneNumberCountryCode));
+    }
+
+    public record User(
+            String email,
+            String govukSigninJourneyId,
+            String ipAddress,
+            String legacySubjectId,
+            String persistentSessionId,
+            String phone,
+            String publicSubjectId,
+            String sessionId,
+            String userId) {}
+
+    public record Restricted(EncodedDeviceInformation deviceInformation) {}
+
+    public record Extensions(String accountDeletionReason, String phoneNumberCountryCode) {}
+}

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthDeleteAccountTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthDeleteAccountTest.java
@@ -1,0 +1,245 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
+
+class AuthDeleteAccountTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-06-02T09:10:11.123Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+
+    @Test
+    void shouldSerializeWithAllFieldsIncludingLegacySubjectId() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client_id")
+                        .withClientSessionId("govuk_signin_journey_id")
+                        .withSessionId("session_id")
+                        .withSubjectId("urn:fdc:gov.uk:2022:user_id")
+                        .withEmail("email")
+                        .withIpAddress("0.0.0.0")
+                        .withPhoneNumber("+447234567890")
+                        .withPersistentSessionId("persistent_session_id")
+                        .withTxmaAuditEncoded("encoded_data");
+
+        var event =
+                AuthDeleteAccount.create(
+                        auditContext,
+                        "urn:fdc:gov.uk:2022:public_subject_id",
+                        "urn:fdc:gov.uk:2022:legacy_subject_id",
+                        "USER_INITIATED",
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_DELETE_ACCOUNT",
+                  "timestamp": 1780391411,
+                  "event_timestamp_ms": 1780391411123,
+                  "client_id": "client_id",
+                  "component_id": "AUTH",
+                  "user": {
+                    "email": "email",
+                    "govuk_signin_journey_id": "govuk_signin_journey_id",
+                    "ip_address": "0.0.0.0",
+                    "legacy_subject_id": "urn:fdc:gov.uk:2022:legacy_subject_id",
+                    "persistent_session_id": "persistent_session_id",
+                    "phone": "+447234567890",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public_subject_id",
+                    "session_id": "session_id",
+                    "user_id": "urn:fdc:gov.uk:2022:user_id"
+                  },
+                  "restricted": {
+                    "device_information": {
+                      "encoded": "encoded_data"
+                    }
+                  },
+                  "extensions": {
+                    "account_deletion_reason": "USER_INITIATED",
+                    "phone_number_country_code": "44"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+
+    @Test
+    void shouldOmitLegacySubjectIdWhenNull() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client_id")
+                        .withClientSessionId("govuk_signin_journey_id")
+                        .withSessionId("session_id")
+                        .withSubjectId("urn:fdc:gov.uk:2022:user_id")
+                        .withEmail("email")
+                        .withIpAddress("0.0.0.0")
+                        .withPhoneNumber("+447234567890")
+                        .withPersistentSessionId("persistent_session_id")
+                        .withTxmaAuditEncoded("encoded_data");
+
+        var event =
+                AuthDeleteAccount.create(
+                        auditContext,
+                        "urn:fdc:gov.uk:2022:public_subject_id",
+                        null,
+                        "USER_INITIATED",
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_DELETE_ACCOUNT",
+                  "timestamp": 1780391411,
+                  "event_timestamp_ms": 1780391411123,
+                  "client_id": "client_id",
+                  "component_id": "AUTH",
+                  "user": {
+                    "email": "email",
+                    "govuk_signin_journey_id": "govuk_signin_journey_id",
+                    "ip_address": "0.0.0.0",
+                    "persistent_session_id": "persistent_session_id",
+                    "phone": "+447234567890",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public_subject_id",
+                    "session_id": "session_id",
+                    "user_id": "urn:fdc:gov.uk:2022:user_id"
+                  },
+                  "restricted": {
+                    "device_information": {
+                      "encoded": "encoded_data"
+                    }
+                  },
+                  "extensions": {
+                    "account_deletion_reason": "USER_INITIATED",
+                    "phone_number_country_code": "44"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+
+    @Test
+    void shouldOmitPhoneNumberCountryCodeWhenPhoneIsBlank() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client_id")
+                        .withClientSessionId("govuk_signin_journey_id")
+                        .withSessionId("session_id")
+                        .withSubjectId("urn:fdc:gov.uk:2022:user_id")
+                        .withEmail("email")
+                        .withIpAddress("0.0.0.0")
+                        .withPhoneNumber("")
+                        .withPersistentSessionId("persistent_session_id")
+                        .withTxmaAuditEncoded("encoded_data");
+
+        var event =
+                AuthDeleteAccount.create(
+                        auditContext,
+                        "urn:fdc:gov.uk:2022:public_subject_id",
+                        null,
+                        "USER_INITIATED",
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_DELETE_ACCOUNT",
+                  "timestamp": 1780391411,
+                  "event_timestamp_ms": 1780391411123,
+                  "client_id": "client_id",
+                  "component_id": "AUTH",
+                  "user": {
+                    "email": "email",
+                    "govuk_signin_journey_id": "govuk_signin_journey_id",
+                    "ip_address": "0.0.0.0",
+                    "persistent_session_id": "persistent_session_id",
+                    "phone": "",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public_subject_id",
+                    "session_id": "session_id",
+                    "user_id": "urn:fdc:gov.uk:2022:user_id"
+                  },
+                  "restricted": {
+                    "device_information": {
+                      "encoded": "encoded_data"
+                    }
+                  },
+                  "extensions": {
+                    "account_deletion_reason": "USER_INITIATED"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+
+    @Test
+    void shouldIncludePhoneNumberCountryCodeWhenPhoneIsValid() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client_id")
+                        .withClientSessionId("govuk_signin_journey_id")
+                        .withSessionId("session_id")
+                        .withSubjectId("urn:fdc:gov.uk:2022:user_id")
+                        .withEmail("email")
+                        .withIpAddress("0.0.0.0")
+                        .withPhoneNumber("+447234567890")
+                        .withPersistentSessionId("persistent_session_id")
+                        .withTxmaAuditEncoded("encoded_data");
+
+        var event =
+                AuthDeleteAccount.create(
+                        auditContext,
+                        "urn:fdc:gov.uk:2022:public_subject_id",
+                        null,
+                        "SECURITY_INITIATED",
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_DELETE_ACCOUNT",
+                  "timestamp": 1780391411,
+                  "event_timestamp_ms": 1780391411123,
+                  "client_id": "client_id",
+                  "component_id": "AUTH",
+                  "user": {
+                    "email": "email",
+                    "govuk_signin_journey_id": "govuk_signin_journey_id",
+                    "ip_address": "0.0.0.0",
+                    "persistent_session_id": "persistent_session_id",
+                    "phone": "+447234567890",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public_subject_id",
+                    "session_id": "session_id",
+                    "user_id": "urn:fdc:gov.uk:2022:user_id"
+                  },
+                  "restricted": {
+                    "device_information": {
+                      "encoded": "encoded_data"
+                    }
+                  },
+                  "extensions": {
+                    "account_deletion_reason": "SECURITY_INITIATED",
+                    "phone_number_country_code": "44"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+}


### PR DESCRIPTION
## What

* Converted the `AUTH_DELETE_ACCOUNT` audit event to be a structured audit event record.
* Updated deletion lambda and services to emit the new structured audit event.

## How to review

1. Code review.
1. Optionally, deploy to a dev environment and test each of the lambdas are working as expected, checking the TxMA queue for each.

## Testing Notes

Deployed to `authdev3` and invoked each of the Lambdas (`manually-delete-account-lambda`, `bulk-remove-account-lambda`, `delete-account-lambda`) to trigger an account deletion. Each lambda was tested against an account whose `UserProfile` item did not have a `LegacySubjectID` present, and then against an item which did have `LegacySubjectID` present. Then checked the `authdev3-account-mgmt-txma-audit-queue` TxMA SQS queue to see if the expected audit event objects were emitted.

### `manually-delete-account-lambda` (TSD user-not-present route)

<details>
<summary>Redacted audit event (`LegacySubjectID` not present on user profile item):</summary>

(Note that this event doesn't include the `user.legacy_subject_id` attribute (as expected)).

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": [REDACTED],
  "event_timestamp_ms": [REDACTED],
  "client_id": "",
  "component_id": "AUTH",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "",
    "ip_address": "",
    "persistent_session_id": "",
    "phone": "[REDACTED]",
    "public_subject_id": "[REDACTED]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[REDACTED]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "SUPPORT_INITIATED",
    "phone_number_country_code": "44"
  }
}
```

</details>

<details>
<summary>Redacted audit event (`LegacySubjectID` present on user profile item):</summary>

(Note that this event includes the `user.legacy_subject_id` attribute (as expected)).

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": [REDACTED],
  "event_timestamp_ms": [REDACTED],
  "client_id": "",
  "component_id": "AUTH",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "",
    "ip_address": "",
    "legacy_subject_id": "some-legacy-subject-id-123",
    "persistent_session_id": "",
    "phone": "[REDACTED]",
    "public_subject_id": "[REDACTED]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[REDACTED]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "SUPPORT_INITIATED",
    "phone_number_country_code": "44"
  }
}
```

</details>

### `bulk-remove-account-lambda` (Auth/security removals user-not-present route)

<details>
<summary>Redacted audit event (`LegacySubjectID` not present on user profile item):</summary>

(Note that this event doesn't include the `user.legacy_subject_id` attribute (as expected)).

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": [REDACTED],
  "event_timestamp_ms": [REDACTED],
  "client_id": "",
  "component_id": "AUTH",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "",
    "ip_address": "",
    "persistent_session_id": "",
    "phone": "[REDACTED]",
    "public_subject_id": "[REDACTED]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[REDACTED]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "SECURITY_INITIATED",
    "phone_number_country_code": "44"
  }
}
```

</details>

<details>
<summary>Redacted audit event (`LegacySubjectID` present on user profile item):</summary>

(Note that this event includes the `user.legacy_subject_id` attribute (as expected)).

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": [REDACTED],
  "event_timestamp_ms": [REDACTED],
  "client_id": "",
  "component_id": "AUTH",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "",
    "ip_address": "",
    "legacy_subject_id": "some-legacy-subject-id-456",
    "persistent_session_id": "",
    "phone": "[REDACTED]",
    "public_subject_id": "[REDACTED]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[REDACTED]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "SECURITY_INITIATED",
    "phone_number_country_code": "44"
  }
}
```

</details>

### `delete-account-lambda` (AM API route)

The `delete-account-lambda` Lambda (AM API route) was tested using the steps listed [here](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4606132332/Manually+Testing+Account+Management+API#Steps-to-test-account-management-%5Bnew%5D) - using the `api-proxy` script - with the following cURL request:

<details>
<summary>Example cURL request for AM API route</summary>

This tests the `delete-account-lambda` Lambda.

```sh
export BASE_URL="http://localhost:8123"
export AUTH_TOKEN="YOUR_TOKEN_HERE"
export EMAIL="YOUR_EMAIL_HERE"

curl -v -X POST "$BASE_URL/delete-account" \
  -H "Authorization: Bearer $AUTH_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"email": "'$EMAIL'"}'
```

</details>

<details>
<summary>Redacted audit event (`LegacySubjectID` not present on user profile item):</summary>

(Note that this event doesn't include the `user.legacy_subject_id` attribute (as expected)).

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": [REDACTED],
  "event_timestamp_ms": [REDACTED],
  "client_id": "[REDACTED]",
  "component_id": "AUTH",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "unknown",
    "ip_address": "127.0.0.1",
    "persistent_session_id": "unknown",
    "public_subject_id": "[REDACTED]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[REDACTED]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "USER_INITIATED"
  }
}
```

</details>

<details>
<summary>Redacted audit event (`LegacySubjectID` present on user profile item):</summary>

(Note that this event includes the `user.legacy_subject_id` attribute (as expected)).

```json
{
  "event_name": "AUTH_DELETE_ACCOUNT",
  "timestamp": [REDACTED],
  "event_timestamp_ms": [REDACTED],
  "client_id": "[REDACTED]",
  "component_id": "AUTH",
  "user": {
    "email": "[REDACTED]",
    "govuk_signin_journey_id": "unknown",
    "ip_address": "127.0.0.1",
    "legacy_subject_id": "some-legacy-subject-id-789",
    "persistent_session_id": "unknown",
    "public_subject_id": "[REDACTED]",
    "session_id": "",
    "user_id": "urn:fdc:gov.uk:2022:[REDACTED]"
  },
  "restricted": {
    "device_information": {
      "encoded": ""
    }
  },
  "extensions": {
    "account_deletion_reason": "USER_INITIATED"
  }
}
```

</details>

## Checklist

- [x] Deployment of this PR will not break active user journeys **- Changes should only affect backend audit event emission**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A**