### PR TITLE
AUT-5551: Delete authenticator items on account deletion

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthenticatorItemKey.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthenticatorItemKey.java
@@ -1,0 +1,36 @@
+package uk.gov.di.accountmanagement.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class AuthenticatorItemKey {
+
+    private static final String ATTRIBUTE_PUBLIC_SUBJECT_ID = "PublicSubjectID";
+    private static final String ATTRIBUTE_SORT_KEY = "SK";
+
+    private String publicSubjectId;
+    private String sortKey;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_PUBLIC_SUBJECT_ID)
+    public String getPublicSubjectId() {
+        return publicSubjectId;
+    }
+
+    public void setPublicSubjectId(String publicSubjectId) {
+        this.publicSubjectId = publicSubjectId;
+    }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute(ATTRIBUTE_SORT_KEY)
+    public String getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(String sortKey) {
+        this.sortKey = sortKey;
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/AccountDeletionService.java
@@ -77,7 +77,10 @@ public class AccountDeletionService {
         var email = userProfile.getEmail();
 
         LOG.info("Deleting user account");
-        dynamoDeleteService.deleteAccount(email, internalCommonSubjectIdentifier.getValue());
+        dynamoDeleteService.deleteAccount(
+                email,
+                internalCommonSubjectIdentifier.getValue(),
+                userProfile.getPublicSubjectID());
 
         if (sendNotification) {
             try {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/DynamoDeleteService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/DynamoDeleteService.java
@@ -4,7 +4,10 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import uk.gov.di.accountmanagement.entity.AuthenticatorItemKey;
 import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
 import uk.gov.di.authentication.shared.entity.AccountModifiers;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
@@ -12,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -22,9 +26,11 @@ public class DynamoDeleteService {
     private static final String USER_PROFILE_TABLE = "user-profile";
     private static final String USER_CREDENTIAL_TABLE = "user-credentials";
     private static final String ACCOUNT_MODIFIERS_TABLE_NAME = "account-modifiers";
+    private static final String AUTHENTICATOR_TABLE = "authenticator";
     private final DynamoDbTable<AccountModifiers> dynamoAccountModifiersTable;
     private final DynamoDbTable<UserProfile> dynamoUserProfileTable;
     private final DynamoDbTable<UserCredentials> dynamoUserCredentialsTable;
+    private final DynamoDbTable<AuthenticatorItemKey> dynamoAuthenticatorTable;
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
 
     public DynamoDeleteService(ConfigurationService configurationService) {
@@ -35,6 +41,8 @@ public class DynamoDeleteService {
         var accountModifiersTableName =
                 TableNameHelper.getFullTableName(
                         ACCOUNT_MODIFIERS_TABLE_NAME, configurationService);
+        var authenticatorTableName =
+                TableNameHelper.getFullTableName(AUTHENTICATOR_TABLE, configurationService);
 
         this.dynamoDbEnhancedClient =
                 DynamoClientHelper.createDynamoEnhancedClient(configurationService);
@@ -47,13 +55,17 @@ public class DynamoDeleteService {
         this.dynamoAccountModifiersTable =
                 dynamoDbEnhancedClient.table(
                         accountModifiersTableName, TableSchema.fromBean(AccountModifiers.class));
+        this.dynamoAuthenticatorTable =
+                dynamoDbEnhancedClient.table(
+                        authenticatorTableName, TableSchema.fromBean(AuthenticatorItemKey.class));
 
         warmUp(dynamoUserProfileTable);
         warmUp(dynamoUserCredentialsTable);
         warmUp(dynamoAccountModifiersTable);
+        warmUp(dynamoAuthenticatorTable);
     }
 
-    public void deleteAccount(String email, String internalSubPairwiseId) {
+    public void deleteAccount(String email, String internalSubPairwiseId, String publicSubjectId) {
         var transactionWriterBuilder =
                 TransactWriteItemsEnhancedRequest.builder()
                         .addDeleteItem(
@@ -75,6 +87,26 @@ public class DynamoDeleteService {
                                 transactionWriterBuilder.addDeleteItem(
                                         dynamoAccountModifiersTable, t));
 
+        getAuthenticatorItems(publicSubjectId)
+                .forEach(
+                        item ->
+                                transactionWriterBuilder.addDeleteItem(
+                                        dynamoAuthenticatorTable,
+                                        Key.builder()
+                                                .partitionValue(item.getPublicSubjectId())
+                                                .sortValue(item.getSortKey())
+                                                .build()));
+
         dynamoDbEnhancedClient.transactWriteItems(transactionWriterBuilder.build());
+    }
+
+    private List<AuthenticatorItemKey> getAuthenticatorItems(String publicSubjectId) {
+        var queryConditional =
+                QueryConditional.keyEqualTo(Key.builder().partitionValue(publicSubjectId).build());
+        return dynamoAuthenticatorTable
+                .query(QueryEnhancedRequest.builder().queryConditional(queryConditional).build())
+                .items()
+                .stream()
+                .toList();
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/DynamoDeleteService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/DynamoDeleteService.java
@@ -1,5 +1,7 @@
 package uk.gov.di.accountmanagement.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -22,6 +24,10 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.warmUp;
 
 public class DynamoDeleteService {
+
+    private static final Logger LOG = LogManager.getLogger(DynamoDeleteService.class);
+    private static final int DYNAMO_TRANSACTION_LIMIT = 100;
+    private static final int GUARANTEED_TRANSACTION_ITEMS = 2;
 
     private static final String USER_PROFILE_TABLE = "user-profile";
     private static final String USER_CREDENTIAL_TABLE = "user-credentials";
@@ -79,23 +85,36 @@ public class DynamoDeleteService {
                                         .partitionValue(email.toLowerCase(Locale.ROOT))
                                         .build());
 
-        Optional.ofNullable(
+        var accountModifiers =
+                Optional.ofNullable(
                         dynamoAccountModifiersTable.getItem(
-                                Key.builder().partitionValue(internalSubPairwiseId).build()))
-                .ifPresent(
-                        t ->
-                                transactionWriterBuilder.addDeleteItem(
-                                        dynamoAccountModifiersTable, t));
+                                Key.builder().partitionValue(internalSubPairwiseId).build()));
 
-        getAuthenticatorItems(publicSubjectId)
-                .forEach(
-                        item ->
-                                transactionWriterBuilder.addDeleteItem(
-                                        dynamoAuthenticatorTable,
-                                        Key.builder()
-                                                .partitionValue(item.getPublicSubjectId())
-                                                .sortValue(item.getSortKey())
-                                                .build()));
+        accountModifiers.ifPresent(
+                t -> transactionWriterBuilder.addDeleteItem(dynamoAccountModifiersTable, t));
+
+        var authenticatorItems = getAuthenticatorItems(publicSubjectId);
+        int transactionItemCount =
+                GUARANTEED_TRANSACTION_ITEMS + (accountModifiers.isPresent() ? 1 : 0);
+        int availableTransactionCapacity = DYNAMO_TRANSACTION_LIMIT - transactionItemCount;
+
+        if (authenticatorItems.size() <= availableTransactionCapacity) {
+            authenticatorItems.forEach(
+                    item ->
+                            transactionWriterBuilder.addDeleteItem(
+                                    dynamoAuthenticatorTable,
+                                    Key.builder()
+                                            .partitionValue(item.getPublicSubjectId())
+                                            .sortValue(item.getSortKey())
+                                            .build()));
+        } else {
+            LOG.warn(
+                    "User has {} authenticator items which exceeds transaction capacity of {}. "
+                            + "Deleting authenticator items prior to the main account deletion transaction.",
+                    authenticatorItems.size(),
+                    availableTransactionCapacity);
+            deleteAuthenticatorItemsIndividually(authenticatorItems);
+        }
 
         dynamoDbEnhancedClient.transactWriteItems(transactionWriterBuilder.build());
     }
@@ -108,5 +127,15 @@ public class DynamoDeleteService {
                 .items()
                 .stream()
                 .toList();
+    }
+
+    private void deleteAuthenticatorItemsIndividually(List<AuthenticatorItemKey> items) {
+        for (AuthenticatorItemKey item : items) {
+            dynamoAuthenticatorTable.deleteItem(
+                    Key.builder()
+                            .partitionValue(item.getPublicSubjectId())
+                            .sortValue(item.getSortKey())
+                            .build());
+        }
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/AuthenticatorItemKeyTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/AuthenticatorItemKeyTest.java
@@ -1,0 +1,30 @@
+package uk.gov.di.accountmanagement.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AuthenticatorItemKeyTest {
+
+    @Test
+    void shouldSetAndGetPublicSubjectId() {
+        var item = new AuthenticatorItemKey();
+        item.setPublicSubjectId("test-public-subject-id");
+        assertEquals("test-public-subject-id", item.getPublicSubjectId());
+    }
+
+    @Test
+    void shouldSetAndGetSortKey() {
+        var item = new AuthenticatorItemKey();
+        item.setSortKey("PASSKEY#credential-123");
+        assertEquals("PASSKEY#credential-123", item.getSortKey());
+    }
+
+    @Test
+    void shouldReturnNullWhenFieldsNotSet() {
+        var item = new AuthenticatorItemKey();
+        assertNull(item.getPublicSubjectId());
+        assertNull(item.getSortKey());
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/AccountDeletionServiceTest.java
@@ -106,6 +106,7 @@ class AccountDeletionServiceTest {
         var expectedEmail = "test@example.com";
         when(userProfile.getEmail()).thenReturn(expectedEmail);
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
+        when(userProfile.getPublicSubjectID()).thenReturn(TEST_PUBLIC_SUBJECT_ID);
         // when
         underTest.removeAccount(
                 Optional.of(input),
@@ -113,7 +114,8 @@ class AccountDeletionServiceTest {
                 StructuredAuditService.UNKNOWN,
                 AccountDeletionReason.USER_INITIATED);
         // then
-        verify(dynamoDeleteService).deleteAccount(eq(expectedEmail), any());
+        verify(dynamoDeleteService)
+                .deleteAccount(eq(expectedEmail), any(), eq(TEST_PUBLIC_SUBJECT_ID));
     }
 
     @Test
@@ -122,7 +124,7 @@ class AccountDeletionServiceTest {
         var expectedException = new RuntimeException();
         when(userProfile.getEmail()).thenReturn("test@example.com");
         when(userProfile.getSubjectID()).thenReturn(new Subject().getValue());
-        doThrow(expectedException).when(dynamoDeleteService).deleteAccount(any(), any());
+        doThrow(expectedException).when(dynamoDeleteService).deleteAccount(any(), any(), any());
 
         // then
         assertThrows(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/services/DynamoDeleteServiceIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/services/DynamoDeleteServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.accountmanagement.services;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.accountmanagement.testsupport.AuthenticatorStoreExtension;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -20,6 +21,7 @@ class DynamoDeleteServiceIntegrationTest {
 
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final Subject SUBJECT = new Subject();
+    private static final String PUBLIC_SUBJECT_ID = new Subject().getValue();
     private static final String INTERNAl_SECTOR_HOST = "test.account.gov.uk";
 
     @RegisterExtension
@@ -28,6 +30,10 @@ class DynamoDeleteServiceIntegrationTest {
     @RegisterExtension
     protected static final AccountModifiersStoreExtension accountModifiersExtension =
             new AccountModifiersStoreExtension();
+
+    @RegisterExtension
+    protected static final AuthenticatorStoreExtension authenticatorStoreExtension =
+            new AuthenticatorStoreExtension();
 
     DynamoDeleteService dynamoDeleteService =
             new DynamoDeleteService(ConfigurationService.getInstance());
@@ -44,7 +50,7 @@ class DynamoDeleteServiceIntegrationTest {
         userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
         accountModifiersExtension.setAccountRecoveryBlock(internalCommonSubjectId);
 
-        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId);
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
 
         var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
         var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
@@ -59,7 +65,7 @@ class DynamoDeleteServiceIntegrationTest {
     void shouldDeleteAccountWhenEntryInAccountModifiersIsNotPresent() {
         userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
 
-        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId);
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
 
         var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
         var userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
@@ -68,5 +74,47 @@ class DynamoDeleteServiceIntegrationTest {
         assertThat(Objects.isNull(userProfile), equalTo(true));
         assertThat(Objects.isNull(userCredentials), equalTo(true));
         assertThat(accountModifiers.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void shouldDeletePasskeyRecordsWhenAccountIsDeleted() {
+        userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-1");
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-2");
+
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
+
+        var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
+        var authenticatorItems = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
+        assertThat(Objects.isNull(userProfile), equalTo(true));
+        assertThat(authenticatorItems.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void shouldDeleteAccountWhenNoPasskeysExist() {
+        userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
+
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
+
+        var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
+        var authenticatorItems = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
+        assertThat(Objects.isNull(userProfile), equalTo(true));
+        assertThat(authenticatorItems.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void shouldDeleteAllPasskeysWhenMultipleExist() {
+        userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-1");
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-2");
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-3");
+
+        var itemsBefore = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
+        assertThat(itemsBefore.size(), equalTo(3));
+
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
+
+        var itemsAfter = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
+        assertThat(itemsAfter.isEmpty(), equalTo(true));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/services/DynamoDeleteServiceIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/services/DynamoDeleteServiceIntegrationTest.java
@@ -11,11 +11,15 @@ import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.extensions.AccountModifiersStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.Objects;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class DynamoDeleteServiceIntegrationTest {
 
@@ -34,6 +38,10 @@ class DynamoDeleteServiceIntegrationTest {
     @RegisterExtension
     protected static final AuthenticatorStoreExtension authenticatorStoreExtension =
             new AuthenticatorStoreExtension();
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(DynamoDeleteService.class);
 
     DynamoDeleteService dynamoDeleteService =
             new DynamoDeleteService(ConfigurationService.getInstance());
@@ -116,5 +124,45 @@ class DynamoDeleteServiceIntegrationTest {
 
         var itemsAfter = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
         assertThat(itemsAfter.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void shouldNotLogWarningWhenPasskeysFitWithinTransaction() {
+        userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-1");
+        authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-2");
+
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
+
+        assertThat(
+                logging.events(),
+                not(
+                        hasItem(
+                                withMessageContaining(
+                                        "Deleting authenticator items prior to the main account deletion transaction"))));
+    }
+
+    @Test
+    void shouldDeletePasskeysOutsideTransactionWhenExceedingCapacity() {
+        userStoreExtension.signUp(TEST_EMAIL, "password-1", SUBJECT);
+
+        for (int i = 0; i < 99; i++) {
+            authenticatorStoreExtension.addMinimalPasskey(PUBLIC_SUBJECT_ID, "credential-" + i);
+        }
+
+        var itemsBefore = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
+        assertThat(itemsBefore.size(), equalTo(99));
+
+        dynamoDeleteService.deleteAccount(TEST_EMAIL, internalCommonSubjectId, PUBLIC_SUBJECT_ID);
+
+        var userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
+        var itemsAfter = authenticatorStoreExtension.getItemsForUser(PUBLIC_SUBJECT_ID);
+        assertThat(Objects.isNull(userProfile), equalTo(true));
+        assertThat(itemsAfter.isEmpty(), equalTo(true));
+        assertThat(
+                logging.events(),
+                hasItem(
+                        withMessageContaining(
+                                "Deleting authenticator items prior to the main account deletion transaction")));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/testsupport/AuthenticatorStoreExtension.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/testsupport/AuthenticatorStoreExtension.java
@@ -1,0 +1,136 @@
+package uk.gov.di.accountmanagement.testsupport;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+public class AuthenticatorStoreExtension implements BeforeAllCallback, AfterEachCallback {
+
+    private static final String TABLE_NAME = "local-authenticator";
+    private static final String PUBLIC_SUBJECT_ID_FIELD = "PublicSubjectID";
+    private static final String SORT_KEY_FIELD = "SK";
+    private static final String REGION_VALUE =
+            System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    private static final String DYNAMO_ENDPOINT =
+            System.getenv().getOrDefault("DYNAMO_ENDPOINT", "http://localhost:8000");
+
+    private DynamoDbClient dynamoDB;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        dynamoDB =
+                DynamoDbClient.builder()
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                        .region(Region.of(REGION_VALUE))
+                        .endpointOverride(URI.create(DYNAMO_ENDPOINT))
+                        .build();
+
+        if (!tableExists()) {
+            createTable();
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        var scanResult = dynamoDB.scan(ScanRequest.builder().tableName(TABLE_NAME).build());
+        for (Map<String, AttributeValue> item : scanResult.items()) {
+            dynamoDB.deleteItem(
+                    DeleteItemRequest.builder()
+                            .tableName(TABLE_NAME)
+                            .key(
+                                    Map.of(
+                                            PUBLIC_SUBJECT_ID_FIELD,
+                                            item.get(PUBLIC_SUBJECT_ID_FIELD),
+                                            SORT_KEY_FIELD,
+                                            item.get(SORT_KEY_FIELD)))
+                            .build());
+        }
+    }
+
+    public void addMinimalPasskey(String publicSubjectId, String credentialId) {
+        dynamoDB.putItem(
+                PutItemRequest.builder()
+                        .tableName(TABLE_NAME)
+                        .item(
+                                Map.of(
+                                        PUBLIC_SUBJECT_ID_FIELD,
+                                        AttributeValue.builder().s(publicSubjectId).build(),
+                                        SORT_KEY_FIELD,
+                                        AttributeValue.builder()
+                                                .s("PASSKEY#" + credentialId)
+                                                .build()))
+                        .build());
+    }
+
+    public List<Map<String, AttributeValue>> getItemsForUser(String publicSubjectId) {
+        var response =
+                dynamoDB.query(
+                        QueryRequest.builder()
+                                .tableName(TABLE_NAME)
+                                .keyConditionExpression("#pk = :pkValue")
+                                .expressionAttributeNames(Map.of("#pk", PUBLIC_SUBJECT_ID_FIELD))
+                                .expressionAttributeValues(
+                                        Map.of(
+                                                ":pkValue",
+                                                AttributeValue.builder()
+                                                        .s(publicSubjectId)
+                                                        .build()))
+                                .build());
+        return response.items();
+    }
+
+    private boolean tableExists() {
+        try {
+            dynamoDB.describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build());
+            return true;
+        } catch (ResourceNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    private void createTable() {
+        dynamoDB.createTable(
+                CreateTableRequest.builder()
+                        .tableName(TABLE_NAME)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .attributeName(PUBLIC_SUBJECT_ID_FIELD)
+                                        .keyType(KeyType.HASH)
+                                        .build(),
+                                KeySchemaElement.builder()
+                                        .attributeName(SORT_KEY_FIELD)
+                                        .keyType(KeyType.RANGE)
+                                        .build())
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(PUBLIC_SUBJECT_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build(),
+                                AttributeDefinition.builder()
+                                        .attributeName(SORT_KEY_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .build());
+    }
+}

--- a/ci/cloudformation/account-management/function/bulk-remove-account.yaml
+++ b/ci/cloudformation/account-management/function/bulk-remove-account.yaml
@@ -50,6 +50,7 @@ Resources:
         - !Ref DynamoUserDeleteAccessPolicy
         - !Ref DynamoAccountModifiersReadAccessPolicy
         - !Ref DynamoAccountModifiersDeleteAccessPolicy
+        - !Ref DynamoAuthenticatorTableReadDeleteAccessPolicy
         - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
         - !Ref LegacyAccountDeletionTopicPolicy
         - !Ref ClientRegistryTableKmsPolicy

--- a/ci/cloudformation/account-management/function/delete-account.yaml
+++ b/ci/cloudformation/account-management/function/delete-account.yaml
@@ -43,6 +43,7 @@ Resources:
         - !Ref DynamoUserDeleteAccessPolicy
         - !Ref DynamoAccountModifiersReadAccessPolicy
         - !Ref DynamoAccountModifiersDeleteAccessPolicy
+        - !Ref DynamoAuthenticatorTableReadDeleteAccessPolicy
         - !Ref AccountModifiersTableKmsPolicy
         - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
         - !Ref RedisParametersAccessPolicy

--- a/ci/cloudformation/account-management/function/manually-delete-account.yaml
+++ b/ci/cloudformation/account-management/function/manually-delete-account.yaml
@@ -57,6 +57,7 @@ Resources:
         - !Ref DynamoUserDeleteAccessPolicy
         - !Ref DynamoAccountModifiersReadAccessPolicy
         - !Ref DynamoAccountModifiersDeleteAccessPolicy
+        - !Ref DynamoAuthenticatorTableReadDeleteAccessPolicy
         - !Ref AuthInternalApiTxMAAuditQueueAccessPolicy
         - !Ref ClientRegistryTableKmsPolicy
         - !Ref EmailCheckResultsTableKmsPolicy

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -284,6 +284,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:653994557586:key/a65848e5-74da-4ea2-9d6d-0a025c35a73f
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/85da3e1d-de4f-4f23-813f-efc4d42b10c8
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f98d3388-f92d-48a0-a29b-dfd7f8a113fd
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d41a1b95-0291-4477-93f7-f1428ceef646
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/03871a19-836e-457e-9179-7870bcbe6c67
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/b5491829-ace6-4028-bf32-1886305daca7
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/aeb88256-7b5d-4707-952e-b522b09d8d5f
@@ -320,6 +321,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:653994557586:key/9f2c0adf-ca5d-42a2-966f-6424311c2ba7
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/0c1930f0-3cb2-4d71-b4a1-e2b9bdd6668c
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/e1d340f9-276d-4f56-b97d-799ae2ddce6f
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/70a5d810-8dcf-449d-bdf0-aed149c52302
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/42f5a19c-11ce-4a0c-8b9d-c162a85d6f51
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/dab5208e-14f1-40c5-b9e6-4dbe8a014d94
@@ -356,6 +358,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:653994557586:key/0797a9bd-d728-4473-9b62-7a43767d75a7
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4d72b78b-e8ed-4b5f-a045-383170969226
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/51712670-ba1d-4f4a-a7de-8fc1f47fec2f
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/38223bde-df39-4240-b614-3169cb19a342
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/258b15a8-6157-439e-8018-24c59b91c8c5
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/e3d591b4-d295-4041-b8f0-f5eb71742014
@@ -392,6 +395,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:653994557586:key/af458b1c-b949-48ee-bc2d-a5a7931113d8
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/7c60a855-8b61-4d0e-be99-f12a22bd2001
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/99608aca-5a73-4073-abae-cdb29fc5b3f4
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c6a2fb5e-c92b-4129-bc0c-d75b2b72bae8
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/e4c701a9-4073-4143-9f12-ddf110b9c720
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/e5103c4f-0fb1-4d89-b396-5a91dad9cb28
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/2e7ec5d4-f4b7-4342-a5d6-15952fd9111b
@@ -435,6 +439,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:761723964695:key/c00f8047-6688-4f72-a887-4ba6810f1ccb
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/ce2114cb-cfe3-4108-a738-4790dbe99f64
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/d4ca8b09-1129-48fd-a8b9-483dece9128b
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3c2113fe-9f53-4bed-a46f-c53f02f6c117
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/91e74f45-3473-4fa3-b35e-b6a1a1fe7a6d
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/147435a7-f01d-4ed3-9485-ebe7f72808dd
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/db350f01-bce4-4da8-9323-e70267569bd8
@@ -480,6 +485,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:758531536632:key/60b5781c-9507-4faf-ab0b-faef7cd7dbd6
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/b52a2843-0d62-404a-a04c-5d47ba9ae54e
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/b8ea7d99-8902-4d91-82a1-cb396d88f6db
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/ed6c6a2d-866f-4e2e-9ebd-c499ce9513c6
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/4ee87f07-df3a-4745-9734-6e9cc7995270
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/32415ead-d88f-4724-aedf-5fe3ce8ed48e
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/9c0cc476-e831-4ebf-81e6-c619e6b795e8
@@ -526,6 +532,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:761723964695:key/c87c5099-d8b5-422b-bd85-fb4559168838
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/f7ca754b-80bb-4f60-a3e5-3963d6827f47
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/5917a6e9-13c3-4276-946b-487a0e6411f9
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/743b2818-03fd-4414-bfaf-6aa8a4bb4e45
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/9372359d-fb44-4182-8977-7254654dcd1a
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/f8897cf9-760f-463e-bb27-a86cc9e629de
       cloudwatchLogRetentionInDays: 30
@@ -573,6 +580,7 @@ Mappings:
       auditPayloadSigningKey: arn:aws:kms:eu-west-2:172348255554:key/c61980c6-950e-42da-90ce-ef9a56491a9b
       authCodeStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/cf8e9b5f-1511-4124-9025-9f98fbf30b01
       authenticationAttemptTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/65fad11d-d525-4fc1-a806-0b304b9dda36
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/b380ea74-d240-4500-b02b-f5c3d414e34e
       authSessionTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/a6becfd6-a3bb-4bfd-ba2f-2bdf35d36e40
       clientRegistryTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/afefa38f-5797-4722-9969-c7ad5ec6d6fe
       TokenSigningkeyArn: arn:aws:kms:eu-west-2:172348255554:key/01c412c6-98de-48b2-9a6d-51f57e8c3d7a
@@ -2195,6 +2203,91 @@ Resources:
                     EnvironmentConfiguration,
                     !Ref Environment,
                     accountModifiersTableEncryptionKey,
+                  ]
+
+  DynamoAuthenticatorTableReadDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing read and delete permissions to the Dynamo Authenticator table"
+      Path: !Sub
+        - /${Env}/am-shared/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowReadAccessToDynamoTables
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+              - dynamodb:Query
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-authenticator
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-authenticator/index/*
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+          - Sid: AllowDeleteAccessToDynamoTables
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-authenticator
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+          - Sid: AllowEncryptionDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    authenticatorTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    authenticatorTableEncryptionKey,
                   ]
 
   ManuallyDeleteAccountFunctionSQSPolicy:


### PR DESCRIPTION
## What

* Create a new DynamoDB bean entity (`AuthenticatorItemKey`) to represent authenticator items.
* Update `DynamoDeleteService` to query and delete a user's authenticator items (such as passkeys) alongside their account deletion.
    * Introduce a capacity check to handle DynamoDB's 100-item transaction limit, falling back to individual deletions if a user has too many authenticators.
* Create a new IAM policy (`DynamoAuthenticatorTableReadDeleteAccessPolicy`) to grant read and delete access to the authenticator table. Attach this to the relevant Lambdas.

NOTE: The long-term aim is to bring account deletion under the account data API, this is a strategic implementation to allow for the release of passkeys in the meantime.

## How to review

1. Code review.
1. Optionally, deploy to a dev environment and test each of the lambdas can perform a deletion as expected.
    - (I've added some testing notes from my testing below)

## Testing Notes

Deployed to `authdev3` and invoked each of the Lambdas (`manually-delete-account-lambda`, `bulk-remove-account-lambda`, `delete-account-lambda`) to trigger an account deletion. Each lambda was tested against an account whose `UserProfile` item did not have a `LegacySubjectID` present, and then against an item which did have `LegacySubjectID` present. Then checked the `authdev3-account-mgmt-txma-audit-queue` TxMA SQS queue to see if the expected audit event objects were emitted.

### `manually-delete-account-lambda` (TSD user-not-present route)

Invoked with request payload following the format `"YOUR_EMAIL_HERE"`. Observed item deletions within `user-profile`, `user-credentials` and `authenticators`, deleting all passkeys for the users public subject ID.

### `bulk-remove-account-lambda` (Auth/security removals user-not-present route)

Invoked with a request payload following the format below. Again, observed the expected deletions including multiple passkeys with that users public subject id.

<details>
<summary>Sample request payload</summary>

```json
{
  "reference": "bulk-delete-testing-AUT-5551",
  "emails": [
    "YOUR_EMAIL_HERE"
  ],
  "createdAfter": "2024-01-01T00:00:00",
  "createdBefore": "2026-07-02T12:00:00"
}

```

</details>


### `delete-account-lambda` (AM API route)

The `delete-account-lambda` Lambda (AM API route) was tested using the steps listed [here](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4606132332/Manually+Testing+Account+Management+API#Steps-to-test-account-management-%5Bnew%5D) - using the `api-proxy` script - with the following cURL request:

<details>
<summary>Example cURL request for AM API route</summary>

This tests the `delete-account-lambda` Lambda.

```sh
export BASE_URL="http://localhost:8123"
export AUTH_TOKEN="YOUR_TOKEN_HERE"
export EMAIL="YOUR_EMAIL_HERE"

curl -v -X POST "$BASE_URL/delete-account" \
  -H "Authorization: Bearer $AUTH_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"email": "'$EMAIL'"}'
```

</details>

Again, observed the expected deletions including multiple passkeys with that users public subject id.

## Checklist

- [x] Deployment of this PR will not break active user journeys
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A, backend change**