### PR TITLE
BAU: Remove EnforceLambdaDeploymentOrder to parallelise Lambda deploys

### DIFF
--- a/ci/cloudformation/auth/function/account-interventions.yaml
+++ b/ci/cloudformation/auth/function/account-interventions.yaml
@@ -96,13 +96,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref TicfCriFunctionAliasactive,
-            "",
-          ]
 
   AccountInterventionsFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/account-recovery.yaml
+++ b/ci/cloudformation/auth/function/account-recovery.yaml
@@ -50,13 +50,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref AccountInterventionsFunctionAliasactive,
-            "",
-          ]
 
   AccountRecoveryFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/ad-jwks.yaml
+++ b/ci/cloudformation/auth/function/ad-jwks.yaml
@@ -34,8 +34,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder: ""
 
   ADJWKSFunctionPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/ci/cloudformation/auth/function/amc-authorize.yaml
+++ b/ci/cloudformation/auth/function/amc-authorize.yaml
@@ -126,8 +126,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder: ""
 
   AMCAuthorizeFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/amc-jwks.yaml
+++ b/ci/cloudformation/auth/function/amc-jwks.yaml
@@ -38,8 +38,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder: ""
 
   AMCJWKSFunctionPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/ci/cloudformation/auth/function/auth-userinfo.yaml
+++ b/ci/cloudformation/auth/function/auth-userinfo.yaml
@@ -67,13 +67,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref AuthTokenFunctionAliasactive,
-            "",
-          ]
 
   AuthUserInfoFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/check-email-fraud-block.yaml
+++ b/ci/cloudformation/auth/function/check-email-fraud-block.yaml
@@ -66,13 +66,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref VerifyMfaCodeFunctionAliasactive,
-            "",
-          ]
 
   CheckEmailFraudBlockFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/check-reauth-user.yaml
+++ b/ci/cloudformation/auth/function/check-reauth-user.yaml
@@ -73,13 +73,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref ReverificationResultFunctionAliasactive,
-            "",
-          ]
 
   CheckReAuthUserFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/email-notification-sqs.yaml
+++ b/ci/cloudformation/auth/function/email-notification-sqs.yaml
@@ -134,13 +134,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref OrchAuthCodeFunctionAliasactive,
-            "",
-          ]
 
   EmailNotificationQueueFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -137,9 +137,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [EnforceLambdaDeploymentOrder, !Ref SignUpFunctionAliasactive, ""]
 
   LoginFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-authorize.yaml
@@ -136,9 +136,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [EnforceLambdaDeploymentOrder, !Ref MfaFunctionAliasactive, ""]
 
   MfaResetAuthorizeFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
@@ -43,13 +43,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref MfaResetAuthorizeFunctionAliasactive,
-            "",
-          ]
 
   MfaResetJarJwkFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/mfa-reset-storage-token-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-storage-token-jwk.yaml
@@ -53,13 +53,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref MfaResetAuthorizeFunctionAliasactive,
-            "",
-          ]
 
   MfaResetStorageTokenJwkFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/notify-callback.yaml
+++ b/ci/cloudformation/auth/function/notify-callback.yaml
@@ -340,13 +340,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref TicfCriFunctionAliasactive,
-            "",
-          ]
 
   NotifyCallbackFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/ci/cloudformation/auth/function/processing-identity.yaml
+++ b/ci/cloudformation/auth/function/processing-identity.yaml
@@ -136,13 +136,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref TicfCriFunctionAliasactive,
-            "",
-          ]
 
   ProcessingIdentityFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/reset-password.yaml
+++ b/ci/cloudformation/auth/function/reset-password.yaml
@@ -120,13 +120,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref ResetPasswordRequestFunctionAliasactive,
-            "",
-          ]
 
   ResetPasswordFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/reverification-result.yaml
+++ b/ci/cloudformation/auth/function/reverification-result.yaml
@@ -90,13 +90,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref IDReverificationStateFunctionAliasactive,
-            "",
-          ]
 
   ReverificationResultFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/send-notification.yaml
+++ b/ci/cloudformation/auth/function/send-notification.yaml
@@ -127,13 +127,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref EmailNotificationQueueFunctionAliasactive,
-            "",
-          ]
 
   SendNotificationFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/sms-quota-monitor.yaml
+++ b/ci/cloudformation/auth/function/sms-quota-monitor.yaml
@@ -32,13 +32,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref TicfCriFunctionAliasactive,
-            "",
-          ]
 
   SmsQuotaMonitorFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/start.yaml
+++ b/ci/cloudformation/auth/function/start.yaml
@@ -78,9 +78,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [EnforceLambdaDeploymentOrder, !Ref LoginFunctionAliasactive, ""]
 
   StartFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/update-profile.yaml
+++ b/ci/cloudformation/auth/function/update-profile.yaml
@@ -61,13 +61,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref ResetPasswordFunctionAliasactive,
-            "",
-          ]
 
   UpdateProfileFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/user-exists.yaml
+++ b/ci/cloudformation/auth/function/user-exists.yaml
@@ -107,13 +107,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref AuthUserInfoFunctionAliasactive,
-            "",
-          ]
 
   UserExistsFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/function/verify-mfa-code.yaml
+++ b/ci/cloudformation/auth/function/verify-mfa-code.yaml
@@ -132,13 +132,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        EnforceLambdaDeploymentOrder:
-          !If [
-            EnforceLambdaDeploymentOrder,
-            !Ref VerifyCodeFunctionAliasactive,
-            "",
-          ]
 
   VerifyMfaCodeFunctionAliasPermission:
     Type: AWS::Lambda::Permission

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -112,17 +112,6 @@ Conditions:
                 ]
               - "0"
 
-  EnforceLambdaDeploymentOrder:
-    Fn::And:
-      - !Condition NotSubEnvironment
-      - Fn::Equals:
-          - !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              EnforceLambdaDeploymentOrder,
-            ]
-          - "Yes"
-
   IsProduction:
     Fn::Equals:
       - !Ref Environment
@@ -423,7 +412,6 @@ Mappings:
       customDocAppClaimEnabled: true
       docAppDomain: https://dcmaw-cri.dev.stubs.account.gov.uk
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      EnforceLambdaDeploymentOrder: "Yes"
       IsSplunkEnabled: "No"
       lambdaMinConcurrency: 0
       EvcsApiVpcEndpointId: ""
@@ -490,7 +478,6 @@ Mappings:
       internationalSmsSendingEnabled: true
       cloudwatchLogRetentionInDays: 7
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      EnforceLambdaDeploymentOrder: "Yes"
       IPVApiEnabled: true
       IsSplunkEnabled: "Yes"
       lambdaMinConcurrency: 0
@@ -562,7 +549,6 @@ Mappings:
       internationalSmsSendingEnabled: true
       cloudwatchLogRetentionInDays: 7
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      EnforceLambdaDeploymentOrder: "Yes"
       IPVApiEnabled: true
       IsSplunkEnabled: "Yes"
       lambdaMinConcurrency: 3
@@ -626,7 +612,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       emailAcctCreationOtpCodeTtlDuration: 3600
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/be1b5ce0-3e55-4705-8437-8b68301ebcb1
-      EnforceLambdaDeploymentOrder: "Yes"
       eventsTopicEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/44a77768-8782-4d8c-8a18-3e2f7d160800
       experianPhoneCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/5c3be595-77cd-444f-a69e-8d9a1e56a75d
       frontendApiFMSTagValue: "authfrontendint"
@@ -700,7 +685,6 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       emailAcctCreationOtpCodeTtlDuration: 3600
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/aca649a0-488b-4696-b94a-49156254afd2
-      EnforceLambdaDeploymentOrder: "Yes"
       eventsTopicEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/417be117-d2cd-45f1-8b07-f30ba68bfaef
       experianPhoneCheckQueueEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/4ea38950-d586-4f00-a19f-47b2ad13dc79
       frontendApiFMSTagValue: "authfrontendprod"


### PR DESCRIPTION
## What

- Remove the `EnforceLambdaDeploymentOrder` condition, environment map entries, and tags from all 23 Lambda function definitions in the auth stack
- This mechanism created artificial serial dependencies between Lambda deployments via tag `!Ref` chains (depth 3, 8 parallel chains), forcing CloudFormation to deploy functions one-at-a-time within each chain
- With this removed, all 34 Lambda functions deploy in parallel during CloudFormation execution
- Expected to reduce auth stack deployment time by ~4 minutes (from ~18min to ~14min)
- The authdev sub-environments have been running without this (it was disabled for sub-environments via the `NotSubEnvironment` condition) with no throttling issues
- The pipeline already uses `AWS_RETRY_MODE=adaptive` which handles any transient API throttling

## How to review

1. Code Review