### PR TITLE
AUT-5397: Add successful password rehashing metric

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -29,6 +29,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
+import uk.gov.di.authentication.shared.helpers.Argon2HashParameters;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -67,6 +68,12 @@ import static uk.gov.di.authentication.frontendapi.services.UserMigrationService
 import static uk.gov.di.authentication.shared.conditions.MfaHelper.getUserMFADetail;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.FAILURE_REASON;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NEW_ITERATIONS;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NEW_MEMORY;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.NEW_PARALLELISM;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.OLD_ITERATIONS;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.OLD_MEMORY;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.OLD_PARALLELISM;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.JOURNEY_TYPE;
@@ -75,6 +82,7 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessio
 import static uk.gov.di.authentication.shared.helpers.NoDefaultMfaMethodLogHelper.logNoDefaultMfaMethodDebug;
 import static uk.gov.di.authentication.shared.helpers.PhoneNumberHelper.formatPhoneNumber;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.authentication.shared.services.CloudwatchMetricsService.UNKNOWN_VALUE;
 
 public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -592,11 +600,41 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                             userCredentials.getPassword(), configurationService);
             LOG.info("Password rehash check: needsRehash={}", needsRehash);
             if (needsRehash) {
+                var oldParams =
+                        Argon2MatcherHelper.extractParameters(userCredentials.getPassword());
                 authenticationService.updatePassword(email, password);
+
                 LOG.info("Password rehash completed for user");
+                emitPasswordRehashMetric(oldParams.orElse(null));
             }
         } catch (Exception e) {
             LOG.error("Error during password rehash", e);
         }
+    }
+
+    private void emitPasswordRehashMetric(Argon2HashParameters oldParams) {
+        String oldMemory = oldParams != null ? String.valueOf(oldParams.memory()) : UNKNOWN_VALUE;
+        String oldIterations =
+                oldParams != null ? String.valueOf(oldParams.iterations()) : UNKNOWN_VALUE;
+        String oldParallelism =
+                oldParams != null ? String.valueOf(oldParams.parallelism()) : UNKNOWN_VALUE;
+
+        cloudwatchMetricsService.incrementCounter(
+                CloudwatchMetrics.PASSWORD_REHASH_COMPLETED.getValue(),
+                Map.of(
+                        ENVIRONMENT.getValue(),
+                        configurationService.getEnvironment(),
+                        OLD_MEMORY.getValue(),
+                        oldMemory,
+                        OLD_ITERATIONS.getValue(),
+                        oldIterations,
+                        OLD_PARALLELISM.getValue(),
+                        oldParallelism,
+                        NEW_MEMORY.getValue(),
+                        String.valueOf(configurationService.getArgon2MemoryInKibibytes()),
+                        NEW_ITERATIONS.getValue(),
+                        String.valueOf(configurationService.getArgon2Iterations()),
+                        NEW_PARALLELISM.getValue(),
+                        String.valueOf(configurationService.getArgon2Parallelism())));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -83,6 +83,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.redactPhoneNumber;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.PASSWORD_REHASH_COMPLETED;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
@@ -883,6 +884,17 @@ class LoginHandlerTest {
             handler.handleRequest(event, context);
 
             verify(authenticationService).updatePassword(EMAIL, CommonTestVariables.PASSWORD);
+            verify(cloudwatchMetricsService)
+                    .incrementCounter(
+                            PASSWORD_REHASH_COMPLETED.getValue(),
+                            Map.of(
+                                    "Environment", "test",
+                                    "OldMemory", "15360",
+                                    "OldIterations", "2",
+                                    "OldParallelism", "1",
+                                    "NewMemory", "32768",
+                                    "NewIterations", "2",
+                                    "NewParallelism", "1"));
         }
 
         @Test
@@ -900,6 +912,8 @@ class LoginHandlerTest {
             handler.handleRequest(event, context);
 
             verify(authenticationService, never()).updatePassword(anyString(), anyString());
+            verify(cloudwatchMetricsService, never())
+                    .incrementCounter(eq("PasswordRehashCompleted"), anyMap());
         }
 
         @Test
@@ -934,6 +948,8 @@ class LoginHandlerTest {
             handler.handleRequest(event, context);
 
             verify(authenticationService, never()).updatePassword(anyString(), anyString());
+            verify(cloudwatchMetricsService, never())
+                    .incrementCounter(eq("PasswordRehashCompleted"), anyMap());
         }
 
         private void setupUserWhoCanSuccessfullyLoginWithPassword(String password) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -27,7 +27,13 @@ public enum CloudwatchMetricDimensions {
             "PasskeyAuthenticationGenerationFailureReason"),
     AMC_JOURNEY_TYPE("AMCJourneyType"),
     AMC_AUTHORISATION_OVERALL_SUCCESS("AMCAuthorisationOverallSuccess"),
-    AMC_SCOPE("AMCScope");
+    AMC_SCOPE("AMCScope"),
+    OLD_MEMORY("OldMemory"),
+    OLD_ITERATIONS("OldIterations"),
+    OLD_PARALLELISM("OldParallelism"),
+    NEW_MEMORY("NewMemory"),
+    NEW_ITERATIONS("NewIterations"),
+    NEW_PARALLELISM("NewParallelism");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -42,7 +42,8 @@ public enum CloudwatchMetrics {
     AMC_AUTHORISATION_RECEIVED("AMCAuthorisationReceived"),
     AMC_FAILURE_GETTING_AUTHORISATION("AMCFailureGettingAuthorisation"),
     PASSKEY_DELETION_SUCCESSFUL("PasskeyDeletionSuccessful"),
-    PASSKEY_DELETION_FAILED("PasskeyDeletionFailed");
+    PASSKEY_DELETION_FAILED("PasskeyDeletionFailed"),
+    PASSWORD_REHASH_COMPLETED("PasswordRehashCompleted");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2HashParameters.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2HashParameters.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.shared.helpers;
+
+public record Argon2HashParameters(int memory, int iterations, int parallelism) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelper.java
@@ -8,6 +8,7 @@ import org.bouncycastle.util.Arrays;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Base64;
+import java.util.Optional;
 
 public class Argon2MatcherHelper {
 
@@ -41,6 +42,19 @@ public class Argon2MatcherHelper {
         } catch (IllegalArgumentException ex) {
             LOG.warn("Unable to parse password hash for rehash check");
             return false;
+        }
+    }
+
+    public static Optional<Argon2HashParameters> extractParameters(String encodedPassword) {
+        try {
+            Argon2Hash decoded = decode(encodedPassword);
+            Argon2Parameters params = decoded.getParameters();
+            return Optional.of(
+                    new Argon2HashParameters(
+                            params.getMemory(), params.getIterations(), params.getLanes()));
+        } catch (IllegalArgumentException ex) {
+            LOG.warn("Unable to parse password hash for parameter extraction");
+            return Optional.empty();
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -56,6 +56,7 @@ public class CloudwatchMetricsService {
     private static final Logger LOG = LogManager.getLogger(CloudwatchMetricsService.class);
     public static final String INTERNATIONAL_SMS_DESTINATION = "INTERNATIONAL";
     public static final String DOMESTIC_SMS_DESTINATION = "DOMESTIC";
+    public static final String UNKNOWN_VALUE = "unknown";
 
     private final ConfigurationService configurationService;
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelperExtractParametersTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/Argon2MatcherHelperExtractParametersTest.java
@@ -1,0 +1,49 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Argon2MatcherHelperExtractParametersTest {
+
+    private static final String HASH_M15360_T2_P1 =
+            "$argon2id$v=19$m=15360,t=2,p=1$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw";
+
+    private static final String HASH_M32768_T3_P4 =
+            "$argon2id$v=19$m=32768,t=3,p=4$c29tZXNhbHRieXRlcw$dGVzdGhhc2hieXRlcw";
+
+    @Test
+    void shouldExtractParametersFromValidHash() {
+        Optional<Argon2HashParameters> result =
+                Argon2MatcherHelper.extractParameters(HASH_M15360_T2_P1);
+
+        assertTrue(result.isPresent());
+        assertEquals(15360, result.get().memory());
+        assertEquals(2, result.get().iterations());
+        assertEquals(1, result.get().parallelism());
+    }
+
+    @Test
+    void shouldExtractDifferentParametersFromValidHash() {
+        Optional<Argon2HashParameters> result =
+                Argon2MatcherHelper.extractParameters(HASH_M32768_T3_P4);
+
+        assertTrue(result.isPresent());
+        assertEquals(32768, result.get().memory());
+        assertEquals(3, result.get().iterations());
+        assertEquals(4, result.get().parallelism());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"not-a-valid-hash", "", "$$$"})
+    void shouldReturnEmptyForInvalidInput(String invalidHash) {
+        Optional<Argon2HashParameters> result = Argon2MatcherHelper.extractParameters(invalidHash);
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## What

- Created `Argon2HashParameters` record to store Argon2 memory, iterations, and parallelism values.
- Added `extractParameters` method to `Argon2MatcherHelper` to parse configuration parameters from existing password hashes.
- Added `PASSWORD_REHASH_COMPLETED` metric and related dimensions to Cloudwatch enums.
- Updated `LoginHandler` to extract old hash parameters and emit a success metric when a password requires a rehash.
- Included both old and new Argon2 configuration values within the emitted metric to facilitate tracking and analysis.

## How to review

1. Code review
1. Deploy to a dev environment using the GitHub dev deployment workflows.
1. Sign in using test credentials that have an outdated Argon2 hash (e.g., different memory, iterations, or parallelism).
1. Check the dev database to confirm the user's password hash has been updated to match the current configuration parameters.
1. Check that the CloudWatch metric was emitted with the expected dimensions following the rehash.

## Testing

Followed the above tests, observed the parameters being upgraded and the `PasswordRehashCompleted` metric being emitted with dimensions as expected:

<img width="2424" height="276" alt="PasswordRehashCompleted audit event" src="https://github.com/user-attachments/assets/e063876c-c713-4bae-bb50-8936455c5961" />

## Revert Steps

Revert the version of the login lambda to the version prior to this change, then revert this PR.

## Checklist

- [x] Deployment of this PR will not break active user journeys **- Rehashing should occur silently on sign in, with any exception caught.**

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**

- [ ] A UCD review has been performed. **- N/A, backend only.**