### PR TITLE
ATO-2724: Create sendRequest method in SISAuthorisationService

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -1,22 +1,6 @@
 package uk.gov.di.authentication.oidc.services;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.nimbusds.jose.EncryptionMethod;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.RSAEncrypter;
-import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import com.nimbusds.jwt.EncryptedJWT;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -47,7 +31,6 @@ import uk.gov.di.orchestration.shared.services.TokenService;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +52,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.orchestration.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.orchestration.sharedtest.utils.JwtUtils.createDummyJwt;
 
 public class InitiateIPVAuthorisationServiceTest {
     private static final String CLIENT_SESSION_ID = "client-session-v1";
@@ -172,8 +156,8 @@ public class InitiateIPVAuthorisationServiceTest {
     }
 
     @Test
-    void shouldReturn302AndRedirectURIWithClaims() throws JOSEException, ParseException {
-        var encryptedJWT = createEncryptedJWT();
+    void shouldReturn302AndRedirectURIWithClaims() throws Exception {
+        var encryptedJWT = createDummyJwt();
         var authRequest = createAuthenticationRequest(claimsSetRequest);
         when(authorisationService.constructRequestJWT(
                         any(State.class),
@@ -270,36 +254,6 @@ public class InitiateIPVAuthorisationServiceTest {
         assertEquals(
                 claimsSetRequestWithStorageTokenClaim.toJSONString(),
                 actualClaimsSetRequest.getValue().toJSONString());
-    }
-
-    private EncryptedJWT createEncryptedJWT() throws JOSEException, ParseException {
-        var ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID("key-id")
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        var ecdsaSigner = new ECDSASigner(ecSigningKey);
-        var jwtClaimsSet =
-                new JWTClaimsSet.Builder()
-                        .claim("redirect_uri", "REDIRECT_URI")
-                        .claim("response_type", ResponseType.CODE.toString())
-                        .claim("client_id", "CLIENT_ID")
-                        .claim("govuk_signin_journey_id", CLIENT_SESSION_ID)
-                        .issuer("CLIENT_ID")
-                        .build();
-        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
-        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
-        signedJWT.sign(ecdsaSigner);
-        var rsaEncryptionKey =
-                new RSAKeyGenerator(2048).keyID("encrytion-key-id").generate().toRSAPublicKey();
-        var jweObject =
-                new JWEObject(
-                        new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
-                                .contentType("JWT")
-                                .build(),
-                        new Payload(signedJWT));
-        jweObject.encrypt(new RSAEncrypter(rsaEncryptionKey));
-        return EncryptedJWT.parse(jweObject.serialize());
     }
 
     private UserInfo generateUserInfo() throws com.nimbusds.oauth2.sdk.ParseException {

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/utils/JwtUtils.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/utils/JwtUtils.java
@@ -1,0 +1,52 @@
+package uk.gov.di.orchestration.sharedtest.utils;
+
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ResponseType;
+
+public class JwtUtils {
+    private JwtUtils() {}
+
+    public static EncryptedJWT createDummyJwt() throws Exception {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .claim("redirect_uri", "http://test-redirect.com")
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("client_id", "test-client-id")
+                        .claim("govuk_signin_journey_id", "test-csid")
+                        .issuer("test-client-id")
+                        .build();
+        var ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID("key-id")
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        var ecdsaSigner = new ECDSASigner(ecSigningKey);
+        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        signedJWT.sign(ecdsaSigner);
+        var jweObject =
+                new JWEObject(
+                        new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                                .contentType("JWT")
+                                .build(),
+                        new Payload(signedJWT));
+        var rsaEncryptionKey =
+                new RSAKeyGenerator(2048).keyID("encrytion-key-id").generate().toRSAPublicKey();
+        jweObject.encrypt(new RSAEncrypter(rsaEncryptionKey));
+        return EncryptedJWT.parse(jweObject.serialize());
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -283,6 +283,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getURLOrThrow("IPV_JWKS_URL");
     }
 
+    public URI getSISAuthorisationURI() {
+        return getURIOrEmpty("SIS_AUTHORISATION_URI");
+    }
+
     public String getSISAudience() {
         return System.getenv().getOrDefault("SIS_AUDIENCE", "");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenService.java
@@ -259,6 +259,10 @@ public class TokenService {
     }
 
     public AccessToken generateStorageToken(Subject internalPairwiseSubject) {
+        return generateStorageToken(internalPairwiseSubject, configService.getIPVAudience());
+    }
+
+    public AccessToken generateStorageToken(Subject internalPairwiseSubject, String audience) {
 
         LOG.info("Generating storage token");
         Date expiryDate = NowHelper.nowPlus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
@@ -266,10 +270,7 @@ public class TokenService {
 
         LOG.info("Storage token being created with JWTID: {}", jwtID);
 
-        List<String> aud =
-                List.of(
-                        configService.getCredentialStoreURI().toString(),
-                        configService.getIPVAudience());
+        List<String> aud = List.of(configService.getCredentialStoreURI().toString(), audience);
 
         JWTClaimsSet.Builder claimSetBuilder =
                 new JWTClaimsSet.Builder()

--- a/sis-api/src/main/java/uk/gov/di/orchestration/sis/service/SISAuthorisationService.java
+++ b/sis-api/src/main/java/uk/gov/di/orchestration/sis/service/SISAuthorisationService.java
@@ -1,43 +1,118 @@
 package uk.gov.di.orchestration.sis.service;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
+import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.security.interfaces.RSAPublicKey;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.RsaKeyHelper.getRsaPublicKeyFromJwksCacheItem;
 
 public class SISAuthorisationService {
+    private static final String STATE_STORAGE_PREFIX = "sis-state:";
     private static final Logger LOG = LogManager.getLogger(SISAuthorisationService.class);
     private final ConfigurationService configurationService;
+    private final TokenService tokenService;
+    private final StateStorageService stateStorageService;
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final JwksCacheService jwksCacheService;
     private final OrchJwtService orchJwtService;
     private final NowHelper.NowClock nowClock;
 
     public SISAuthorisationService(
             ConfigurationService configurationService,
+            TokenService tokenService,
+            StateStorageService stateStorageService,
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             JwksCacheService jwksCacheService,
             OrchJwtService orchJwtService,
             NowHelper.NowClock nowClock) {
         this.configurationService = configurationService;
+        this.tokenService = tokenService;
+        this.stateStorageService = stateStorageService;
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.jwksCacheService = jwksCacheService;
         this.orchJwtService = orchJwtService;
         this.nowClock = nowClock;
+    }
+
+    public APIGatewayProxyResponseEvent sendRequest(
+            AuthenticationRequest authRequest,
+            UserInfo userInfo,
+            String rpClientID,
+            String sessionId,
+            String clientSessionId,
+            Boolean reproveIdentity,
+            List<String> levelsOfConfidence) {
+        if (!configurationService.isIdentityEnabled()) {
+            LOG.error("Identity is not enabled");
+            throw new RuntimeException("Identity is not enabled");
+        }
+
+        attachLogFieldToLogs(CLIENT_ID, rpClientID);
+        LOG.info("Initiated SIS authorisation request");
+        var internalCommonSubjectId = userInfo.getSubject();
+
+        var state = new State();
+
+        var claimsSetRequest = buildClaimsRequest(authRequest, internalCommonSubjectId);
+
+        var encryptedJWT =
+                constructRequestJWT(
+                        state,
+                        authRequest.getScope(),
+                        internalCommonSubjectId,
+                        claimsSetRequest,
+                        Optional.ofNullable(clientSessionId).orElse("unknown"),
+                        userInfo.getEmailAddress(),
+                        levelsOfConfidence,
+                        reproveIdentity);
+
+        var sisAuthRequest =
+                new AuthorizationRequest.Builder(
+                                new ResponseType(ResponseType.Value.CODE),
+                                new ClientID(configurationService.getSISAuthorisationClientId()))
+                        .endpointURI(configurationService.getSISAuthorisationURI())
+                        .requestObject(encryptedJWT)
+                        .build();
+        stateStorageService.storeState(STATE_STORAGE_PREFIX + sessionId, state.getValue());
+        crossBrowserOrchestrationService.storeClientSessionIdAgainstState(clientSessionId, state);
+        // TODO: Add audit events
+        // TODO: Add cloudwatch metric for SISHandoff
+        LOG.info(
+                "Successfully processed SIS authorisation request, redirect URI {}",
+                sisAuthRequest.toURI().toString());
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, sisAuthRequest.toURI().toString()), null);
     }
 
     public EncryptedJWT constructRequestJWT(
@@ -87,5 +162,24 @@ public class SISAuthorisationService {
     private RSAPublicKey getPublicEncryptionKey() {
         LOG.info("Getting SIS Encryption JWK via JWKS endpoint");
         return getRsaPublicKeyFromJwksCacheItem(jwksCacheService.getOrGenerateSISJwksCacheItem());
+    }
+
+    private ClaimsSetRequest buildClaimsRequest(
+            AuthenticationRequest authRequest, Subject internalPairwiseSubject) {
+
+        ClaimsSetRequest claimsSetRequest =
+                Optional.ofNullable(authRequest)
+                        .map(AuthenticationRequest::getOIDCClaims)
+                        .map(OIDCClaimsRequest::getUserInfoClaimsRequest)
+                        .orElse(new ClaimsSetRequest());
+
+        LOG.info("Adding storageAccessToken claim to SIS claims request");
+        AccessToken storageToken =
+                tokenService.generateStorageToken(
+                        internalPairwiseSubject, configurationService.getSISAudience());
+
+        return claimsSetRequest.add(
+                new ClaimsSetRequest.Entry(configurationService.getStorageTokenClaimName())
+                        .withValues(List.of(storageToken.getValue())));
     }
 }

--- a/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
+++ b/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
@@ -4,13 +4,21 @@ import com.google.gson.GsonBuilder;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.ClaimRequirement;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.approvaltests.JsonApprovals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,41 +28,70 @@ import uk.gov.di.orchestration.shared.entity.JwksCacheItem;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.net.URI;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.orchestration.sharedtest.utils.JwtUtils.createDummyJwt;
 import static uk.gov.di.orchestration.sharedtest.utils.KeyPairUtils.generateRsaKeyPair;
 
 class SISAuthorisationServiceTest {
     private static final String KEY_ID = "14342354354353";
     private static final String SIS_CLIENT_ID = "sis-client-id";
     private static final URI SIS_URI = URI.create("http://sis/");
+    private static final URI SIS_AUTHORISATION_URI = URI.create("http://sis/oauth2/authorize");
     private static final URI SIS_CALLBACK_URI = URI.create("http://localhost/oidc/sis/callback");
     private static final String SIS_SIGNING_KEY_ALIAS = "test-signing-key-id";
     private static final Instant NOW = Instant.parse("2026-06-29T15:00:00Z");
+    private static final String CLIENT_SESSION_ID = "client-session-v1";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final List<String> LEVELS_OF_CONFIDENCE = List.of("P0", "P2");
+    private static final String SESSION_ID = "a-session-id";
+    private static final String RP_PAIRWISE_ID = "urn:fdc:gov.uk:2022:dkjfshsdkjh";
+    private final ClaimsSetRequest.Entry nameEntry =
+            new ClaimsSetRequest.Entry("name").withClaimRequirement(ClaimRequirement.ESSENTIAL);
+    private final ClaimsSetRequest.Entry birthDateEntry =
+            new ClaimsSetRequest.Entry("birthdate")
+                    .withClaimRequirement(ClaimRequirement.VOLUNTARY);
+    private final ClaimsSetRequest claimsSetRequest =
+            new ClaimsSetRequest().add(nameEntry).add(birthDateEntry);
+    private final AccessToken storageToken = new BearerAccessToken("test-token", 180, null);
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final TokenService tokenService = mock(TokenService.class);
+    private final StateStorageService stateStorageService = mock(StateStorageService.class);
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
     private final JwksCacheService jwksCacheService = mock(JwksCacheService.class);
     private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
     private SISAuthorisationService authorisationService;
@@ -63,6 +100,7 @@ class SISAuthorisationServiceTest {
 
     @BeforeEach
     void setup() throws Exception {
+        when(configurationService.isIdentityEnabled()).thenReturn(true);
         when(configurationService.getSISAuthorisationClientId()).thenReturn(SIS_CLIENT_ID);
         when(configurationService.getSISAuthorisationCallbackURI()).thenReturn(SIS_CALLBACK_URI);
         when(configurationService.getSISAudience()).thenReturn(SIS_URI.toString());
@@ -78,14 +116,45 @@ class SISAuthorisationServiceTest {
         when(jwksCacheService.getOrGenerateSISJwksCacheItem())
                 .thenReturn(new JwksCacheItem(jwksUrl.toString(), publicEncJwk, 300));
         when(configurationService.getSISTokenSigningKeyAlias()).thenReturn(SIS_SIGNING_KEY_ALIAS);
+        when(configurationService.getStorageTokenClaimName())
+                .thenReturn("https://vocab.account.gov.uk/v1/storageAccessToken");
+        when(configurationService.getSISAuthorisationURI()).thenReturn(SIS_AUTHORISATION_URI);
+
+        when(tokenService.generateStorageToken(any(), eq(SIS_URI.toString())))
+                .thenReturn(storageToken);
 
         authorisationService =
                 new SISAuthorisationService(
                         configurationService,
                         tokenService,
+                        stateStorageService,
+                        crossBrowserOrchestrationService,
                         jwksCacheService,
                         orchJwtService,
                         new NowHelper.NowClock(Clock.fixed(NOW, ZoneOffset.UTC)));
+    }
+
+    @Test
+    void shouldThrowWhenIdentityIsNotEnabled() throws ParseException {
+        when(configurationService.isIdentityEnabled()).thenReturn(false);
+        var authRequest = createAuthenticationRequest(claimsSetRequest);
+        var userInfo = generateUserInfo();
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                authorisationService.sendRequest(
+                                        authRequest,
+                                        userInfo,
+                                        CLIENT_ID,
+                                        SESSION_ID,
+                                        CLIENT_SESSION_ID,
+                                        false,
+                                        LEVELS_OF_CONFIDENCE),
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("Identity is not enabled"));
     }
 
     @Test
@@ -136,5 +205,83 @@ class SISAuthorisationServiceTest {
                 equalTo(Date.from(NOW.plus(3, ChronoUnit.MINUTES))));
 
         JsonApprovals.verifyAsJson(actualClaims.toJSONObject(), GsonBuilder::serializeNulls);
+    }
+
+    @Test
+    void shouldReturn302AndRedirectURIWithClaims() throws Exception {
+        var dummyJwt = createDummyJwt();
+        when(orchJwtService.signAndEncryptJWT(any(), anyString(), any())).thenReturn(dummyJwt);
+        var authRequest = createAuthenticationRequest(claimsSetRequest);
+        var userInfo = generateUserInfo();
+        var response =
+                authorisationService.sendRequest(
+                        authRequest,
+                        userInfo,
+                        CLIENT_ID,
+                        SESSION_ID,
+                        CLIENT_SESSION_ID,
+                        false,
+                        LEVELS_OF_CONFIDENCE);
+        assertThat(response, hasStatus(302));
+        String redirectLocation = response.getHeaders().get("Location");
+        assertThat(redirectLocation, startsWith(SIS_AUTHORISATION_URI.toString()));
+
+        assertThat(splitQuery(redirectLocation).get("request"), equalTo(dummyJwt.serialize()));
+        verify(stateStorageService).storeState(eq("sis-state:" + SESSION_ID), anyString());
+        verify(crossBrowserOrchestrationService)
+                .storeClientSessionIdAgainstState(eq(CLIENT_SESSION_ID), any(State.class));
+    }
+
+    private static Map<String, String> splitQuery(String stringUrl) {
+        URI uri = URI.create(stringUrl);
+        Map<String, String> queryPairs = new LinkedHashMap<>();
+        String query = uri.getQuery();
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            queryPairs.put(
+                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
+        }
+        return queryPairs;
+    }
+
+    private AuthenticationRequest createAuthenticationRequest(
+            ClaimsSetRequest authenticationClaimSetRequest) {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        var oidcClaimsRequest =
+                new OIDCClaimsRequest().withUserInfoClaimsRequest(authenticationClaimSetRequest);
+        return new AuthenticationRequest.Builder(
+                        new ResponseType(ResponseType.Value.CODE),
+                        scope,
+                        new ClientID(CLIENT_ID),
+                        SIS_AUTHORISATION_URI)
+                .state(new State())
+                .nonce(new Nonce())
+                .claims(oidcClaimsRequest)
+                .build();
+    }
+
+    private UserInfo generateUserInfo() throws com.nimbusds.oauth2.sdk.ParseException {
+        String jsonString =
+                String.format(
+                        """
+                                {
+                                    "sub": "urn:fdc:gov.uk:2022:jdgfhgfsdret",
+                                    "legacy_subject_id": "odkjfshsdkjhdkjfshsdkjhdkjfshsdkjh",
+                                    "public_subject_id": "pdkjfshsdkjhdkjfshsdkjhdkjfshsdkjh",
+                                    "local_account_id": "dkjfshsdkjhdkjfshsdkjhdkjfshsdkjh",
+                                    "rp_pairwise_id": "%s",
+                                    "email": "test@email.com",
+                                    "email_verified": true,
+                                    "phone_number": "007492837401",
+                                    "phone_number_verified": true,
+                                    "new_account": "true",
+                                    "salt": ""
+                                }
+                                """,
+                        RP_PAIRWISE_ID);
+        return UserInfo.parse(jsonString);
     }
 }

--- a/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
+++ b/sis-api/src/test/java/uk/gov/di/orchestration/sis/service/SISAuthorisationServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.JwksCacheService;
 import uk.gov.di.orchestration.shared.services.OrchJwtService;
+import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.net.URI;
 import java.net.URL;
@@ -53,6 +54,7 @@ class SISAuthorisationServiceTest {
     private static final Instant NOW = Instant.parse("2026-06-29T15:00:00Z");
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final TokenService tokenService = mock(TokenService.class);
     private final JwksCacheService jwksCacheService = mock(JwksCacheService.class);
     private final OrchJwtService orchJwtService = mock(OrchJwtService.class);
     private SISAuthorisationService authorisationService;
@@ -80,6 +82,7 @@ class SISAuthorisationServiceTest {
         authorisationService =
                 new SISAuthorisationService(
                         configurationService,
+                        tokenService,
                         jwksCacheService,
                         orchJwtService,
                         new NowHelper.NowClock(Clock.fixed(NOW, ZoneOffset.UTC)));


### PR DESCRIPTION
### Wider context of change

We would like to redirect users to SIS before sending them to IPV. At the moment we have code to create a request JWT and we are asserting the correct claims are set on this request object. We would now like to use this request object and return an API response to redirect the user to the SIS authorisation URI, including the request object as a query parameter like we do for IPV.

### What’s changed

This PR adds a new method `sendRequest` to the `SISAuthorisationService`. This method creates a new auth request for SIS, using the `constructRequestJWT` method. It then saves the new state generated to the `stateStorageService` and `crossBrowserOrchestrationService`. Finally, it returns an API response redirect the user to the redirect URI generated by the auth request

There are still a few bits missing such as audit events and cloudwatch metrics, but these will be addressed in future PRs

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

