### PR TITLE
ATO-2540: Validate reauth requests with stored signing key in prod

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -110,6 +110,7 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
       !Equals [integration, !Ref Environment],
+      !Equals [production, !Ref Environment],
     ]
   PublishOldExternalTokenSigningKeys: !Equals [production, !Ref Environment]
 


### PR DESCRIPTION
### What’s changed

This PR enables a feature flag in production which will use a JWK stored in the template config to validate reauth requests instead of using a JWK created from a key in KMS

Note that we are still publishing the old key to our JWKS endpoint, it just wont be used after this change. There will be a follow up PR to stop publishing this key once we are happy this change has not affected anything

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
