### PR TITLE
AUT-5648: remove old phone check SQS policy and SQS url

### DIFF
--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -8,17 +8,6 @@ data "terraform_remote_state" "shared" {
   }
 }
 
-data "terraform_remote_state" "contra" {
-  backend = "s3"
-  config = {
-    bucket      = var.contra_state_bucket
-    key         = "${var.environment}-experian-phone-check-terraform.tfstate"
-    assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
-    region      = var.aws_region
-  }
-}
-
-
 locals {
   redis_key                                       = "session"
   authentication_vpc_arn                          = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
@@ -53,8 +42,6 @@ locals {
   authentication_attempt_kms_key_arn              = data.terraform_remote_state.shared.outputs.authentication_attempt_kms_key_arn
   auth_session_table_encryption_key_arn           = data.terraform_remote_state.shared.outputs.auth_session_table_encryption_key_arn
   email_check_results_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.email_check_results_encryption_policy_arn
-  experian_phone_check_sqs_queue_id               = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_id
-  experian_phone_check_sqs_queue_policy_arn       = data.terraform_remote_state.contra.outputs.aws_experian_phone_check_sqs_policy_arn
   id_reverification_state_key_arn                 = data.terraform_remote_state.shared.outputs.id_reverification_state_key_arn
   secure_pipelines_environment                    = var.environment == "authdev3" ? "dev" : var.environment
   test_client_allow_list_secret_access_policy_arn = var.test_clients_enabled ? data.terraform_remote_state.shared.outputs.test_client_allow_list_secret_access_policy_arn : null

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -19,7 +19,6 @@ module "frontend_api_verify_mfa_code_role_with_combined_auth_attempts_policy" {
     local.account_modifiers_encryption_policy_arn,
     local.client_registry_encryption_policy_arn,
     local.user_credentials_encryption_policy_arn,
-    local.experian_phone_check_sqs_queue_policy_arn
   ], var.test_clients_enabled && local.test_client_allow_list_secret_access_policy_arn != null ? [local.test_client_allow_list_secret_access_policy_arn] : [])
   extra_tags = {
     Service = "verify-mfa-code"
@@ -45,7 +44,6 @@ module "verify_mfa_code" {
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP     = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                    = var.test_clients_enabled ? "true" : "false"
     INTERNAl_SECTOR_URI                     = var.internal_sector_uri
-    EXPERIAN_PHONE_CHECKER_QUEUE_URL        = local.experian_phone_check_sqs_queue_id
     PHONE_CHECKER_WITH_RETRY                = var.phone_checker_with_retry
     CODE_MAX_RETRIES_INCREASED              = var.code_max_retries_increased
     REDUCED_LOCKOUT_DURATION                = var.reduced_lockout_duration


### PR DESCRIPTION
## What

AUT-5648: remove old phone check SQS policy and SQS url

Not this lambda is not in use its legacy Lambda , removing the policy attachment so we can delete legacy Experian phone check resource   

## How to review

1. Code Review
