### PR TITLE
BAU: Fix CVE-2026-45536: bump netty-transport-native-epoll and add kqueue constraint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,14 @@ subprojects {
                     because 'CVE-2026-45674 is fixed in io.netty:netty-resolver-dns:4.2.15.Final and higher'
                 }
 
+                classpath('io.netty:netty-transport-native-epoll:[4.2.15.Final,5.0)') {
+                    because 'CVE-2026-45536 is fixed in io.netty:netty-transport-native-epoll:4.2.15.Final and higher'
+                }
+
+                classpath('io.netty:netty-transport-native-kqueue:[4.2.15.Final,5.0)') {
+                    because 'CVE-2026-45536 is fixed in io.netty:netty-transport-native-kqueue:4.2.15.Final and higher'
+                }
+
                 // Apache Commons constraints
                 classpath('commons-beanutils:commons-beanutils:[1.11.0,)') {
                     because 'CVE-2025-48734 is fixed in commons-beanutils:commons-beanutils:1.11.0 and higher'
@@ -171,8 +179,12 @@ subprojects {
                         because 'CVE-2025-58057 is fixed in io.netty:netty-codec:4.1.125.Final and higher'
                     }
 
-                    add(conf.name, 'io.netty:netty-transport-native-epoll:[4.2.13.Final,5.0)') {
-                        because 'CVE-2026-42577 is fixed in io.netty:netty-transport-native-epoll:4.2.13.Final and higher'
+                    add(conf.name, 'io.netty:netty-transport-native-epoll:[4.2.15.Final,5.0)') {
+                        because 'CVE-2026-45536 is fixed in io.netty:netty-transport-native-epoll:4.2.15.Final and higher'
+                    }
+
+                    add(conf.name, 'io.netty:netty-transport-native-kqueue:[4.2.15.Final,5.0)') {
+                        because 'CVE-2026-45536 is fixed in io.netty:netty-transport-native-kqueue:4.2.15.Final and higher'
                     }
 
                     add(conf.name, 'io.netty:netty-handler-proxy:[4.1.133.Final,4.2.0)') {


### PR DESCRIPTION

## What

BAU: Fix CVE-2026-45536: bump netty-transport-native-epoll and add kqueue constraint

Bump netty-transport-native-epoll from [4.2.13.Final,5.0) to [4.2.15.Final,5.0) and add netty-transport-native-kqueue constraint at [4.2.15.Final,5.0) to mitigate file descriptor leak in Unix domain sockets (CVE-2026-45536).

## How to review

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Test app is working correctly (or run acceptance tests)

Deployed to authdev2 and tested.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

