### PR TITLE
AUT-5599: Add inactive account scan lambda (scanning user-profile table only)

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -1,0 +1,72 @@
+Resources:
+  InactiveAccountDataExportLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub
+        - "${EnvironmentName}-inactive-account-data-export-lambda"
+        - EnvironmentName:
+            !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      CodeUri: ./utils/build/distributions/utils.zip
+      Handler: uk.gov.di.authentication.utils.lambda.InactiveAccountDataExportHandler::handleRequest
+      ReservedConcurrentExecutions: 1
+      Environment:
+        Variables:
+          ENVIRONMENT:
+            !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          DYNAMO_ARN_PREFIX: !Sub
+            - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
+            - DataStoreAccountId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dataStoreAccountId,
+                ]
+      Policies:
+        - !Ref LambdaBasicExecutionPolicy
+        - !Ref DynamoUserReadAccessPolicy
+        - !Ref CloudWatchLogsKmsAccessPolicy
+      AutoPublishAlias: live
+      LoggingConfig:
+        LogGroup: !Ref InactiveAccountDataExportLogGroup
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+          - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+      Tags:
+        Name: !Sub
+          - "${EnvironmentName}-inactive-account-data-export-lambda"
+          - EnvironmentName:
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+        Environment:
+          !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+
+  InactiveAccountDataExportLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - "/aws/lambda/${EnvironmentName}-inactive-account-data-export-lambda"
+        - EnvironmentName:
+            !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      RetentionInDays: !If
+        - UseSubEnvironment
+        - !FindInMap [
+            EnvironmentConfiguration,
+            !Ref SubEnvironment,
+            logRetentionDays,
+          ]
+        - !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            logRetentionDays,
+          ]
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+
+  InactiveAccountDataExportLogSubscription:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsSplunkEnabled
+    Properties:
+      LogGroupName: !Ref InactiveAccountDataExportLogGroup
+      FilterPattern: ""
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
@@ -1,0 +1,6 @@
+package uk.gov.di.authentication.utils.entity;
+
+import com.google.gson.annotations.Expose;
+
+public record InactiveAccountDataExportRequest(
+        @Expose Integer parallelism, @Expose Integer totalSegments) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportResponse.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportResponse.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.utils.entity;
+
+import com.google.gson.annotations.Expose;
+
+public record InactiveAccountDataExportResponse(@Expose long totalItemsScanned) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -5,10 +5,20 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeUnit;
 
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
@@ -18,6 +28,11 @@ public class InactiveAccountDataExportHandler
 
     private static final Logger LOG = LogManager.getLogger(InactiveAccountDataExportHandler.class);
     private static final String USER_PROFILE_TABLE = "user-profile";
+
+    private static final String PROJECTION_EXPRESSION =
+            "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt";
+    private static final Map<String, String> EXPRESSION_ATTRIBUTE_NAMES =
+            Map.of("#ts", "timestamp");
 
     private final DynamoDbClient client;
     private final String userProfileTableName;
@@ -43,11 +58,82 @@ public class InactiveAccountDataExportHandler
                     "Request must contain 'parallelism' and 'totalSegments' fields.");
         }
 
+        int parallelism = request.parallelism();
+        int totalSegments = request.totalSegments();
+
         LOG.info(
                 "Inactive account data export request: parallelism={}, totalSegments={}",
-                request.parallelism(),
-                request.totalSegments());
+                parallelism,
+                totalSegments);
 
-        return new InactiveAccountDataExportResponse(0);
+        List<ForkJoinTask<Long>> tasks = new ArrayList<>();
+        ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism);
+
+        try {
+            for (int segment = 0; segment < totalSegments; segment++) {
+                final int currentSegment = segment;
+                tasks.add(forkJoinPool.submit(() -> scanSegment(currentSegment, totalSegments)));
+            }
+
+            gracefulPoolShutdown(forkJoinPool);
+
+            long totalItemsScanned = 0;
+            for (ForkJoinTask<Long> task : tasks) {
+                totalItemsScanned += task.join();
+            }
+
+            LOG.info("Scan completed: {} total items scanned", totalItemsScanned);
+
+            return new InactiveAccountDataExportResponse(totalItemsScanned);
+        } finally {
+            forcePoolShutdown(forkJoinPool);
+        }
+    }
+
+    private long scanSegment(int segment, int totalSegments) {
+        Map<String, AttributeValue> lastKey = null;
+        long itemsScanned = 0;
+
+        do {
+            ScanRequest.Builder requestBuilder =
+                    ScanRequest.builder()
+                            .tableName(userProfileTableName)
+                            .segment(segment)
+                            .totalSegments(totalSegments)
+                            .projectionExpression(PROJECTION_EXPRESSION)
+                            .expressionAttributeNames(EXPRESSION_ATTRIBUTE_NAMES);
+
+            if (lastKey != null && !lastKey.isEmpty()) {
+                requestBuilder.exclusiveStartKey(lastKey);
+            }
+
+            ScanResponse response = client.scan(requestBuilder.build());
+
+            itemsScanned += response.items().size();
+
+            lastKey = response.lastEvaluatedKey();
+        } while (lastKey != null && !lastKey.isEmpty());
+
+        LOG.info("Segment {} completed: {} items scanned", segment, itemsScanned);
+
+        return itemsScanned;
+    }
+
+    private static void gracefulPoolShutdown(ForkJoinPool forkJoinPool) {
+        forkJoinPool.shutdown();
+        try {
+            if (!forkJoinPool.awaitTermination(15, TimeUnit.MINUTES)) {
+                LOG.warn("ForkJoinPool did not terminate within 15 minutes");
+            }
+        } catch (InterruptedException e) {
+            LOG.error("ForkJoinPool termination interrupted", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void forcePoolShutdown(ForkJoinPool forkJoinPool) {
+        if (!forkJoinPool.isShutdown()) {
+            forkJoinPool.shutdownNow();
+        }
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -1,0 +1,53 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.authentication.shared.helpers.TableNameHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
+import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportResponse;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
+
+public class InactiveAccountDataExportHandler
+        implements RequestHandler<
+                InactiveAccountDataExportRequest, InactiveAccountDataExportResponse> {
+
+    private static final Logger LOG = LogManager.getLogger(InactiveAccountDataExportHandler.class);
+    private static final String USER_PROFILE_TABLE = "user-profile";
+
+    private final DynamoDbClient client;
+    private final String userProfileTableName;
+
+    public InactiveAccountDataExportHandler(
+            ConfigurationService configurationService, DynamoDbClient client) {
+        this.client = client;
+        this.userProfileTableName =
+                TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService);
+    }
+
+    public InactiveAccountDataExportHandler() {
+        this(
+                ConfigurationService.getInstance(),
+                createDynamoClient(ConfigurationService.getInstance()));
+    }
+
+    @Override
+    public InactiveAccountDataExportResponse handleRequest(
+            InactiveAccountDataExportRequest request, Context context) {
+        if (request == null || request.parallelism() == null || request.totalSegments() == null) {
+            throw new IllegalArgumentException(
+                    "Request must contain 'parallelism' and 'totalSegments' fields.");
+        }
+
+        LOG.info(
+                "Inactive account data export request: parallelism={}, totalSegments={}",
+                request.parallelism(),
+                request.totalSegments());
+
+        return new InactiveAccountDataExportResponse(0);
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -2,16 +2,32 @@ package uk.gov.di.authentication.utils.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class InactiveAccountDataExportHandlerTest {
+
+    private static final TableSchema<UserProfile> USER_PROFILE_SCHEMA =
+            TableSchema.fromBean(UserProfile.class);
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDbClient client = mock(DynamoDbClient.class);
@@ -22,52 +38,85 @@ class InactiveAccountDataExportHandlerTest {
     }
 
     @Test
-    void shouldThrowIfRequestIsNull() {
+    void shouldThrowIfRequestIsMissingRequiredFields() {
         var handler = createHandler();
 
-        var exception =
-                assertThrows(
-                        IllegalArgumentException.class, () -> handler.handleRequest(null, context));
-
-        assertTrue(exception.getMessage().contains("parallelism"));
-        assertTrue(exception.getMessage().contains("totalSegments"));
+        assertThrows(IllegalArgumentException.class, () -> handler.handleRequest(null, context));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        handler.handleRequest(
+                                new InactiveAccountDataExportRequest(null, 5), context));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        handler.handleRequest(
+                                new InactiveAccountDataExportRequest(10, null), context));
     }
 
     @Test
-    void shouldThrowIfParallelismIsNull() {
+    void shouldPaginateThroughAllPagesInSegment() {
+        int itemCount = 25;
+        int pageSize = 5;
+        mockScanWithPagination(itemCount, pageSize);
+
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(null, 7);
-
-        var exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> handler.handleRequest(request, context));
-
-        assertTrue(exception.getMessage().contains("parallelism"));
-        assertTrue(exception.getMessage().contains("totalSegments"));
-    }
-
-    @Test
-    void shouldThrowIfTotalSegmentsIsNull() {
-        var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(7, null);
-
-        var exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> handler.handleRequest(request, context));
-
-        assertTrue(exception.getMessage().contains("parallelism"));
-        assertTrue(exception.getMessage().contains("totalSegments"));
-    }
-
-    @Test
-    void shouldAcceptValidRequest() {
-        var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(7, 7);
+        var request = new InactiveAccountDataExportRequest(4, 1);
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(0, response.totalItemsScanned());
+        assertEquals(itemCount, response.totalItemsScanned());
+    }
+
+    private Map<String, AttributeValue> createItem(int index) {
+        var profile =
+                new UserProfile()
+                        .withEmail("user" + index + "@example.com")
+                        .withCreated("2024-01-15")
+                        .withUpdated("2024-06-20")
+                        .withPublicSubjectID("public-subject-" + index)
+                        .withSubjectID("subject-" + index)
+                        .withSalt(ByteBuffer.wrap(new byte[] {(byte) index, 42}))
+                        .withTermsAndConditions(
+                                new TermsAndConditions("1.5", "2024-01-15T09:30:00Z"));
+        return USER_PROFILE_SCHEMA.itemToMap(profile, true);
+    }
+
+    private void mockScanWithPagination(int totalItems, int pageSize) {
+        List<ScanResponse> pages = buildPages(totalItems, pageSize);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        when(client.scan(any(ScanRequest.class)))
+                .thenAnswer(invocation -> pages.get(callCount.getAndIncrement()));
+    }
+
+    private List<ScanResponse> buildPages(int totalItems, int pageSize) {
+        List<Map<String, AttributeValue>> allItems = new ArrayList<>();
+        for (int i = 1; i <= totalItems; i++) {
+            allItems.add(createItem(i));
+        }
+
+        List<ScanResponse> pages = new ArrayList<>();
+        for (int start = 0; start < totalItems; start += pageSize) {
+            int end = Math.min(start + pageSize, totalItems);
+            List<Map<String, AttributeValue>> pageItems = allItems.subList(start, end);
+            boolean hasMorePages = end < totalItems;
+
+            ScanResponse.Builder responseBuilder =
+                    ScanResponse.builder()
+                            .items(pageItems)
+                            .count(pageItems.size())
+                            .scannedCount(pageItems.size());
+
+            if (hasMorePages) {
+                responseBuilder.lastEvaluatedKey(
+                        Map.of(
+                                UserProfile.ATTRIBUTE_EMAIL,
+                                AttributeValue.builder().s("lastKey-" + end).build()));
+            }
+
+            pages.add(responseBuilder.build());
+        }
+        return pages;
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -1,0 +1,73 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class InactiveAccountDataExportHandlerTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoDbClient client = mock(DynamoDbClient.class);
+    private final Context context = mock(Context.class);
+
+    private InactiveAccountDataExportHandler createHandler() {
+        return new InactiveAccountDataExportHandler(configurationService, client);
+    }
+
+    @Test
+    void shouldThrowIfRequestIsNull() {
+        var handler = createHandler();
+
+        var exception =
+                assertThrows(
+                        IllegalArgumentException.class, () -> handler.handleRequest(null, context));
+
+        assertTrue(exception.getMessage().contains("parallelism"));
+        assertTrue(exception.getMessage().contains("totalSegments"));
+    }
+
+    @Test
+    void shouldThrowIfParallelismIsNull() {
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, 7);
+
+        var exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> handler.handleRequest(request, context));
+
+        assertTrue(exception.getMessage().contains("parallelism"));
+        assertTrue(exception.getMessage().contains("totalSegments"));
+    }
+
+    @Test
+    void shouldThrowIfTotalSegmentsIsNull() {
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(7, null);
+
+        var exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> handler.handleRequest(request, context));
+
+        assertTrue(exception.getMessage().contains("parallelism"));
+        assertTrue(exception.getMessage().contains("totalSegments"));
+    }
+
+    @Test
+    void shouldAcceptValidRequest() {
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(7, 7);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(0, response.totalItemsScanned());
+    }
+}


### PR DESCRIPTION
## What

- Added infrastructure and handler code for a new inactive account data export Lambda.
- Implemented a parallel scan to efficiently read from the `user-profile` DynamoDB table.
- Added request/response entities, input validation, and unit tests.

A subsequent ticket (AUT-5651) will extend this scan to the `user-credentials` DynamoDB table.
AUT-5658 and AUT-5653 will handle persisting some of this data in a separate table.

## How to review

1. Code review
1. Optionally, deploy the `utils` module to a dev environment and make a test request to the `*-inactive-account-data-export-lambda` Lambda to scan the dev table, ensure there are no errors and that the expected number of items are scanned through the logs.
    - I have followed these steps - see "Testing" section below

## Testing

Deployed the `utils` module to authdev1 and made a test request to the `authdev1-inactive-account-data-export-lambda` Lambda to scan the dev table with the payload:
```json
{
  "parallelism": 5,
  "totalSegments": 3
}
```

No errors seen and verified that the correct number of items (all in the `user-profile` table) were scanned:

```
Inactive account data export request: parallelism=5, totalSegments=3

Segment 2 completed: 470 items scanned

Segment 0 completed: 461 items scanned

Segment 1 completed: 509 items scanned

Scan completed: 1440 total items scanned
```

Item count for the table being scanned (matches the number of items scanned by the Lambda):
<img width="529" height="108" alt="user-profile table item count" src="https://github.com/user-attachments/assets/e15a807e-0fd9-4075-af62-fd560e9879b5" />

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A, utils lambda, scanning only**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A.**
- [ ] A UCD review has been performed. **- N/A**
