### PR TITLE
AUT-5545: Number of passkeys metric

### DIFF
--- a/ci/cloudformation/utils/function/account-metrics.yaml
+++ b/ci/cloudformation/utils/function/account-metrics.yaml
@@ -24,6 +24,7 @@ Resources:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoCredentialReadAccessPolicy
+        - !Ref DynamoAuthenticatorDescribeAccessPolicy
         - !Ref CloudWatchLogsKmsAccessPolicy
       AutoPublishAlias: live
       LoggingConfig:

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -140,6 +140,7 @@ Mappings:
     authdev1:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f7c048d2-6e3c-46a3-b4eb-39fb964bee4f
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5d6c761d-797a-45f7-a3cc-0bd9c10acb28
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d41a1b95-0291-4477-93f7-f1428ceef646
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/aeb88256-7b5d-4707-952e-b522b09d8d5f
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c4d54754-4c7f-47d2-b54f-4868342b3660
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/13a8b94f-21da-4835-9882-89fcef4a494a
@@ -171,6 +172,7 @@ Mappings:
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/7d25305d-ff63-42ed-827b-83141db54866
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/dab5208e-14f1-40c5-b9e6-4dbe8a014d94
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/80a61dd9-80c0-4d09-8b4b-9c1d0752c1a5
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/86a459b9-4cae-4ed2-99da-dbd0f6eb13a9
@@ -202,6 +204,7 @@ Mappings:
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/9fde06f2-7014-4a13-a57e-7562157bf657
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/e3d591b4-d295-4041-b8f0-f5eb71742014
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ab3306cf-843a-423d-96f8-4c88e3fa1906
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/9d378f4a-de27-486a-93a4-56515d9ab372
@@ -233,6 +236,7 @@ Mappings:
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5e64dd3f-adb6-4a3c-8737-0da6e76b2d95
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c6a2fb5e-c92b-4129-bc0c-d75b2b72bae8
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/2e7ec5d4-f4b7-4342-a5d6-15952fd9111b
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/348c86dd-4507-4472-ab33-ee7448ce8959
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d81e16ea-860d-4e30-b271-d0e658ba8bbc
@@ -264,6 +268,7 @@ Mappings:
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/13c5043c-3c9e-4370-bff6-b70c2d8bc609
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3c2113fe-9f53-4bed-a46f-c53f02f6c117
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/db350f01-bce4-4da8-9323-e70267569bd8
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2c3850f1-c841-487c-8236-746f01ff707d
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/c6826c50-04a2-450a-95c5-0e1309b74d0e
@@ -295,6 +300,7 @@ Mappings:
     staging:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/36434b6d-1d77-4cee-af4b-70cf39109e52
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/ed6c6a2d-866f-4e2e-9ebd-c499ce9513c6
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/9c0cc476-e831-4ebf-81e6-c619e6b795e8
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/ed0ff55f-0ab2-463e-9c76-56be7052a436
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/c289d5e1-1fd7-4629-9f3d-c059aabed970
@@ -326,6 +332,7 @@ Mappings:
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2f7fd1cc-c0e1-40f5-a747-2ed29e02427d
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/743b2818-03fd-4414-bfaf-6aa8a4bb4e45
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/85164499-9392-458c-8596-b5a810ca90f6
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/be1b5ce0-3e55-4705-8437-8b68301ebcb1
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/44a77768-8782-4d8c-8a18-3e2f7d160800
@@ -357,6 +364,7 @@ Mappings:
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/7f36e093-d4c1-4b18-8cf3-0c11a59e6d67
+      authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/b380ea74-d240-4500-b02b-f5c3d414e34e
       commonPasswordsTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/679eab90-3e6b-4409-b60f-03687fc52118
       emailCheckResultTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/aca649a0-488b-4696-b94a-49156254afd2
       cloudwatchEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/417be117-d2cd-45f1-8b07-f30ba68bfaef
@@ -921,6 +929,54 @@ Resources:
                     EnvironmentConfiguration,
                     !Ref Environment,
                     userProfileTableEncryptionKey,
+                  ]
+
+  DynamoAuthenticatorDescribeAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing DescribeTable permissions to the authenticator table"
+      Path: !Sub
+        - /${Env}/utils/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowDescribeAccessToAuthenticatorTable
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-authenticator
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+          - Sid: AllowAccessToKms
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    authenticatorTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    authenticatorTableEncryptionKey,
                   ]
 
   # Policy for common_passwords table read write access with KMS

--- a/ci/terraform/utils/account_metrics_lambda.tf
+++ b/ci/terraform/utils/account_metrics_lambda.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "account_metrics_dynamo_access" {
 
     resources = [
       data.aws_dynamodb_table.user_profile.arn,
+      data.aws_dynamodb_table.authenticator.arn,
     ]
   }
 
@@ -23,12 +24,16 @@ data "aws_iam_policy_document" "account_metrics_dynamo_access" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [local.user_profile_kms_key_arn, local.authenticator_kms_key_arn]
   }
 }
 
 data "aws_dynamodb_table" "user_profile" {
   name = "${var.environment}-user-profile"
+}
+
+data "aws_dynamodb_table" "authenticator" {
+  name = "${var.environment}-authenticator"
 }
 
 resource "aws_iam_policy" "account_metrics_dynamo_access" {

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -27,6 +27,7 @@ locals {
   common_passwords_encryption_policy_arn = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   user_profile_kms_key_arn               = data.terraform_remote_state.shared.outputs.user_profile_kms_key_arn
   user_credentials_kms_key_arn           = data.terraform_remote_state.shared.outputs.user_credentials_kms_key_arn
+  authenticator_kms_key_arn              = data.terraform_remote_state.shared.outputs.authenticator_table_encryption_key_arn
 
   slack_event_sns_topic_arn = data.terraform_remote_state.shared.outputs.slack_event_sns_topic_arn
   aws_account_alias         = data.terraform_remote_state.shared.outputs.aws_account_alias

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
@@ -13,7 +13,8 @@ import java.util.Map;
 
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 
-public class AccountMetricPublishHandler implements RequestHandler<ScheduledEvent, Long> {
+public class AccountMetricPublishHandler
+        implements RequestHandler<ScheduledEvent, Map<String, Long>> {
 
     private final ConfigurationService configurationService;
     private final DynamoDbClient client;
@@ -35,7 +36,13 @@ public class AccountMetricPublishHandler implements RequestHandler<ScheduledEven
     }
 
     @Override
-    public Long handleRequest(ScheduledEvent input, Context context) {
+    public Map<String, Long> handleRequest(ScheduledEvent input, Context context) {
+        var counts = new java.util.HashMap<String, Long>();
+        counts.putAll(publishUserProfileMetrics());
+        return counts;
+    }
+
+    private Map<String, Long> publishUserProfileMetrics() {
         var result =
                 client.describeTable(
                         DescribeTableRequest.builder()
@@ -55,6 +62,8 @@ public class AccountMetricPublishHandler implements RequestHandler<ScheduledEven
         cloudwatchMetricsService.putEmbeddedValue(
                 "NumberOfVerifiedAccounts", numberOfVerifiedAccounts, Map.of());
 
-        return numberOfVerifiedAccounts;
+        return Map.of(
+                "NumberOfAccounts", numberOfAccounts,
+                "NumberOfVerifiedAccounts", numberOfVerifiedAccounts);
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
@@ -39,6 +39,7 @@ public class AccountMetricPublishHandler
     public Map<String, Long> handleRequest(ScheduledEvent input, Context context) {
         var counts = new java.util.HashMap<String, Long>();
         counts.putAll(publishUserProfileMetrics());
+        counts.putAll(publishAuthenticatorMetrics());
         return counts;
     }
 
@@ -65,5 +66,20 @@ public class AccountMetricPublishHandler
         return Map.of(
                 "NumberOfAccounts", numberOfAccounts,
                 "NumberOfVerifiedAccounts", numberOfVerifiedAccounts);
+    }
+
+    private Map<String, Long> publishAuthenticatorMetrics() {
+        var result =
+                client.describeTable(
+                        DescribeTableRequest.builder()
+                                .tableName(
+                                        TableNameHelper.getFullTableName(
+                                                "authenticator", configurationService))
+                                .build());
+        var numberOfPasskeys = result.table().itemCount();
+
+        cloudwatchMetricsService.putEmbeddedValue("NumberOfPasskeys", numberOfPasskeys, Map.of());
+
+        return Map.of("NumberOfPasskeys", numberOfPasskeys);
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -55,12 +56,14 @@ class AccountMetricPublishHandlerTest {
                                                 .build())
                                 .build());
 
-        handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
+        var result = handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
 
         verify(cloudwatchMetricsService, times(1))
                 .putEmbeddedValue("NumberOfAccounts", 5100, Map.of());
         verify(cloudwatchMetricsService, times(1))
                 .putEmbeddedValue("NumberOfVerifiedAccounts", 5000, Map.of());
+        assertEquals(5100L, result.get("NumberOfAccounts"));
+        assertEquals(5000L, result.get("NumberOfVerifiedAccounts"));
     }
 
     @Test

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandlerTest.java
@@ -55,6 +55,12 @@ class AccountMetricPublishHandlerTest {
                                                 .itemCount(5100l)
                                                 .build())
                                 .build());
+        when(client.describeTable(
+                        DescribeTableRequest.builder().tableName("test-authenticator").build()))
+                .thenReturn(
+                        DescribeTableResponse.builder()
+                                .table(TableDescription.builder().itemCount(1200l).build())
+                                .build());
 
         var result = handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
 
@@ -62,8 +68,11 @@ class AccountMetricPublishHandlerTest {
                 .putEmbeddedValue("NumberOfAccounts", 5100, Map.of());
         verify(cloudwatchMetricsService, times(1))
                 .putEmbeddedValue("NumberOfVerifiedAccounts", 5000, Map.of());
+        verify(cloudwatchMetricsService, times(1))
+                .putEmbeddedValue("NumberOfPasskeys", 1200, Map.of());
         assertEquals(5100L, result.get("NumberOfAccounts"));
         assertEquals(5000L, result.get("NumberOfVerifiedAccounts"));
+        assertEquals(1200L, result.get("NumberOfPasskeys"));
     }
 
     @Test


### PR DESCRIPTION
## What

Add a metric for the number of passkeys in the database to the account-metrics-publish-lambda.

- Changes applied to both terraform and cloudformation (as utils migration in progress)
- Lambda refactored to create separate functions to read from different tables

Current running times in production just over 2 seconds so plenty of headroom to add another count:

`REPORT RequestId: 1a492fe6-0530-4ed9-8f7d-79f96fa57e2b	Duration: 685.80 ms	Billed Duration: 2877 ms	Memory Size: 4096 MB	Max Memory Used: 231 MB	Init Duration: 2191.11 ms	`

Terraform deployment tested in di-auth-development authdev1:

```
{
  "NumberOfVerifiedAccounts": 1438,
  "NumberOfAccounts": 1440,
  "NumberOfPasskeys": 16
}
```

Cloudformation deployment tested in di-authentication-development authdev1:

```
{
  "NumberOfVerifiedAccounts": 1438,
  "NumberOfAccounts": 1440,
  "NumberOfPasskeys": 16
}

```

## How to review



1. Code Review
1. Deploy to both terraform and cloudformations dev environments using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Run the lambdas in the console

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
