### PR TITLE
ATO-2540: Stop publishing old ext token signing key in prod

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -112,7 +112,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  PublishOldExternalTokenSigningKeys: !Equals [production, !Ref Environment]
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
@@ -3409,10 +3408,7 @@ Resources:
             ]
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
-          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: !If
-            - PublishOldExternalTokenSigningKeys
-            - true
-            - false
+          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: false
           DOC_APP_SIGNING_KEY_ALIAS: !Ref OrchDocAppSigningKmsKeyAlias
       Policies:
         - !Ref IdTokenKmsAccessPolicy
@@ -4045,10 +4041,7 @@ Resources:
             - UseStoredOldIdTokenPublicKeys
             - true
             - false
-          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: !If
-            - PublishOldExternalTokenSigningKeys
-            - true
-            - false
+          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: false
           IDENTITY_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}


### PR DESCRIPTION
### Wider context of change

Now we are supporting validation of reauth journeys with a stored external token signing key in all environments, we can stop publishing the old external token signing key to the JWKS endpoint in production

### What’s changed

This PR stops publishing the old external token signing key in production.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
