### PR TITLE
AUT-5598: Add email and public subject ID to AUTH_CODE_VERIFIED and AUTH_TOKEN_SENT_TO_ORCHESTRATION

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -17,6 +17,9 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -39,10 +42,10 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaCreateFailureReason;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
@@ -83,6 +86,7 @@ public class MFAMethodsCreateHandler
     private final AuditService auditService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final MfaMethodsMigrationService mfaMethodsMigrationService;
+    private final StructuredAuditService structuredAuditService;
     private static final Logger LOG = LogManager.getLogger(MFAMethodsCreateHandler.class);
 
     public MFAMethodsCreateHandler() {
@@ -103,6 +107,7 @@ public class MFAMethodsCreateHandler
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.mfaMethodsMigrationService = new MfaMethodsMigrationService(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     public MFAMethodsCreateHandler(
@@ -113,7 +118,8 @@ public class MFAMethodsCreateHandler
             AuditService auditService,
             AwsSqsClient sqsClient,
             CloudwatchMetricsService cloudwatchMetricsService,
-            MfaMethodsMigrationService mfaMethodsMigrationService) {
+            MfaMethodsMigrationService mfaMethodsMigrationService,
+            StructuredAuditService structuredAuditService) {
         this.configurationService = configurationService;
         this.mfaMethodsService = mfaMethodsService;
         this.dynamoService = dynamoService;
@@ -122,6 +128,7 @@ public class MFAMethodsCreateHandler
         this.auditService = auditService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.mfaMethodsMigrationService = mfaMethodsMigrationService;
+        this.structuredAuditService = structuredAuditService;
     }
 
     @Override
@@ -259,7 +266,7 @@ public class MFAMethodsCreateHandler
         MfaMethodCreateRequest mfaMethodCreateRequest = maybeValidRequest.getSuccess();
 
         var auditEventStatus =
-                sendAuditEvent(AUTH_CODE_VERIFIED, auditContext, mfaMethodCreateRequest);
+                sendAuthCodeVerifiedEvent(auditContext, userProfile, mfaMethodCreateRequest);
         if (auditEventStatus.isFailure()) {
             LOG.error(auditEventStatus.getFailure());
             return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
@@ -309,11 +316,6 @@ public class MFAMethodsCreateHandler
         if (addCompletedResult.isFailure()) {
             LOG.error(addCompletedResult.getFailure());
             return generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure());
-        }
-
-        if (auditEventStatus.isFailure()) {
-            LOG.error(auditEventStatus.getFailure());
-            return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
         }
 
         if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
@@ -433,6 +435,48 @@ public class MFAMethodsCreateHandler
         } else {
             return baseAuditContext;
         }
+    }
+
+    private Result<ErrorResponse, Void> sendAuthCodeVerifiedEvent(
+            AuditContext auditContext,
+            UserProfile userProfile,
+            MfaMethodCreateRequest mfaMethodCreateRequest) {
+        try {
+            var mfaType = mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString();
+            var mfaPriority = PriorityIdentifier.BACKUP.name().toLowerCase();
+
+            String mfaCodeEntered = null;
+            String notificationType = null;
+            if (mfaMethodCreateRequest.mfaMethod().method()
+                    instanceof RequestSmsMfaDetail smsDetail) {
+                mfaCodeEntered = smsDetail.otp();
+                notificationType = MFA_SMS.name();
+            }
+
+            var extensions =
+                    new AuthCodeVerified.Extensions(
+                            notificationType,
+                            null,
+                            "false",
+                            ACCOUNT_MANAGEMENT.getValue(),
+                            mfaCodeEntered,
+                            mfaType,
+                            mfaPriority);
+
+            var event =
+                    AuthCodeVerified.create(
+                            auditContext,
+                            userProfile.getPublicSubjectID(),
+                            ComponentId.HOME,
+                            extensions,
+                            Clock.systemUTC());
+            structuredAuditService.submitAuditEvent(event);
+        } catch (Exception e) {
+            LOG.error("Error submitting audit event", e);
+            return Result.failure(ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT);
+        }
+
+        return Result.success(null);
     }
 
     private Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -16,6 +16,9 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -39,12 +42,12 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaUpdateFailure;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_SWITCH_FAILED;
@@ -59,6 +62,7 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -84,6 +88,7 @@ public class MFAMethodsPutHandler
     private final MfaMethodsMigrationService mfaMethodsMigrationService;
     private final AuditService auditService;
     private final DynamoService dynamoService;
+    private final StructuredAuditService structuredAuditService;
 
     private final Json serialisationService = SerializationService.getInstance();
 
@@ -105,6 +110,7 @@ public class MFAMethodsPutHandler
         this.auditService = new AuditService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.mfaMethodsMigrationService = new MfaMethodsMigrationService(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     public MFAMethodsPutHandler(
@@ -115,7 +121,8 @@ public class MFAMethodsPutHandler
             AwsSqsClient sqsClient,
             AuditService auditService,
             DynamoService dynamoService,
-            MfaMethodsMigrationService mfaMethodsMigrationService) {
+            MfaMethodsMigrationService mfaMethodsMigrationService,
+            StructuredAuditService structuredAuditService) {
         this.configurationService = configurationService;
         this.mfaMethodsService = mfaMethodsService;
         this.authenticationService = authenticationService;
@@ -124,6 +131,7 @@ public class MFAMethodsPutHandler
         this.auditService = auditService;
         this.dynamoService = dynamoService;
         this.mfaMethodsMigrationService = mfaMethodsMigrationService;
+        this.structuredAuditService = structuredAuditService;
     }
 
     @Override
@@ -226,12 +234,7 @@ public class MFAMethodsPutHandler
                 putRequest.request.mfaMethod().priorityIdentifier().equals(DEFAULT)
                         && putRequest.request.mfaMethod().method() == null;
         if (!isSwitch) {
-            var maybeAuditEventStatus =
-                    sendAuditEvent(
-                            AUTH_CODE_VERIFIED,
-                            putRequest,
-                            mfaMethodResult.mfaMethod(),
-                            auditContext);
+            var maybeAuditEventStatus = sendAuthCodeVerifiedEvent(putRequest, auditContext);
             if (maybeAuditEventStatus.isFailure()) {
                 return maybeAuditEventStatus.getFailure();
             }
@@ -551,6 +554,50 @@ public class MFAMethodsPutHandler
             }
             default -> Result.success(null);
         };
+    }
+
+    private Result<APIGatewayProxyResponseEvent, Void> sendAuthCodeVerifiedEvent(
+            ValidPutRequest putRequest, AuditContext auditContext) {
+        try {
+            var requestedMethod = putRequest.request.mfaMethod();
+
+            String mfaCodeEntered = null;
+            String notificationType = null;
+            if (requestedMethod.method() instanceof RequestSmsMfaDetail requestSmsMfaDetail
+                    && requestSmsMfaDetail.otp() != null) {
+                mfaCodeEntered = requestSmsMfaDetail.otp();
+                notificationType = MFA_SMS.name();
+            }
+
+            var priority = requestedMethod.priorityIdentifier().name().toLowerCase();
+            var mfaType = requestedMethod.method().mfaMethodType().toString();
+
+            var extensions =
+                    new AuthCodeVerified.Extensions(
+                            notificationType,
+                            null,
+                            "false",
+                            ACCOUNT_MANAGEMENT.getValue(),
+                            mfaCodeEntered,
+                            mfaType,
+                            priority);
+
+            var event =
+                    AuthCodeVerified.create(
+                            auditContext,
+                            putRequest.publicSubjectId(),
+                            ComponentId.HOME,
+                            extensions,
+                            Clock.systemUTC());
+            structuredAuditService.submitAuditEvent(event);
+        } catch (Exception e) {
+            LOG.error("Error submitting audit event", e);
+            return Result.failure(
+                    generateApiGatewayProxyErrorResponse(
+                            500, ErrorResponse.FAILED_TO_RAISE_AUDIT_EVENT));
+        }
+
+        return Result.success(null);
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> sendAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -20,6 +20,8 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -62,7 +64,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
-import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_CODE_VERIFIED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
@@ -112,6 +113,8 @@ class MFAMethodsCreateHandlerTest {
     private static final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private final MfaMethodsMigrationService mfaMethodsMigrationService =
             mock(MfaMethodsMigrationService.class);
     private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
@@ -202,7 +205,8 @@ class MFAMethodsCreateHandlerTest {
                         auditService,
                         sqsClient,
                         cloudwatchMetricsService,
-                        mfaMethodsMigrationService);
+                        mfaMethodsMigrationService,
+                        structuredAuditService);
         when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(TEST_SALT);
@@ -281,17 +285,18 @@ class MFAMethodsCreateHandlerTest {
                     JsonParser.parseString(expectedResponse).getAsJsonObject().toString();
             assertEquals(expectedResponseParsedToString, result.getBody());
 
-            verify(auditService)
-                    .submitAuditEvent(
-                            AUTH_CODE_VERIFIED,
-                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
-                            AUDIT_EVENT_COMPONENT_ID_HOME,
-                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
-                            pair("mfa-type", SMS.name()),
-                            pair("mfa-method", BACKUP.name().toLowerCase()),
-                            pair("account-recovery", "false"),
-                            pair("MFACodeEntered", TEST_OTP),
-                            pair("notification-type", MFA_SMS.name()));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            MFA_SMS.name(),
+                            null,
+                            "false",
+                            ACCOUNT_MANAGEMENT.getValue(),
+                            TEST_OTP,
+                            SMS.name(),
+                            BACKUP.name().toLowerCase());
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+            assertEquals(AUDIT_EVENT_COMPONENT_ID_HOME, authCodeVerifiedEvent.componentId());
 
             verify(auditService)
                     .submitAuditEvent(
@@ -381,15 +386,18 @@ class MFAMethodsCreateHandlerTest {
                             any(),
                             any(AuditService.MetadataPair[].class));
 
-            verify(auditService)
-                    .submitAuditEvent(
-                            AUTH_CODE_VERIFIED,
-                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
-                            AUDIT_EVENT_COMPONENT_ID_HOME,
-                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
-                            pair("mfa-type", AUTH_APP.name()),
-                            pair("mfa-method", BACKUP.name().toLowerCase()),
-                            pair("account-recovery", "false"));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            null,
+                            null,
+                            "false",
+                            ACCOUNT_MANAGEMENT.getValue(),
+                            null,
+                            AUTH_APP.name(),
+                            BACKUP.name().toLowerCase());
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+            assertEquals(AUDIT_EVENT_COMPONENT_ID_HOME, authCodeVerifiedEvent.componentId());
 
             verify(auditService)
                     .submitAuditEvent(
@@ -453,17 +461,18 @@ class MFAMethodsCreateHandlerTest {
 
             handler.handleRequest(event, context);
 
-            verify(auditService)
-                    .submitAuditEvent(
-                            AUTH_CODE_VERIFIED,
-                            BASE_AUDIT_CONTEXT.withPhoneNumber(TEST_E164_PHONE_NUMBER),
-                            AUDIT_EVENT_COMPONENT_ID_HOME,
-                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
-                            pair("mfa-type", SMS.name()),
-                            pair("mfa-method", BACKUP.name().toLowerCase()),
-                            pair("account-recovery", "false"),
-                            pair("MFACodeEntered", TEST_OTP),
-                            pair("notification-type", MFA_SMS.name()));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            MFA_SMS.name(),
+                            null,
+                            "false",
+                            ACCOUNT_MANAGEMENT.getValue(),
+                            TEST_OTP,
+                            SMS.name(),
+                            BACKUP.name().toLowerCase());
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+            assertEquals(AUDIT_EVENT_COMPONENT_ID_HOME, authCodeVerifiedEvent.componentId());
         }
     }
 
@@ -828,5 +837,11 @@ class MFAMethodsCreateHandlerTest {
             assertThat(result, hasJsonBody(ErrorResponse.INVALID_PRINCIPAL));
             verifyNoInteractions(auditService);
         }
+    }
+
+    private AuthCodeVerified captureAuthCodeVerifiedEvent() {
+        var argCaptor = ArgumentCaptor.forClass(AuthCodeVerified.class);
+        verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+        return argCaptor.getValue();
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandlerTest.java
@@ -11,12 +11,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.accountmanagement.services.MfaMethodsMigrationService;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -92,6 +95,8 @@ class MFAMethodsPutHandlerTest {
     private static final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private static final MFAMethodsService mfaMethodsService = mock(MFAMethodsService.class);
     private static final AuditService auditService = mock(AuditService.class);
+    private static final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private static final DynamoService dynamoService = mock(DynamoService.class);
     private static final AuthenticationService authenticationService =
             mock(AuthenticationService.class);
@@ -139,6 +144,7 @@ class MFAMethodsPutHandlerTest {
                 codeStorageService,
                 mfaMethodsService,
                 auditService,
+                structuredAuditService,
                 dynamoService,
                 authenticationService,
                 sqsClient,
@@ -161,7 +167,8 @@ class MFAMethodsPutHandlerTest {
                         sqsClient,
                         auditService,
                         dynamoService,
-                        mfaMethodsMigrationService);
+                        mfaMethodsMigrationService,
+                        structuredAuditService);
     }
 
     @Test
@@ -619,17 +626,18 @@ class MFAMethodsPutHandlerTest {
 
         handler.handleRequest(eventWithUpdateRequest, context);
 
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_CODE_VERIFIED,
-                        BASE_AUDIT_CONTEXT.withPhoneNumber(UK_MOBILE_NUMBER),
-                        AUDIT_EVENT_COMPONENT_ID_HOME,
-                        pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
-                        pair("MFACodeEntered", TEST_OTP),
-                        pair("notification-type", "MFA_SMS"),
-                        pair("account-recovery", "false"),
-                        pair("mfa-method", DEFAULT_SMS_METHOD.getPriority().toLowerCase()),
-                        pair("mfa-type", DEFAULT_SMS_METHOD.getMfaMethodType()));
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        "MFA_SMS",
+                        null,
+                        "false",
+                        ACCOUNT_MANAGEMENT.getValue(),
+                        TEST_OTP,
+                        DEFAULT_SMS_METHOD.getMfaMethodType(),
+                        DEFAULT_SMS_METHOD.getPriority().toLowerCase());
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+        assertEquals(AUDIT_EVENT_COMPONENT_ID_HOME, authCodeVerifiedEvent.componentId());
     }
 
     @Test
@@ -648,7 +656,7 @@ class MFAMethodsPutHandlerTest {
 
         handler.handleRequest(eventWithUpdateRequest, context);
 
-        verify(auditService, never()).submitAuditEvent(eq(AUTH_CODE_VERIFIED), any());
+        verify(structuredAuditService, never()).submitAuditEvent(any(AuthCodeVerified.class));
     }
 
     private static Stream<Arguments> migrationFailureReasonsToExpectedStatusCodes() {
@@ -1360,5 +1368,11 @@ class MFAMethodsPutHandlerTest {
     private static void setupValidOtpForEmail(String otp, String email) {
         when(codeStorageService.isValidOtpCode(email, otp, NotificationType.VERIFY_PHONE_NUMBER))
                 .thenReturn(true);
+    }
+
+    private AuthCodeVerified captureAuthCodeVerifiedEvent() {
+        var argCaptor = ArgumentCaptor.forClass(AuthCodeVerified.class);
+        verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+        return argCaptor.getValue();
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -196,7 +196,6 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             codeVerifiedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
             codeVerifiedAttributes.put(EXTENSIONS_MFA_TYPE, SMS.name());
-            codeVerifiedAttributes.put(EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE, "44");
             codeVerifiedAttributes.put(EXTENSIONS_NOTIFICATION_TYPE, "MFA_SMS");
             eventExpectations.put(AUTH_CODE_VERIFIED.name(), codeVerifiedAttributes);
 

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthCodeVerified.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthCodeVerified.java
@@ -1,0 +1,51 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.shared.RestrictedDeviceInformation;
+import uk.gov.di.authentication.auditevents.entity.shared.Users.UserWithoutPhone;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public record AuthCodeVerified(
+        String eventName,
+        long timestamp,
+        long eventTimestampMs,
+        String clientId,
+        String componentId,
+        UserWithoutPhone user,
+        RestrictedDeviceInformation restricted,
+        Extensions extensions)
+        implements StructuredAuditEvent {
+
+    public static AuthCodeVerified create(
+            AuditContext auditContext,
+            String publicSubjectId,
+            ComponentId componentId,
+            Extensions extensions,
+            Clock clock) {
+        var eventName = "AUTH_CODE_VERIFIED";
+        Instant now = clock.instant();
+        var user = UserWithoutPhone.fromAuditContext(auditContext, publicSubjectId);
+        var restricted = RestrictedDeviceInformation.from(auditContext);
+        return new AuthCodeVerified(
+                eventName,
+                now.getEpochSecond(),
+                now.toEpochMilli(),
+                auditContext.clientId(),
+                componentId.getValue(),
+                user,
+                restricted,
+                extensions);
+    }
+
+    public record Extensions(
+            @SerializedName("notification-type") String notificationType,
+            @SerializedName("loginFailureCount") Integer loginFailureCount,
+            @SerializedName("account-recovery") Object accountRecovery,
+            @SerializedName("journey-type") String journeyType,
+            @SerializedName("MFACodeEntered") String mfaCodeEntered,
+            @SerializedName("mfa-type") String mfaType,
+            @SerializedName("mfa-method") String mfaMethod) {}
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthDeleteAccount.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthDeleteAccount.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.auditevents.entity;
 
 import uk.gov.di.audit.AuditContext;
-import uk.gov.di.authentication.auditevents.entity.shared.EncodedDeviceInformation;
+import uk.gov.di.authentication.auditevents.entity.shared.RestrictedDeviceInformation;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 
 import java.time.Clock;
@@ -14,7 +14,7 @@ public record AuthDeleteAccount(
         String clientId,
         String componentId,
         User user,
-        Restricted restricted,
+        RestrictedDeviceInformation restricted,
         Extensions extensions)
         implements StructuredAuditEvent {
 
@@ -45,7 +45,7 @@ public record AuthDeleteAccount(
                         publicSubjectId,
                         auditContext.sessionId(),
                         auditContext.subjectId()),
-                new Restricted(EncodedDeviceInformation.from(auditContext)),
+                RestrictedDeviceInformation.from(auditContext),
                 new Extensions(reason, phoneNumberCountryCode));
     }
 
@@ -59,8 +59,6 @@ public record AuthDeleteAccount(
             String publicSubjectId,
             String sessionId,
             String userId) {}
-
-    public record Restricted(EncodedDeviceInformation deviceInformation) {}
 
     public record Extensions(String accountDeletionReason, String phoneNumberCountryCode) {}
 }

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessful.java
@@ -30,10 +30,11 @@ public record AuthPasskeyVerificationSuccessful(
             List<PasskeyAllowCredentials> passkeyAllowedCredentials,
             PasskeyDetail passkey,
             String credentialId,
+            String publicSubjectId,
             Clock clock) {
         var eventName = "AUTH_PASSKEY_VERIFICATION_SUCCESSFUL";
         Instant now = clock.instant();
-        var user = UserWithoutPhone.fromAuditContext(auditContext);
+        var user = UserWithoutPhone.fromAuditContext(auditContext, publicSubjectId);
         var restricted =
                 new Restricted(
                         EncodedDeviceInformation.from(auditContext),

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthTokenSentToOrchestration.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthTokenSentToOrchestration.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import uk.gov.di.audit.AuditContext;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public record AuthTokenSentToOrchestration(
+        String eventName,
+        long timestamp,
+        long eventTimestampMs,
+        String clientId,
+        String componentId,
+        User user)
+        implements StructuredAuditEvent {
+
+    public static AuthTokenSentToOrchestration create(
+            AuditContext auditContext, String email, String publicSubjectId, Clock clock) {
+        var eventName = "AUTH_TOKEN_SENT_TO_ORCHESTRATION";
+        Instant now = clock.instant();
+        var user = new User(auditContext.subjectId(), email, publicSubjectId);
+        return new AuthTokenSentToOrchestration(
+                eventName,
+                now.getEpochSecond(),
+                now.toEpochMilli(),
+                auditContext.clientId(),
+                ComponentId.AUTH.getValue(),
+                user);
+    }
+
+    public record User(String userId, String email, String publicSubjectId) {}
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/RestrictedDeviceInformation.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/RestrictedDeviceInformation.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.auditevents.entity.shared;
+
+import uk.gov.di.audit.AuditContext;
+
+public record RestrictedDeviceInformation(EncodedDeviceInformation deviceInformation) {
+    public static RestrictedDeviceInformation from(AuditContext auditContext) {
+        return new RestrictedDeviceInformation(EncodedDeviceInformation.from(auditContext));
+    }
+}

--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/Users/UserWithoutPhone.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/shared/Users/UserWithoutPhone.java
@@ -8,7 +8,8 @@ public record UserWithoutPhone(
         String ipAddress,
         String persistentSessionId,
         String sessionId,
-        String userId) {
+        String userId,
+        String publicSubjectId) {
     public static UserWithoutPhone fromAuditContext(AuditContext auditContext) {
         return new UserWithoutPhone(
                 auditContext.email(),
@@ -16,6 +17,19 @@ public record UserWithoutPhone(
                 auditContext.ipAddress(),
                 auditContext.persistentSessionId(),
                 auditContext.sessionId(),
-                auditContext.subjectId());
+                auditContext.subjectId(),
+                null);
+    }
+
+    public static UserWithoutPhone fromAuditContext(
+            AuditContext auditContext, String publicSubjectId) {
+        return new UserWithoutPhone(
+                auditContext.email(),
+                auditContext.clientSessionId(),
+                auditContext.ipAddress(),
+                auditContext.persistentSessionId(),
+                auditContext.sessionId(),
+                auditContext.subjectId(),
+                publicSubjectId);
     }
 }

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthCodeVerifiedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthCodeVerifiedTest.java
@@ -1,0 +1,113 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
+
+class AuthCodeVerifiedTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-06-10T13:13:04.730565Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+
+    private final AuditContext auditContext =
+            AuditContext.emptyAuditContext()
+                    .withClientId("client-id")
+                    .withEmail("test@example.com")
+                    .withSubjectId("internal-common-subject-id")
+                    .withPersistentSessionId("persistent-session-id")
+                    .withSessionId("session-id")
+                    .withClientSessionId("signin-journey-id")
+                    .withIpAddress("192.0.2.0/24")
+                    .withTxmaAuditEncoded("encoded-device-info");
+
+    @Test
+    void shouldSerialiseAnAuthCodeVerifiedAuditEventWithAllExtensions() {
+        var extensions =
+                new AuthCodeVerified.Extensions(
+                        "MFA_SMS", 0, false, "SIGN_IN", "196306", "SMS", "default");
+
+        var event =
+                AuthCodeVerified.create(
+                        auditContext,
+                        "urn:fdc:gov.uk:2022:public-subject-id",
+                        ComponentId.AUTH,
+                        extensions,
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_CODE_VERIFIED",
+                  "timestamp": 1781097184,
+                  "event_timestamp_ms": 1781097184730,
+                  "client_id": "client-id",
+                  "component_id": "AUTH",
+                  "user": {
+                    "email": "test@example.com",
+                    "govuk_signin_journey_id": "signin-journey-id",
+                    "ip_address": "192.0.2.0/24",
+                    "persistent_session_id": "persistent-session-id",
+                    "session_id": "session-id",
+                    "user_id": "internal-common-subject-id",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public-subject-id"
+                  },
+                  "restricted": {
+                    "device_information": {
+                      "encoded": "encoded-device-info"
+                    }
+                  },
+                  "extensions": {
+                    "notification-type": "MFA_SMS",
+                    "loginFailureCount": 0,
+                    "account-recovery": false,
+                    "journey-type": "SIGN_IN",
+                    "MFACodeEntered": "196306",
+                    "mfa-type": "SMS",
+                    "mfa-method": "default"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+
+    @Test
+    void shouldSerialiseAnAuthCodeVerifiedAuditEventWithMinimalExtensions() {
+        var extensions =
+                new AuthCodeVerified.Extensions(
+                        null, null, false, "ACCOUNT_MANAGEMENT", null, "AUTH_APP", "backup");
+
+        var event =
+                AuthCodeVerified.create(
+                        auditContext,
+                        "urn:fdc:gov.uk:2022:public-subject-id",
+                        ComponentId.HOME,
+                        extensions,
+                        FIXED_CLOCK);
+
+        var actualEvent = event.serialize();
+        var actualEventAsJsonObject = JsonParser.parseString(actualEvent).getAsJsonObject();
+
+        var expectedExtensions =
+                """
+                {
+                  "account-recovery": false,
+                  "journey-type": "ACCOUNT_MANAGEMENT",
+                  "mfa-type": "AUTH_APP",
+                  "mfa-method": "backup"
+                }
+                """;
+
+        var actualExtensionsSection = actualEventAsJsonObject.get("extensions");
+        assertEquals(asJson(expectedExtensions), actualExtensionsSection);
+    }
+}

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessfulTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyVerificationSuccessfulTest.java
@@ -44,6 +44,7 @@ class AuthPasskeyVerificationSuccessfulTest {
                         passkeyAllowCredentials,
                         passkey,
                         "credential-1",
+                        "urn:fdc:gov.uk:2022:public-subject-id",
                         fixedClock);
 
         var actualEvent = event.serialize();
@@ -62,7 +63,8 @@ class AuthPasskeyVerificationSuccessfulTest {
                     "ip_address": "192.0.2.0/24",
                     "persistent_session_id": "persistent-session-id",
                     "session_id": "session-id",
-                    "user_id": "internal-common-subject-id"
+                    "user_id": "internal-common-subject-id",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public-subject-id"
                   },
                   "restricted": {
                     "device_information": {

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthTokenSentToOrchestrationTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthTokenSentToOrchestrationTest.java
@@ -1,0 +1,53 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
+
+class AuthTokenSentToOrchestrationTest {
+
+    @Test
+    void shouldSerialiseAnAuthTokenSentToOrchestrationAuditEvent() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client-id")
+                        .withSubjectId("urn:fdc:gov.uk:2022:internal-pairwise-id")
+                        .withClientSessionId("signin-journey-id");
+
+        var fixedInstant = Instant.parse("2026-06-10T13:13:04.730565Z");
+        var fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
+
+        var event =
+                AuthTokenSentToOrchestration.create(
+                        auditContext,
+                        "test@example.com",
+                        "urn:fdc:gov.uk:2022:public-subject-id",
+                        fixedClock);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                {
+                  "event_name": "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+                  "timestamp": 1781097184,
+                  "event_timestamp_ms": 1781097184730,
+                  "client_id": "client-id",
+                  "component_id": "AUTH",
+                  "user": {
+                    "user_id": "urn:fdc:gov.uk:2022:internal-pairwise-id",
+                    "email": "test@example.com",
+                    "public_subject_id": "urn:fdc:gov.uk:2022:public-subject-id"
+                  }
+                }
+                """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+}

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/shared/Users/UserWithoutPhoneTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/shared/Users/UserWithoutPhoneTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.audit.AuditContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class UserWithoutPhoneTest {
 
@@ -26,5 +27,30 @@ class UserWithoutPhoneTest {
         assertEquals(auditContext.persistentSessionId(), user.persistentSessionId());
         assertEquals(auditContext.sessionId(), user.sessionId());
         assertEquals(auditContext.subjectId(), user.userId());
+        assertNull(user.publicSubjectId());
+    }
+
+    @Test
+    void createsAUserWithPublicSubjectIdFromTheCorrectAuditContextFields() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withEmail("test@example.com")
+                        .withSubjectId("internal-common-subject-id")
+                        .withPersistentSessionId("persistent-session-id")
+                        .withSessionId("session-id")
+                        .withClientSessionId("signin-journey-id")
+                        .withIpAddress("192.0.2.0/24");
+
+        var user =
+                UserWithoutPhone.fromAuditContext(
+                        auditContext, "urn:fdc:gov.uk:2022:public-subject-id");
+
+        assertEquals(auditContext.email(), user.email());
+        assertEquals(auditContext.clientSessionId(), user.govukSigninJourneyId());
+        assertEquals(auditContext.ipAddress(), user.ipAddress());
+        assertEquals(auditContext.persistentSessionId(), user.persistentSessionId());
+        assertEquals(auditContext.sessionId(), user.sessionId());
+        assertEquals(auditContext.subjectId(), user.userId());
+        assertEquals("urn:fdc:gov.uk:2022:public-subject-id", user.publicSubjectId());
     }
 }

--- a/auth-external-api/build.gradle
+++ b/auth-external-api/build.gradle
@@ -18,6 +18,7 @@ dependencies {
             libs.bundles.nimbus
 
     implementation project(":shared")
+    implementation project(":audit-events")
 
     runtimeOnly libs.bundles.loggingRuntime,
             platform(libs.openTelemetryBom),

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -17,6 +17,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthTokenSentToOrchestration;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.external.exceptions.AuthCodeStoreRetreivalException;
 import uk.gov.di.authentication.external.services.TokenService;
 import uk.gov.di.authentication.external.validators.TokenRequestValidator;
@@ -37,13 +39,13 @@ import uk.gov.di.authentication.shared.services.SystemService;
 
 import java.net.URI;
 import java.security.spec.X509EncodedKeySpec;
+import java.time.Clock;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent.AUTH_TOKEN_SENT_TO_ORCHESTRATION;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -61,6 +63,7 @@ public class TokenHandler
     private final AuditService auditService;
     private final AuthenticationService authenticationService;
     private final RemoteJwksService authJwksService;
+    private final StructuredAuditService structuredAuditService;
 
     public TokenHandler(
             ConfigurationService configurationService,
@@ -70,7 +73,8 @@ public class TokenHandler
             TokenRequestValidator tokenRequestValidator,
             AuditService auditService,
             AuthenticationService authenticationService,
-            RemoteJwksService authJwksService) {
+            RemoteJwksService authJwksService,
+            StructuredAuditService structuredAuditService) {
         this.configurationService = configurationService;
         this.authorisationCodeService = authorisationCodeService;
         this.accessTokenStoreService = accessTokenStoreService;
@@ -79,6 +83,7 @@ public class TokenHandler
         this.auditService = auditService;
         this.authenticationService = authenticationService;
         this.authJwksService = authJwksService;
+        this.structuredAuditService = structuredAuditService;
     }
 
     public TokenHandler() {
@@ -100,6 +105,7 @@ public class TokenHandler
         this.auditService = new AuditService(configurationService);
         this.authenticationService = new DynamoService(configurationService);
         this.authJwksService = new RemoteJwksService(configurationService.getAuthJwksUrl());
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     @Override
@@ -211,7 +217,13 @@ public class TokenHandler
                                             .orElse(AuditService.UNKNOWN))
                             .withClientSessionId(authCodeStore.getJourneyID());
 
-            auditService.submitAuditEvent(AUTH_TOKEN_SENT_TO_ORCHESTRATION, auditContext);
+            var auditEvent =
+                    AuthTokenSentToOrchestration.create(
+                            auditContext,
+                            userProfile.getEmail(),
+                            userProfile.getPublicSubjectID(),
+                            Clock.systemUTC());
+            structuredAuditService.submitAuditEvent(auditEvent);
 
             Map<String, String> headers = new HashMap<>();
             headers.put("Content-Type", "application/json");

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -23,8 +23,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
-import uk.gov.di.audit.AuditContext;
-import uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent;
+import uk.gov.di.authentication.auditevents.entity.AuthTokenSentToOrchestration;
+import uk.gov.di.authentication.auditevents.entity.StructuredAuditEvent;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.external.services.TokenService;
 import uk.gov.di.authentication.external.validators.TokenRequestValidator;
 import uk.gov.di.authentication.shared.entity.AuthCodeStore;
@@ -64,6 +65,8 @@ class TokenHandlerTest {
     private static final ClientSubjectHelper clientSubjectHelper = mock(ClientSubjectHelper.class);
     private static final TokenService tokenUtilityService = mock(TokenService.class);
     private static final AuditService auditService = mock(AuditService.class);
+    private static final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private static final DynamoService dynamoService = mock(DynamoService.class);
     private static final BearerAccessToken SUCCESS_TOKEN_RESPONSE_ACCESS_TOKEN =
             new BearerAccessToken();
@@ -77,8 +80,14 @@ class TokenHandlerTest {
     private static final String CLIENT_ID = "test-client-id";
     private static final Long PASSWORD_RESET_TIME = 1710255274L;
     private static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final String USER_EMAIL = "test@example.com";
+    private static final String PUBLIC_SUBJECT_ID = "urn:fdc:gov.uk:2022:public-subject-id";
     private static final UserProfile USER_PROFILE =
-            new UserProfile().withSubjectID("any").withSalt(ByteBuffer.allocateDirect(12345));
+            new UserProfile()
+                    .withSubjectID("any")
+                    .withSalt(ByteBuffer.allocateDirect(12345))
+                    .withEmail(USER_EMAIL)
+                    .withPublicSubjectID(PUBLIC_SUBJECT_ID);
     private static final AuthCodeStore VALID_AUTH_CODE_STORE =
             new AuthCodeStore()
                     .withAuthCode(VALID_AUTH_CODE)
@@ -151,7 +160,8 @@ class TokenHandlerTest {
                         tokenRequestValidator,
                         auditService,
                         dynamoService,
-                        authJwksService);
+                        authJwksService,
+                        structuredAuditService);
         ecKeyPair = new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
         when(authJwksService.retrieveJwkFromURLWithKeyId(ecKeyPair.getKeyID()))
                 .thenReturn(ecKeyPair.toPublicJWK());
@@ -300,19 +310,15 @@ class TokenHandlerTest {
                         VALID_AUTH_CODE_STORE.getPasswordResetTime());
         verify(authCodeService).updateHasBeenUsed(VALID_AUTH_CODE, true);
 
-        verify(auditService)
-                .submitAuditEvent(
-                        AuthExternalApiAuditableEvent.AUTH_TOKEN_SENT_TO_ORCHESTRATION,
-                        new AuditContext(
-                                CLIENT_ID,
-                                CLIENT_SESSION_ID,
-                                AuditService.UNKNOWN,
-                                internalPairwiseId,
-                                AuditService.UNKNOWN,
-                                AuditService.UNKNOWN,
-                                AuditService.UNKNOWN,
-                                AuditService.UNKNOWN,
-                                AuditService.UNKNOWN));
+        var argCaptor = org.mockito.ArgumentCaptor.forClass(StructuredAuditEvent.class);
+        verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+        var capturedEvent = (AuthTokenSentToOrchestration) argCaptor.getValue();
+        assertEquals("AUTH_TOKEN_SENT_TO_ORCHESTRATION", capturedEvent.eventName());
+        assertEquals(CLIENT_ID, capturedEvent.clientId());
+        assertEquals("AUTH", capturedEvent.componentId());
+        assertEquals(internalPairwiseId, capturedEvent.user().userId());
+        assertEquals(USER_EMAIL, capturedEvent.user().email());
+        assertEquals(PUBLIC_SUBJECT_ID, capturedEvent.user().publicSubjectId());
     }
 
     private Map<String, List<String>> privateKeyJWTParams() throws JOSEException {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionSe
 import uk.gov.di.authentication.frontendapi.services.webauthn.RelyingPartyProvider;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
@@ -132,10 +133,13 @@ public class FinishPasskeyAssertionHandler
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+        var publicSubjectId =
+                userContext.getUserProfile().map(UserProfile::getPublicSubjectID).orElse(null);
         return passkeyAssertionService.finishAssertion(
                 userContext.getAuthSession().getPasskeyAssertionRequest(),
                 request.pkc(),
-                auditContext);
+                auditContext,
+                publicSubjectId);
     }
 
     private Result<FinishPasskeyAssertionFailureReason, Void> updatePasskeyRecord(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -7,6 +7,9 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
@@ -47,6 +50,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
+import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,6 +98,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
     private final TestUserHelper testUserHelper;
+    private final StructuredAuditService structuredAuditService;
 
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
@@ -106,7 +111,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
-            TestUserHelper testUserHelper) {
+            TestUserHelper testUserHelper,
+            StructuredAuditService structuredAuditService) {
         super(
                 VerifyCodeRequest.class,
                 configurationService,
@@ -120,6 +126,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
         this.testUserHelper = testUserHelper;
+        this.structuredAuditService = structuredAuditService;
     }
 
     public VerifyCodeHandler() {
@@ -137,6 +144,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.testUserHelper = new TestUserHelper(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     public VerifyCodeHandler(
@@ -151,6 +159,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         this.mfaMethodsService = new MFAMethodsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
         this.testUserHelper = new TestUserHelper(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     @Override
@@ -567,16 +576,61 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
         codeStorageService.deleteOtpCode(otpCodeIdentifier, notificationType);
 
-        var metadataPairArray =
-                metadataPairs(
-                        notificationType,
-                        journeyType,
-                        codeRequest,
-                        loginFailureCount,
-                        false,
-                        initialMetadataPairs);
-        auditService.submitAuditEvent(
-                FrontendAuditableEvent.AUTH_CODE_VERIFIED, auditContext, metadataPairArray);
+        auditSuccess(
+                notificationType,
+                journeyType,
+                codeRequest,
+                loginFailureCount,
+                initialMetadataPairs,
+                auditContext,
+                userContext);
+    }
+
+    private void auditSuccess(
+            NotificationType notificationType,
+            JourneyType journeyType,
+            VerifyCodeRequest codeRequest,
+            int loginFailureCount,
+            List<AuditService.MetadataPair> initialMetadataPairs,
+            AuditContext auditContext,
+            UserContext userContext) {
+        String mfaType = null;
+        Integer failureCount = null;
+        String mfaCodeEntered = null;
+        String mfaMethod =
+                initialMetadataPairs.stream()
+                        .filter(p -> p.key().equals(AUDIT_EVENT_EXTENSIONS_MFA_METHOD))
+                        .map(p -> (String) p.value())
+                        .findFirst()
+                        .orElse(null);
+
+        if (notificationType == MFA_SMS) {
+            mfaType = MFAMethodType.SMS.getValue();
+            failureCount = loginFailureCount;
+            mfaCodeEntered = codeRequest.code();
+        }
+
+        var extensions =
+                new AuthCodeVerified.Extensions(
+                        notificationType.name(),
+                        failureCount,
+                        journeyType == JourneyType.ACCOUNT_RECOVERY,
+                        String.valueOf(journeyType),
+                        mfaCodeEntered,
+                        mfaType,
+                        mfaMethod);
+
+        var publicSubjectId =
+                userContext.getUserProfile().map(UserProfile::getPublicSubjectID).orElse(null);
+
+        var event =
+                AuthCodeVerified.create(
+                        auditContext,
+                        publicSubjectId,
+                        ComponentId.AUTH,
+                        extensions,
+                        Clock.systemUTC());
+        structuredAuditService.submitAuditEvent(event);
     }
 
     void preserveReauthCountsForAuditIfJourneyIsReauth(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -7,6 +7,9 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.entity.ComponentId;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -51,6 +54,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
+import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -95,6 +99,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private final MFAMethodsService mfaMethodsService;
     private final UserActionsManager userActionsManager;
     private final TestUserHelper testUserHelper;
+    private final StructuredAuditService structuredAuditService;
 
     public VerifyMfaCodeHandler(
             ConfigurationService configurationService,
@@ -107,7 +112,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             AuthSessionService authSessionService,
             MFAMethodsService mfaMethodsService,
             UserActionsManager userActionsManager,
-            TestUserHelper testUserHelper) {
+            TestUserHelper testUserHelper,
+            StructuredAuditService structuredAuditService) {
         super(
                 VerifyMfaCodeRequest.class,
                 configurationService,
@@ -121,6 +127,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.mfaMethodsService = mfaMethodsService;
         this.userActionsManager = userActionsManager;
         this.testUserHelper = testUserHelper;
+        this.structuredAuditService = structuredAuditService;
     }
 
     public VerifyMfaCodeHandler() {
@@ -146,6 +153,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     public VerifyMfaCodeHandler(
@@ -168,6 +176,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.userActionsManager = new UserActionsManager(configurationService);
+        this.structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     @Override
@@ -393,7 +402,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
             auditFailure(codeRequest, errorResponse, authSession, auditContext, activeMfaMethod);
         } else {
-            auditSuccess(codeRequest, authSession, auditContext, activeMfaMethod);
+            auditSuccess(codeRequest, auditContext, activeMfaMethod, userProfile);
 
             processSuccessfulCodeSession(
                     userContext.getAuthSession(),
@@ -431,16 +440,45 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     private void auditSuccess(
             VerifyMfaCodeRequest codeRequest,
-            AuthSessionItem authSession,
             AuditContext auditContext,
-            Optional<MFAMethod> activeMfaMethod) {
-        var metadataPairs =
-                metadataPairsForEvent(
-                        AUTH_CODE_VERIFIED,
-                        authSession.getEmailAddress(),
-                        codeRequest,
-                        activeMfaMethod);
-        auditService.submitAuditEvent(AUTH_CODE_VERIFIED, auditContext, metadataPairs);
+            Optional<MFAMethod> activeMfaMethod,
+            UserProfile userProfile) {
+        var methodType = codeRequest.getMfaMethodType();
+        var journeyType = codeRequest.getJourneyType();
+
+        String notificationType = null;
+        if (MFAMethodType.SMS.getValue().equals(methodType.getValue())) {
+            notificationType =
+                    getNotificationTypeFromJourney(codeRequest)
+                            .map(Enum::name)
+                            .orElse(AuditService.UNKNOWN);
+        }
+
+        String mfaMethod =
+                getPriorityIdentifier(codeRequest, activeMfaMethod)
+                        .map(id -> id.name().toLowerCase())
+                        .orElse(null);
+
+        var extensions =
+                new AuthCodeVerified.Extensions(
+                        notificationType,
+                        null,
+                        journeyType == JourneyType.ACCOUNT_RECOVERY,
+                        String.valueOf(journeyType),
+                        codeRequest.getCode(),
+                        methodType.getValue(),
+                        mfaMethod);
+
+        var publicSubjectId = userProfile != null ? userProfile.getPublicSubjectID() : null;
+
+        var event =
+                AuthCodeVerified.create(
+                        auditContext,
+                        publicSubjectId,
+                        ComponentId.AUTH,
+                        extensions,
+                        Clock.systemUTC());
+        structuredAuditService.submitAuditEvent(event);
     }
 
     private void auditFailure(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -59,7 +59,8 @@ public class PasskeyAssertionService {
     public Result<FinishPasskeyAssertionFailureReason, AssertionResult> finishAssertion(
             String assertionRequestJson,
             String publicKeyCredentialJson,
-            AuditContext auditContext) {
+            AuditContext auditContext,
+            String publicSubjectId) {
         PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
                 credential;
         try {
@@ -104,7 +105,7 @@ public class PasskeyAssertionService {
         }
 
         emitAuthPasskeyVerificationSuccessEvent(
-                auditContext, assertionRequest, assertionResult, credential);
+                auditContext, assertionRequest, assertionResult, credential, publicSubjectId);
 
         return Result.success(assertionResult);
     }
@@ -166,7 +167,8 @@ public class PasskeyAssertionService {
             AssertionRequest assertionRequest,
             AssertionResult assertionResult,
             PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
-                    publicKeyCredential) {
+                    publicKeyCredential,
+            String publicSubjectId) {
         var passkeyDetail =
                 PasskeyDetail.verificationSuccessful(
                         userVerificationStringFrom(assertionRequest),
@@ -180,6 +182,7 @@ public class PasskeyAssertionService {
                         passkeyAllowedCredentialsFrom(assertionRequest),
                         passkeyDetail,
                         publicKeyCredential.getId().getBase64Url(),
+                        publicSubjectId,
                         Clock.systemUTC());
         structuredAuditService.submitAuditEvent(event);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -79,7 +79,7 @@ class FinishPasskeyAssertionHandlerTest {
         void shouldReturn200WhenPasskeyAssertionSuccessful() {
             // Given
             AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(Result.success(mockAssertionResult));
 
             // When
@@ -93,7 +93,7 @@ class FinishPasskeyAssertionHandlerTest {
         void shouldReportCorrectPasskeyReceivedWhenAssertionSuccessful() {
             // Given
             AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(Result.success(mockAssertionResult));
 
             // When
@@ -108,7 +108,7 @@ class FinishPasskeyAssertionHandlerTest {
         void shouldEmitCloudwatchMetricsWhenAssertionSuccessful() {
             // Given
             AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(Result.success(mockAssertionResult));
 
             // When
@@ -149,7 +149,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReportIncorrectPasskeyReceivedWhenAssertionUnsuccessful() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR));
@@ -165,7 +165,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReturn500WhenAssertionRequestDeserializationFails() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason
@@ -182,7 +182,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReturn400WhenPKCDeserializationFails() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(
                             Result.failure(FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR));
 
@@ -197,7 +197,7 @@ class FinishPasskeyAssertionHandlerTest {
         @Test
         void shouldReturn401WhenPasskeyAssertionFailed() {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR));
@@ -215,7 +215,7 @@ class FinishPasskeyAssertionHandlerTest {
         void shouldEmitVerificationFailureMetricWhenAssertionFailsForAnyReason(
                 FinishPasskeyAssertionFailureReason failureReason) {
             // Given
-            when(passkeyAssertionService.finishAssertion(any(), any(), any()))
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(Result.failure(failureReason));
 
             // When

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -17,6 +17,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaResetType;
 import uk.gov.di.authentication.frontendapi.entity.ReauthFailureReasons;
@@ -65,6 +67,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -153,6 +156,8 @@ class VerifyCodeHandlerTest {
                     .withRpSectorIdentifierHost(CLIENT_SECTOR_HOST);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final DynamoAccountModifiersService accountModifiersService =
@@ -208,7 +213,8 @@ class VerifyCodeHandlerTest {
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
-                        testUserHelper);
+                        testUserHelper,
+                        structuredAuditService);
 
         when(authenticationService.getUserProfileFromEmail(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -277,19 +283,21 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService).deleteOtpCode(EMAIL, emailNotificationType);
         verifyNoInteractions(accountModifiersService);
         verify(authSessionService).updateSession(any(AuthSessionItem.class));
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT,
-                        pair("notification-type", emailNotificationType.name()),
-                        pair(
-                                "account-recovery",
-                                emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)),
-                        pair(
-                                "journey-type",
-                                emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
-                                        ? "ACCOUNT_RECOVERY"
-                                        : "REGISTRATION"));
+
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        emailNotificationType.name(),
+                        null,
+                        emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES),
+                        emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
+                                ? "ACCOUNT_RECOVERY"
+                                : "REGISTRATION",
+                        null,
+                        null,
+                        null);
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
         Arrays.stream(CountType.values())
                 .forEach(
                         countType ->
@@ -315,19 +323,20 @@ class VerifyCodeHandlerTest {
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN),
-                        pair("notification-type", emailNotificationType.name()),
-                        pair(
-                                "account-recovery",
-                                emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)),
-                        pair(
-                                "journey-type",
-                                emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
-                                        ? "ACCOUNT_RECOVERY"
-                                        : "REGISTRATION"));
+
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        emailNotificationType.name(),
+                        null,
+                        emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES),
+                        emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
+                                ? "ACCOUNT_RECOVERY"
+                                : "REGISTRATION",
+                        null,
+                        null,
+                        null);
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
     }
 
     @ParameterizedTest
@@ -409,13 +418,12 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verifyNoInteractions(accountModifiersService);
         verify(codeStorageService).deleteOtpCode(email, VERIFY_EMAIL);
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT_FOR_TEST_CLIENT.withEmail(email),
-                        pair("notification-type", VERIFY_EMAIL.name()),
-                        pair("account-recovery", false),
-                        pair("journey-type", "REGISTRATION"));
+
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        VERIFY_EMAIL.name(), null, false, "REGISTRATION", null, null, null);
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
     }
 
     @ParameterizedTest
@@ -444,13 +452,11 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verifyNoInteractions(accountModifiersService);
         verify(codeStorageService).deleteOtpCode(email, VERIFY_EMAIL);
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT_FOR_TEST_CLIENT.withEmail(email),
-                        pair("notification-type", VERIFY_EMAIL.name()),
-                        pair("account-recovery", false),
-                        pair("journey-type", "REGISTRATION"));
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        VERIFY_EMAIL.name(), null, false, "REGISTRATION", null, null, null);
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
         verifyNoInteractions(authenticationAttemptsService);
     }
 
@@ -607,19 +613,19 @@ class VerifyCodeHandlerTest {
         verify(authSessionService, atLeastOnce())
                 .updateSession(
                         argThat(s -> s.getAchievedCredentialStrength().equals(MEDIUM_LEVEL)));
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT,
-                        pair("mfa-method", "default"),
-                        pair("notification-type", MFA_SMS.name()),
-                        pair("account-recovery", false),
-                        pair(
-                                "journey-type",
-                                journeyType != null ? String.valueOf(journeyType) : "SIGN_IN"),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", MAX_RETRIES - 1),
-                        pair("MFACodeEntered", "123456"));
+
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        MFA_SMS.name(),
+                        MAX_RETRIES - 1,
+                        false,
+                        journeyType != null ? String.valueOf(journeyType) : "SIGN_IN",
+                        CODE,
+                        MFAMethodType.SMS.getValue(),
+                        "default");
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.AUTH_ACCOUNT_RECOVERY_BLOCK_REMOVED,
@@ -664,17 +670,18 @@ class VerifyCodeHandlerTest {
         assertThat(authSession.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         verify(codeStorageService)
                 .deleteOtpCode(EMAIL.concat(BACKUP_SMS_METHOD.getDestination()), MFA_SMS);
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT,
-                        pair("mfa-method", "backup"),
-                        pair("notification-type", MFA_SMS.name()),
-                        pair("account-recovery", false),
-                        pair("journey-type", "SIGN_IN"),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", MAX_RETRIES - 1),
-                        pair("MFACodeEntered", "123456"));
+
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        MFA_SMS.name(),
+                        MAX_RETRIES - 1,
+                        false,
+                        "SIGN_IN",
+                        CODE,
+                        MFAMethodType.SMS.getValue(),
+                        "backup");
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
     }
 
     @Test
@@ -697,17 +704,19 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService)
                 .deleteOtpCode(EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS);
         verify(accountModifiersService, never()).removeAccountRecoveryBlockIfPresent(anyString());
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                        AUDIT_CONTEXT,
-                        pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
-                        pair("notification-type", MFA_SMS.name()),
-                        pair("account-recovery", false),
-                        pair("journey-type", "SIGN_IN"),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()),
-                        pair("loginFailureCount", MAX_RETRIES - 1),
-                        pair("MFACodeEntered", "123456"));
+
+        var expectedExtensions =
+                new AuthCodeVerified.Extensions(
+                        MFA_SMS.name(),
+                        MAX_RETRIES - 1,
+                        false,
+                        "SIGN_IN",
+                        CODE,
+                        MFAMethodType.SMS.getValue(),
+                        "default");
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccessWithMfa(
                         AuthSessionItem.AccountState.EXISTING,
@@ -1306,5 +1315,11 @@ class VerifyCodeHandlerTest {
                                     MFA_RESET_TYPE.getValue(),
                                     MfaResetType.FORCED_INTERNATIONAL_NUMBERS.toString()));
         }
+    }
+
+    private AuthCodeVerified captureAuthCodeVerifiedEvent() {
+        var argCaptor = ArgumentCaptor.forClass(AuthCodeVerified.class);
+        verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+        return argCaptor.getValue();
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -16,6 +16,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthCodeVerified;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -84,12 +86,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_METHOD;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_RESET_TYPE;
-import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_PHONE_NUMBER_COUNTRY_CODE;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -169,6 +168,8 @@ class VerifyMfaCodeHandlerTest {
     private final UserProfile userProfile = mock(UserProfile.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
     private final AuthenticationAttemptsService authenticationAttemptsService =
@@ -223,7 +224,8 @@ class VerifyMfaCodeHandlerTest {
                         authSessionService,
                         mfaMethodsService,
                         userActionsManager,
-                        testUserHelper);
+                        testUserHelper,
+                        structuredAuditService);
     }
 
     @AfterEach
@@ -262,13 +264,18 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", false),
-                    pair("journey-type", REGISTRATION),
-                    pair("MFACodeEntered", CODE),
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            null,
+                            null,
+                            false,
+                            String.valueOf(REGISTRATION),
+                            CODE,
+                            MFAMethodType.AUTH_APP.getValue(),
+                            "default");
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
             verify(cloudwatchMetricsService)
                     .incrementAuthenticationSuccessWithMfa(
                             AuthSessionItem.AccountState.NEW,
@@ -298,15 +305,7 @@ class VerifyMfaCodeHandlerTest {
             var result = handler.handleRequest(event, context);
 
             assertThat(result, hasStatus(204));
-            verify(auditService)
-                    .submitAuditEvent(
-                            FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                            AUDIT_CONTEXT.withTxmaAuditEncoded(AuditService.UNKNOWN),
-                            pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                            pair("account-recovery", false),
-                            pair("journey-type", REGISTRATION),
-                            pair("MFACodeEntered", CODE),
-                            pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"));
+            verify(structuredAuditService).submitAuditEvent(any(AuthCodeVerified.class));
         }
 
         @Test
@@ -339,13 +338,18 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", false),
-                    pair("journey-type", JourneyType.PASSWORD_RESET_MFA),
-                    pair("MFACodeEntered", CODE),
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            null,
+                            null,
+                            false,
+                            String.valueOf(JourneyType.PASSWORD_RESET_MFA),
+                            CODE,
+                            MFAMethodType.AUTH_APP.getValue(),
+                            "default");
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
             verify(cloudwatchMetricsService)
                     .incrementAuthenticationSuccessWithMfa(
                             AuthSessionItem.AccountState.EXISTING,
@@ -384,14 +388,18 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", false),
-                    pair("journey-type", REGISTRATION),
-                    pair("MFACodeEntered", CODE),
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
-                    pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, VERIFY_PHONE_NUMBER.name()));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            VERIFY_PHONE_NUMBER.name(),
+                            null,
+                            false,
+                            String.valueOf(REGISTRATION),
+                            CODE,
+                            MFAMethodType.SMS.getValue(),
+                            "default");
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
             verify(cloudwatchMetricsService)
                     .incrementAuthenticationSuccessWithMfa(
                             AuthSessionItem.AccountState.NEW,
@@ -428,13 +436,18 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", true),
-                    pair("journey-type", JourneyType.ACCOUNT_RECOVERY),
-                    pair("MFACodeEntered", CODE),
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            null,
+                            null,
+                            true,
+                            String.valueOf(JourneyType.ACCOUNT_RECOVERY),
+                            CODE,
+                            MFAMethodType.AUTH_APP.getValue(),
+                            "default");
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
             verify(cloudwatchMetricsService)
                     .incrementAuthenticationSuccessWithMfa(
                             AuthSessionItem.AccountState.EXISTING,
@@ -490,14 +503,18 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
 
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                    pair("mfa-type", MFAMethodType.SMS.getValue()),
-                    pair("account-recovery", isAccountRecovery),
-                    pair("journey-type", journeyType),
-                    pair("MFACodeEntered", CODE),
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
-                    pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, notificationType));
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            notificationType,
+                            null,
+                            isAccountRecovery,
+                            String.valueOf(journeyType),
+                            CODE,
+                            MFAMethodType.SMS.getValue(),
+                            "default");
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
             verify(cloudwatchMetricsService)
                     .incrementAuthenticationSuccessWithMfa(
                             AuthSessionItem.AccountState.EXISTING,
@@ -557,13 +574,19 @@ class VerifyMfaCodeHandlerTest {
             verify(codeStorageService, never())
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
-            assertAuditEventSubmittedWithMetadata(
-                    FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                    pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
-                    pair("account-recovery", false),
-                    pair("journey-type", journeyType),
-                    pair("MFACodeEntered", CODE),
-                    pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, expectedMethodPriority));
+
+            var expectedExtensions =
+                    new AuthCodeVerified.Extensions(
+                            null,
+                            null,
+                            false,
+                            String.valueOf(journeyType),
+                            CODE,
+                            MFAMethodType.AUTH_APP.getValue(),
+                            expectedMethodPriority);
+            var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+            assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
+
             verify(cloudwatchMetricsService)
                     .incrementAuthenticationSuccessWithMfa(
                             AuthSessionItem.AccountState.EXISTING,
@@ -1560,14 +1583,15 @@ class VerifyMfaCodeHandlerTest {
 
         boolean isAccountRecoveryJourney = journeyType.equals(ACCOUNT_RECOVERY);
 
-        assertAuditEventSubmittedWithMetadata(
-                FrontendAuditableEvent.AUTH_CODE_VERIFIED,
-                pair(AUDIT_EVENT_EXTENSIONS_MFA_TYPE, MFAMethodType.SMS.getValue()),
-                pair(AUDIT_EVENT_EXTENSIONS_ACCOUNT_RECOVERY, isAccountRecoveryJourney),
-                pair(AUDIT_EVENT_EXTENSIONS_JOURNEY_TYPE, journeyType),
-                pair(AUDIT_EVENT_EXTENSIONS_MFA_CODE_ENTERED, CODE),
-                pair(AUDIT_EVENT_EXTENSIONS_MFA_METHOD, "default"),
-                pair(AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE, expectedNotificationType));
+        var authCodeVerifiedEvent = captureAuthCodeVerifiedEvent();
+        assertEquals(MFAMethodType.SMS.getValue(), authCodeVerifiedEvent.extensions().mfaType());
+        assertEquals(
+                isAccountRecoveryJourney, authCodeVerifiedEvent.extensions().accountRecovery());
+        assertEquals(String.valueOf(journeyType), authCodeVerifiedEvent.extensions().journeyType());
+        assertEquals(CODE, authCodeVerifiedEvent.extensions().mfaCodeEntered());
+        assertEquals("default", authCodeVerifiedEvent.extensions().mfaMethod());
+        assertEquals(
+                expectedNotificationType, authCodeVerifiedEvent.extensions().notificationType());
     }
 
     @Test
@@ -1615,5 +1639,11 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verify(userActionsManager)
                 .correctAuthAppOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
+    }
+
+    private AuthCodeVerified captureAuthCodeVerifiedEvent() {
+        var argCaptor = ArgumentCaptor.forClass(AuthCodeVerified.class);
+        verify(structuredAuditService).submitAuditEvent(argCaptor.capture());
+        return argCaptor.getValue();
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -58,6 +58,7 @@ class PasskeyAssertionServiceTest {
     private static final String VERIFICATION_FAILED_EVENT_NAME = "AUTH_PASSKEY_VERIFICATION_FAILED";
     private static final AuditContext AUDIT_CONTEXT =
             AuditContext.emptyAuditContext().withEmail(EMAIL);
+    private static final String TEST_PUBLIC_SUBJECT_ID = PUBLIC_SUBJECT_ID;
 
     @BeforeEach
     void setup() {
@@ -120,7 +121,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 AssertionResult actualAssertionResult =
-                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getSuccess();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                                .getSuccess();
 
                 // Then
                 assertEquals(actualAssertionResult, mockAssertionResult);
@@ -149,7 +152,9 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenReturn(assertionResult);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getSuccess();
+                passkeyAssertionService
+                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                        .getSuccess();
 
                 // Then
                 var argCaptor = ArgumentCaptor.forClass(StructuredAuditEvent.class);
@@ -195,7 +200,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -215,7 +222,9 @@ class PasskeyAssertionServiceTest {
                         .thenThrow(JsonProcessingException.class);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                passkeyAssertionService
+                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                        .getFailure();
 
                 // Then
                 var expectedPasskeyDetail =
@@ -236,7 +245,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -252,7 +263,9 @@ class PasskeyAssertionServiceTest {
                 when(jsonParser.parsePublicKeyCredential(any())).thenThrow(IOException.class);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                passkeyAssertionService
+                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                        .getFailure();
 
                 // Then
                 var expectedPasskeyDetail =
@@ -276,7 +289,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -300,7 +315,9 @@ class PasskeyAssertionServiceTest {
                 when(relyingParty.finishAssertion(any())).thenThrow(AssertionFailedException.class);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                passkeyAssertionService
+                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                        .getFailure();
 
                 // Then
                 var expectedFailureReason =
@@ -336,7 +353,9 @@ class PasskeyAssertionServiceTest {
 
                 // When
                 FinishPasskeyAssertionFailureReason actualFailureReason =
-                        passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                        passkeyAssertionService
+                                .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                                .getFailure();
 
                 // Then
                 assertEquals(
@@ -369,7 +388,9 @@ class PasskeyAssertionServiceTest {
                 when(jsonParser.parsePublicKeyCredential(any())).thenReturn(publicKeyCredential);
 
                 // When
-                passkeyAssertionService.finishAssertion("", "", AUDIT_CONTEXT).getFailure();
+                passkeyAssertionService
+                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
+                        .getFailure();
 
                 // Then
                 var expectedPasskeyDetail =


### PR DESCRIPTION
## What

* Migrated `AUTH_CODE_VERIFIED` and `AUTH_TOKEN_SENT_TO_ORCHESTRATION` to the `StructuredAuditService` to prevent unpopulated fields from serialising as `null` in TxMA JSON payloads.
* Added `user.email` and `user.public_subject_id` to these events, and to `AUTH_PASSKEY_VERIFICATION_SUCCESSFUL`, to provide richer downstream audit logging for use by the home team for inactive account deletions.
* Fixed invalid test assertion on `AUTH_CODE_VERIFIED` emission - see 96c6a2f90eb64f68c15d50ec563526c3447dc561 description

## How to review

1. Code review - suggested commit-by-commit
1. Optionally, deploy to a dev environment and trigger authentication, MFA, and passkey journeys to verify the emitted audit events in the TxMA queues.
    - Note that i have tested this below

## Testing

### VerifyCodeHandler
Verified structured audit event payload during email/SMS code verification.

Identified by `notification-type: VERIFY_EMAIL` and `journey-type: REGISTRATION` as only `VerifyCodeHandler` handles email OTP verification during registration.

<details>
<summary>AUTH_CODE_VERIFIED Test Event</summary>

```json
{
  "event_name": "AUTH_CODE_VERIFIED",
  "timestamp":REDACTED,
  "event_timestamp_ms":REDACTED,
  "client_id": "REDACTED",
  "component_id": "AUTH",
  "user": {
    "email": "REDACTED",
    "govuk_signin_journey_id": "REDACTED",
    "ip_address": "REDACTED",
    "persistent_session_id": "REDACTED",
    "session_id": "REDACTED"
  },
  "restricted": {
    "device_information": {
      "encoded": "REDACTED"
    }
  },
  "extensions": {
    "notification-type": "VERIFY_EMAIL",
    "account-recovery": false,
    "journey-type": "REGISTRATION"
  }
}
```

</details>

### VerifyMfaCodeHandler
Verified structured audit event payload during MFA code verification.

Identified by `mfa-type: AUTH_APP` as only `VerifyMfaCodeHandler` handles auth app TOTP verification. `VerifyCodeHandler` never processes auth app codes.

<details>
<summary>AUTH_CODE_VERIFIED Test Event</summary>

```json
{
  "timestamp":REDACTED,
  "event_timestamp_ms":REDACTED,
  "event_name": "AUTH_CODE_VERIFIED",
  "client_id": "REDACTED",
  "component_id": "AUTH",
  "user": {
    "user_id": "urn:fdc:gov.uk:2022:REDACTED",
    "email": "REDACTED",
    "phone": "",
    "ip_address": "REDACTED",
    "session_id": "REDACTED",
    "persistent_session_id": "REDACTED",
    "govuk_signin_journey_id": "REDACTED"
  },
  "restricted": {
    "device_information": {
      "encoded": "REDACTED"
    }
  },
  "extensions": {
    "account-recovery": false,
    "journey-type": "SIGN_IN",
    "MFACodeEntered": "REDACTED",
    "mfa-type": "AUTH_APP",
    "mfa-method": "default"
  }
}
```

</details>

### TokenHandler
Verified `AUTH_TOKEN_SENT_TO_ORCHESTRATION` payload includes the user's email and public subject ID.

<details>
<summary>AUTH_TOKEN_SENT_TO_ORCHESTRATION Test Event</summary>

```json
{
  "event_name": "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
  "timestamp":REDACTED,
  "event_timestamp_ms":REDACTED,
  "client_id": "REDACTED",
  "component_id": "AUTH",
  "user": {
    "user_id": "urn:fdc:gov.uk:2022:REDACTED",
    "email": "REDACTED",
    "public_subject_id": "REDACTED"
  }
}
```

</details>

### MFAMethodsCreateHandler
Verified audit event generation and structured payload mapping during MFA method creation.

Identified by `component_id: HOME`, `mfa-method: backup`, and `journey-type: ACCOUNT_MANAGEMENT` as only `MFAMethodsCreateHandler` emits `AUTH_CODE_VERIFIED` for backup method creation.

<details>
<summary>AUTH_CODE_VERIFIED Test Event</summary>

```json
{
  "event_name": "AUTH_CODE_VERIFIED",
  "timestamp": "REDACTED",
  "event_timestamp_ms": "REDACTED",
  "client_id": "",
  "component_id": "HOME",
  "user": {
    "email": "REDACTED",
    "govuk_signin_journey_id": "REDACTED",
    "ip_address": "REDACTED",
    "persistent_session_id": "REDACTED",
    "session_id": "REDACTED",
    "user_id": "urn:fdc:gov.uk:2022:REDACTED",
    "public_subject_id": "REDACTED"
  },
  "restricted": {
    "device_information": {
      "encoded": "REDACTED"
    }
  },
  "extensions": {
    "account-recovery": "false",
    "journey-type": "ACCOUNT_MANAGEMENT",
    "mfa-type": "AUTH_APP",
    "mfa-method": "backup"
  }
}
```

</details>

### MFAMethodsPutHandler
Verified audit event generation and structured payload mapping during MFA method updates.

Identified by `component_id: HOME`, `mfa-method: default`, and `journey-type: ACCOUNT_MANAGEMENT` as only `MFAMethodsPutHandler` emits `AUTH_CODE_VERIFIED` for default method updates.

<details>
<summary>AUTH_CODE_VERIFIED Test Event</summary>

```json
{
  "event_name": "AUTH_CODE_VERIFIED",
  "timestamp": "REDACTED",
  "event_timestamp_ms": "REDACTED",
  "client_id": "",
  "component_id": "HOME",
  "user": {
    "email": "REDACTED",
    "govuk_signin_journey_id": "REDACTED",
    "ip_address": "REDACTED",
    "persistent_session_id": "REDACTED",
    "session_id": "REDACTED",
    "user_id": "urn:fdc:gov.uk:2022:REDACTED",
    "public_subject_id": "REDACTED"
  },
  "restricted": {
    "device_information": {
      "encoded": "REDACTED"
    }
  },
  "extensions": {
    "account-recovery": "false",
    "journey-type": "ACCOUNT_MANAGEMENT",
    "mfa-type": "AUTH_APP",
    "mfa-method": "default"
  }
}
```

</details>

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A: Changes only affect backend audit event generation and do not alter active user session structures or journey logic.**
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] No changes required or changes have been made to stub-orchestration. **- N/A.**
- [ ] A UCD review has been performed. **- N/A.**
