### PR TITLE
ATO-2700: Add records to be migrated

### DIFF
--- a/ci/stack-orchestration/integration-migrated-records.json
+++ b/ci/stack-orchestration/integration-migrated-records.json
@@ -1,0 +1,18 @@
+{
+  "Comment": "Importing records from old hosted zone",
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "_d273aa4a1c12c8ba616d6298da83d1fa.oidc.integration.account.gov.uk.",
+        "Type": "CNAME",
+        "TTL": 60,
+        "ResourceRecords": [
+          {
+            "Value": "_235f69b7f975db48f7eea5d43724c68a.snmnbsbtgy.acm-validations.aws."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/ci/stack-orchestration/production-migrated-records.json
+++ b/ci/stack-orchestration/production-migrated-records.json
@@ -1,0 +1,18 @@
+{
+  "Comment": "Importing records from old hosted zone",
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "_ec07f09329c6edb637c173f61b8dd45f.oidc.account.gov.uk.",
+        "Type": "CNAME",
+        "TTL": 60,
+        "ResourceRecords": [
+          {
+            "Value": "_2955e7860640816d252b5cf34a0d03d3.snmnbsbtgy.acm-validations.aws."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/ci/stack-orchestration/staging-migrated-records.json
+++ b/ci/stack-orchestration/staging-migrated-records.json
@@ -1,0 +1,18 @@
+{
+  "Comment": "Importing records from old hosted zone",
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "_13b6ab079152a15639fc90ac07ea8d95.oidc.staging.account.gov.uk.",
+        "Type": "CNAME",
+        "TTL": 60,
+        "ResourceRecords": [
+          {
+            "Value": "_1984a5aa27f4aab499604df64358758e.mntkzmhvxg.acm-validations.aws."
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Wider context of change

As part of migrating our hosted zone, there are some records we will need to manually migrate that will not be managed in IaC. As part of getting ready for the migration we can store these in our source code

### What’s changed
- Adds manually migrated record files for staging, int and prod


### Manual testing

- N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
