### PR TITLE
Aut 5503: Remove authentication attempts feature flag

### DIFF
--- a/ci/cloudformation/auth/function/check-reauth-user.yaml
+++ b/ci/cloudformation/auth/function/check-reauth-user.yaml
@@ -11,7 +11,6 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler::handleRequest
       Environment:
         Variables:
-          AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
             - DataStoreAccountId:

--- a/ci/cloudformation/auth/function/login.yaml
+++ b/ci/cloudformation/auth/function/login.yaml
@@ -39,7 +39,6 @@ Resources:
               passwordRehashOnLoginEnabled,
               DefaultValue: "false",
             ]
-          AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           DYNAMO_ARN_PREFIX: !Sub
             - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
             - DataStoreAccountId:

--- a/ci/cloudformation/auth/function/start.yaml
+++ b/ci/cloudformation/auth/function/start.yaml
@@ -50,7 +50,6 @@ Resources:
             - "https://identity.account.gov.uk"
           REDIS_KEY: "session"
           TXMA_AUDIT_QUEUE_URL: !GetAtt AuthInternalApiTxMAAuditQueue.QueueUrl
-          AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           AUTH_SESSION_USE_STRONGLY_CONSISTENT_READS:
             !FindInMap [
               EnvironmentConfiguration,

--- a/ci/cloudformation/auth/function/verify-code.yaml
+++ b/ci/cloudformation/auth/function/verify-code.yaml
@@ -11,7 +11,6 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest
       Environment:
         Variables:
-          AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           CODE_MAX_RETRIES_INCREASED: !Sub
             - "{{resolve:ssm:/deploy/${env}/code_max_retries_increased}}"
             - env:

--- a/ci/cloudformation/auth/function/verify-mfa-code.yaml
+++ b/ci/cloudformation/auth/function/verify-mfa-code.yaml
@@ -11,7 +11,6 @@ Resources:
       Handler: uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest
       Environment:
         Variables:
-          AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED: "true"
           CODE_MAX_RETRIES_INCREASED: !Sub
             - "{{resolve:ssm:/deploy/${env}/code_max_retries_increased}}"
             - env:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -249,7 +249,7 @@ public class StartHandler
             }
 
             boolean isBlockedForReauth = false;
-            if (configurationService.isAuthenticationAttemptsServiceEnabled() && reauthenticate) {
+            if (reauthenticate) {
                 var permissionContext =
                         buildPermissionContext(authSession, startRequest, userContext);
                 var permissionResult =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -377,17 +377,15 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             AuditContext auditContext,
             Optional<MFAMethod> maybeRequestedSmsMfaMethod) {
         if (journeyType == REAUTHENTICATION && notificationType == MFA_SMS) {
-            if (configurationService.isAuthenticationAttemptsServiceEnabled()) {
-                authenticationAttemptsService.createOrIncrementCount(
-                        subjectId,
-                        NowHelper.nowPlus(
-                                        configurationService.getReauthEnterSMSCodeCountTTL(),
-                                        ChronoUnit.SECONDS)
-                                .toInstant()
-                                .getEpochSecond(),
-                        REAUTHENTICATION,
-                        CountType.ENTER_MFA_CODE);
-            }
+            authenticationAttemptsService.createOrIncrementCount(
+                    subjectId,
+                    NowHelper.nowPlus(
+                                    configurationService.getReauthEnterSMSCodeCountTTL(),
+                                    ChronoUnit.SECONDS)
+                            .toInstant()
+                            .getEpochSecond(),
+                    REAUTHENTICATION,
+                    CountType.ENTER_MFA_CODE);
         } else {
             processBlockedCodeSession(
                     errorResponse,
@@ -404,8 +402,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             String subjectId,
             AuditContext auditContext,
             Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
+        if (journeyType == REAUTHENTICATION) {
             var countsByJourney =
                     maybeRpPairwiseId.isEmpty()
                             ? authenticationAttemptsService.getCountsByJourney(
@@ -559,7 +556,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             : null);
         }
 
-        if (configurationService.isAuthenticationAttemptsServiceEnabled() && subjectId != null) {
+        if (subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
                     journeyType, subjectId, authSession, maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
@@ -587,8 +584,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             String subjectId,
             AuthSessionItem authSession,
             Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
+        if (journeyType == REAUTHENTICATION) {
             var counts =
                     maybeRpPairwiseId.isPresent()
                             ? authenticationAttemptsService

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -249,9 +249,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             UserProfile userProfile,
             AuditContext auditContext,
             Optional<String> maybeRpPairwiseId) {
-        if (configurationService.isAuthenticationAttemptsServiceEnabled()
-                && REAUTHENTICATION.equals(journeyType)
-                && userProfile != null) {
+        if (REAUTHENTICATION.equals(journeyType) && userProfile != null) {
             var counts =
                     maybeRpPairwiseId.isEmpty()
                             ? authenticationAttemptsService.getCountsByJourney(
@@ -381,9 +379,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         codeRequest.getJourneyType());
             }
 
-            if (isInvalidReauthAuthAppAttempt(errorResponse, codeRequest)
-                    && configurationService.isAuthenticationAttemptsServiceEnabled()
-                    && subjectId != null) {
+            if (isInvalidReauthAuthAppAttempt(errorResponse, codeRequest) && subjectId != null) {
                 authenticationAttemptsService.createOrIncrementCount(
                         subjectId,
                         NowHelper.nowPlus(
@@ -553,9 +549,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             Optional<String> maybeRpPairwiseId,
             UserProfile userProfile) {
 
-        if (configurationService.isAuthenticationAttemptsServiceEnabled()
-                && codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP
-                && subjectId != null) {
+        if (codeRequest.getMfaMethodType() == MFAMethodType.AUTH_APP && subjectId != null) {
             preserveReauthCountsForAuditIfJourneyIsReauth(
                     codeRequest.getJourneyType(), subjectId, authSession, maybeRpPairwiseId);
             clearReauthErrorCountsForSuccessfullyAuthenticatedUser(subjectId);
@@ -615,8 +609,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             String subjectId,
             AuthSessionItem authSession,
             Optional<String> maybeRpPairwiseId) {
-        if (journeyType == REAUTHENTICATION
-                && configurationService.isAuthenticationAttemptsServiceEnabled()) {
+        if (journeyType == REAUTHENTICATION) {
             var counts =
                     maybeRpPairwiseId.isPresent()
                             ? authenticationAttemptsService

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -55,7 +55,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandler.REAUTHENTICATE_HEADER;
@@ -219,28 +218,6 @@ class StartHandlerTest {
     }
 
     @Test
-    void shouldNotCallAuthenticationAttemptsServiceWhenFeatureFlagIsOff()
-            throws Json.JsonException {
-        var isAuthenticated = false;
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(false);
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
-
-        // This should not be called. Setup here is to ensure that the feature flag is determining
-        // this test's behaviour
-        when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
-                        any(), any(), any()))
-                .thenReturn(Map.of(CountType.ENTER_PASSWORD, 100));
-
-        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
-        useValidSession();
-        var body = makeRequestBody(null, null, TEST_RP_PAIRWISE_ID, isAuthenticated);
-        var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
-        handler.handleRequest(event, context);
-
-        verifyNoInteractions(authenticationAttemptsService);
-    }
-
-    @Test
     void checkAuditEventStillEmittedWhenTICFHeaderNotProvided() throws Json.JsonException {
         var isAuthenticated = false;
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
@@ -392,7 +369,6 @@ class StartHandlerTest {
             throws Json.JsonException {
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
         when(userProfile.getSubjectID()).thenReturn(TEST_SUBJECT_ID);
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
@@ -616,7 +592,6 @@ class StartHandlerTest {
     void shouldHandleReauthWithBlockedCountTypesButNoSubjectId() throws Json.JsonException {
         var userStartInfo = new UserStartInfo(false, false, false, null, null, null, true, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
 
         // Mock session with no internal subject ID
         when(authSessionService.getUpdatedPreviousSessionOrCreateNew(any(), any()))
@@ -795,7 +770,6 @@ class StartHandlerTest {
     void shouldHandleNullFailureReasonInCloudwatchMetrics() throws Json.JsonException {
         var userStartInfo = new UserStartInfo(false, false, true, null, null, null, true, false);
         usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
         when(userProfile.getSubjectID()).thenReturn(TEST_SUBJECT_ID);
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
@@ -825,29 +799,6 @@ class StartHandlerTest {
         // Should handle null failure reason and use "unknown"
         verify(cloudwatchMetricsService)
                 .incrementCounter(eq(CloudwatchMetrics.REAUTH_FAILED.getValue()), any(Map.class));
-    }
-
-    @Test
-    void shouldHandleReauthWhenAttemptsServiceDisabled() throws Json.JsonException {
-        var userStartInfo = new UserStartInfo(false, false, false, null, null, null, false, false);
-        usingStartServiceThatReturns(userContext, getClientStartInfo(), userStartInfo);
-        when(configurationService.isAuthenticationAttemptsServiceEnabled())
-                .thenReturn(false); // Disabled
-        useValidSession();
-
-        var body = makeRequestBody(null, null, TEST_RP_PAIRWISE_ID, false);
-        var event = apiRequestEventWithHeadersAndBody(headersWithReauthenticate("true"), body);
-        var result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(200));
-        // Should not call authentication attempts service when disabled
-        verifyNoInteractions(authenticationAttemptsService);
-        // Should still emit reauth requested event
-        verify(auditService)
-                .submitAuditEvent(
-                        eq(FrontendAuditableEvent.AUTH_REAUTH_REQUESTED),
-                        any(),
-                        any(AuditService.MetadataPair[].class));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -74,6 +74,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -189,6 +190,8 @@ class VerifyCodeHandlerTest {
         assertThat(
                 logging.events(),
                 not(hasItem(withMessageContaining(CLIENT_ID, TEST_CLIENT_CODE, SESSION_ID))));
+
+        reset(authenticationAttemptsService);
     }
 
     @BeforeEach
@@ -287,7 +290,11 @@ class VerifyCodeHandlerTest {
                                 emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                                         ? "ACCOUNT_RECOVERY"
                                         : "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
+        Arrays.stream(CountType.values())
+                .forEach(
+                        countType ->
+                                verify(authenticationAttemptsService)
+                                        .deleteCount(TEST_SUBJECT_ID, REAUTHENTICATION, countType));
     }
 
     @ParameterizedTest
@@ -321,7 +328,6 @@ class VerifyCodeHandlerTest {
                                 emailNotificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                                         ? "ACCOUNT_RECOVERY"
                                         : "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -410,7 +416,6 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_EMAIL.name()),
                         pair("account-recovery", false),
                         pair("journey-type", "REGISTRATION"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @ParameterizedTest
@@ -516,7 +521,6 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.TOO_MANY_INVALID_MFA_OTPS_ENTERED));
         verifyNoInteractions(accountModifiersService);
         verifyNoInteractions(auditService);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     // TODO remove temporary ZDD measure to reference existing deprecated keys when expired
@@ -632,7 +636,6 @@ class VerifyCodeHandlerTest {
                         journeyType != null ? journeyType : JourneyType.SIGN_IN,
                         MFAMethodType.SMS,
                         PriorityIdentifier.DEFAULT);
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -672,7 +675,6 @@ class VerifyCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
                         pair("loginFailureCount", MAX_RETRIES - 1),
                         pair("MFACodeEntered", "123456"));
-        verifyNoInteractions(authenticationAttemptsService);
     }
 
     @Test
@@ -686,7 +688,6 @@ class VerifyCodeHandlerTest {
                 .thenReturn(false);
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        withReauthTurnedOn();
         authSession.setIsNewAccount(AuthSessionItem.AccountState.EXISTING);
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -735,7 +736,6 @@ class VerifyCodeHandlerTest {
                 .thenReturn(MAX_RETRIES - 1);
         when(accountModifiersService.isAccountRecoveryBlockPresent(INTERNAL_COMMON_SUBJECT_ID))
                 .thenReturn(false);
-        withReauthTurnedOn();
 
         var result = makeCallWithCode(CODE, MFA_SMS.toString());
 
@@ -796,7 +796,6 @@ class VerifyCodeHandlerTest {
     @MethodSource("codeRequestTypes")
     void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenSignInExceedMaxRetryCount(
             CodeRequestType codeRequestType, JourneyType journeyType) {
-        withReauthTurnedOn();
         when(configurationService.getLockoutDuration()).thenReturn(LOCKOUT_DURATION);
         when(codeStorageService.getOtpCode(
                         EMAIL.concat(DEFAULT_SMS_METHOD.getDestination()), MFA_SMS))
@@ -978,7 +977,6 @@ class VerifyCodeHandlerTest {
                 .thenReturn(Optional.of(CODE));
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
-        withReauthTurnedOn();
         var existingCounts = Map.of(ENTER_EMAIL, 5, ENTER_PASSWORD, 1);
         when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                         any(), any(), eq(REAUTHENTICATION)))
@@ -1021,7 +1019,6 @@ class VerifyCodeHandlerTest {
     @Test
     void shouldIncrementEnterMFAAuthenticationAttemptCountOnFailedReauthenticationAttempt() {
         long ttl = 120L;
-        withReauthTurnedOn();
         when(mfaMethodsService.getMfaMethods(EMAIL))
                 .thenReturn(Result.success(List.of(DEFAULT_SMS_METHOD)));
         when(configurationService.getReauthEnterSMSCodeCountTTL()).thenReturn(ttl);
@@ -1072,7 +1069,6 @@ class VerifyCodeHandlerTest {
             String expectedFailureReason) {
         try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
                 Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            withReauthTurnedOn();
             when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                             any(), any(), eq(REAUTHENTICATION)))
                     .thenReturn(Map.of(countType, MAX_RETRIES));
@@ -1209,10 +1205,6 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
         verify(userActionsManager)
                 .correctSmsOtpReceived(any(), argThat(pc -> pc.authSessionItem() != null));
-    }
-
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
     }
 
     @Nested

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -905,7 +905,6 @@ class VerifyMfaCodeHandlerTest {
         void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
                 JourneyType journeyType, CodeRequestType codeRequestType)
                 throws Json.JsonException {
-            withReauthTurnedOn();
             when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                     .thenReturn(Optional.of(authAppCodeProcessor));
             when(authAppCodeProcessor.validateCode())
@@ -998,7 +997,6 @@ class VerifyMfaCodeHandlerTest {
             verify(codeStorageService, never())
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
             assertAuditEventSubmittedWithMetadata(
                     FrontendAuditableEvent.AUTH_CODE_MAX_RETRIES_REACHED,
                     pair("mfa-type", MFAMethodType.AUTH_APP.getValue()),
@@ -1046,7 +1044,6 @@ class VerifyMfaCodeHandlerTest {
                     .saveBlockedForEmail(EMAIL, CODE_BLOCKED_KEY_PREFIX, 900L);
             verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(EMAIL);
             verifyNoInteractions(cloudwatchMetricsService);
-            verifyNoInteractions(authenticationAttemptsService);
 
             ArgumentCaptor<AuditService.MetadataPair[]> metadataCaptor =
                     ArgumentCaptor.forClass(AuditService.MetadataPair[].class);
@@ -1088,7 +1085,6 @@ class VerifyMfaCodeHandlerTest {
         void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
                 JourneyType journeyType, CodeRequestType codeRequestType)
                 throws Json.JsonException {
-            withReauthTurnedOn();
             when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                     .thenReturn(Optional.of(phoneNumberCodeProcessor));
             when(phoneNumberCodeProcessor.validateCode())
@@ -1311,7 +1307,6 @@ class VerifyMfaCodeHandlerTest {
         long ttl = 3600L;
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
         when(authAppCodeProcessor.validateCode())
                 .thenReturn(Optional.of(ErrorResponse.INVALID_AUTH_APP_CODE_ENTERED));
         when(configurationService.getReauthEnterAuthAppCodeCountTTL()).thenReturn(ttl);
@@ -1337,7 +1332,6 @@ class VerifyMfaCodeHandlerTest {
                     throws Json.JsonException {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
 
         var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
@@ -1376,7 +1370,6 @@ class VerifyMfaCodeHandlerTest {
                     throws Json.JsonException {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
-        withReauthTurnedOn();
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.empty());
 
         var existingCounts = Map.of(CountType.ENTER_PASSWORD, 5, ENTER_MFA_CODE, 4);
@@ -1433,7 +1426,6 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         try (MockedStatic<ClientSubjectHelper> mockedClientSubjectHelperClass =
                 Mockito.mockStatic(ClientSubjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
-            when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
             when(authenticationAttemptsService.getCountsByJourneyForSubjectIdAndRpPairwiseId(
                             any(), any(), eq(REAUTHENTICATION)))
                     .thenReturn(Map.of(countType, MAX_RETRIES));
@@ -1486,10 +1478,6 @@ class VerifyMfaCodeHandlerTest {
     private void assertAuditEventSubmittedWithMetadata(
             AuditableEvent event, AuditService.MetadataPair... pairs) {
         verify(auditService).submitAuditEvent(event, AUDIT_CONTEXT, pairs);
-    }
-
-    private void withReauthTurnedOn() {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -150,7 +150,6 @@ class StartServiceTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void shouldCreateUserStartInfoWithCorrectReauthBlockedValue(boolean isBlockedForReauth) {
-        when(configurationService.isAuthenticationAttemptsServiceEnabled()).thenReturn(true);
         var maxRetries = 6;
         when(configurationService.getMaxPasswordRetries()).thenReturn(maxRetries);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -83,28 +83,13 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
     public static final String ENCODED_DEVICE_INFORMATION =
             "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
 
-    private static final IntegrationTestConfigurationService CONFIGURATION_SERVICE =
-            new IntegrationTestConfigurationService(
-                    notificationsQueue, tokenSigner, configurationParameters) {
-
-                @Override
-                public String getTxmaAuditQueueUrl() {
-                    return txmaAuditQueue.getQueueUrl();
-                }
-
-                @Override
-                public boolean isAuthenticationAttemptsServiceEnabled() {
-                    return true;
-                }
-            };
-
     @BeforeEach
     void setup() throws Json.JsonException {
         authSessionExtension.addSession(SESSION_ID);
         authSessionExtension.addEmailToSession(SESSION_ID, TEST_EMAIL);
         authSessionExtension.addClientIdToSession(SESSION_ID, CLIENT_ID.getValue());
         requestHeaders = createHeaders(SESSION_ID);
-        handler = new CheckReAuthUserHandler(CONFIGURATION_SERVICE);
+        handler = new CheckReAuthUserHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -864,11 +864,6 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
             }
 
             @Override
-            public boolean isAuthenticationAttemptsServiceEnabled() {
-                return true;
-            }
-
-            @Override
             public boolean isForcedMFAResetAfterMFACheckEnabled() {
                 return true;
             }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -1571,11 +1571,6 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             }
 
             @Override
-            public boolean isAuthenticationAttemptsServiceEnabled() {
-                return true;
-            }
-
-            @Override
             public boolean isForcedMFAResetAfterMFACheckEnabled() {
                 return true;
             }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -178,11 +178,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
                         public String getTxmaAuditQueueUrl() {
                             return txmaAuditQueue.getQueueUrl();
                         }
-
-                        @Override
-                        public boolean isAuthenticationAttemptsServiceEnabled() {
-                            return true;
-                        }
                     };
 
     protected static final ConfigurationService EMAIL_CHECK_AND_TXMA_ENABLED_CONFIGURATION_SERVICE =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -785,12 +785,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals(FEATURE_SWITCH_ON);
     }
 
-    public boolean isAuthenticationAttemptsServiceEnabled() {
-        return System.getenv()
-                .getOrDefault("AUTHENTICATION_ATTEMPTS_SERVICE_ENABLED", FEATURE_SWITCH_OFF)
-                .equals(FEATURE_SWITCH_ON);
-    }
-
     public boolean isBulkUserEmailEmailSendingEnabled() {
         return System.getenv()
                 .getOrDefault("BULK_USER_EMAIL_EMAIL_SENDING_ENABLED", FEATURE_SWITCH_OFF)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -559,11 +559,6 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void isAuthenticationAttemptsServiceEnabledShouldEqualDefaultWhenEnvVarUnset() {
-        assertFalse(configurationService.isAuthenticationAttemptsServiceEnabled());
-    }
-
-    @Test
     void getAccountManagementNotifyDestinations() {
         assertNull(configurationService.getAccountManagementNotifyBucketDestination());
     }


### PR DESCRIPTION
This feature flag was introduced to support the switchover from storing counts for reauth journeys from redis to dynamo.

The feature flag has been on in all environments for a long time, and we do not intend to switch it off (in fact, some of the code in the permissions manager already assumes it's on and no longer reads from the featur flag).

Therefore, we can remove the feature flag from and retain the 'on' behaviour in all cases.

## How to review


* Commit by commit, verifying that the behaviour retained is the same as feature flag = on