### PR TITLE
AUT-5625: Set timeout in assertion options to 1 hour

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -37,6 +37,7 @@ public class PasskeyAssertionService {
     private final PasskeyJsonParser jsonParser;
     private static final Logger LOG = LogManager.getLogger(PasskeyAssertionService.class);
     private final StructuredAuditService structuredAuditService;
+    private static final Long ONE_HOUR_IN_MILLISECONDS = 3_600_000L;
 
     public PasskeyAssertionService(
             RelyingParty relyingParty,
@@ -53,6 +54,7 @@ public class PasskeyAssertionService {
                 StartAssertionOptions.builder()
                         .userHandle(Optional.of(userHandle))
                         .userVerification(UserVerificationRequirement.REQUIRED)
+                        .timeout(ONE_HOUR_IN_MILLISECONDS)
                         .build());
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -77,6 +77,7 @@ class PasskeyAssertionServiceTest {
             @Test
             void shouldReturnAssertionRequestIfRelyingPartyStartAssertionSucceeds() {
                 // Given
+                final Long ONE_HOUR_IN_MILLISECONDS = 3_600_000L;
                 var mockAssertionRequest = mock(AssertionRequest.class);
                 when(relyingParty.startAssertion(any())).thenReturn(mockAssertionRequest);
 
@@ -88,6 +89,7 @@ class PasskeyAssertionServiceTest {
                                                         PUBLIC_SUBJECT_ID.getBytes(
                                                                 StandardCharsets.UTF_8))))
                                 .userVerification(UserVerificationRequirement.REQUIRED)
+                                .timeout(ONE_HOUR_IN_MILLISECONDS)
                                 .build();
 
                 // When


### PR DESCRIPTION
## What

Sets the `timeout` field in the `PublicKeyCredentialRequestOptions` to 1 hour. This allows the native popup to remain open for longer, rather than leaving it up to the browser/SimpleWebAuthnBrowser to decide.

https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#timeout

## How to review

1. Code Review
2. Deploy to an env and ensure the popup stays open for a while
    Test across different browsers, because they set different timeouts (source https://satragno.com/blog/webauthn-timeout/)
    * Chrome - 20 hours
    * Safari - 2 minutes
    * Firefox - 30 seconds