### PR TITLE
ATO-2213: Remove leftover keys

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -66,14 +66,6 @@ public class JwksHandler
 
             signingKeys.add(jwksService.getPublicDocAppSigningJwkWithOpaqueId());
 
-            if (configurationService.isPublishOldExternalTokenSigningKeysEnabled()) {
-                signingKeys.add(jwksService.getPublicTokenJwkWithOpaqueId());
-
-                if (configurationService.isRsaSigningAvailable()) {
-                    signingKeys.add(jwksService.getPublicTokenRsaJwkWithOpaqueId());
-                }
-            }
-
             signingKeys.add(jwksService.getNextPublicTokenJwkWithOpaqueIdV2());
 
             if (configurationService.isRsaSigningAvailable()) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
@@ -97,28 +97,6 @@ class JwksHandlerTest {
         assertThat(response, hasHeader("Cache-Control", "max-age=86400"));
     }
 
-    @Test
-    void shouldPublishOldEcKeyWhenOldPublishEnabled() throws JOSEException {
-        when(configurationService.isPublishOldExternalTokenSigningKeysEnabled()).thenReturn(true);
-
-        var tokenSigningKey = generateECKey();
-        var docAppSigningKey = generateECKey();
-        var newTokenSigningKeyV2 = generateECKey();
-
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
-        when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
-        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newTokenSigningKeyV2);
-
-        var event = new APIGatewayProxyRequestEvent();
-        var result = handler.handleRequest(event, context);
-
-        var expectedJWKSet =
-                new JWKSet(List.of(docAppSigningKey, tokenSigningKey, newTokenSigningKeyV2));
-
-        assertThat(result, hasStatus(200));
-        assertThat(result, hasBody(expectedJWKSet.toString(true)));
-    }
-
     private static ECKey generateECKey() throws JOSEException {
         return new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
     }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/basetest/IntegrationTest.java
@@ -220,11 +220,6 @@ public class IntegrationTest {
         }
 
         @Override
-        public String getExternalTokenSigningKeyAlias() {
-            return externalTokenSigner.getKeyAlias();
-        }
-
-        @Override
         public String getNextExternalTokenSigningKeyAliasV2() {
             return externalTokenSigner.getNewKeyAliasV2();
         }

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/TokenSigningExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/TokenSigningExtension.java
@@ -35,8 +35,7 @@ public class TokenSigningExtension extends KmsKeyExtension {
     public void beforeAll(ExtensionContext context) {
         super.beforeAll(context);
         kmsConnectionService =
-                new KmsConnectionService(
-                        Optional.of(LOCALSTACK_ENDPOINT), REGION, getKeyId(), getNewKeyIdV2());
+                new KmsConnectionService(Optional.of(LOCALSTACK_ENDPOINT), REGION, getNewKeyIdV2());
     }
 
     public SignedJWT signJwt(JWTClaimsSet claimsSet) {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -385,10 +385,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("TEST_CLIENTS_ENABLED");
     }
 
-    public String getExternalTokenSigningKeyAlias() {
-        return System.getenv("EXTERNAL_TOKEN_SIGNING_KEY_ALIAS");
-    }
-
     public String getExternalTokenSigningKeyRsaAlias() {
         return System.getenv("EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -385,10 +385,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("TEST_CLIENTS_ENABLED");
     }
 
-    public String getExternalTokenSigningKeyRsaAlias() {
-        return System.getenv("EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS");
-    }
-
     public String getNextExternalTokenSigningKeyAliasV2() {
         return System.getenv("NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -405,10 +405,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("STORED_OLD_ID_TOKEN_EC_PUBLIC_KEYS");
     }
 
-    public boolean isPublishOldExternalTokenSigningKeysEnabled() {
-        return getFlagOrFalse("PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS");
-    }
-
     public boolean isRsaSigningAvailable() {
         return List.of("dev", "build", "staging", "integration", "production")
                 .contains(getEnvironment());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -410,10 +410,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .contains(getEnvironment());
     }
 
-    public boolean isUseStoredOldIdTokenPublicKeysEnabled() {
-        return getFlagOrFalse("USE_STORED_OLD_ID_TOKEN_PUBLIC_KEYS");
-    }
-
     public boolean isSingleFactorAccountDeletionEnabled() {
         return getFlagOrFalse("SINGLE_FACTOR_ACCOUNT_DELETION_ENABLED");
     }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -46,11 +46,6 @@ public class JwksService {
         this.kmsConnectionService = kmsConnectionService;
     }
 
-    public JWK getPublicTokenJwkWithOpaqueId() {
-        LOG.info("Retrieving EC public key");
-        return getPublicJWKWithKeyId(configurationService.getExternalTokenSigningKeyAlias());
-    }
-
     public JWK getPublicTokenRsaJwkWithOpaqueId() {
         LOG.info("Retrieving RSA public key");
         return getPublicJWKWithKeyId(configurationService.getExternalTokenSigningKeyRsaAlias());

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -46,11 +46,6 @@ public class JwksService {
         this.kmsConnectionService = kmsConnectionService;
     }
 
-    public JWK getPublicTokenRsaJwkWithOpaqueId() {
-        LOG.info("Retrieving RSA public key");
-        return getPublicJWKWithKeyId(configurationService.getExternalTokenSigningKeyRsaAlias());
-    }
-
     public ArrayList<ECKey> getStoredOldPublicTokenJwksWithOpaqueId() {
         try {
             LOG.info("Retrieving stored EC public key");

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/KmsConnectionService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/KmsConnectionService.java
@@ -22,14 +22,12 @@ public class KmsConnectionService {
         this(
                 configurationService.getLocalstackEndpointUri(),
                 configurationService.getAwsRegion(),
-                configurationService.getExternalTokenSigningKeyAlias(),
                 configurationService.getNextExternalTokenSigningKeyAliasV2());
     }
 
     public KmsConnectionService(
             Optional<String> localstackEndpointUri,
             String awsRegion,
-            String tokenSigningKeyId,
             String newTokenSigningKeyIdV2) {
         if (localstackEndpointUri.isPresent()) {
             LOG.info("Localstack endpoint URI is present: {}", localstackEndpointUri.get());
@@ -45,9 +43,6 @@ public class KmsConnectionService {
                             .region(Region.of(awsRegion))
                             .credentialsProvider(DefaultCredentialsProvider.builder().build())
                             .build();
-        }
-        if (tokenSigningKeyId != null) {
-            warmUp(tokenSigningKeyId);
         }
         if (newTokenSigningKeyIdV2 != null) {
             warmUp(newTokenSigningKeyIdV2);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
@@ -106,21 +106,12 @@ public class TokenValidationService {
     }
 
     private boolean validateWithOldECPublicKey(SignedJWT jwt) throws JOSEException {
-        if (configuration.isUseStoredOldIdTokenPublicKeysEnabled()
-                || !configuration.isPublishOldExternalTokenSigningKeysEnabled()) {
-            var oldStoredPublicKeys = jwksService.getStoredOldPublicTokenJwksWithOpaqueId();
-            Optional<ECKey> optionalPublicKey =
-                    oldStoredPublicKeys.stream()
-                            .filter(
-                                    key ->
-                                            Objects.equals(
-                                                    jwt.getHeader().getKeyID(), key.getKeyID()))
-                            .findFirst();
-            return optionalPublicKey.isPresent()
-                    && jwt.verify(new ECDSAVerifier(optionalPublicKey.get()));
-        } else {
-            var oldPublicKey = jwksService.getPublicTokenJwkWithOpaqueId();
-            return jwt.verify(new ECDSAVerifier(oldPublicKey.toECKey()));
-        }
+        var oldStoredPublicKeys = jwksService.getStoredOldPublicTokenJwksWithOpaqueId();
+        Optional<ECKey> optionalPublicKey =
+                oldStoredPublicKeys.stream()
+                        .filter(key -> Objects.equals(jwt.getHeader().getKeyID(), key.getKeyID()))
+                        .findFirst();
+        return optionalPublicKey.isPresent()
+                && jwt.verify(new ECDSAVerifier(optionalPublicKey.get()));
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
@@ -47,15 +47,15 @@ class JwksServiceTest {
     }
 
     @Test
-    void shouldRetrievePublicTokenSigningRsaKeyFromKmsAndParseToJwk() throws Exception {
-        var keyAlias = "25252525252525";
-        when(configurationService.getExternalTokenSigningKeyRsaAlias()).thenReturn(keyAlias);
+    void shouldRetrieveExternalTokenSigningRSAKeyFromKmsAndParseToJwk() throws Exception {
+        var keyAlias = "test-external-token-signing-key-rsa-alias";
+        when(configurationService.getNextExternalTokenSigningKeyRsaAliasV2()).thenReturn(keyAlias);
 
         var publicKey = generateRsaKey().toPublicKey().getEncoded();
         mockKmsPublicKeyResponse(
                 publicKey, SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256, keyAlias);
 
-        JWK publicKeyJwk = jwksService.getPublicTokenRsaJwkWithOpaqueId();
+        JWK publicKeyJwk = jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2();
 
         assertThat(publicKeyJwk.getKeyID(), equalTo(hashSha256String(keyAlias)));
         assertThat(publicKeyJwk.getAlgorithm(), equalTo(JWSAlgorithm.RS256));

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/JwksServiceTest.java
@@ -32,14 +32,14 @@ class JwksServiceTest {
             new JwksService(configurationService, kmsConnectionService);
 
     @Test
-    void shouldRetrievePublicTokenSigningKeyFromKmsAndParseToJwk() throws Exception {
-        var keyAlias = "14342354354353";
-        when(configurationService.getExternalTokenSigningKeyAlias()).thenReturn(keyAlias);
+    void shouldRetrieveExternalTokenSigningECKeyFromKmsAndParseToJwk() throws Exception {
+        var keyAlias = "test-external-token-signing-key-alias";
+        when(configurationService.getNextExternalTokenSigningKeyAliasV2()).thenReturn(keyAlias);
 
         var publicKey = generateECKey().toPublicKey().getEncoded();
         mockKmsPublicKeyResponse(publicKey, keyAlias);
 
-        JWK publicKeyJwk = jwksService.getPublicTokenJwkWithOpaqueId();
+        JWK publicKeyJwk = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
 
         assertThat(publicKeyJwk.getKeyID(), equalTo(hashSha256String(keyAlias)));
         assertThat(publicKeyJwk.getAlgorithm(), equalTo(JWSAlgorithm.ES256));

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenServiceTest.java
@@ -152,7 +152,6 @@ class TokenServiceTest {
 
     @Test
     void shouldGenerateTokenResponseWithRefreshToken() throws ParseException, JOSEException {
-        when(configurationService.getExternalTokenSigningKeyAlias()).thenReturn(KEY_ID);
         createSignedIdToken();
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();
@@ -215,7 +214,6 @@ class TokenServiceTest {
         var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
 
-        when(configurationService.getExternalTokenSigningKeyAlias()).thenReturn(KEY_ID);
         createSignedIdToken();
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();
@@ -274,7 +272,6 @@ class TokenServiceTest {
     @Test
     void shouldGenerateTokenResponseWithoutRefreshTokenWhenOfflineAccessScopeIsMissing()
             throws ParseException, JOSEException {
-        when(configurationService.getExternalTokenSigningKeyAlias()).thenReturn(KEY_ID);
         when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
         createSignedIdToken();
         createSignedAccessToken();
@@ -302,7 +299,6 @@ class TokenServiceTest {
 
     @Test
     void shouldNotIncludeInternalIdentifiersInTokens() throws ParseException, JOSEException {
-        when(configurationService.getExternalTokenSigningKeyAlias()).thenReturn(KEY_ID);
         when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
         createSignedIdToken();
         createSignedAccessToken();

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
@@ -95,12 +95,10 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldSuccessfullyValidateNewV2RsaSignedAccessToken() throws JOSEException {
-        var rsaKey = generateCustomRsaKeyPair(KEY_ID);
         var newRSAKey = generateCustomRsaKeyPair(NEW_V2_KEY_ID);
         var newRSASigner = new RSASSASigner(newRSAKey);
 
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
         when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2()).thenReturn(newRSAKey);
 
         SignedJWT signedAccessToken = createCustomSignedAccessToken(newRSASigner, NEW_V2_KEY_ID);
@@ -112,12 +110,10 @@ class TokenValidationServiceTest {
     @Test
     void shouldFailToValidateRsaKeyAccessTokenIfKeyIdInvalid() throws JOSEException {
         var wrongRSAKey = generateCustomRsaKeyPair(FAILED_KEY_ID);
-        var rsaKey = generateCustomRsaKeyPair(KEY_ID);
         var newRSAKey = generateCustomRsaKeyPair(NEW_V2_KEY_ID);
         var rsaSigner = new RSASSASigner(wrongRSAKey);
 
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
-        when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
         when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2()).thenReturn(newRSAKey);
 
         SignedJWT signedAccessToken = createCustomSignedAccessToken(rsaSigner, FAILED_KEY_ID);

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
@@ -168,30 +168,12 @@ class TokenValidationServiceTest {
         }
 
         @Test
-        void
-                shouldSuccessfullyValidateOldStoredECKeyReauthIDTokenWhenKeyIdMatchesAndStoredKeyEnabled() {
+        void shouldSuccessfullyValidateOldStoredECKeyReauthIDTokenWhenKeyIdMatches() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
 
             when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
                     .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
-            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(true);
-
-            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, oldStoredECKey);
-            assertTrue(
-                    tokenValidationService.isReauthTokenSignatureValid(
-                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
-        }
-
-        @Test
-        void
-                shouldSuccessfullyValidateOldStoredECKeyReauthIDTokenWhenKeyIdMatchesAndStoredKeyDisabledAndOldKeyIsNotPublished() {
-            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-            var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
-
-            when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
-                    .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
-            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(false);
 
             SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, oldStoredECKey);
             assertTrue(
@@ -207,7 +189,6 @@ class TokenValidationServiceTest {
 
             when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
                     .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
-            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(true);
 
             SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, failedECKey);
             assertFalse(
@@ -220,7 +201,6 @@ class TokenValidationServiceTest {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
             when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
                     .thenReturn(new ArrayList<>());
-            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(true);
 
             SignedJWT signedIdToken = createSignedIdToken(expiryDate);
             assertFalse(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
@@ -52,7 +52,8 @@ class TokenValidationServiceTest {
     @BeforeEach
     void setUp() throws JOSEException {
         ecJWK = generateECKeyPair();
-        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(ecJWK.toPublicJWK());
+        when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
+                .thenReturn(new ArrayList<>(List.of(ecJWK.toECKey())));
 
         newV2ECJWK = generateCustomECKeyPair(NEW_V2_KEY_ID);
         newV2Signer = new ECDSASigner(newV2ECJWK);
@@ -131,9 +132,6 @@ class TokenValidationServiceTest {
         void shouldSuccessfullyValidateReauthIDToken() {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
 
-            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
-                    .thenReturn(true);
-
             SignedJWT signedIdToken = createSignedIdToken(expiryDate);
             assertTrue(
                     tokenValidationService.isReauthTokenSignatureValid(signedIdToken.serialize()));
@@ -142,9 +140,6 @@ class TokenValidationServiceTest {
         @Test
         void shouldNotFailSignatureValidationIfReauthIDTokenHasExpired() {
             Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
-
-            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
-                    .thenReturn(true);
 
             SignedJWT signedIdToken = createSignedIdToken(expiryDate);
             assertTrue(
@@ -156,20 +151,6 @@ class TokenValidationServiceTest {
             Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
 
             SignedJWT signedIdToken = createSignedIdTokenWithV2Key(expiryDate);
-            assertTrue(
-                    tokenValidationService.isReauthTokenSignatureValid(
-                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
-        }
-
-        @Test
-        void
-                shouldSuccessfullyValidateReauthIDTokenWithOldKeyWhenKeyIdMatchesAndOldKeyIsPublished() {
-            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
-
-            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
-                    .thenReturn(true);
-
-            SignedJWT signedIdToken = createSignedIdToken(expiryDate);
             assertTrue(
                     tokenValidationService.isReauthTokenSignatureValid(
                             new BearerAccessToken(signedIdToken.serialize()).getValue()));
@@ -211,8 +192,6 @@ class TokenValidationServiceTest {
             when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
                     .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
             when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(false);
-            when(configurationService.isPublishOldExternalTokenSigningKeysEnabled())
-                    .thenReturn(false);
 
             SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, oldStoredECKey);
             assertTrue(

--- a/template.yaml
+++ b/template.yaml
@@ -167,7 +167,6 @@ Mappings:
       newauthAccountId: "975050272416"
       authEnvironment: authdev3
       serviceDomain: authdev3.dev.account.gov.uk
-      idTokenKeyArn: arn:aws:kms:eu-west-2:653994557586:key/853e9af8-2f07-439d-97da-c72fa5b238e9
       idTokenKeyRsaArn: arn:aws:kms:eu-west-2:653994557586:key/17e5e566-4e99-43b4-ad59-e1ef924a582b
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:653994557586:authdev3-back-channel-logout-queue
       docAppBackendUri: https://dcmaw-cri.build.stubs.account.gov.uk
@@ -205,7 +204,6 @@ Mappings:
       newauthAccountId: "058264536367"
       authEnvironment: build
       serviceDomain: build.account.gov.uk
-      idTokenKeyArn: arn:aws:kms:eu-west-2:761723964695:key/ca2e4723-7ae8-478d-8fa2-baad3f71f506
       idTokenKeyRsaArn: arn:aws:kms:eu-west-2:761723964695:key/0189356a-b80f-4f12-9f31-60f5b34a574f
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:761723964695:build-back-channel-logout-queue
       docAppBackendUri: https://dcmaw-cri.build.stubs.account.gov.uk
@@ -243,7 +241,6 @@ Mappings:
       newauthAccountId: "851725205974"
       authEnvironment: staging
       serviceDomain: staging.account.gov.uk
-      idTokenKeyArn: arn:aws:kms:eu-west-2:758531536632:key/11af3935-0304-4813-bc16-302ab942c75a
       idTokenKeyRsaArn: arn:aws:kms:eu-west-2:758531536632:key/1d506b73-c506-4cec-bc46-db0ac1a54149
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:758531536632:staging-back-channel-logout-queue
       docAppBackendUri: https://api-backend-api.review-b.staging.account.gov.uk
@@ -283,7 +280,6 @@ Mappings:
       newauthAccountId: "211125600642"
       authEnvironment: integration
       serviceDomain: integration.account.gov.uk
-      idTokenKeyArn: arn:aws:kms:eu-west-2:761723964695:key/44d26c18-f460-4d6f-b94c-3f356540a055
       idTokenKeyRsaArn: arn:aws:kms:eu-west-2:761723964695:key/6eadd5bf-8a7f-4062-88c4-7774f070df02
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:761723964695:integration-back-channel-logout-queue
       docAppBackendUri: https://api-backend-api.review-b.integration.account.gov.uk
@@ -321,7 +317,6 @@ Mappings:
       newauthAccountId: "211125303002"
       authEnvironment: production
       serviceDomain: account.gov.uk
-      idTokenKeyArn: arn:aws:kms:eu-west-2:172348255554:key/01c412c6-98de-48b2-9a6d-51f57e8c3d7a
       idTokenKeyRsaArn: arn:aws:kms:eu-west-2:172348255554:key/ce5d0a05-909c-449b-be82-87009f5bef9a
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:172348255554:production-back-channel-logout-queue
       docAppBackendUri: https://api-backend-api.review-b.account.gov.uk
@@ -1919,12 +1914,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
           OIDC_API_BASE_URL: !Sub
             - https://oidc.${ServiceDomain}/
             - ServiceDomain:
@@ -2320,12 +2309,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -2529,12 +2512,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -3390,12 +3367,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -4020,12 +3991,6 @@ Resources:
                   authEnvironment,
                 ]
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           STORED_OLD_ID_TOKEN_EC_PUBLIC_KEYS:
             !FindInMap [
@@ -4256,12 +4221,6 @@ Resources:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
           IDENTITY_ENABLED: true # Note that this sets whether the ipv api is turned on or not, it is not an indicator of whether a full identity journey can be completed
-          EXTERNAL_TOKEN_SIGNING_KEY_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyArn,
-            ]
           EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
             !FindInMap [
               EnvironmentConfiguration,
@@ -6962,17 +6921,6 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: AllowIdTokenSigningKms
-            Effect: Allow
-            Action:
-              - kms:Sign
-              - kms:GetPublicKey
-            Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  idTokenKeyArn,
-                ]
           - Sid: AllowNewIdTokenSigningKmsV2
             Effect: Allow
             Action:

--- a/template.yaml
+++ b/template.yaml
@@ -204,7 +204,6 @@ Mappings:
       newauthAccountId: "058264536367"
       authEnvironment: build
       serviceDomain: build.account.gov.uk
-      idTokenKeyRsaArn: arn:aws:kms:eu-west-2:761723964695:key/0189356a-b80f-4f12-9f31-60f5b34a574f
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:761723964695:build-back-channel-logout-queue
       docAppBackendUri: https://dcmaw-cri.build.stubs.account.gov.uk
       docAppDomain: https://dcmaw-cri.build.stubs.account.gov.uk
@@ -241,7 +240,6 @@ Mappings:
       newauthAccountId: "851725205974"
       authEnvironment: staging
       serviceDomain: staging.account.gov.uk
-      idTokenKeyRsaArn: arn:aws:kms:eu-west-2:758531536632:key/1d506b73-c506-4cec-bc46-db0ac1a54149
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:758531536632:staging-back-channel-logout-queue
       docAppBackendUri: https://api-backend-api.review-b.staging.account.gov.uk
       docAppDomain: https://api.review-b.staging.account.gov.uk
@@ -280,7 +278,6 @@ Mappings:
       newauthAccountId: "211125600642"
       authEnvironment: integration
       serviceDomain: integration.account.gov.uk
-      idTokenKeyRsaArn: arn:aws:kms:eu-west-2:761723964695:key/6eadd5bf-8a7f-4062-88c4-7774f070df02
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:761723964695:integration-back-channel-logout-queue
       docAppBackendUri: https://api-backend-api.review-b.integration.account.gov.uk
       docAppDomain: https://api.review-b.integration.account.gov.uk
@@ -317,7 +314,6 @@ Mappings:
       newauthAccountId: "211125303002"
       authEnvironment: production
       serviceDomain: account.gov.uk
-      idTokenKeyRsaArn: arn:aws:kms:eu-west-2:172348255554:key/ce5d0a05-909c-449b-be82-87009f5bef9a
       backchannelLogoutQueueArn: arn:aws:sqs:eu-west-2:172348255554:production-back-channel-logout-queue
       docAppBackendUri: https://api-backend-api.review-b.account.gov.uk
       docAppDomain: https://api.review-b.account.gov.uk
@@ -2309,12 +2305,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           OIDC_API_BASE_URL: !Sub
@@ -2512,12 +2502,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           OIDC_API_BASE_URL: !Sub
@@ -3367,12 +3351,6 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: false
@@ -4221,12 +4199,6 @@ Resources:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           ENVIRONMENT: !Sub ${Environment}
           IDENTITY_ENABLED: true # Note that this sets whether the ipv api is turned on or not, it is not an indicator of whether a full identity journey can be completed
-          EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              idTokenKeyRsaArn,
-            ]
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_ALIAS_V2: !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
           NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2: !Ref OrchExternalTokenRsaSigningKmsKeyAliasV2
           OIDC_API_BASE_URL: !Sub
@@ -6935,17 +6907,6 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: AllowIdTokenSigningKmsRsa
-            Effect: Allow
-            Action:
-              - kms:Sign
-              - kms:GetPublicKey
-            Resource:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  idTokenKeyRsaArn,
-                ]
           - Sid: AllowNewIdTokenSigningKmsV2
             Effect: Allow
             Action:

--- a/template.yaml
+++ b/template.yaml
@@ -104,14 +104,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  UseStoredOldIdTokenPublicKeys:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
 
   #region API Migration Feature Flags
   # Please keep separate from the other ones
@@ -4041,10 +4033,6 @@ Resources:
               !Ref Environment,
               oldIdTokenECPublicKeys,
             ]
-          USE_STORED_OLD_ID_TOKEN_PUBLIC_KEYS: !If
-            - UseStoredOldIdTokenPublicKeys
-            - true
-            - false
           IDENTITY_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}

--- a/template.yaml
+++ b/template.yaml
@@ -4045,7 +4045,6 @@ Resources:
             - UseStoredOldIdTokenPublicKeys
             - true
             - false
-          PUBLISH_OLD_EXTERNAL_TOKEN_SIGNING_KEYS: false
           IDENTITY_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}


### PR DESCRIPTION
### Wider context of change

We recently switched to using a new external token signing key, and moved the old keys into the template as a variable so we can still support verifying refresh tokens. We now no longer need the old external token signing keys, so we can safely remove them now.

### What’s changed

This PR removes the old external token signing keys, as well as the feature flags used during the migration process.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
