### PR TITLE
AUT-5651: Extend inactive account scan lambda to join on user-credentials table

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -24,6 +24,7 @@ Resources:
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
+        - !Ref DynamoCredentialReadAccessPolicy
         - !Ref CloudWatchLogsKmsAccessPolicy
       AutoPublishAlias: live
       LoggingConfig:

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
@@ -3,4 +3,4 @@ package uk.gov.di.authentication.utils.entity;
 import com.google.gson.annotations.Expose;
 
 public record InactiveAccountDataExportRequest(
-        @Expose Integer parallelism, @Expose Integer totalSegments) {}
+        @Expose Integer parallelism, @Expose Integer totalSegments, @Expose Integer maxRetries) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -1,0 +1,63 @@
+package uk.gov.di.authentication.utils.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InactiveAccountDataExportHelper {
+
+    private static final Logger LOG = LogManager.getLogger(InactiveAccountDataExportHelper.class);
+    private static final long BASE_BACKOFF_MS = 100;
+
+    private InactiveAccountDataExportHelper() {}
+
+    public static List<Map<String, AttributeValue>> buildCredentialKeys(
+            List<Map<String, AttributeValue>> userProfileItems) {
+        List<Map<String, AttributeValue>> keys = new ArrayList<>();
+
+        for (Map<String, AttributeValue> profileItem : userProfileItems) {
+            AttributeValue email = profileItem.get(UserCredentials.ATTRIBUTE_EMAIL);
+            if (email != null) {
+                keys.add(Map.of(UserCredentials.ATTRIBUTE_EMAIL, email));
+            }
+        }
+
+        return keys;
+    }
+
+    public static Map<String, KeysAndAttributes> extractUnprocessedKeys(
+            BatchGetItemResponse response, String tableName) {
+        Map<String, KeysAndAttributes> unprocessed = response.unprocessedKeys();
+        if (unprocessed == null || unprocessed.isEmpty()) {
+            return Map.of();
+        }
+
+        KeysAndAttributes keysAndAttrs = unprocessed.get(tableName);
+        if (keysAndAttrs == null || keysAndAttrs.keys().isEmpty()) {
+            return Map.of();
+        }
+
+        return new HashMap<>(unprocessed);
+    }
+
+    public static void backoff(int retryCount) {
+        try {
+            Thread.sleep(BASE_BACKOFF_MS * (1L << (retryCount - 1)));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.error("Backoff sleep interrupted during BatchGetItem retry");
+        }
+    }
+
+    public static long countMissingCredentials(int requestedCount, int returnedCount) {
+        return Math.max(0, requestedCount - returnedCount);
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -6,6 +6,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
@@ -14,6 +17,7 @@ import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportResponse;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
@@ -21,6 +25,10 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
 
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.backoff;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildCredentialKeys;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
 
 public class InactiveAccountDataExportHandler
         implements RequestHandler<
@@ -30,11 +38,14 @@ public class InactiveAccountDataExportHandler
     private static final String USER_PROFILE_TABLE = "user-profile";
     private static final String USER_CREDENTIALS_TABLE = "user-credentials";
     private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final int BATCH_GET_ITEM_MAX_SIZE = 100;
 
-    private static final String PROJECTION_EXPRESSION =
+    private static final String USER_PROFILE_PROJECTION_EXPRESSION =
             "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt";
-    private static final Map<String, String> EXPRESSION_ATTRIBUTE_NAMES =
+    private static final Map<String, String> USER_PROFILE_EXPRESSION_ATTRIBUTE_NAMES =
             Map.of("#ts", "timestamp");
+    private static final String USER_CREDENTIALS_PROJECTION_EXPRESSION =
+            "Email,Created,Updated,MigratedPassword";
 
     private final DynamoDbClient client;
     private final String userProfileTableName;
@@ -79,7 +90,9 @@ public class InactiveAccountDataExportHandler
         try {
             for (int segment = 0; segment < totalSegments; segment++) {
                 final int currentSegment = segment;
-                tasks.add(forkJoinPool.submit(() -> scanSegment(currentSegment, totalSegments)));
+                tasks.add(
+                        forkJoinPool.submit(
+                                () -> scanSegment(currentSegment, totalSegments, maxRetries)));
             }
 
             gracefulPoolShutdown(forkJoinPool);
@@ -103,9 +116,11 @@ public class InactiveAccountDataExportHandler
         }
     }
 
-    private SegmentResult scanSegment(int segment, int totalSegments) {
+    private SegmentResult scanSegment(int segment, int totalSegments, int maxRetries) {
         Map<String, AttributeValue> lastKey = null;
         long itemsScanned = 0;
+        long missingCredentialsCount = 0;
+        List<Map<String, AttributeValue>> currentBatch = new ArrayList<>();
 
         do {
             ScanRequest.Builder requestBuilder =
@@ -113,8 +128,8 @@ public class InactiveAccountDataExportHandler
                             .tableName(userProfileTableName)
                             .segment(segment)
                             .totalSegments(totalSegments)
-                            .projectionExpression(PROJECTION_EXPRESSION)
-                            .expressionAttributeNames(EXPRESSION_ATTRIBUTE_NAMES);
+                            .projectionExpression(USER_PROFILE_PROJECTION_EXPRESSION)
+                            .expressionAttributeNames(USER_PROFILE_EXPRESSION_ATTRIBUTE_NAMES);
 
             if (lastKey != null && !lastKey.isEmpty()) {
                 requestBuilder.exclusiveStartKey(lastKey);
@@ -132,14 +147,96 @@ public class InactiveAccountDataExportHandler
                 throw e;
             }
 
-            itemsScanned += response.items().size();
+            for (Map<String, AttributeValue> item : response.items()) {
+                itemsScanned++;
+                currentBatch.add(item);
+
+                if (currentBatch.size() >= BATCH_GET_ITEM_MAX_SIZE) {
+                    missingCredentialsCount += batchGetUserCredentials(currentBatch, maxRetries);
+                    currentBatch.clear();
+                }
+            }
 
             lastKey = response.lastEvaluatedKey();
         } while (lastKey != null && !lastKey.isEmpty());
 
-        LOG.info("Segment {} completed: {} items scanned", segment, itemsScanned);
+        if (!currentBatch.isEmpty()) {
+            missingCredentialsCount += batchGetUserCredentials(currentBatch, maxRetries);
+            currentBatch.clear();
+        }
 
-        return new SegmentResult(itemsScanned, 0);
+        LOG.info(
+                "Segment {} completed: {} items scanned, {} missing credentials",
+                segment,
+                itemsScanned,
+                missingCredentialsCount);
+
+        return new SegmentResult(itemsScanned, missingCredentialsCount);
+    }
+
+    private long batchGetUserCredentials(
+            List<Map<String, AttributeValue>> userProfileItems, int maxRetries) {
+        if (userProfileItems.isEmpty()) {
+            return 0;
+        }
+
+        List<Map<String, AttributeValue>> keys = buildCredentialKeys(userProfileItems);
+        if (keys.isEmpty()) {
+            return userProfileItems.size();
+        }
+
+        List<Map<String, AttributeValue>> results = fetchWithRetry(keys, maxRetries);
+
+        return countMissingCredentials(keys.size(), results.size());
+    }
+
+    private List<Map<String, AttributeValue>> fetchWithRetry(
+            List<Map<String, AttributeValue>> keys, int maxRetries) {
+        List<Map<String, AttributeValue>> allResults = new ArrayList<>();
+
+        Map<String, KeysAndAttributes> requestItems = new HashMap<>();
+        requestItems.put(
+                userCredentialsTableName,
+                KeysAndAttributes.builder()
+                        .keys(keys)
+                        .projectionExpression(USER_CREDENTIALS_PROJECTION_EXPRESSION)
+                        .build());
+
+        int retryCount = 0;
+
+        while (!requestItems.isEmpty()) {
+            BatchGetItemResponse response =
+                    client.batchGetItem(
+                            BatchGetItemRequest.builder().requestItems(requestItems).build());
+
+            List<Map<String, AttributeValue>> results =
+                    response.responses().get(userCredentialsTableName);
+            if (results != null) {
+                allResults.addAll(results);
+            }
+
+            requestItems = extractUnprocessedKeys(response, userCredentialsTableName);
+
+            if (!requestItems.isEmpty()) {
+                retryCount++;
+                int unprocessedCount = requestItems.get(userCredentialsTableName).keys().size();
+                if (retryCount > maxRetries) {
+                    LOG.error(
+                            "Failed to process {} keys after {} retries",
+                            unprocessedCount,
+                            maxRetries);
+                    break;
+                }
+                LOG.warn(
+                        "{} unprocessed keys (attempt {}/{})",
+                        unprocessedCount,
+                        retryCount,
+                        maxRetries);
+                backoff(retryCount);
+            }
+        }
+
+        return allResults;
     }
 
     private record SegmentResult(long itemsScanned, long missingCredentialsCount) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -28,6 +28,8 @@ public class InactiveAccountDataExportHandler
 
     private static final Logger LOG = LogManager.getLogger(InactiveAccountDataExportHandler.class);
     private static final String USER_PROFILE_TABLE = "user-profile";
+    private static final String USER_CREDENTIALS_TABLE = "user-credentials";
+    private static final int DEFAULT_MAX_RETRIES = 3;
 
     private static final String PROJECTION_EXPRESSION =
             "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt";
@@ -36,12 +38,15 @@ public class InactiveAccountDataExportHandler
 
     private final DynamoDbClient client;
     private final String userProfileTableName;
+    private final String userCredentialsTableName;
 
     public InactiveAccountDataExportHandler(
             ConfigurationService configurationService, DynamoDbClient client) {
         this.client = client;
         this.userProfileTableName =
                 TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService);
+        this.userCredentialsTableName =
+                TableNameHelper.getFullTableName(USER_CREDENTIALS_TABLE, configurationService);
     }
 
     public InactiveAccountDataExportHandler() {
@@ -60,11 +65,13 @@ public class InactiveAccountDataExportHandler
 
         int parallelism = request.parallelism();
         int totalSegments = request.totalSegments();
+        int maxRetries = request.maxRetries() != null ? request.maxRetries() : DEFAULT_MAX_RETRIES;
 
         LOG.info(
-                "Inactive account data export request: parallelism={}, totalSegments={}",
+                "Inactive account data export request: parallelism={}, totalSegments={}, maxRetries={}",
                 parallelism,
-                totalSegments);
+                totalSegments,
+                maxRetries);
 
         List<ForkJoinTask<Long>> tasks = new ArrayList<>();
         ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism);

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -73,7 +73,7 @@ public class InactiveAccountDataExportHandler
                 totalSegments,
                 maxRetries);
 
-        List<ForkJoinTask<Long>> tasks = new ArrayList<>();
+        List<ForkJoinTask<SegmentResult>> tasks = new ArrayList<>();
         ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism);
 
         try {
@@ -85,11 +85,17 @@ public class InactiveAccountDataExportHandler
             gracefulPoolShutdown(forkJoinPool);
 
             long totalItemsScanned = 0;
-            for (ForkJoinTask<Long> task : tasks) {
-                totalItemsScanned += task.join();
+            long totalMissingCredentials = 0;
+            for (ForkJoinTask<SegmentResult> task : tasks) {
+                SegmentResult result = task.join();
+                totalItemsScanned += result.itemsScanned();
+                totalMissingCredentials += result.missingCredentialsCount();
             }
 
-            LOG.info("Scan completed: {} total items scanned", totalItemsScanned);
+            LOG.info(
+                    "Scan completed: {} total items scanned, {} missing credentials",
+                    totalItemsScanned,
+                    totalMissingCredentials);
 
             return new InactiveAccountDataExportResponse(totalItemsScanned);
         } finally {
@@ -97,7 +103,7 @@ public class InactiveAccountDataExportHandler
         }
     }
 
-    private long scanSegment(int segment, int totalSegments) {
+    private SegmentResult scanSegment(int segment, int totalSegments) {
         Map<String, AttributeValue> lastKey = null;
         long itemsScanned = 0;
 
@@ -114,7 +120,17 @@ public class InactiveAccountDataExportHandler
                 requestBuilder.exclusiveStartKey(lastKey);
             }
 
-            ScanResponse response = client.scan(requestBuilder.build());
+            ScanResponse response;
+            try {
+                response = client.scan(requestBuilder.build());
+            } catch (Exception e) {
+                LOG.error(
+                        "Scan failed for segment {}: {} - {}",
+                        segment,
+                        e.getClass().getSimpleName(),
+                        e.getMessage());
+                throw e;
+            }
 
             itemsScanned += response.items().size();
 
@@ -123,8 +139,10 @@ public class InactiveAccountDataExportHandler
 
         LOG.info("Segment {} completed: {} items scanned", segment, itemsScanned);
 
-        return itemsScanned;
+        return new SegmentResult(itemsScanned, 0);
     }
+
+    private record SegmentResult(long itemsScanned, long missingCredentialsCount) {}
 
     private static void gracefulPoolShutdown(ForkJoinPool forkJoinPool) {
         forkJoinPool.shutdown();

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -1,0 +1,123 @@
+package uk.gov.di.authentication.utils.helpers;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildCredentialKeys;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
+
+class InactiveAccountDataExportHelperTest {
+
+    private static final String TABLE_NAME = "test-user-credentials";
+
+    @Test
+    void buildCredentialKeysShouldExtractEmailKeysFromProfileItems() {
+        List<Map<String, AttributeValue>> profileItems =
+                List.of(
+                        Map.of("Email", AttributeValue.builder().s("a@example.com").build()),
+                        Map.of("Email", AttributeValue.builder().s("b@example.com").build()),
+                        Map.of("Email", AttributeValue.builder().s("c@example.com").build()));
+
+        var keys = buildCredentialKeys(profileItems);
+
+        assertEquals(3, keys.size());
+        assertEquals("a@example.com", keys.get(0).get("Email").s());
+        assertEquals("b@example.com", keys.get(1).get("Email").s());
+        assertEquals("c@example.com", keys.get(2).get("Email").s());
+    }
+
+    @Test
+    void buildCredentialKeysShouldReturnEmptyListForEmptyInput() {
+        var keys = buildCredentialKeys(List.of());
+
+        assertTrue(keys.isEmpty());
+    }
+
+    @Test
+    void extractUnprocessedKeysShouldReturnEmptyMapWhenNoUnprocessedKeys() {
+        var response =
+                BatchGetItemResponse.builder().responses(Map.of(TABLE_NAME, List.of())).build();
+
+        var result = extractUnprocessedKeys(response, TABLE_NAME);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void extractUnprocessedKeysShouldReturnEmptyMapWhenTableNotInUnprocessed() {
+        var response =
+                BatchGetItemResponse.builder()
+                        .responses(Map.of(TABLE_NAME, List.of()))
+                        .unprocessedKeys(
+                                Map.of(
+                                        "other-table",
+                                        KeysAndAttributes.builder()
+                                                .keys(
+                                                        List.of(
+                                                                Map.of(
+                                                                        "Email",
+                                                                        AttributeValue.builder()
+                                                                                .s("x@example.com")
+                                                                                .build())))
+                                                .build()))
+                        .build();
+
+        var result = extractUnprocessedKeys(response, TABLE_NAME);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void extractUnprocessedKeysShouldReturnKeysWhenPresent() {
+        List<Map<String, AttributeValue>> unprocessed =
+                List.of(
+                        Map.of("Email", AttributeValue.builder().s("a@example.com").build()),
+                        Map.of("Email", AttributeValue.builder().s("b@example.com").build()));
+
+        var response =
+                BatchGetItemResponse.builder()
+                        .responses(Map.of(TABLE_NAME, List.of()))
+                        .unprocessedKeys(
+                                Map.of(
+                                        TABLE_NAME,
+                                        KeysAndAttributes.builder().keys(unprocessed).build()))
+                        .build();
+
+        var result = extractUnprocessedKeys(response, TABLE_NAME);
+
+        assertEquals(2, result.get(TABLE_NAME).keys().size());
+    }
+
+    @Test
+    void countMissingCredentialsShouldReturnZeroWhenAllReturned() {
+        assertEquals(0, countMissingCredentials(5, 5));
+    }
+
+    @Test
+    void countMissingCredentialsShouldReturnDifferenceWhenSomeMissing() {
+        assertEquals(3, countMissingCredentials(10, 7));
+    }
+
+    @Test
+    void countMissingCredentialsShouldReturnZeroWhenReturnedExceedsRequested() {
+        assertEquals(0, countMissingCredentials(3, 5));
+    }
+
+    @Test
+    void countMissingCredentialsShouldReturnRequestedCountWhenNoneReturned() {
+        assertEquals(5, countMissingCredentials(5, 0));
+    }
+
+    @Test
+    void countMissingCredentialsShouldReturnZeroForZeroInputs() {
+        assertEquals(0, countMissingCredentials(0, 0));
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -46,12 +46,40 @@ class InactiveAccountDataExportHandlerTest {
                 IllegalArgumentException.class,
                 () ->
                         handler.handleRequest(
-                                new InactiveAccountDataExportRequest(null, 5), context));
+                                new InactiveAccountDataExportRequest(null, 5, null), context));
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
                         handler.handleRequest(
-                                new InactiveAccountDataExportRequest(10, null), context));
+                                new InactiveAccountDataExportRequest(10, null, null), context));
+    }
+
+    @Test
+    void shouldDefaultMaxRetriesToThreeWhenNull() {
+        int itemCount = 5;
+        int pageSize = 5;
+        mockScanWithPagination(itemCount, pageSize);
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(4, 1, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+    }
+
+    @Test
+    void shouldUseExplicitMaxRetriesValue() {
+        int itemCount = 5;
+        int pageSize = 5;
+        mockScanWithPagination(itemCount, pageSize);
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(4, 1, 5);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
     }
 
     @Test
@@ -61,7 +89,7 @@ class InactiveAccountDataExportHandlerTest {
         mockScanWithPagination(itemCount, pageSize);
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest(4, 1);
+        var request = new InactiveAccountDataExportRequest(4, 1, null);
 
         var response = handler.handleRequest(request, context);
 

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -1,11 +1,15 @@
 package uk.gov.di.authentication.utils.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -15,6 +19,7 @@ import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23,16 +28,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class InactiveAccountDataExportHandlerTest {
 
     private static final TableSchema<UserProfile> USER_PROFILE_SCHEMA =
             TableSchema.fromBean(UserProfile.class);
+    private static final String ENVIRONMENT = "test";
+    private static final String USER_CREDENTIALS_TABLE = ENVIRONMENT + "-user-credentials";
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDbClient client = mock(DynamoDbClient.class);
     private final Context context = mock(Context.class);
+
+    @BeforeEach
+    void setUp() {
+        when(configurationService.getEnvironment()).thenReturn(ENVIRONMENT);
+    }
 
     private InactiveAccountDataExportHandler createHandler() {
         return new InactiveAccountDataExportHandler(configurationService, client);
@@ -60,6 +75,7 @@ class InactiveAccountDataExportHandlerTest {
         int itemCount = 5;
         int pageSize = 5;
         mockScanWithPagination(itemCount, pageSize);
+        mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
         var request = new InactiveAccountDataExportRequest(4, 1, null);
@@ -74,6 +90,7 @@ class InactiveAccountDataExportHandlerTest {
         int itemCount = 5;
         int pageSize = 5;
         mockScanWithPagination(itemCount, pageSize);
+        mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
         var request = new InactiveAccountDataExportRequest(4, 1, 5);
@@ -88,6 +105,7 @@ class InactiveAccountDataExportHandlerTest {
         int itemCount = 25;
         int pageSize = 5;
         mockScanWithPagination(itemCount, pageSize);
+        mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
         var request = new InactiveAccountDataExportRequest(4, 1, null);
@@ -108,8 +126,195 @@ class InactiveAccountDataExportHandlerTest {
         var handler = createHandler();
         var request = new InactiveAccountDataExportRequest(1, 1, null);
 
-        assertThrows(
-                DynamoDbException.class, () -> handler.handleRequest(request, context));
+        assertThrows(DynamoDbException.class, () -> handler.handleRequest(request, context));
+    }
+
+    @Test
+    void shouldJoinAllItemsWhenAllCredentialsExist() {
+        int itemCount = 5;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+        verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldRetryUnprocessedKeysSuccessfully() {
+        int itemCount = 5;
+        mockScanWithPagination(itemCount, itemCount);
+
+        AtomicInteger batchCallCount = new AtomicInteger(0);
+        when(client.batchGetItem(any(BatchGetItemRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            BatchGetItemRequest request = invocation.getArgument(0);
+                            KeysAndAttributes keysAndAttrs =
+                                    request.requestItems().get(USER_CREDENTIALS_TABLE);
+                            List<Map<String, AttributeValue>> keys = keysAndAttrs.keys();
+                            int call = batchCallCount.getAndIncrement();
+
+                            if (call == 0) {
+                                // First call: return 3 items, leave 2 unprocessed
+                                List<Map<String, AttributeValue>> results = new ArrayList<>();
+                                for (int i = 0; i < 3; i++) {
+                                    String email = keys.get(i).get("Email").s();
+                                    results.add(createCredentialItem(email));
+                                }
+                                Map<String, KeysAndAttributes> unprocessed =
+                                        Map.of(
+                                                USER_CREDENTIALS_TABLE,
+                                                KeysAndAttributes.builder()
+                                                        .keys(keys.subList(3, 5))
+                                                        .projectionExpression(
+                                                                "Email,Created,Updated,MigratedPassword")
+                                                        .build());
+                                return BatchGetItemResponse.builder()
+                                        .responses(Map.of(USER_CREDENTIALS_TABLE, results))
+                                        .unprocessedKeys(unprocessed)
+                                        .build();
+                            } else {
+                                // Second call: return remaining items
+                                List<Map<String, AttributeValue>> results = new ArrayList<>();
+                                for (Map<String, AttributeValue> key : keys) {
+                                    String email = key.get("Email").s();
+                                    results.add(createCredentialItem(email));
+                                }
+                                return BatchGetItemResponse.builder()
+                                        .responses(Map.of(USER_CREDENTIALS_TABLE, results))
+                                        .build();
+                            }
+                        });
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, 3);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+        verify(client, times(2)).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldCountUnprocessedKeysAsMissingAfterRetriesExhausted() {
+        int itemCount = 5;
+        mockScanWithPagination(itemCount, itemCount);
+
+        // Always return unprocessed keys for items 4 and 5
+        when(client.batchGetItem(any(BatchGetItemRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            BatchGetItemRequest request = invocation.getArgument(0);
+                            KeysAndAttributes keysAndAttrs =
+                                    request.requestItems().get(USER_CREDENTIALS_TABLE);
+                            List<Map<String, AttributeValue>> keys = keysAndAttrs.keys();
+
+                            List<Map<String, AttributeValue>> results = new ArrayList<>();
+                            List<Map<String, AttributeValue>> unprocessedKeys = new ArrayList<>();
+
+                            for (int i = 0; i < keys.size(); i++) {
+                                String email = keys.get(i).get("Email").s();
+                                if (email.startsWith("user4") || email.startsWith("user5")) {
+                                    unprocessedKeys.add(keys.get(i));
+                                } else {
+                                    results.add(createCredentialItem(email));
+                                }
+                            }
+
+                            BatchGetItemResponse.Builder responseBuilder =
+                                    BatchGetItemResponse.builder()
+                                            .responses(Map.of(USER_CREDENTIALS_TABLE, results));
+
+                            if (!unprocessedKeys.isEmpty()) {
+                                responseBuilder.unprocessedKeys(
+                                        Map.of(
+                                                USER_CREDENTIALS_TABLE,
+                                                KeysAndAttributes.builder()
+                                                        .keys(unprocessedKeys)
+                                                        .projectionExpression(
+                                                                "Email,Created,Updated,MigratedPassword")
+                                                        .build()));
+                            }
+
+                            return responseBuilder.build();
+                        });
+
+        var handler = createHandler();
+        // maxRetries = 2 so total attempts = initial + 2 retries = 3
+        var request = new InactiveAccountDataExportRequest(1, 1, 2);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+        // Initial call + 2 retries = 3 calls
+        verify(client, times(3)).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldNotCallBatchGetItemWhenSegmentIsEmpty() {
+        mockScanWithPagination(0, 1);
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(0, response.totalItemsScanned());
+        verify(client, never()).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldBatchAtExactly100Items() {
+        int itemCount = 100;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+        verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldSplitIntoMultipleBatchesWhenOver100Items() {
+        int itemCount = 101;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+        // 101 items = batch of 100 + final batch of 1 = 2 calls
+        verify(client, times(2)).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldAccumulateItemsAcrossPagesBeforeBatching() {
+        // 25 items across 5 pages of 5 items each — all in one batch at the end
+        int itemCount = 25;
+        int pageSize = 5;
+        mockScanWithPagination(itemCount, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.totalItemsScanned());
+        // 25 items < 100 so only final partial batch = 1 call
+        verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
     }
 
     private Map<String, AttributeValue> createItem(int index) {
@@ -126,12 +331,44 @@ class InactiveAccountDataExportHandlerTest {
         return USER_PROFILE_SCHEMA.itemToMap(profile, true);
     }
 
+    private Map<String, AttributeValue> createCredentialItem(String email) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("Email", AttributeValue.builder().s(email).build());
+        item.put("Created", AttributeValue.builder().s("2024-01-15").build());
+        item.put("Updated", AttributeValue.builder().s("2024-06-20").build());
+        item.put("MigratedPassword", AttributeValue.builder().s("migrated-hash").build());
+        return item;
+    }
+
     private void mockScanWithPagination(int totalItems, int pageSize) {
         List<ScanResponse> pages = buildPages(totalItems, pageSize);
         AtomicInteger callCount = new AtomicInteger(0);
 
         when(client.scan(any(ScanRequest.class)))
                 .thenAnswer(invocation -> pages.get(callCount.getAndIncrement()));
+    }
+
+    private void mockBatchGetItemWithFullMatch() {
+        when(client.batchGetItem(any(BatchGetItemRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            BatchGetItemRequest request = invocation.getArgument(0);
+                            KeysAndAttributes keysAndAttrs =
+                                    request.requestItems().get(USER_CREDENTIALS_TABLE);
+                            if (keysAndAttrs == null || keysAndAttrs.keys().isEmpty()) {
+                                return BatchGetItemResponse.builder()
+                                        .responses(Map.of(USER_CREDENTIALS_TABLE, List.of()))
+                                        .build();
+                            }
+                            List<Map<String, AttributeValue>> results = new ArrayList<>();
+                            for (Map<String, AttributeValue> key : keysAndAttrs.keys()) {
+                                String email = key.get("Email").s();
+                                results.add(createCredentialItem(email));
+                            }
+                            return BatchGetItemResponse.builder()
+                                    .responses(Map.of(USER_CREDENTIALS_TABLE, results))
+                                    .build();
+                        });
     }
 
     private List<ScanResponse> buildPages(int totalItems, int pageSize) {
@@ -141,6 +378,11 @@ class InactiveAccountDataExportHandlerTest {
         }
 
         List<ScanResponse> pages = new ArrayList<>();
+        if (totalItems == 0) {
+            pages.add(ScanResponse.builder().items(List.of()).count(0).scannedCount(0).build());
+            return pages;
+        }
+
         for (int start = 0; start < totalItems; start += pageSize) {
             int end = Math.min(start + pageSize, totalItems);
             List<Map<String, AttributeValue>> pageItems = allItems.subList(start, end);

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -94,6 +95,21 @@ class InactiveAccountDataExportHandlerTest {
         var response = handler.handleRequest(request, context);
 
         assertEquals(itemCount, response.totalItemsScanned());
+    }
+
+    @Test
+    void shouldLogErrorAndPropagateExceptionWhenScanFails() {
+        when(client.scan(any(ScanRequest.class)))
+                .thenThrow(
+                        DynamoDbException.builder()
+                                .message("Provisioned throughput exceeded")
+                                .build());
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(1, 1, null);
+
+        assertThrows(
+                DynamoDbException.class, () -> handler.handleRequest(request, context));
     }
 
     private Map<String, AttributeValue> createItem(int index) {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

**Utils lambda changes only**

- Joins user profiles with user credentials via batched `BatchGetItem`.
- Tracks missing user credential items.

AUT-5658 and AUT-5653 will handle persisting some of this data in a separate table.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy the `utils` module to a dev environment and make a test request to the `*-inactive-account-data-export-lambda` Lambda to scan the dev tables, ensure there are no errors and that the expected number of items are scanned through the logs.
    - I have followed these steps - see "Testing" section below

## Testing

Deployed the `utils` module to authdev1 and made a test request to the `authdev1-inactive-account-data-export-lambda` Lambda to scan the dev table with the payload:
```json
{
  "parallelism": 5,
  "totalSegments": 3
}
```

No errors seen and verified that the correct number of items (all in the `user-profile` table) were scanned and that there were no missing user credentials items:

<details>

<summary>Log output</summary>

```
Inactive account data export request: parallelism=5, totalSegments=3, maxRetries=3
Segment 0 completed: 461 items scanned, 0 missing credentials
Segment 2 completed: 470 items scanned, 0 missing credentials
Segment 1 completed: 509 items scanned, 0 missing credentials
Scan completed: 1440 total items scanned, 0 missing credentials
```

</details>

Then manually deleted a dev user credentials item and reran with the same config, verified that all items were scanned and that there was 1 missing user credentials item:

<details>

<summary>Log output</summary>

```
Inactive account data export request: parallelism=5, totalSegments=3, maxRetries=3
Segment 2 completed: 470 items scanned, 0 missing credentials
Segment 0 completed: 461 items scanned, 0 missing credentials
Segment 1 completed: 509 items scanned, 1 missing credentials
Scan completed: 1440 total items scanned, 1 missing credentials
```

</details>

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A, utils lambda, scanning only**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A.**
- [ ] A UCD review has been performed. **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Initial lambda creation: https://github.com/govuk-one-login/authentication-api/pull/8586