### PR TITLE
ATO-2749: Create EndOfJourneyService

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/EndOfJourneyService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/EndOfJourneyService.java
@@ -1,0 +1,128 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
+import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
+import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static uk.gov.di.orchestration.shared.entity.AccountInterventionStatus.SUSPENDED_REPROVE_ID;
+import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class EndOfJourneyService {
+
+    private static final Logger LOG = LogManager.getLogger(EndOfJourneyService.class);
+    private final ConfigurationService configurationService;
+    private final AccountInterventionService accountInterventionService;
+    private final LogoutService logoutService;
+    private final OrchAuthCodeService orchAuthCodeService;
+
+    public EndOfJourneyService(
+            ConfigurationService configurationService,
+            AccountInterventionService accountInterventionService,
+            LogoutService logoutService,
+            OrchAuthCodeService orchAuthCodeService) {
+        this.configurationService = configurationService;
+        this.accountInterventionService = accountInterventionService;
+        this.logoutService = logoutService;
+        this.orchAuthCodeService = orchAuthCodeService;
+    }
+
+    public AccountIntervention getIntervention(
+            String internalCommonSubjectId, AuditContext auditContext) {
+        return segmentedFunctionCall(
+                "AIS: getAccountIntervention",
+                () ->
+                        accountInterventionService.getAccountIntervention(
+                                internalCommonSubjectId, auditContext));
+    }
+
+    public Optional<APIGatewayProxyResponseEvent> getAndCheckForIntervention(
+            OrchSessionItem orchSession,
+            AuditContext auditContext,
+            TxmaAuditUser auditUser,
+            String clientId,
+            boolean isAuthJourney) {
+        return checkForIntervention(
+                orchSession,
+                getIntervention(orchSession.getInternalCommonSubjectId(), auditContext),
+                auditUser,
+                clientId,
+                isAuthJourney);
+    }
+
+    public Optional<APIGatewayProxyResponseEvent> checkForIntervention(
+            OrchSessionItem orchSession,
+            AccountIntervention intervention,
+            TxmaAuditUser auditUser,
+            String clientId,
+            boolean isAuthJourney) {
+        if (configurationService.isAccountInterventionServiceActionEnabled()) {
+            if (isAuthJourney && SUSPENDED_REPROVE_ID.equals(intervention.getStatus())) {
+                return Optional.empty();
+            }
+            if (intervention.getBlocked() || intervention.getSuspended()) {
+                return Optional.of(
+                        logoutService.handleAccountInterventionLogout(
+                                new DestroySessionsRequest(orchSession.getSessionId(), orchSession),
+                                auditUser,
+                                clientId,
+                                intervention));
+            }
+        }
+        return Optional.empty();
+    }
+
+    public AuthenticationSuccessResponse generateSuccessfulAuthResponse(
+            AuthenticationRequest authRequest,
+            String clientId,
+            String clientSessionId,
+            String email,
+            OrchSessionItem orchSession) {
+        var authCode =
+                orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        clientId,
+                        clientSessionId,
+                        email,
+                        orchSession.getAuthTime(),
+                        orchSession.getInternalCommonSubjectId());
+        return new AuthenticationSuccessResponse(
+                authRequest.getRedirectionURI(),
+                authCode,
+                null,
+                null,
+                authRequest.getState(),
+                null,
+                authRequest.getResponseMode());
+    }
+
+    public APIGatewayProxyResponseEvent generateAuthenticationErrorResponse(
+            AuthenticationRequest authenticationRequest, ErrorObject error) {
+        LOG.warn(
+                "Error in Authorisation Response. ErrorCode: {}. ErrorDescription: {}.",
+                error.getCode(),
+                error.getDescription());
+        var errorResponseUri =
+                new AuthenticationErrorResponse(
+                                authenticationRequest.getRedirectionURI(),
+                                error,
+                                authenticationRequest.getState(),
+                                authenticationRequest.getResponseMode())
+                        .toURI();
+
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, errorResponseUri.toString()), null);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/LogoutService.java
@@ -166,8 +166,18 @@ public class LogoutService {
             APIGatewayProxyRequestEvent input,
             String clientId,
             AccountIntervention intervention) {
+        return handleAccountInterventionLogout(
+                request,
+                createAuditUser(input, request.getSessionId(), internalCommonSubjectId),
+                clientId,
+                intervention);
+    }
 
-        var auditUser = createAuditUser(input, request.getSessionId(), internalCommonSubjectId);
+    public APIGatewayProxyResponseEvent handleAccountInterventionLogout(
+            DestroySessionsRequest request,
+            TxmaAuditUser auditUser,
+            String clientId,
+            AccountIntervention intervention) {
 
         destroySessions(request);
         metrics.incrementLogout(Optional.of(clientId), Optional.of(intervention));
@@ -244,13 +254,25 @@ public class LogoutService {
 
     private TxmaAuditUser createAuditUser(
             APIGatewayProxyRequestEvent input, String sessionId, String internalCommonSubjectId) {
+        return createAuditUser(
+                extractIpAddress(input),
+                extractPersistentIdFromCookieHeader(input.getHeaders()),
+                sessionId,
+                CookieHelper.getClientSessionIdFromRequestHeaders(input.getHeaders()).orElse(null),
+                internalCommonSubjectId);
+    }
+
+    private TxmaAuditUser createAuditUser(
+            String ipAddress,
+            String persistentSessionId,
+            String sessionId,
+            String clientSessionId,
+            String internalCommonSubjectId) {
         return TxmaAuditUser.user()
-                .withIpAddress(extractIpAddress(input))
-                .withPersistentSessionId(extractPersistentIdFromCookieHeader(input.getHeaders()))
+                .withIpAddress(ipAddress)
+                .withPersistentSessionId(persistentSessionId)
                 .withSessionId(sessionId)
-                .withGovukSigninJourneyId(
-                        CookieHelper.getClientSessionIdFromRequestHeaders(input.getHeaders())
-                                .orElse(null))
+                .withGovukSigninJourneyId(clientSessionId)
                 .withUserId(internalCommonSubjectId);
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/EndOfJourneyServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/EndOfJourneyServiceTest.java
@@ -1,0 +1,215 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.entity.AccountIntervention;
+import uk.gov.di.orchestration.shared.entity.AccountInterventionState;
+import uk.gov.di.orchestration.shared.entity.DestroySessionsRequest;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EndOfJourneyServiceTest {
+    private static final AccountIntervention NO_INTERVENTION =
+            new AccountIntervention(new AccountInterventionState(false, false, false, false));
+    private static final AccountIntervention BLOCKED_INTERVENTION =
+            new AccountIntervention(new AccountInterventionState(true, false, false, false));
+    private static final AccountIntervention SUSPENDED_NO_ACTION =
+            new AccountIntervention(new AccountInterventionState(false, true, false, false));
+    private static final AccountIntervention SUSPENDED_WITH_REPROVE_IDENTITY =
+            new AccountIntervention(new AccountInterventionState(false, true, true, false));
+    private static final String SESSION_ID = "a-session-id";
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
+            "urn:fdc:gov.uk:2022:0VzHWj9aaJpyHXJX8B5QJ-UOUibweHmkSg1GjF6w9yM";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String CLIENT_SESSION_ID = "test-csid";
+    private static final String EMAIL = "test@email.com";
+    private static final Long AUTH_TIME = 123456L;
+    private static final String ERROR_PAGE_URI = "http://test.com/error";
+    private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AccountInterventionService accountInterventionService =
+            mock(AccountInterventionService.class);
+    private final LogoutService logoutService = mock(LogoutService.class);
+    private final OrchAuthCodeService orchAuthCodeService = mock(OrchAuthCodeService.class);
+    private final AuditContext auditContext = mock(AuditContext.class);
+    private final TxmaAuditUser auditUser = mock(TxmaAuditUser.class);
+    private final OrchSessionItem orchSession =
+            new OrchSessionItem(SESSION_ID)
+                    .withInternalCommonSubjectId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER)
+                    .withAuthTime(AUTH_TIME);
+    private EndOfJourneyService service;
+
+    @BeforeEach
+    void setup() {
+        when(logoutService.handleAccountInterventionLogout(
+                        new DestroySessionsRequest(SESSION_ID, orchSession),
+                        auditUser,
+                        CLIENT_ID,
+                        BLOCKED_INTERVENTION))
+                .thenReturn(RedirectService.redirectToFrontendErrorPage(ERROR_PAGE_URI));
+        when(logoutService.handleAccountInterventionLogout(
+                        new DestroySessionsRequest(SESSION_ID, orchSession),
+                        auditUser,
+                        CLIENT_ID,
+                        SUSPENDED_NO_ACTION))
+                .thenReturn(RedirectService.redirectToFrontendErrorPage(ERROR_PAGE_URI));
+        when(configurationService.isAccountInterventionServiceActionEnabled()).thenReturn(true);
+        when(orchAuthCodeService.generateAndSaveAuthorisationCode(
+                        CLIENT_ID,
+                        CLIENT_SESSION_ID,
+                        EMAIL,
+                        AUTH_TIME,
+                        TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER))
+                .thenReturn(AUTH_CODE);
+        orchSession.addClientSession(CLIENT_SESSION_ID);
+        service =
+                new EndOfJourneyService(
+                        configurationService,
+                        accountInterventionService,
+                        logoutService,
+                        orchAuthCodeService);
+    }
+
+    @Nested
+    class HandleAccountInterventions {
+
+        @Test
+        void shouldRedirectAndLogoutWhenAISReturnsBlocked() {
+            var response =
+                    service.checkForIntervention(
+                            orchSession, BLOCKED_INTERVENTION, auditUser, CLIENT_ID, true);
+
+            assertTrue(response.isPresent());
+            assertThat(response.get().getHeaders().get("Location"), equalTo(ERROR_PAGE_URI));
+        }
+
+        @Test
+        void shouldRedirectAndLogoutWhenAISReturnsSuspended() {
+            var response =
+                    service.checkForIntervention(
+                            orchSession, SUSPENDED_NO_ACTION, auditUser, CLIENT_ID, true);
+
+            assertTrue(response.isPresent());
+            assertThat(response.get().getHeaders().get("Location"), equalTo(ERROR_PAGE_URI));
+        }
+
+        @Test
+        void shouldNotRedirectAndLogoutIfAISReturnsNoInterventions() {
+            var response =
+                    service.checkForIntervention(
+                            orchSession, NO_INTERVENTION, auditUser, CLIENT_ID, true);
+
+            assertTrue(response.isEmpty());
+        }
+
+        @Test
+        void shouldNotRedirectAndLogoutIfAISReturnsSuspendedWithReproveWhenOnAuthOnlyJourney() {
+            var response =
+                    service.checkForIntervention(
+                            orchSession,
+                            SUSPENDED_WITH_REPROVE_IDENTITY,
+                            auditUser,
+                            CLIENT_ID,
+                            true);
+
+            assertTrue(response.isEmpty());
+        }
+
+        @Test
+        void shouldNotRedirectAndLogoutIfAISIsDisabled() {
+            when(configurationService.isAccountInterventionServiceActionEnabled())
+                    .thenReturn(false);
+
+            var response =
+                    service.checkForIntervention(
+                            orchSession, BLOCKED_INTERVENTION, auditUser, CLIENT_ID, true);
+
+            assertTrue(response.isEmpty());
+        }
+
+        @Test
+        void shouldGetInterventionFromAISServiceThenRedirect() {
+            when(accountInterventionService.getAccountIntervention(
+                            TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER, auditContext))
+                    .thenReturn(BLOCKED_INTERVENTION);
+
+            var response =
+                    service.getAndCheckForIntervention(
+                            orchSession, auditContext, auditUser, CLIENT_ID, true);
+
+            assertTrue(response.isPresent());
+            assertThat(response.get().getHeaders().get("Location"), equalTo(ERROR_PAGE_URI));
+        }
+    }
+
+    @Nested
+    class GenerateAuthResponse {
+        private final State state = new State();
+        private final Nonce nonce = new Nonce();
+        private final URI redirectUri = URI.create("http://rp-url/redirect");
+        private final ResponseMode responseMode = ResponseMode.QUERY;
+        private final AuthenticationRequest authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                Scope.parse("openid"),
+                                new ClientID(CLIENT_ID),
+                                redirectUri)
+                        .state(state)
+                        .nonce(nonce)
+                        .responseMode(responseMode)
+                        .build();
+
+        @Test
+        void shouldGenerateAuthCodeAndCreateSuccessfulAuthResponse() {
+            var response =
+                    service.generateSuccessfulAuthResponse(
+                            authRequest, CLIENT_ID, CLIENT_SESSION_ID, EMAIL, orchSession);
+
+            verify(orchAuthCodeService)
+                    .generateAndSaveAuthorisationCode(
+                            CLIENT_ID,
+                            CLIENT_SESSION_ID,
+                            EMAIL,
+                            AUTH_TIME,
+                            TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
+            assertThat(response.getRedirectionURI(), equalTo(redirectUri));
+            assertThat(response.getAuthorizationCode(), equalTo(AUTH_CODE));
+            assertThat(response.getState(), equalTo(state));
+            assertThat(response.getResponseMode(), equalTo(responseMode));
+        }
+
+        @Test
+        void shouldCreateAuthResponseWithError() {
+            var error = new ErrorObject("test_error", "Test Description");
+            var response = service.generateAuthenticationErrorResponse(authRequest, error);
+            var expectedUri =
+                    redirectUri
+                            + "?error=test_error"
+                            + "&error_description=Test+Description"
+                            + "&state="
+                            + state;
+            assertThat(response.getStatusCode(), equalTo(302));
+            assertThat(response.getHeaders().get("Location"), equalTo(expectedUri));
+        }
+    }
+}


### PR DESCRIPTION
### Wider context of change

We have 2 places in the code (Auth and IPV) where we check for an AIS intervention, and logout the user if the response is BLOCKED or SUSPENDED. We will be adding another place soon where this will be called too (in SIS). It would be useful to extract this into its own service so we can reference the same code in all 3 places.

### What’s changed

This PR creates a new service called AISLogoutService (i'm open to better names!) which logs the user out if they have a BLOCKED or SUSPENDED AIS response. 

This code is the same as the `IPVCallbackHandler.checkForAisIntervention` method

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

