### PR TITLE
Bau/introduce tap and tap failure

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -267,11 +267,11 @@ public class MFAMethodsCreateHandler
                         userProfile.getEmail(), mfaMethodCreateRequest.mfaMethod());
 
         if (addBackupMfaResult.isFailure()) {
-            auditEventStatus =
+            var addFailedAuditStatus =
                     sendAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
-            if (auditEventStatus.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
+            if (addFailedAuditStatus.isFailure()) {
+                return generateApiGatewayProxyErrorResponse(500, addFailedAuditStatus.getFailure());
             }
             return handleCreateBackupMfaFailure(addBackupMfaResult.getFailure());
         }
@@ -281,11 +281,11 @@ public class MFAMethodsCreateHandler
 
         if (backupMfaMethodAsResponse.isFailure()) {
             LOG.error(backupMfaMethodAsResponse.getFailure());
-            auditEventStatus =
+            var addFailedAuditStatus =
                     sendAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
-            if (auditEventStatus.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
+            if (addFailedAuditStatus.isFailure()) {
+                return generateApiGatewayProxyErrorResponse(500, addFailedAuditStatus.getFailure());
             }
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
@@ -295,11 +295,6 @@ public class MFAMethodsCreateHandler
 
         if (addCompletedResult.isFailure()) {
             return generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure());
-        }
-
-        if (auditEventStatus.isFailure()) {
-            LOG.error(auditEventStatus.getFailure());
-            return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
         }
 
         if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -194,12 +194,7 @@ public class MFAMethodsCreateHandler
                             configurationService.isAccountManagementInternationalSmsEnabled());
 
             if (invalidPhoneNumber.isPresent()) {
-                var auditEventStatus =
-                        sendAuditEvent(
-                                AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
-                if (auditEventStatus.isFailure()) {
-                    LOG.error(auditEventStatus.getFailure());
-                }
+                sendAuditEvent(AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
                 return Result.failure(invalidPhoneNumber.get());
             }
 
@@ -210,12 +205,7 @@ public class MFAMethodsCreateHandler
                             NotificationType.VERIFY_PHONE_NUMBER);
             if (!isValidOtpCode) {
                 LOG.info("Invalid OTP presented.");
-                var auditEventStatus =
-                        sendAuditEvent(
-                                AUTH_INVALID_CODE_SENT, auditContext, mfaMethodCreateRequest);
-                if (auditEventStatus.isFailure()) {
-                    LOG.error(auditEventStatus.getFailure());
-                }
+                sendAuditEvent(AUTH_INVALID_CODE_SENT, auditContext, mfaMethodCreateRequest);
                 return Result.failure(INVALID_OTP);
             }
         }
@@ -261,7 +251,6 @@ public class MFAMethodsCreateHandler
         var auditEventStatus =
                 sendAuditEvent(AUTH_CODE_VERIFIED, auditContext, mfaMethodCreateRequest);
         if (auditEventStatus.isFailure()) {
-            LOG.error(auditEventStatus.getFailure());
             return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
         }
 
@@ -282,7 +271,6 @@ public class MFAMethodsCreateHandler
                     sendAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
             if (auditEventStatus.isFailure()) {
-                LOG.error(auditEventStatus.getFailure());
                 return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
             }
             return handleCreateBackupMfaFailure(addBackupMfaResult.getFailure());
@@ -297,7 +285,6 @@ public class MFAMethodsCreateHandler
                     sendAuditEvent(
                             AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
             if (auditEventStatus.isFailure()) {
-                LOG.error(auditEventStatus.getFailure());
                 return generateApiGatewayProxyErrorResponse(500, auditEventStatus.getFailure());
             }
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
@@ -307,7 +294,6 @@ public class MFAMethodsCreateHandler
                 sendAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext, mfaMethodCreateRequest);
 
         if (addCompletedResult.isFailure()) {
-            LOG.error(addCompletedResult.getFailure());
             return generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure());
         }
 
@@ -321,7 +307,6 @@ public class MFAMethodsCreateHandler
                     sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, auditContext, mfaMethodCreateRequest);
 
             if (updatePhoneNumberResult.isFailure()) {
-                LOG.error(updatePhoneNumberResult.getFailure());
                 return generateApiGatewayProxyErrorResponse(
                         500, updatePhoneNumberResult.getFailure());
             }
@@ -444,11 +429,12 @@ public class MFAMethodsCreateHandler
         var metadataPairs = metadataPairsForEvent(auditEvent, mfaMethodCreateRequest);
         return AuditHelper.sendAuditEvent(
                         auditEvent, enrichedAuditContext, auditService, LOG, metadataPairs)
-                .map(
-                        sucess -> {
-                            LOG.info("Successfully submitted audit event: {}", auditEvent.name());
-                            return sucess;
-                        });
+                .tap(
+                        success ->
+                                LOG.info(
+                                        "Successfully submitted audit event: {}",
+                                        auditEvent.name()))
+                .tapFailure(LOG::error);
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -434,7 +434,12 @@ public class MFAMethodsCreateHandler
                                 LOG.info(
                                         "Successfully submitted audit event: {}",
                                         auditEvent.name()))
-                .tapFailure(LOG::error);
+                .tapFailure(
+                        f ->
+                                LOG.error(
+                                        "Failure {} when attempting to emit audit event: {}",
+                                        f,
+                                        auditEvent.name()));
     }
 
     private void addSessionIdToLogs(APIGatewayProxyRequestEvent input) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsPutHandler.java
@@ -569,11 +569,7 @@ public class MFAMethodsPutHandler
         return AuditHelper.sendAuditEvent(
                         auditEvent, contextWithPhoneNumber, auditService, LOG, pairs)
                 .mapFailure(f -> generateApiGatewayProxyErrorResponse(500, f))
-                .map(
-                        success -> {
-                            LOG.info("Successfully submitted audit event: {}", auditEvent.name());
-                            return success;
-                        });
+                .tap(s -> LOG.info("Successfully submitted audit event: {}", auditEvent.name()));
     }
 
     private Result<APIGatewayProxyResponseEvent, Void> emitAuditEventForAuthAppUpdate(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -97,19 +97,18 @@ public class FinishPasskeyAssertionHandler
 
         return verifyPasskeyAssertion(userContext, request, input)
                 .flatMap(this::updatePasskeyRecord)
-                .map(success -> reportCorrectPasskeyReceived(userContext))
+                .tap(success -> reportCorrectPasskeyReceived(userContext))
+                .tapFailure(failure -> reportIncorrectPasskeyReceived(userContext, failure))
                 .fold(
-                        failure -> {
-                            reportIncorrectPasskeyReceived(userContext, failure);
-                            return switch (failure) {
-                                case PARSING_ASSERTION_REQUEST_ERROR -> generateApiGatewayProxyErrorResponse(
-                                        500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
-                                case PARSING_PKC_ERROR -> generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.PASSKEY_ASSERTION_INVALID_PKC);
-                                case ASSERTION_FAILED_ERROR -> generateApiGatewayProxyErrorResponse(
-                                        401, ErrorResponse.PASSKEY_ASSERTION_FAILED);
-                            };
-                        },
+                        failure ->
+                                switch (failure) {
+                                    case PARSING_ASSERTION_REQUEST_ERROR -> generateApiGatewayProxyErrorResponse(
+                                            500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
+                                    case PARSING_PKC_ERROR -> generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.PASSKEY_ASSERTION_INVALID_PKC);
+                                    case ASSERTION_FAILED_ERROR -> generateApiGatewayProxyErrorResponse(
+                                            401, ErrorResponse.PASSKEY_ASSERTION_FAILED);
+                                },
                         success -> generateApiGatewayProxyResponse(200, ""));
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Result.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public sealed interface Result<F, S> permits Result.Failure, Result.Success {
@@ -45,6 +46,10 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
 
     <T> T fold(Function<F, T> failureMapper, Function<S, T> successMapper);
 
+    Result<F, S> tap(Consumer<S> action);
+
+    Result<F, S> tapFailure(Consumer<F> action);
+
     record Failure<F, S>(F value) implements Result<F, S> {
         @Override
         public boolean isFailure() {
@@ -84,6 +89,17 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
         @Override
         public <T> T fold(Function<F, T> failureMapper, Function<S, T> successMapper) {
             return failureMapper.apply(value);
+        }
+
+        @Override
+        public Result<F, S> tap(Consumer<S> action) {
+            return this;
+        }
+
+        @Override
+        public Result<F, S> tapFailure(Consumer<F> action) {
+            action.accept(this.value());
+            return this;
         }
     }
 
@@ -126,6 +142,17 @@ public sealed interface Result<F, S> permits Result.Failure, Result.Success {
         @Override
         public <T> T fold(Function<F, T> failureMapper, Function<S, T> successMapper) {
             return successMapper.apply(value);
+        }
+
+        @Override
+        public Result<F, S> tap(Consumer<S> action) {
+            action.accept(this.value());
+            return this;
+        }
+
+        @Override
+        public Result<F, S> tapFailure(Consumer<F> action) {
+            return this;
         }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ResultTest.java
@@ -1,10 +1,12 @@
 package uk.gov.di.authentication.shared.entity;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -196,6 +198,127 @@ class ResultTest {
             assertEquals("Found failure abc", failureLogs.get(0));
             assertEquals(
                     Result.<Integer, Integer>failure(failureString.length()), mapFailureResult);
+        }
+    }
+
+    @Nested
+    class TapAndTapFailureTests {
+        private ArrayList<String> logsEmitted;
+
+        @BeforeEach
+        void setup() {
+            logsEmitted = new ArrayList<>();
+        }
+
+        @Test
+        void tapShouldPerformASideEffectOnASuccessAndReturnOriginalResult() {
+            var successValue = 1;
+            var originalSuccess = Result.success(successValue);
+
+            var tapResult =
+                    originalSuccess.tap(i -> logFunction(String.format("Got success value %d", i)));
+
+            assertLogged("Got success value 1");
+
+            assertEquals(originalSuccess, tapResult);
+        }
+
+        @Test
+        void tapShouldPerformMultipleSideEffectsOnASuccessAndReturnOriginalResult() {
+            var successValue = 5;
+            var originalSuccess = Result.success(successValue);
+            var originalSumOfValues = 100;
+            var sumOfSuccessesSoFar = new AtomicInteger(originalSumOfValues);
+
+            var tapResult =
+                    originalSuccess.tap(
+                            i -> {
+                                logFunction(String.format("Got success value %d", i));
+                                sumOfSuccessesSoFar.set(sumOfSuccessesSoFar.get() + i);
+                            });
+
+            assertLogged("Got success value 5");
+
+            assertEquals(originalSumOfValues + successValue, sumOfSuccessesSoFar.get());
+
+            assertEquals(originalSuccess, tapResult);
+        }
+
+        @Test
+        void tapShouldNotPerformASideEffectOnAFailureAndReturnOriginalResult() {
+            var originalFailure = Result.<String, Integer>failure("some failure");
+
+            var tapResult =
+                    originalFailure.tap(i -> logFunction(String.format("Got success value %d", i)));
+
+            assertLogsEmpty();
+            assertEquals(originalFailure, tapResult);
+        }
+
+        @Test
+        void tapFailureShouldNotPerformASideEffectOnASuccessAndReturnOriginalResult() {
+            var successValue = 1;
+            var originalSuccess = Result.success(successValue);
+            var originalNumberOfFailures = 100;
+            AtomicInteger numberOfFailuresSoFar = new AtomicInteger(originalNumberOfFailures);
+
+            var tapFailureResult =
+                    originalSuccess.tapFailure(
+                            f -> numberOfFailuresSoFar.set(numberOfFailuresSoFar.get() + 1));
+
+            assertEquals(originalNumberOfFailures, numberOfFailuresSoFar.get());
+
+            assertEquals(originalSuccess, tapFailureResult);
+        }
+
+        @Test
+        void tapFailureShouldPerformASideEffectOnAFailureAndReturnOriginalResult() {
+            var originalFailure = Result.<String, Integer>failure("some failure");
+
+            var originalNumberOfFailures = 100;
+            AtomicInteger numberOfFailuresSoFar = new AtomicInteger(originalNumberOfFailures);
+
+            var tapFailureResult =
+                    originalFailure.tapFailure(
+                            f -> numberOfFailuresSoFar.set(numberOfFailuresSoFar.get() + 1));
+
+            assertEquals(originalNumberOfFailures + 1, numberOfFailuresSoFar.get());
+
+            assertEquals(originalFailure, tapFailureResult);
+        }
+
+        @Test
+        void tapFailureShouldPerformMultipleSideEffectsOnAFailureAndReturnOriginalResult() {
+            var originalFailure = Result.<String, Integer>failure("some failure");
+
+            var originalNumberOfFailures = 100;
+            AtomicInteger numberOfFailuresSoFar = new AtomicInteger(originalNumberOfFailures);
+
+            var tapFailureResult =
+                    originalFailure.tapFailure(
+                            f -> {
+                                numberOfFailuresSoFar.set(numberOfFailuresSoFar.get() + 1);
+                                logFunction(String.format("Got failure: %s", f));
+                            });
+
+            assertEquals(originalNumberOfFailures + 1, numberOfFailuresSoFar.get());
+
+            assertLogged("Got failure: some failure");
+
+            assertEquals(originalFailure, tapFailureResult);
+        }
+
+        private void logFunction(String s) {
+            logsEmitted.add(s);
+        }
+
+        private void assertLogsEmpty() {
+            assertEquals(0, logsEmitted.size());
+        }
+
+        private void assertLogged(String expected) {
+            assertEquals(1, logsEmitted.size());
+            assertEquals(expected, logsEmitted.get(0));
         }
     }
 }


### PR DESCRIPTION
Introduce new methods on the result type - `.tap` and `.tapFailure`

These are sugar for cases where we perform side effects depending on whether the result is a success or failure, and then return the original result.

So given a result `myResult`, this:

```
return myResult.map(s ->  {
  LOG.info('success');
  return s;
  }
);
```
can be replaced by
```
return myResult.tap(s ->  LOG.info('success'));
```

and this:

```
return myResult.mapFailure(f ->  {
  LOG.error('failure');
  return f;
  }
);
```
can be replaced by:
```
return myResult.tapFailure(f ->  LOG.error('failure'));
```


Use this in a few places in the code.
