### PR TITLE
ATO-2707: Remove custom domain from old API GW staging

### DIFF
--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -164,5 +164,6 @@ lambda_max_concurrency = 10
 
 use_strongly_consistent_reads = true
 
-ipv_jwks_call_enabled = true
-ipv_jwks_url          = "https://api.identity.staging.account.gov.uk/.well-known/jwks.json"
+ipv_jwks_call_enabled          = true
+ipv_jwks_url                   = "https://api.identity.staging.account.gov.uk/.well-known/jwks.json"
+deploy_oidc_api_gateway_domain = false


### PR DESCRIPTION
### Wider context of change
Now that traffic is no longer being served on the old API Gateway, we can remove the custom domain from it. This frees it up for the new API Gateway to claim it, as API Gateway custom domains must be unique across an AWS region

This is Step 4.1 of our [rollout plan](https://govukverify.atlassian.net/wiki/x/UpHujQE)

### What’s changed
- sets the feature flag `deploy_oidc_api_gateway_domain` to false - removing the API Gateway custom domain 


### Manual testing

- N/A

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
