### PR TITLE
ATO-2751: Create method to send user identity request

### DIFF
--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtils.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtils.java
@@ -1,0 +1,66 @@
+package uk.gov.di.orchestration.identity.utils;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
+
+import java.io.IOException;
+
+public class IdentityCallbackUtils {
+    private IdentityCallbackUtils() {}
+
+    private static final Logger LOG = LogManager.getLogger(IdentityCallbackUtils.class);
+
+    public static HTTPRequest createUserIdentityRequest(
+            TokenResponse tokenResponse, String backendUri) {
+        return new UserInfoRequest(
+                        ConstructUriHelper.buildURI(backendUri, "user-identity"),
+                        tokenResponse.toSuccessResponse().getTokens().getBearerAccessToken())
+                .toHTTPRequest();
+    }
+
+    public static UserInfo sendUserIdentityRequest(HTTPRequest httpRequest)
+            throws UnsuccessfulCredentialResponseException {
+        try {
+            LOG.info("Sending userinfo request");
+            int count = 0;
+            int maxTries = 2;
+            UserInfoResponse userIdentityResponse;
+            do {
+                if (count > 0) LOG.warn("Retrying user identity request");
+                count++;
+                var httpResponse = httpRequest.send();
+                userIdentityResponse = UserInfoResponse.parse(httpResponse);
+                if (!httpResponse.indicatesSuccess()) {
+                    LOG.warn(
+                            "Unsuccessful {} response from user identity endpoint on attempt {}: {} ",
+                            httpResponse.getStatusCode(),
+                            count,
+                            httpResponse.getBody());
+                }
+            } while (!userIdentityResponse.indicatesSuccess() && count < maxTries);
+
+            if (!userIdentityResponse.indicatesSuccess()) {
+                LOG.error("Response from user-identity does not indicate success");
+                throw new UnsuccessfulCredentialResponseException(
+                        userIdentityResponse.toErrorResponse().toString());
+            } else {
+                return userIdentityResponse.toSuccessResponse().getUserInfo();
+            }
+        } catch (ParseException e) {
+            LOG.error("Error when attempting to parse HTTPResponse to UserInfoResponse");
+            throw new UnsuccessfulCredentialResponseException(
+                    "Error when attempting to parse http response to UserInfoResponse");
+        } catch (IOException e) {
+            LOG.error("Error when attempting to call user-identity endpoint", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtilsTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtilsTest.java
@@ -1,0 +1,121 @@
+package uk.gov.di.orchestration.identity.utils;
+
+import com.nimbusds.common.contenttype.ContentType;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IdentityCallbackUtilsTest {
+    private static final Subject SUBJECT =
+            new Subject("urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
+    private static final String SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT =
+            "{"
+                    + " \"sub\": \""
+                    + SUBJECT
+                    + "\","
+                    + " \"vot\": \"P2\","
+                    + " \"vtm\": \"<trust mark>\""
+                    + "}";
+    private static final String BACKEND_URI = "http://test-backend-uri";
+    private static final BearerAccessToken BEARER_ACCESS_TOKEN = new BearerAccessToken();
+    private static final TokenResponse SUCCESSFUL_TOKEN_RESPONSE =
+            new AccessTokenResponse(new Tokens(BEARER_ACCESS_TOKEN, null));
+
+    @Nested
+    class SendUserIdentityRequest {
+        @Test
+        void shouldCreateUserIdentityRequest() throws Exception {
+            var httpRequest =
+                    IdentityCallbackUtils.createUserIdentityRequest(
+                            SUCCESSFUL_TOKEN_RESPONSE, BACKEND_URI);
+
+            assertThat(httpRequest.getMethod(), equalTo(HTTPRequest.Method.GET));
+            assertThat(httpRequest.getURI(), equalTo(new URI(BACKEND_URI + "/user-identity")));
+            assertThat(
+                    httpRequest.getAuthorization(),
+                    equalTo(BEARER_ACCESS_TOKEN.toAuthorizationHeader()));
+        }
+
+        @Test
+        void shouldReturnUserInfoResponseIfUserIdentityRequestIsSuccessful() throws Exception {
+            var mockedRequest = mock(HTTPRequest.class);
+            when(mockedRequest.send()).thenReturn(successfulUserIdentityResponse());
+
+            var response = IdentityCallbackUtils.sendUserIdentityRequest(mockedRequest);
+
+            assertThat(response.getSubject(), equalTo(SUBJECT));
+        }
+
+        @Test
+        void shouldThrowExceptionIfUserIdentityRequestExceedsNumberOfRetries() throws Exception {
+            var mockedRequest = mock(HTTPRequest.class);
+            when(mockedRequest.send()).thenReturn(unsuccessfulUserIdentityResponse());
+
+            assertThrows(
+                    UnsuccessfulCredentialResponseException.class,
+                    () -> IdentityCallbackUtils.sendUserIdentityRequest(mockedRequest));
+        }
+
+        @Test
+        void shouldReturnUserInfoResponseIfUserIdentityRequestIsSuccessfulAfterRetry()
+                throws Exception {
+            var mockedRequest = mock(HTTPRequest.class);
+            when(mockedRequest.send())
+                    .thenReturn(unsuccessfulUserIdentityResponse())
+                    .thenReturn(successfulUserIdentityResponse());
+
+            var response = IdentityCallbackUtils.sendUserIdentityRequest(mockedRequest);
+
+            assertThat(response.getSubject(), equalTo(SUBJECT));
+        }
+
+        @Test
+        void shouldThrowExceptionIfUserIdentityResponseIsInvalidJSON() throws Exception {
+            var invalidJsonResponse = new HTTPResponse(200);
+            invalidJsonResponse.setBody("{");
+            var mockedRequest = mock(HTTPRequest.class);
+            when(mockedRequest.send()).thenReturn(invalidJsonResponse);
+
+            assertThrows(
+                    UnsuccessfulCredentialResponseException.class,
+                    () -> IdentityCallbackUtils.sendUserIdentityRequest(mockedRequest));
+        }
+
+        @Test
+        void shouldThrowExceptionIfUserIdentityRequestIsInterrupted() throws Exception {
+            var mockedRequest = mock(HTTPRequest.class);
+            when(mockedRequest.send()).thenThrow(new IOException("Network interruption"));
+
+            assertThrows(
+                    RuntimeException.class,
+                    () -> IdentityCallbackUtils.sendUserIdentityRequest(mockedRequest));
+        }
+    }
+
+    private static HTTPResponse successfulUserIdentityResponse() {
+        var httpResponse = new HTTPResponse(200);
+        httpResponse.setEntityContentType(ContentType.APPLICATION_JSON);
+        httpResponse.setBody(SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT);
+        return httpResponse;
+    }
+
+    private static HTTPResponse unsuccessfulUserIdentityResponse() {
+        return new HTTPResponse(500);
+    }
+}


### PR DESCRIPTION
### Wider context of change

This is part of the work to consolidate the identity callback code so it can be shared between IPV and SIS

### What’s changed

This PR adds a method to create and send a user identity request given a `TokenResponse` and `backendUri`. 

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
