### PR TITLE
ATO-2753: Create method to validate user identity response

### DIFF
--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/exceptions/IdentityCallbackException.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/exceptions/IdentityCallbackException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.identity.exceptions;
+
+public class IdentityCallbackException extends RuntimeException {
+    public IdentityCallbackException(String message) {
+        super(message);
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtils.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtils.java
@@ -1,5 +1,7 @@
 package uk.gov.di.orchestration.identity.utils;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
@@ -8,10 +10,17 @@ import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.identity.exceptions.IdentityCallbackException;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VTM;
 
 public class IdentityCallbackUtils {
     private IdentityCallbackUtils() {}
@@ -62,5 +71,25 @@ public class IdentityCallbackUtils {
             LOG.error("Error when attempting to call user-identity endpoint", e);
             throw new RuntimeException(e);
         }
+    }
+
+    public static Optional<ErrorObject> validateUserIdentityResponse(
+            UserInfo userIdentityUserInfo,
+            List<LevelOfConfidence> requestedLoCs,
+            String trustmarkURL)
+            throws IdentityCallbackException {
+        LOG.info("Validating userinfo response");
+        for (LevelOfConfidence loc : requestedLoCs) {
+            if (loc.getValue().equals(userIdentityUserInfo.getClaim(VOT.getValue()))) {
+
+                if (!trustmarkURL.equals(userIdentityUserInfo.getClaim(VTM.getValue()))) {
+                    LOG.warn("VTM does not contain expected trustmark URL");
+                    throw new IdentityCallbackException("Identity trustmark is invalid");
+                }
+                return Optional.empty();
+            }
+        }
+        LOG.warn("User identity response missing vot or vot not in vtr list.");
+        return Optional.of(OAuth2Error.ACCESS_DENIED);
     }
 }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtilsTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtilsTest.java
@@ -8,20 +8,29 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.identity.exceptions.IdentityCallbackException;
+import uk.gov.di.orchestration.shared.entity.LevelOfConfidence;
 import uk.gov.di.orchestration.shared.exceptions.UnsuccessfulCredentialResponseException;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
+import static com.nimbusds.oauth2.sdk.OAuth2Error.ACCESS_DENIED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.identity.utils.IdentityCallbackUtils.validateUserIdentityResponse;
 
 class IdentityCallbackUtilsTest {
+
+    private static final String TRUSTMARK_URL = "http://test.com/trustmark";
     private static final Subject SUBJECT =
             new Subject("urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
     private static final String SUCCESSFUL_USER_INFO_HTTP_RESPONSE_CONTENT =
@@ -105,6 +114,51 @@ class IdentityCallbackUtilsTest {
             assertThrows(
                     RuntimeException.class,
                     () -> IdentityCallbackUtils.sendUserIdentityRequest(mockedRequest));
+        }
+    }
+
+    @Nested
+    class ValidateUserIdentityResponse {
+
+        @Test
+        void shouldReturnAccessDeniedIfVotIsNotContainedInRequestedLoCs() {
+            var userInfo = new UserInfo(SUBJECT);
+            userInfo.setClaim("vot", LevelOfConfidence.MEDIUM_LEVEL.getValue());
+
+            var result =
+                    validateUserIdentityResponse(
+                            userInfo, List.of(LevelOfConfidence.NONE), TRUSTMARK_URL);
+
+            assertTrue(result.isPresent());
+            assertThat(result.get(), equalTo(ACCESS_DENIED));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenVtmDoesNotEqualTrustmarkUrl() {
+            var userInfo = new UserInfo(SUBJECT);
+            userInfo.setClaim("vot", LevelOfConfidence.MEDIUM_LEVEL.getValue());
+            userInfo.setClaim("vtm", "http://different-trustmark-url");
+
+            assertThrows(
+                    IdentityCallbackException.class,
+                    () ->
+                            validateUserIdentityResponse(
+                                    userInfo,
+                                    List.of(LevelOfConfidence.MEDIUM_LEVEL),
+                                    TRUSTMARK_URL));
+        }
+
+        @Test
+        void shouldNotReturnErrorIfVotIsInRequestedLoCsAndVtmMatchesTrustmarkUrl() {
+            var userInfo = new UserInfo(SUBJECT);
+            userInfo.setClaim("vot", LevelOfConfidence.MEDIUM_LEVEL.getValue());
+            userInfo.setClaim("vtm", TRUSTMARK_URL);
+
+            var result =
+                    validateUserIdentityResponse(
+                            userInfo, List.of(LevelOfConfidence.MEDIUM_LEVEL), TRUSTMARK_URL);
+
+            assertTrue(result.isEmpty());
         }
     }
 


### PR DESCRIPTION
### Wider context of change

This is part of the work to consolidate the identity callback code so it can be shared between IPV and SIS

### What’s changed

This PR adds a method to validate a user identity response, which has been copied from IPVCallbackHelper

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
