### PR TITLE
ATO-2759: Create method to save identity claims to dynamo

### DIFF
--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelper.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelper.java
@@ -1,32 +1,47 @@
 package uk.gov.di.orchestration.identity.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.identity.entity.AuditEventConfiguration;
 import uk.gov.di.orchestration.identity.entity.IdentityTokenService;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
+import uk.gov.di.orchestration.shared.entity.IdentityClaims;
+import uk.gov.di.orchestration.shared.entity.ValidClaims;
 import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 
+import java.util.HashMap;
+import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.orchestration.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class IdentityCallbackHelper {
+
+    private static final Logger LOG = LogManager.getLogger(IdentityCallbackHelper.class);
     private final IdentityTokenService identityTokenService;
     private final AuditService auditService;
     private final AuditEventConfiguration auditEventConfiguration;
     private final CommonFrontend frontend;
+    private final DynamoIdentityService dynamoIdentityService;
 
     public IdentityCallbackHelper(
             IdentityTokenService identityTokenService,
             AuditService auditService,
             AuditEventConfiguration auditEventConfiguration,
-            CommonFrontend frontend) {
+            CommonFrontend frontend,
+            DynamoIdentityService dynamoIdentityService) {
         this.identityTokenService = identityTokenService;
         this.auditService = auditService;
         this.auditEventConfiguration = auditEventConfiguration;
         this.frontend = frontend;
+        this.dynamoIdentityService = dynamoIdentityService;
     }
 
     public Optional<APIGatewayProxyResponseEvent> makeTokenRequest(
@@ -47,5 +62,38 @@ public class IdentityCallbackHelper {
         auditService.submitAuditEvent(
                 auditEventConfiguration.successfulTokenResponseReceived(), clientId, user);
         return Optional.empty();
+    }
+
+    public void saveIdentityClaimsToDynamo(
+            String clientSessionId,
+            Subject rpPairwiseSubject,
+            UserInfo userIdentityUserInfo,
+            Long spotQueuedAt) {
+        LOG.info("Checking for additional identity claims to save to dynamo");
+        var additionalClaims = new HashMap<String, String>();
+        ValidClaims.getAllValidClaims().stream()
+                .filter(t -> !t.equals(ValidClaims.CORE_IDENTITY_JWT.getValue()))
+                .filter(claim -> Objects.nonNull(userIdentityUserInfo.toJSONObject().get(claim)))
+                .forEach(
+                        finalClaim ->
+                                additionalClaims.put(
+                                        finalClaim,
+                                        userIdentityUserInfo
+                                                .toJSONObject()
+                                                .get(finalClaim)
+                                                .toString()));
+        LOG.info("Additional identity claims present: {}", !additionalClaims.isEmpty());
+
+        var ipvCoreIdentityClaim =
+                userIdentityUserInfo.getClaim(IdentityClaims.CORE_IDENTITY.getValue());
+        String ipvCoreIdentityString =
+                ipvCoreIdentityClaim == null ? "" : ipvCoreIdentityClaim.toString();
+        dynamoIdentityService.saveIdentityClaims(
+                clientSessionId,
+                rpPairwiseSubject.getValue(),
+                additionalClaims,
+                (String) userIdentityUserInfo.getClaim(VOT.getValue()),
+                ipvCoreIdentityString,
+                spotQueuedAt);
     }
 }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelperTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelperTest.java
@@ -4,9 +4,13 @@ import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
@@ -16,10 +20,13 @@ import uk.gov.di.orchestration.identity.testsupport.TestAuditEvent;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.logging.log4j.Level.ERROR;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withLevelAndMessageContaining;
+import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 public class IdentityCallbackHelperTest {
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
@@ -39,12 +47,17 @@ public class IdentityCallbackHelperTest {
     private final IdentityTokenService identityTokenService = mock(IdentityTokenService.class);
     private final CommonFrontend frontend = mock(CommonFrontend.class);
     private final AuditService auditService = mock(AuditService.class);
+    private final DynamoIdentityService dynamoIdentityService = mock(DynamoIdentityService.class);
     private final AuditEventConfiguration auditEventConfiguration =
             new AuditEventConfiguration(
                     TestAuditEvent.TEST_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                     TestAuditEvent.TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
     private final TxmaAuditUser user = mock(TxmaAuditUser.class);
     private IdentityCallbackHelper helper;
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(IdentityCallbackHelper.class);
 
     @RegisterExtension
     private final CaptureLoggingExtension redirectLogging =
@@ -54,41 +67,199 @@ public class IdentityCallbackHelperTest {
     void setUp() {
         helper =
                 new IdentityCallbackHelper(
-                        identityTokenService, auditService, auditEventConfiguration, frontend);
+                        identityTokenService,
+                        auditService,
+                        auditEventConfiguration,
+                        frontend,
+                        dynamoIdentityService);
         when(frontend.errorURI()).thenReturn(FRONT_END_ERROR_URI);
     }
 
-    @Test
-    void shouldRedirectToFrontendErrorPageWhenTokenResponseIsNotSuccessful() {
-        withUnsuccessfulTokenResponse();
+    @Nested
+    class MakeTokenRequest {
+        @Test
+        void shouldRedirectToFrontendErrorPageWhenTokenResponseIsNotSuccessful() {
+            withUnsuccessfulTokenResponse();
 
-        var response = helper.makeTokenRequest(AUTH_CODE.toString(), CLIENT_ID, user);
+            var response = helper.makeTokenRequest(AUTH_CODE.toString(), CLIENT_ID, user);
 
-        assertTrue(response.isPresent());
-        assertThat(
-                response.get().getHeaders().get("Location"),
-                startsWith(FRONT_END_ERROR_URI.toString()));
+            assertTrue(response.isPresent());
+            assertThat(
+                    response.get().getHeaders().get("Location"),
+                    startsWith(FRONT_END_ERROR_URI.toString()));
 
-        assertAuditEventSent(TestAuditEvent.TEST_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
-        verifyNoMoreInteractions(auditService);
+            assertAuditEventSent(TestAuditEvent.TEST_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
+            verifyNoMoreInteractions(auditService);
 
-        assertThat(
-                redirectLogging.events(),
-                hasItem(
-                        withLevelAndMessageContaining(
-                                ERROR,
-                                "Redirecting to frontend error page: " + FRONT_END_ERROR_URI)));
+            assertThat(
+                    redirectLogging.events(),
+                    hasItem(
+                            withLevelAndMessageContaining(
+                                    ERROR,
+                                    "Redirecting to frontend error page: " + FRONT_END_ERROR_URI)));
+        }
+
+        @Test
+        void shouldNotRedirectWhenTokenResponseIsSuccessful() {
+            withSuccessfulTokenResponse();
+
+            var response = helper.makeTokenRequest(AUTH_CODE.toString(), CLIENT_ID, user);
+
+            assertTrue(response.isEmpty());
+            assertAuditEventSent(TestAuditEvent.TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
+            verifyNoMoreInteractions(auditService);
+        }
     }
 
-    @Test
-    void shouldNotRedirectWhenTokenResponseIsSuccessful() {
-        withSuccessfulTokenResponse();
+    @Nested
+    class SaveIdentityClaimsToDynamo {
+        private static final String CLIENT_SESSION_ID = "test-csid";
+        private static final Subject RP_PAIRWISE_SUBJECT = new Subject("rp-pairwise-id");
+        private static final long SPOT_QUEUED_AT = 12345L;
 
-        var response = helper.makeTokenRequest(AUTH_CODE.toString(), CLIENT_ID, user);
+        @Test
+        void shouldSaveAdditionalIdentityClaimsToDynamo() {
+            var userInfo =
+                    new UserInfo(
+                            new JSONObject(
+                                    Map.of(
+                                            "sub", "sub-val",
+                                            "vot", "P2",
+                                            "vtm", "http://test-trustmark-uri",
+                                            "https://vocab.account.gov.uk/v1/coreIdentity",
+                                                    "core-identity",
+                                            "https://vocab.account.gov.uk/v1/passport",
+                                                    "passport")));
+            helper.saveIdentityClaimsToDynamo(
+                    CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, userInfo, SPOT_QUEUED_AT);
 
-        assertTrue(response.isEmpty());
-        assertAuditEventSent(TestAuditEvent.TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED);
-        verifyNoMoreInteractions(auditService);
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withMessageContaining(
+                                    "Checking for additional identity claims to save to dynamo")));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Additional identity claims present: true")));
+            verify(dynamoIdentityService)
+                    .saveIdentityClaims(
+                            CLIENT_SESSION_ID,
+                            "rp-pairwise-id",
+                            Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
+                            "P2",
+                            "core-identity",
+                            SPOT_QUEUED_AT);
+        }
+
+        @Test
+        void handlesMissingCoreIdentity() {
+            var userInfo =
+                    new UserInfo(
+                            new JSONObject(
+                                    Map.of(
+                                            "sub", "sub-val",
+                                            "vot", "P2",
+                                            "vtm", "http://test-trustmark-uri",
+                                            "https://vocab.account.gov.uk/v1/passport",
+                                                    "passport")));
+            helper.saveIdentityClaimsToDynamo(
+                    CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, userInfo, SPOT_QUEUED_AT);
+
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withMessageContaining(
+                                    "Checking for additional identity claims to save to dynamo")));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Additional identity claims present: true")));
+            verify(dynamoIdentityService)
+                    .saveIdentityClaims(
+                            CLIENT_SESSION_ID,
+                            "rp-pairwise-id",
+                            Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
+                            "P2",
+                            "",
+                            SPOT_QUEUED_AT);
+        }
+
+        @Test
+        void handlesNullCoreIdentity() {
+            var userInfo =
+                    new UserInfo(
+                            new JSONObject(
+                                    new HashMap<String, String>() {
+                                        {
+                                            put("sub", "sub-val");
+                                            put("vot", "P2");
+                                            put("vtm", "http://test-trustmark-url");
+                                            put(
+                                                    "https://vocab.account.gov.uk/v1/coreIdentity",
+                                                    null);
+                                            put(
+                                                    "https://vocab.account.gov.uk/v1/passport",
+                                                    "passport");
+                                        }
+                                    }));
+            helper.saveIdentityClaimsToDynamo(
+                    CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, userInfo, SPOT_QUEUED_AT);
+
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withMessageContaining(
+                                    "Checking for additional identity claims to save to dynamo")));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Additional identity claims present: true")));
+            verify(dynamoIdentityService)
+                    .saveIdentityClaims(
+                            CLIENT_SESSION_ID,
+                            "rp-pairwise-id",
+                            Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
+                            "P2",
+                            "",
+                            SPOT_QUEUED_AT);
+        }
+
+        @Test
+        void handlesNullSpotQueuedAtTimestamp() {
+            var userInfo =
+                    new UserInfo(
+                            new JSONObject(
+                                    new HashMap<String, String>() {
+                                        {
+                                            put("sub", "sub-val");
+                                            put("vot", "P2");
+                                            put("vtm", "http://test-trustmark-uri");
+                                            put(
+                                                    "https://vocab.account.gov.uk/v1/coreIdentity",
+                                                    null);
+                                            put(
+                                                    "https://vocab.account.gov.uk/v1/passport",
+                                                    "passport");
+                                        }
+                                    }));
+            helper.saveIdentityClaimsToDynamo(
+                    CLIENT_SESSION_ID, RP_PAIRWISE_SUBJECT, userInfo, null);
+
+            assertThat(
+                    logging.events(),
+                    hasItem(
+                            withMessageContaining(
+                                    "Checking for additional identity claims to save to dynamo")));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Additional identity claims present: true")));
+            verify(dynamoIdentityService)
+                    .saveIdentityClaims(
+                            CLIENT_SESSION_ID,
+                            "rp-pairwise-id",
+                            Map.of("https://vocab.account.gov.uk/v1/passport", "passport"),
+                            "P2",
+                            "",
+                            null);
+        }
     }
 
     private void withSuccessfulTokenResponse() {


### PR DESCRIPTION
### Wider context of change

This is part of the work to consolidate the identity callback code so it can be shared between IPV and SIS

### What’s changed

This PR adds a method to build and save identity claims to dynamo, given a user's UserInfo. This has been copied from IPVCallbackHelper

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
