### PR TITLE
Aut 5553/update passkey after successful verification

### DIFF
--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysUpdateRequest.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysUpdateRequest.java
@@ -5,5 +5,5 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record PasskeysUpdateRequest(
-        @SerializedName("signCount") @Expose @Required Integer signCount,
+        @SerializedName("signCount") @Expose @Required Integer signCount, // TODO make long
         @SerializedName("lastUsedAt") @Expose @Required String lastUsedAt) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/FinishPasskeyAssertionFailureReason.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/FinishPasskeyAssertionFailureReason.java
@@ -3,7 +3,8 @@ package uk.gov.di.authentication.frontendapi.entity;
 public enum FinishPasskeyAssertionFailureReason {
     PARSING_ASSERTION_REQUEST_ERROR("parsing_assertion_request_error"),
     PARSING_PKC_ERROR("parsing_pkc_error"),
-    ASSERTION_FAILED_ERROR("assertion_failed_error");
+    ASSERTION_FAILED_ERROR("assertion_failed_error"),
+    ERROR_UPDATING_PASSKEY_RECORD("error_updating_passkey_record");
 
     private final String value;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyUpdateError.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyUpdateError.java
@@ -7,7 +7,9 @@ public enum PasskeyUpdateError {
     PASSKEY_UPDATE_INTERNAL_SERVER_ERROR("Passkey update account data api internal server error"),
     PASSKEY_UPDATE_UNEXPECTED_RESPONSE_CODE(
             "Account data api returned unexpected response code for update passkeys"),
-    ERROR_CREATING_ACCESS_TOKEN("Failure constructing adapi access token");
+    ERROR_CREATING_ACCESS_TOKEN("Failure constructing adapi access token"),
+    IO_EXCEPTION("IO exception calling passkey update endpoint"),
+    INTERRUPTED_EXCEPTION("Interrupted exception calling passkey update endpoint");
 
     private final String value;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyUpdateError.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyUpdateError.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.frontendapi.entity.passkeys;
+
+public enum PasskeyUpdateError {
+    PASSKEY_UPDATE_BAD_REQUEST("Passkey update bad request"),
+    PASSKEY_UPDATE_UNAUTHORISED("Passkey update unauthorised request"),
+    PASSKEY_OR_USER_NOT_FOUND("Passkey or user not found"),
+    PASSKEY_UPDATE_INTERNAL_SERVER_ERROR("Passkey update account data api internal server error"),
+    PASSKEY_UPDATE_UNEXPECTED_RESPONSE_CODE(
+            "Account data api returned unexpected response code for update passkeys");
+
+    private final String value;
+
+    PasskeyUpdateError(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyUpdateError.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/passkeys/PasskeyUpdateError.java
@@ -6,7 +6,8 @@ public enum PasskeyUpdateError {
     PASSKEY_OR_USER_NOT_FOUND("Passkey or user not found"),
     PASSKEY_UPDATE_INTERNAL_SERVER_ERROR("Passkey update account data api internal server error"),
     PASSKEY_UPDATE_UNEXPECTED_RESPONSE_CODE(
-            "Account data api returned unexpected response code for update passkeys");
+            "Account data api returned unexpected response code for update passkeys"),
+    ERROR_CREATING_ACCESS_TOKEN("Failure constructing adapi access token");
 
     private final String value;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -109,7 +109,8 @@ public class FinishPasskeyAssertionHandler
                 .fold(
                         failure ->
                                 switch (failure) {
-                                    case PARSING_ASSERTION_REQUEST_ERROR -> generateApiGatewayProxyErrorResponse(
+                                    case PARSING_ASSERTION_REQUEST_ERROR,
+                                            ERROR_UPDATING_PASSKEY_RECORD -> generateApiGatewayProxyErrorResponse(
                                             500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
                                     case PARSING_PKC_ERROR -> generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.PASSKEY_ASSERTION_INVALID_PKC);
@@ -156,10 +157,8 @@ public class FinishPasskeyAssertionHandler
         var result =
                 passkeysService.updatePasskey(
                         publicSubjectId, sessionId, passkeyId, signCount, Clock.systemUTC());
-        if (result.isFailure()) {
-            throw new RuntimeException("TODO");
-        }
-        return Result.success(null);
+        return result.tapFailure(f -> LOG.error(f.getValue()))
+                .mapFailure(f -> FinishPasskeyAssertionFailureReason.ERROR_UPDATING_PASSKEY_RECORD);
     }
 
     private Void reportCorrectPasskeyReceived(UserContext userContext) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionRequest;
+import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.DefaultPasskeyJsonParser;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.RelyingPartyProvider;
@@ -29,6 +30,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import uk.gov.di.authentication.userpermissions.entity.PermissionContext;
 
+import java.time.Clock;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
@@ -46,6 +48,7 @@ public class FinishPasskeyAssertionHandler
     private final PasskeyAssertionService passkeyAssertionService;
     private final UserActionsManager userActionsManager;
     private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final PasskeysService passkeysService;
 
     public FinishPasskeyAssertionHandler() {
         this(ConfigurationService.getInstance());
@@ -57,7 +60,8 @@ public class FinishPasskeyAssertionHandler
             AuthSessionService authSessionService,
             PasskeyAssertionService passkeyAssertionService,
             UserActionsManager userActionsManager,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            CloudwatchMetricsService cloudwatchMetricsService,
+            PasskeysService passkeysService) {
         super(
                 FinishPasskeyAssertionRequest.class,
                 configurationService,
@@ -66,6 +70,7 @@ public class FinishPasskeyAssertionHandler
         this.passkeyAssertionService = passkeyAssertionService;
         this.userActionsManager = userActionsManager;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.passkeysService = passkeysService;
     }
 
     public FinishPasskeyAssertionHandler(ConfigurationService configurationService) {
@@ -77,6 +82,7 @@ public class FinishPasskeyAssertionHandler
                         new StructuredAuditService(configurationService));
         this.userActionsManager = new UserActionsManager(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.passkeysService = new PasskeysService(configurationService);
     }
 
     @Override
@@ -97,7 +103,7 @@ public class FinishPasskeyAssertionHandler
         reportPasskeyAuthenticationSuccess();
 
         return verifyPasskeyAssertion(userContext, request, input)
-                .flatMap(this::updatePasskeyRecord)
+                .flatMap(assertionResult -> updatePasskeyRecord(assertionResult, userContext))
                 .tap(success -> reportCorrectPasskeyReceived(userContext))
                 .tapFailure(failure -> reportIncorrectPasskeyReceived(userContext, failure))
                 .fold(
@@ -142,8 +148,17 @@ public class FinishPasskeyAssertionHandler
     }
 
     private Result<FinishPasskeyAssertionFailureReason, Void> updatePasskeyRecord(
-            AssertionResult assertionResult) {
-        // TODO - AUT-4938 - Update database with latest passkey values
+            AssertionResult assertionResult, UserContext userContext) {
+        var publicSubjectId = userContext.getUserProfile().get().getPublicSubjectID();
+        var sessionId = userContext.getAuthSession().getSessionId();
+        var passkeyId = assertionResult.getCredential().getCredentialId().getBase64Url();
+        var signCount = assertionResult.getSignatureCount();
+        var result =
+                passkeysService.updatePasskey(
+                        publicSubjectId, sessionId, passkeyId, signCount, Clock.systemUTC());
+        if (result.isFailure()) {
+            throw new RuntimeException("TODO");
+        }
         return Result.success(null);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -102,8 +102,18 @@ public class FinishPasskeyAssertionHandler
 
         reportPasskeyAuthenticationSuccess();
 
+        var maybeUserProfile = userContext.getUserProfile();
+
+        if (maybeUserProfile.isEmpty()) {
+            LOG.error("User profile not found for finish passkey assertion");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.USER_NOT_FOUND);
+        }
+        var userProfile = maybeUserProfile.get();
+
         return verifyPasskeyAssertion(userContext, request, input)
-                .flatMap(assertionResult -> updatePasskeyRecord(assertionResult, userContext))
+                .flatMap(
+                        assertionResult ->
+                                updatePasskeyRecord(assertionResult, userContext, userProfile))
                 .tap(success -> reportCorrectPasskeyReceived(userContext))
                 .tapFailure(failure -> reportIncorrectPasskeyReceived(userContext, failure))
                 .fold(
@@ -149,8 +159,8 @@ public class FinishPasskeyAssertionHandler
     }
 
     private Result<FinishPasskeyAssertionFailureReason, Void> updatePasskeyRecord(
-            AssertionResult assertionResult, UserContext userContext) {
-        var publicSubjectId = userContext.getUserProfile().get().getPublicSubjectID();
+            AssertionResult assertionResult, UserContext userContext, UserProfile userProfile) {
+        var publicSubjectId = userProfile.getPublicSubjectID();
         var sessionId = userContext.getAuthSession().getSessionId();
         var passkeyId = assertionResult.getCredential().getCredentialId().getBase64Url();
         var signCount = assertionResult.getSignatureCount();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyUpdateError;
 import uk.gov.di.authentication.shared.entity.AccessTokenScope;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -112,7 +113,7 @@ public class PasskeysService {
         }
     }
 
-    public Result<String, Void> updatePasskey(
+    public Result<PasskeyUpdateError, Void> updatePasskey(
             String publicSubjectId,
             String sessionId,
             String passkeyIdentifier,
@@ -137,8 +138,16 @@ public class PasskeysService {
                         .build();
 
         try {
-            httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            return Result.emptySuccess();
+            var result = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return switch (result.statusCode()) {
+                case 204 -> Result.emptySuccess();
+                case 400 -> Result.failure(PasskeyUpdateError.PASSKEY_UPDATE_BAD_REQUEST);
+                case 403 -> Result.failure(PasskeyUpdateError.PASSKEY_UPDATE_UNAUTHORISED);
+                case 404 -> Result.failure(PasskeyUpdateError.PASSKEY_OR_USER_NOT_FOUND);
+                case 500 -> Result.failure(PasskeyUpdateError.PASSKEY_UPDATE_INTERNAL_SERVER_ERROR);
+                default -> Result.failure(
+                        PasskeyUpdateError.PASSKEY_UPDATE_UNEXPECTED_RESPONSE_CODE);
+            };
         } catch (Exception e) {
             throw new RuntimeException("TODO");
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -159,8 +159,20 @@ public class PasskeysService {
                 default -> Result.failure(
                         PasskeyUpdateError.PASSKEY_UPDATE_UNEXPECTED_RESPONSE_CODE);
             };
-        } catch (Exception e) {
-            throw new RuntimeException("TODO");
+        } catch (IOException e) {
+            LOG.error("IOException in update passkeys", e);
+            return Result.failure(PasskeyUpdateError.IO_EXCEPTION);
+        } catch (InterruptedException e) {
+            if (e.getCause() instanceof LinkageError) {
+                // In rare cases we see a linkage error within the HTTP Client
+                // which fails all future requests made by the lambda
+                // As a temporary measure we crash the lambda to force a restart
+                LOG.error("Linkage error making passkey update request, exiting with fault");
+                System.exit(1);
+            }
+            LOG.error("Interrupted exception in update passkeys");
+            Thread.currentThread().interrupt();
+            return Result.failure(PasskeyUpdateError.INTERRUPTED_EXCEPTION);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -67,7 +67,7 @@ public class PasskeysService {
                 createAccountDataApiAccessToken(
                         publicSubjectId, sessionId, List.of(AccountDataScope.PASSKEY_RETRIEVE));
         if (accountDataApiAccessTokenResult.isFailure()) {
-            return Result.failure(accountDataApiAccessTokenResult.getFailure());
+            return Result.failure(PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN);
         }
 
         var accountDataBaseUri = configurationService.getAccountDataURI();
@@ -132,8 +132,19 @@ public class PasskeysService {
         var bodyPublisher =
                 HttpRequest.BodyPublishers.ofString(
                         serialisationService.writeValueAsString(updateRequest));
+        var accountDataApiAccessTokenResult =
+                createAccountDataApiAccessToken(
+                        publicSubjectId, sessionId, List.of(AccountDataScope.PASSKEY_UPDATE));
+        if (accountDataApiAccessTokenResult.isFailure()) {
+            return Result.failure(PasskeyUpdateError.ERROR_CREATING_ACCESS_TOKEN);
+        }
         var request =
                 HttpRequest.newBuilder(updatePasskeysRequestUri)
+                        .header(
+                                "Authorization",
+                                accountDataApiAccessTokenResult
+                                        .getSuccess()
+                                        .toAuthorizationHeader())
                         .method("PATCH", bodyPublisher)
                         .build();
 
@@ -167,7 +178,7 @@ public class PasskeysService {
         }
     }
 
-    private Result<PasskeyRetrieveError, BearerAccessToken> createAccountDataApiAccessToken(
+    private Result<String, BearerAccessToken> createAccountDataApiAccessToken(
             String publicSubjectId, String sessionId, List<AccessTokenScope> scopes) {
         return accessTokenConstructorService
                 .createSignedAccessToken(
@@ -185,7 +196,7 @@ public class PasskeysService {
                             LOG.warn(
                                     "Error creating account data api access token. Error: {}",
                                     failure);
-                            return PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN;
+                            return "Error creating access token";
                         });
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.shared.entity.AccessTokenScope;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.passkeys.PasskeysRetrieveResponse;
+import uk.gov.di.authentication.shared.entity.passkeys.PasskeysUpdateRequest;
 import uk.gov.di.authentication.shared.helpers.HttpClientHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -108,6 +109,38 @@ public class PasskeysService {
             LOG.error("Interrupted exception in retrieve passkeys");
             Thread.currentThread().interrupt();
             return Result.failure(PasskeyRetrieveError.INTERRUPTED_EXCEPTION);
+        }
+    }
+
+    public Result<String, Void> updatePasskey(
+            String publicSubjectId,
+            String sessionId,
+            String passkeyIdentifier,
+            int signCount,
+            Clock clock) {
+        var accountDataBaseUri = configurationService.getAccountDataURI();
+        var updatePasskeysRequestUri =
+                buildURI(
+                        accountDataBaseUri,
+                        "/accounts/"
+                                + publicSubjectId
+                                + "/authenticators/passkeys/"
+                                + passkeyIdentifier);
+        var serialisationService = SerializationService.getInstance();
+        var updateRequest = new PasskeysUpdateRequest(signCount, clock.instant().toString());
+        var bodyPublisher =
+                HttpRequest.BodyPublishers.ofString(
+                        serialisationService.writeValueAsString(updateRequest));
+        var request =
+                HttpRequest.newBuilder(updatePasskeysRequestUri)
+                        .method("PATCH", bodyPublisher)
+                        .build();
+
+        try {
+            httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return Result.emptySuccess();
+        } catch (Exception e) {
+            throw new RuntimeException("TODO");
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysService.java
@@ -117,7 +117,7 @@ public class PasskeysService {
             String publicSubjectId,
             String sessionId,
             String passkeyIdentifier,
-            int signCount,
+            long signCount,
             Clock clock) {
         var accountDataBaseUri = configurationService.getAccountDataURI();
         var updatePasskeysRequestUri =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -277,6 +277,19 @@ class FinishPasskeyAssertionHandlerTest {
         }
 
         @Test
+        void shouldReturn400IfNoUserProfile() {
+            // Given
+            when(authenticationService.getUserProfileFromEmail(EMAIL)).thenReturn(Optional.empty());
+
+            // When
+            var response = handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+            // Then
+            assertThat(response, hasStatus(400));
+            assertThat(response, hasJsonBody(ErrorResponse.USER_NOT_FOUND));
+        }
+
+        @Test
         void shouldReturn400WhenPKCDeserializationFails() {
             // Given
             when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyUpdateError;
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
@@ -237,6 +238,35 @@ class FinishPasskeyAssertionHandlerTest {
                             Result.failure(
                                     FinishPasskeyAssertionFailureReason
                                             .PARSING_ASSERTION_REQUEST_ERROR));
+
+            // When
+            var response = handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+            // Then
+            assertThat(response, hasStatus(500));
+            assertThat(response, hasJsonBody(ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR));
+        }
+
+        @Test
+        void shouldReturn500WhenUpdateRequestFails() throws Base64UrlException {
+            // Given
+            var mockAssertionResult = mock(AssertionResult.class);
+            var mockCredential = mock(RegisteredCredential.class);
+            when(mockCredential.getCredentialId())
+                    .thenReturn(ByteArray.fromBase64Url(CREDENTIAL_ID));
+            when(mockAssertionResult.getCredential()).thenReturn(mockCredential);
+            when(mockAssertionResult.getSignatureCount()).thenReturn(SIGN_COUNT);
+
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
+                    .thenReturn(Result.success(mockAssertionResult));
+
+            when(passkeysService.updatePasskey(
+                            PUBLIC_SUBJECT_ID,
+                            SESSION_ID,
+                            CREDENTIAL_ID,
+                            SIGN_COUNT,
+                            Clock.systemUTC()))
+                    .thenReturn(Result.failure(PasskeyUpdateError.PASSKEY_UPDATE_BAD_REQUEST));
 
             // When
             var response = handler.handleRequest(finishPasskeyAssertionRequest(), context);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -3,28 +3,36 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.yubico.webauthn.AssertionResult;
+import com.yubico.webauthn.RegisteredCredential;
+import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.exception.Base64UrlException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
+import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
 import uk.gov.di.authentication.frontendapi.services.webauthn.PasskeyAssertionService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.userpermissions.UserActionsManager;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -34,7 +42,9 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.PASSKEY_AUTHENTICATION_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.PASSKEY_VERIFICATION_FAILED;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.PASSKEY_VERIFICATION_SUCCESSFUL;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -51,10 +61,14 @@ class FinishPasskeyAssertionHandlerTest {
     private final UserActionsManager userActionsManager = mock(UserActionsManager.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
+    private final PasskeysService passkeysService = mock(PasskeysService.class);
     private FinishPasskeyAssertionHandler handler;
-    private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(SESSION_ID);
+    private final AuthSessionItem authSession =
+            new AuthSessionItem().withSessionId(SESSION_ID).withEmailAddress(EMAIL);
 
     private static final String ENV = "test";
+    private static final String CREDENTIAL_ID = "some-passkey-id";
+    private static final Long SIGN_COUNT = 5L;
 
     @BeforeEach
     void setup() {
@@ -62,6 +76,12 @@ class FinishPasskeyAssertionHandlerTest {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(authSessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(authSession));
+        when(authenticationService.getUserProfileFromEmail(EMAIL))
+                .thenReturn(
+                        Optional.of(
+                                new UserProfile()
+                                        .withEmail(EMAIL)
+                                        .withPublicSubjectID(PUBLIC_SUBJECT_ID)));
 
         handler =
                 new FinishPasskeyAssertionHandler(
@@ -70,17 +90,35 @@ class FinishPasskeyAssertionHandlerTest {
                         authSessionService,
                         passkeyAssertionService,
                         userActionsManager,
-                        cloudwatchMetricsService);
+                        cloudwatchMetricsService,
+                        passkeysService);
     }
 
     @Nested
     class Success {
-        @Test
-        void shouldReturn200WhenPasskeyAssertionSuccessful() {
-            // Given
-            AssertionResult mockAssertionResult = mock(AssertionResult.class);
+        void setupSuccess() throws Base64UrlException {
+            var mockAssertionResult = mock(AssertionResult.class);
+            var mockCredential = mock(RegisteredCredential.class);
+            when(mockCredential.getCredentialId())
+                    .thenReturn(ByteArray.fromBase64Url(CREDENTIAL_ID));
+            when(mockAssertionResult.getCredential()).thenReturn(mockCredential);
+            when(mockAssertionResult.getSignatureCount()).thenReturn(SIGN_COUNT);
+
             when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(Result.success(mockAssertionResult));
+            when(passkeysService.updatePasskey(
+                            PUBLIC_SUBJECT_ID,
+                            SESSION_ID,
+                            CREDENTIAL_ID,
+                            SIGN_COUNT,
+                            Clock.systemUTC()))
+                    .thenReturn(Result.emptySuccess());
+        }
+
+        @Test
+        void shouldReturn200WhenPasskeyAssertionSuccessful() throws Base64UrlException {
+            // Given
+            setupSuccess();
 
             // When
             var response = handler.handleRequest(finishPasskeyAssertionRequest(), context);
@@ -90,11 +128,9 @@ class FinishPasskeyAssertionHandlerTest {
         }
 
         @Test
-        void shouldReportCorrectPasskeyReceivedWhenAssertionSuccessful() {
+        void shouldReportCorrectPasskeyReceivedWhenAssertionSuccessful() throws Base64UrlException {
             // Given
-            AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
-                    .thenReturn(Result.success(mockAssertionResult));
+            setupSuccess();
 
             // When
             handler.handleRequest(finishPasskeyAssertionRequest(), context);
@@ -105,11 +141,9 @@ class FinishPasskeyAssertionHandlerTest {
         }
 
         @Test
-        void shouldEmitCloudwatchMetricsWhenAssertionSuccessful() {
+        void shouldEmitCloudwatchMetricsWhenAssertionSuccessful() throws Base64UrlException {
             // Given
-            AssertionResult mockAssertionResult = mock(AssertionResult.class);
-            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
-                    .thenReturn(Result.success(mockAssertionResult));
+            setupSuccess();
 
             // When
             handler.handleRequest(finishPasskeyAssertionRequest(), context);
@@ -125,6 +159,22 @@ class FinishPasskeyAssertionHandlerTest {
 
             verify(cloudwatchMetricsService, never())
                     .incrementCounter(eq(PASSKEY_VERIFICATION_FAILED), anyMap());
+        }
+
+        @Test
+        void shouldUpdatePasskeyWhenAssertionSuccessful() throws Base64UrlException {
+            setupSuccess();
+            // When
+            handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+            // Then
+            verify(passkeysService, times(1))
+                    .updatePasskey(
+                            PUBLIC_SUBJECT_ID,
+                            SESSION_ID,
+                            CREDENTIAL_ID,
+                            SIGN_COUNT,
+                            Clock.systemUTC());
         }
     }
 
@@ -160,6 +210,23 @@ class FinishPasskeyAssertionHandlerTest {
             // Then
             verify(userActionsManager, times(1)).incorrectPasskeyReceived(any(), any());
             verify(userActionsManager, times(0)).correctPasskeyReceived(any(), any());
+        }
+
+        @Test
+        void shouldNotUpdatePasskeyRecordWhenAssertionUnsuccessful() {
+            // Given
+            when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
+                    .thenReturn(
+                            Result.failure(
+                                    FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR));
+
+            // When
+            handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+            // Then
+            verify(passkeysService, never())
+                    .updatePasskey(
+                            anyString(), anyString(), anyString(), anyLong(), any(Clock.class));
         }
 
         @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -79,7 +79,7 @@ class PasskeysServiceTest {
     }
 
     @Nested
-    class SuccessCases {
+    class HasActivePasskey {
         private static Stream<Arguments> successfulTestCases() {
             return Stream.of(
                     Arguments.of(List.of(aPasskeyWithId("123456")), true),
@@ -129,28 +129,6 @@ class PasskeysServiceTest {
             assertEquals(expectedResult, hasActivePasskey);
         }
 
-        @Test
-        void retrievePasskeysShouldReturnFullResponseOnSuccess()
-                throws IOException, InterruptedException {
-            when(httpResponse.body())
-                    .thenReturn(passkeyResponse(List.of(aPasskeyWithId("123456"))));
-            when(httpResponse.statusCode()).thenReturn(200);
-            when(httpClient.send(
-                            argThat(
-                                    request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                            any()))
-                    .thenReturn(httpResponse);
-
-            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
-            assertTrue(result.isSuccess());
-            assertEquals(1, result.getSuccess().passkeys().size());
-            assertEquals("123456", result.getSuccess().passkeys().get(0).passkeyId());
-        }
-    }
-
-    @Nested
-    class FailureCases {
         @Test
         void hasActivePasskeyShouldReturnFailureWhenAccountDataApiReturnsANon200ResponseCode()
                 throws IOException, InterruptedException {
@@ -219,6 +197,41 @@ class PasskeysServiceTest {
         }
 
         @Test
+        void retrievePasskeysShouldReturnFailureIfErrorCreatingAccessToken() {
+            when(accessTokenConstructorService.createSignedAccessToken(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
+
+            assertTrue(result.isFailure());
+            assertEquals(PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN, result.getFailure());
+            verifyNoInteractions(httpClient);
+        }
+    }
+
+    @Nested
+    class RetrievePasskeys {
+        @Test
+        void retrievePasskeysShouldReturnFullResponseOnSuccess()
+                throws IOException, InterruptedException {
+            when(httpResponse.body())
+                    .thenReturn(passkeyResponse(List.of(aPasskeyWithId("123456"))));
+            when(httpResponse.statusCode()).thenReturn(200);
+            when(httpClient.send(
+                            argThat(
+                                    request ->
+                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
+                            any()))
+                    .thenReturn(httpResponse);
+
+            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
+            assertTrue(result.isSuccess());
+            assertEquals(1, result.getSuccess().passkeys().size());
+            assertEquals("123456", result.getSuccess().passkeys().get(0).passkeyId());
+        }
+
+        @Test
         void shouldReturnFailureWhenApiReturnsNon200() throws IOException, InterruptedException {
             when(httpResponse.statusCode()).thenReturn(500);
             when(httpClient.send(
@@ -232,19 +245,6 @@ class PasskeysServiceTest {
             assertTrue(result.isFailure());
             assertEquals(
                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
-        }
-
-        @Test
-        void retrievePasskeysShouldReturnFailureIfErrorCreatingAccessToken() {
-            when(accessTokenConstructorService.createSignedAccessToken(
-                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
-                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
-
-            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
-
-            assertTrue(result.isFailure());
-            assertEquals(PasskeyRetrieveError.ERROR_CREATING_ACCESS_TOKEN, result.getFailure());
-            verifyNoInteractions(httpClient);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -392,6 +392,41 @@ class PasskeysServiceTest {
 
             verify(httpClient, never()).send(any(), any());
         }
+
+        private static Stream<Arguments> exceptionsToExpectedErrors() {
+            return Stream.of(
+                    Arguments.of(new IOException("uh oh"), PasskeyUpdateError.IO_EXCEPTION),
+                    Arguments.of(
+                            new InterruptedException("uh oh"),
+                            PasskeyUpdateError.INTERRUPTED_EXCEPTION));
+        }
+
+        @MethodSource("exceptionsToExpectedErrors")
+        @ParameterizedTest
+        void updatePasskeyShouldReturnFailureWhenAccountDataApiThrowsAnIOException(
+                Exception e, PasskeyUpdateError expectedError)
+                throws IOException, InterruptedException {
+            when(httpClient.send(
+                            argThat(
+                                    request ->
+                                            request.uri().equals(URI.create(UPDATE_PASSKEY_URL))),
+                            any()))
+                    .thenThrow(e);
+
+            var signCount = 2;
+            var result =
+                    passkeysService.updatePasskey(
+                            PUBLIC_SUBJECT_ID,
+                            SESSION_ID,
+                            PASSKEY_IDENTIFIER,
+                            signCount,
+                            FIXED_CLOCK);
+
+            assertTrue(result.isFailure());
+
+            var failure = result.getFailure();
+            assertEquals(expectedError, failure);
+        }
     }
 
     private String passkeyResponse(List<String> passkeys) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -92,20 +92,14 @@ class PasskeysServiceTest {
         void hasActivePasskeyShouldReturnTheExpectedResultForASuccessfulPasskeysResponse(
                 List<String> returnedPasskeys, boolean expectedResult)
                 throws IOException, InterruptedException {
-            when(httpResponse.body()).thenReturn(passkeyResponse(returnedPasskeys));
-            when(httpResponse.statusCode()).thenReturn(200);
-            when(httpClient.send(
-                            argThat(
-                                    request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                            any()))
-                    .thenReturn(httpResponse);
+            var responseBody = passkeyResponse(returnedPasskeys);
+            stubPasskeyRetrieveToReturn(200, responseBody);
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
+
             assertTrue(result.isSuccess());
 
-            var expectedAuthorizationHeader =
-                    Optional.of(ADAPI_BEARER_ACCESS_TOKEN.toAuthorizationHeader());
+            var expectedAuthorizationHeader = Optional.of(ADAPI_BEARER_ACCESS_TOKEN.toAuthorizationHeader());
             verify(httpClient)
                     .send(
                             argThat(
@@ -132,15 +126,10 @@ class PasskeysServiceTest {
         @Test
         void hasActivePasskeyShouldReturnFailureWhenAccountDataApiReturnsANon200ResponseCode()
                 throws IOException, InterruptedException {
-            when(httpResponse.statusCode()).thenReturn(500);
-            when(httpClient.send(
-                            argThat(
-                                    request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                            any()))
-                    .thenReturn(httpResponse);
+            stubPasskeyRetrieveToReturn(500, "");
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
+
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -152,21 +141,14 @@ class PasskeysServiceTest {
         void
                 hasActivePasskeyShouldReturnFailureWhenAccountDataApiResponseReturnsResponseThatCannotBeParsedAsPasskeysRetrieveResponse(
                         String invalidResponseBody) throws IOException, InterruptedException {
-            when(httpResponse.body()).thenReturn(invalidResponseBody);
-            when(httpResponse.statusCode()).thenReturn(200);
-            when(httpClient.send(
-                            argThat(
-                                    request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                            any()))
-                    .thenReturn(httpResponse);
+            stubPasskeyRetrieveToReturn(200, invalidResponseBody);
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
+
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
-            assertEquals(
-                    PasskeyRetrieveError.ERROR_PARSING_RESPONSE_FROM_PASSKEY_RETRIEVE, failure);
+            assertEquals(PasskeyRetrieveError.ERROR_PARSING_RESPONSE_FROM_PASSKEY_RETRIEVE, failure);
         }
 
         private static Stream<Arguments> exceptionsToExpectedErrors() {
@@ -190,6 +172,7 @@ class PasskeysServiceTest {
                     .thenThrow(e);
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
+
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
@@ -215,15 +198,8 @@ class PasskeysServiceTest {
         @Test
         void retrievePasskeysShouldReturnFullResponseOnSuccess()
                 throws IOException, InterruptedException {
-            when(httpResponse.body())
-                    .thenReturn(passkeyResponse(List.of(aPasskeyWithId("123456"))));
-            when(httpResponse.statusCode()).thenReturn(200);
-            when(httpClient.send(
-                            argThat(
-                                    request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                            any()))
-                    .thenReturn(httpResponse);
+            var responseBody = passkeyResponse(List.of(aPasskeyWithId("123456")));
+            stubPasskeyRetrieveToReturn(200, responseBody);
 
             var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isSuccess());
@@ -233,18 +209,11 @@ class PasskeysServiceTest {
 
         @Test
         void shouldReturnFailureWhenApiReturnsNon200() throws IOException, InterruptedException {
-            when(httpResponse.statusCode()).thenReturn(500);
-            when(httpClient.send(
-                            argThat(
-                                    request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                            any()))
-                    .thenReturn(httpResponse);
+            stubPasskeyRetrieveToReturn(500, "");
 
             var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
-            assertEquals(
-                    PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
+            assertEquals(PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
         }
     }
 
@@ -272,5 +241,15 @@ class PasskeysServiceTest {
                 }
                 """
                 .formatted(id);
+    }
+
+
+    private void stubPasskeyRetrieveToReturn(int statusCode, String body) throws IOException, InterruptedException {
+        when(httpResponse.body()).thenReturn(body);
+        when(httpResponse.statusCode()).thenReturn(statusCode);
+        when(httpClient.send(
+                argThat(request -> request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
+                any()))
+                .thenReturn(httpResponse);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
+import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyUpdateError;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.JwtFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -301,6 +302,46 @@ class PasskeysServiceTest {
                             "{\"signCount\":%d,\"lastUsedAt\":\"%s\"}", signCount, FIXED_TIMESTAMP);
             assertEquals(expectedRequestBody, actualRequestBody);
             assertEquals("PATCH", sentRequest.method());
+        }
+
+        private static Stream<Arguments> responseCodesAndBodiesToExpectedErrors() {
+
+            return Stream.of(
+                    Arguments.of(
+                            400,
+                            "{\"code\":4000,\"message\":\"Invalid request body\"}",
+                            PasskeyUpdateError.PASSKEY_UPDATE_BAD_REQUEST),
+                    Arguments.of(
+                            403,
+                            "{\"code\":4000,\"message\":\"Unauthorised\"}",
+                            PasskeyUpdateError.PASSKEY_UPDATE_UNAUTHORISED),
+                    Arguments.of(
+                            404,
+                            "{\"code\":4040,\"message\":\"Passkey not found\"}",
+                            PasskeyUpdateError.PASSKEY_OR_USER_NOT_FOUND),
+                    Arguments.of(
+                            500,
+                            "{\"code\":5000,\"message\":\"Internal server error\"}",
+                            PasskeyUpdateError.PASSKEY_UPDATE_INTERNAL_SERVER_ERROR),
+                    Arguments.of(
+                            418,
+                            "{\"code\":4180,\"message\":\"Teapot\"}",
+                            PasskeyUpdateError.PASSKEY_UPDATE_UNEXPECTED_RESPONSE_CODE));
+        }
+
+        @ParameterizedTest
+        @MethodSource("responseCodesAndBodiesToExpectedErrors")
+        void updatePasskeyShouldHandleNon204Responses(
+                int responseStatus, String responseBody, PasskeyUpdateError expectedError)
+                throws IOException, InterruptedException {
+            stubApiResponseToReturn(UPDATE_PASSKEY_URL, responseStatus, responseBody);
+
+            var result =
+                    passkeysService.updatePasskey(
+                            PUBLIC_SUBJECT_ID, SESSION_ID, PASSKEY_IDENTIFIER, 2, FIXED_CLOCK);
+
+            assertTrue(result.isFailure());
+            assertEquals(expectedError, result.getFailure());
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -43,6 +43,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -302,6 +303,32 @@ class PasskeysServiceTest {
                             "{\"signCount\":%d,\"lastUsedAt\":\"%s\"}", signCount, FIXED_TIMESTAMP);
             assertEquals(expectedRequestBody, actualRequestBody);
             assertEquals("PATCH", sentRequest.method());
+            var expectedAuthorizationHeader =
+                    Optional.of(ADAPI_BEARER_ACCESS_TOKEN.toAuthorizationHeader());
+            assertEquals(
+                    expectedAuthorizationHeader, sentRequest.headers().firstValue("Authorization"));
+        }
+
+        @Test
+        void updatePasskeyShouldCreateAnAccessTokenWithTheRelevantData()
+                throws IOException, InterruptedException {
+            var signCount = 2;
+            stubApiResponseToReturn(UPDATE_PASSKEY_URL, 204, "");
+
+            passkeysService.updatePasskey(
+                    PUBLIC_SUBJECT_ID, SESSION_ID, PASSKEY_IDENTIFIER, signCount, FIXED_CLOCK);
+
+            verify(accessTokenConstructorService)
+                    .createSignedAccessToken(
+                            eq(PUBLIC_SUBJECT_ID),
+                            eq(List.of(AccountDataScope.PASSKEY_UPDATE)),
+                            eq(SESSION_ID),
+                            any(),
+                            any(),
+                            eq(AUTH_TO_ACCOUNT_DATA_AUDIENCE),
+                            eq(AUTH_ISSUER_CLAIM),
+                            eq(AMC_CLIENT_ID),
+                            eq(AUTH_TO_ACCOUNT_DATA_SIGNING_KEY));
         }
 
         private static Stream<Arguments> responseCodesAndBodiesToExpectedErrors() {
@@ -342,6 +369,28 @@ class PasskeysServiceTest {
 
             assertTrue(result.isFailure());
             assertEquals(expectedError, result.getFailure());
+        }
+
+        @Test
+        void updatePasskeyShouldReturnErrorWhenTokenCreationFails()
+                throws IOException, InterruptedException {
+            when(accessTokenConstructorService.createSignedAccessToken(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
+
+            var signCount = 2;
+            var result =
+                    passkeysService.updatePasskey(
+                            PUBLIC_SUBJECT_ID,
+                            SESSION_ID,
+                            PASSKEY_IDENTIFIER,
+                            signCount,
+                            FIXED_CLOCK);
+
+            assertTrue(result.isFailure());
+            assertEquals(PasskeyUpdateError.ERROR_CREATING_ACCESS_TOKEN, result.getFailure());
+
+            verify(httpClient, never()).send(any(), any());
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -99,26 +99,6 @@ class PasskeysServiceTest {
 
             assertTrue(result.isSuccess());
 
-            var expectedAuthorizationHeader = Optional.of(ADAPI_BEARER_ACCESS_TOKEN.toAuthorizationHeader());
-            verify(httpClient)
-                    .send(
-                            argThat(
-                                    request ->
-                                            request.headers()
-                                                    .firstValue("Authorization")
-                                                    .equals(expectedAuthorizationHeader)),
-                            any());
-            verify(accessTokenConstructorService)
-                    .createSignedAccessToken(
-                            eq(PUBLIC_SUBJECT_ID),
-                            eq(List.of(AccountDataScope.PASSKEY_RETRIEVE)),
-                            eq(SESSION_ID),
-                            any(),
-                            any(),
-                            eq(AUTH_TO_ACCOUNT_DATA_AUDIENCE),
-                            eq(AUTH_ISSUER_CLAIM),
-                            eq(AMC_CLIENT_ID),
-                            eq(AUTH_TO_ACCOUNT_DATA_SIGNING_KEY));
             var hasActivePasskey = result.getSuccess();
             assertEquals(expectedResult, hasActivePasskey);
         }
@@ -148,7 +128,8 @@ class PasskeysServiceTest {
             assertTrue(result.isFailure());
 
             var failure = result.getFailure();
-            assertEquals(PasskeyRetrieveError.ERROR_PARSING_RESPONSE_FROM_PASSKEY_RETRIEVE, failure);
+            assertEquals(
+                    PasskeyRetrieveError.ERROR_PARSING_RESPONSE_FROM_PASSKEY_RETRIEVE, failure);
         }
 
         private static Stream<Arguments> exceptionsToExpectedErrors() {
@@ -208,12 +189,56 @@ class PasskeysServiceTest {
         }
 
         @Test
+        void retrievePasskeyShouldCreateAnAccessTokenWithTheRelevantData()
+                throws IOException, InterruptedException {
+            stubPasskeyRetrieveToReturn(200, passkeyResponse(List.of()));
+
+            var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
+
+            assertTrue(result.isSuccess());
+
+            verify(accessTokenConstructorService)
+                    .createSignedAccessToken(
+                            eq(PUBLIC_SUBJECT_ID),
+                            eq(List.of(AccountDataScope.PASSKEY_RETRIEVE)),
+                            eq(SESSION_ID),
+                            any(),
+                            any(),
+                            eq(AUTH_TO_ACCOUNT_DATA_AUDIENCE),
+                            eq(AUTH_ISSUER_CLAIM),
+                            eq(AMC_CLIENT_ID),
+                            eq(AUTH_TO_ACCOUNT_DATA_SIGNING_KEY));
+        }
+
+        @Test
+        void retrievePasskeysShouldMakeACallWithAnAuthorizationHeader()
+                throws IOException, InterruptedException {
+            stubPasskeyRetrieveToReturn(200, passkeyResponse(List.of()));
+
+            var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
+
+            assertTrue(result.isSuccess());
+
+            var expectedAuthorizationHeader =
+                    Optional.of(ADAPI_BEARER_ACCESS_TOKEN.toAuthorizationHeader());
+            verify(httpClient)
+                    .send(
+                            argThat(
+                                    request ->
+                                            request.headers()
+                                                    .firstValue("Authorization")
+                                                    .equals(expectedAuthorizationHeader)),
+                            any());
+        }
+
+        @Test
         void shouldReturnFailureWhenApiReturnsNon200() throws IOException, InterruptedException {
             stubPasskeyRetrieveToReturn(500, "");
 
             var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
-            assertEquals(PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
+            assertEquals(
+                    PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
         }
     }
 
@@ -243,13 +268,13 @@ class PasskeysServiceTest {
                 .formatted(id);
     }
 
-
-    private void stubPasskeyRetrieveToReturn(int statusCode, String body) throws IOException, InterruptedException {
+    private void stubPasskeyRetrieveToReturn(int statusCode, String body)
+            throws IOException, InterruptedException {
         when(httpResponse.body()).thenReturn(body);
         when(httpResponse.statusCode()).thenReturn(statusCode);
         when(httpClient.send(
-                argThat(request -> request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                any()))
+                        argThat(request -> request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
+                        any()))
                 .thenReturn(httpResponse);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/passkeys/PasskeysServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyRetrieveError;
 import uk.gov.di.authentication.shared.entity.AccountDataScope;
 import uk.gov.di.authentication.shared.entity.JwtFailureReason;
@@ -16,12 +18,22 @@ import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.AccessTokenConstructorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Flow;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,9 +60,13 @@ class PasskeysServiceTest {
             new PasskeysService(configurationService, httpClient, accessTokenConstructorService);
 
     private static final String ACCOUNT_DATA_BASE_URI = "https://example.com";
-    private static final String EXPECTED_REQUEST_URL =
+    private static final String RETRIEVE_PASSKEYS_URL =
             "%s/accounts/%s/authenticators/passkeys"
                     .formatted(ACCOUNT_DATA_BASE_URI, PUBLIC_SUBJECT_ID);
+    private static final String PASSKEY_IDENTIFIER = "some-passkey-id";
+    private static final String UPDATE_PASSKEY_URL =
+            "%s/accounts/%s/authenticators/passkeys/%s"
+                    .formatted(ACCOUNT_DATA_BASE_URI, PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER);
     private static final BearerAccessToken ADAPI_BEARER_ACCESS_TOKEN =
             new BearerAccessToken("adapi_bearer");
     private static final String AUTH_ISSUER_CLAIM = "https://signin.account.gov.uk/";
@@ -93,7 +109,7 @@ class PasskeysServiceTest {
                 List<String> returnedPasskeys, boolean expectedResult)
                 throws IOException, InterruptedException {
             var responseBody = passkeyResponse(returnedPasskeys);
-            stubPasskeyRetrieveToReturn(200, responseBody);
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 200, responseBody);
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
 
@@ -106,7 +122,7 @@ class PasskeysServiceTest {
         @Test
         void hasActivePasskeyShouldReturnFailureWhenAccountDataApiReturnsANon200ResponseCode()
                 throws IOException, InterruptedException {
-            stubPasskeyRetrieveToReturn(500, "");
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 500, "");
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
 
@@ -121,7 +137,7 @@ class PasskeysServiceTest {
         void
                 hasActivePasskeyShouldReturnFailureWhenAccountDataApiResponseReturnsResponseThatCannotBeParsedAsPasskeysRetrieveResponse(
                         String invalidResponseBody) throws IOException, InterruptedException {
-            stubPasskeyRetrieveToReturn(200, invalidResponseBody);
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 200, invalidResponseBody);
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
 
@@ -148,7 +164,8 @@ class PasskeysServiceTest {
             when(httpClient.send(
                             argThat(
                                     request ->
-                                            request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
+                                            request.uri()
+                                                    .equals(URI.create(RETRIEVE_PASSKEYS_URL))),
                             any()))
                     .thenThrow(e);
 
@@ -180,7 +197,7 @@ class PasskeysServiceTest {
         void retrievePasskeysShouldReturnFullResponseOnSuccess()
                 throws IOException, InterruptedException {
             var responseBody = passkeyResponse(List.of(aPasskeyWithId("123456")));
-            stubPasskeyRetrieveToReturn(200, responseBody);
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 200, responseBody);
 
             var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isSuccess());
@@ -191,7 +208,7 @@ class PasskeysServiceTest {
         @Test
         void retrievePasskeyShouldCreateAnAccessTokenWithTheRelevantData()
                 throws IOException, InterruptedException {
-            stubPasskeyRetrieveToReturn(200, passkeyResponse(List.of()));
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 200, passkeyResponse(List.of()));
 
             var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
 
@@ -213,7 +230,7 @@ class PasskeysServiceTest {
         @Test
         void retrievePasskeysShouldMakeACallWithAnAuthorizationHeader()
                 throws IOException, InterruptedException {
-            stubPasskeyRetrieveToReturn(200, passkeyResponse(List.of()));
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 200, passkeyResponse(List.of()));
 
             var result = passkeysService.hasActivePasskey(PUBLIC_SUBJECT_ID, SESSION_ID);
 
@@ -233,12 +250,57 @@ class PasskeysServiceTest {
 
         @Test
         void shouldReturnFailureWhenApiReturnsNon200() throws IOException, InterruptedException {
-            stubPasskeyRetrieveToReturn(500, "");
+            stubApiResponseToReturn(RETRIEVE_PASSKEYS_URL, 500, "");
 
             var result = passkeysService.retrievePasskeys(PUBLIC_SUBJECT_ID, SESSION_ID);
             assertTrue(result.isFailure());
             assertEquals(
                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE, result.getFailure());
+        }
+    }
+
+    @Nested
+    class UpdatePasskey {
+        private static final String FIXED_TIMESTAMP = "2021-09-01T22:10:00.012Z";
+        private static final Clock FIXED_CLOCK =
+                Clock.fixed(Instant.parse(FIXED_TIMESTAMP), ZoneId.of("UTC"));
+
+        @Test
+        void updatePasskeyShouldReturnSuccessOnSuccessfulResponse()
+                throws IOException, InterruptedException {
+            var signCount = 2;
+            stubApiResponseToReturn(UPDATE_PASSKEY_URL, 204, "");
+
+            var result =
+                    passkeysService.updatePasskey(
+                            PUBLIC_SUBJECT_ID,
+                            SESSION_ID,
+                            PASSKEY_IDENTIFIER,
+                            signCount,
+                            FIXED_CLOCK);
+
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        void updatePasskeyShouldMakeTheRelevantRequestToTheAccountDataApi()
+                throws IOException, InterruptedException, ExecutionException {
+            stubApiResponseToReturn(UPDATE_PASSKEY_URL, 204, "");
+
+            var signCount = 2;
+            passkeysService.updatePasskey(
+                    PUBLIC_SUBJECT_ID, SESSION_ID, PASSKEY_IDENTIFIER, signCount, FIXED_CLOCK);
+
+            var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+            verify(httpClient).send(httpRequestCaptor.capture(), ArgumentMatchers.any());
+            var sentRequest = httpRequestCaptor.getValue();
+
+            var actualRequestBody = bodyPublisherToString(sentRequest.bodyPublisher().get());
+            var expectedRequestBody =
+                    String.format(
+                            "{\"signCount\":%d,\"lastUsedAt\":\"%s\"}", signCount, FIXED_TIMESTAMP);
+            assertEquals(expectedRequestBody, actualRequestBody);
+            assertEquals("PATCH", sentRequest.method());
         }
     }
 
@@ -268,13 +330,42 @@ class PasskeysServiceTest {
                 .formatted(id);
     }
 
-    private void stubPasskeyRetrieveToReturn(int statusCode, String body)
+    private void stubApiResponseToReturn(String uri, int statusCode, String body)
             throws IOException, InterruptedException {
         when(httpResponse.body()).thenReturn(body);
         when(httpResponse.statusCode()).thenReturn(statusCode);
-        when(httpClient.send(
-                        argThat(request -> request.uri().equals(URI.create(EXPECTED_REQUEST_URL))),
-                        any()))
+        when(httpClient.send(argThat(request -> request.uri().equals(URI.create(uri))), any()))
                 .thenReturn(httpResponse);
+    }
+
+    private static String bodyPublisherToString(HttpRequest.BodyPublisher bodyPublisher)
+            throws ExecutionException, InterruptedException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        bodyPublisher.subscribe(
+                new Flow.Subscriber<>() {
+                    @Override
+                    public void onSubscribe(Flow.Subscription subscription) {
+                        subscription.request(Long.MAX_VALUE);
+                    }
+
+                    @Override
+                    public void onNext(ByteBuffer item) {
+                        byteArrayOutputStream.write(
+                                item.array(), item.arrayOffset(), item.remaining());
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        future.completeExceptionally(throwable);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        future.complete(null);
+                    }
+                });
+        future.get();
+        return byteArrayOutputStream.toString(StandardCharsets.UTF_8);
     }
 }

--- a/local-running/src/main/java/uk/gov/di/authentication/local/LocalAuthApi.java
+++ b/local-running/src/main/java/uk/gov/di/authentication/local/LocalAuthApi.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.local;
 
 import io.javalin.Javalin;
 import uk.gov.di.authentication.accountdata.lambda.PasskeysRetrieveHandler;
+import uk.gov.di.authentication.accountdata.lambda.PasskeysUpdateHandler;
 import uk.gov.di.authentication.external.lambda.TokenHandler;
 import uk.gov.di.authentication.external.lambda.UserInfoHandler;
 import uk.gov.di.authentication.frontendapi.lambda.AMCAuthorizeHandler;
@@ -105,6 +106,9 @@ public class LocalAuthApi {
                             config.routes.get(
                                     "/accounts/{publicSubjectId}/authenticators/passkeys",
                                     handlerFor(new PasskeysRetrieveHandler()));
+                            config.routes.patch(
+                                    "/accounts/{publicSubjectId}/authenticators/passkeys/{passkeyId}",
+                                    handlerFor(new PasskeysUpdateHandler()));
                         });
 
         // Start app

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysUpdateRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysUpdateRequest.java
@@ -5,5 +5,5 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record PasskeysUpdateRequest(
-        @SerializedName("signCount") @Expose @Required Integer signCount,
+        @SerializedName("signCount") @Expose @Required Long signCount,
         @SerializedName("lastUsedAt") @Expose @Required String lastUsedAt) {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysUpdateRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysUpdateRequest.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.shared.entity.passkeys;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public record PasskeysUpdateRequest(
+        @SerializedName("signCount") @Expose @Required Integer signCount,
+        @SerializedName("lastUsedAt") @Expose @Required String lastUsedAt) {}


### PR DESCRIPTION
Make a call to the account data api after successful verification of a passkey in the finish passkey assertion handler to update the passkey's sign count and last used at timestamp.

To follow: updating the type of the sign count in the account data api to reflect the change on this side from int -> long.
