### PR TITLE
AUT-5690: update account data types

### DIFF
--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/services/DynamoPasskeyServiceIntegrationTest.java
@@ -52,7 +52,7 @@ class DynamoPasskeyServiceIntegrationTest {
                             PRIMARY_PASSKEY_ID,
                             PASSKEY_AAGUID,
                             true,
-                            1,
+                            1L,
                             PASSKEY_TRANSPORTS,
                             true,
                             false,
@@ -82,7 +82,7 @@ class DynamoPasskeyServiceIntegrationTest {
             assertThat(savedPasskey.getCredentialId(), equalTo(PRIMARY_PASSKEY_ID));
             assertThat(savedPasskey.getPasskeyAaguid(), equalTo(PASSKEY_AAGUID));
             assertThat(savedPasskey.getPasskeyIsAttested(), equalTo(true));
-            assertThat(savedPasskey.getPasskeySignCount(), equalTo(1));
+            assertThat(savedPasskey.getPasskeySignCount(), equalTo(1L));
             assertThat(savedPasskey.getPasskeyTransports(), equalTo(PASSKEY_TRANSPORTS));
             assertThat(savedPasskey.getPasskeyBackupEligible(), equalTo(true));
             assertThat(savedPasskey.getPasskeyBackedUp(), equalTo(false));
@@ -260,7 +260,7 @@ class DynamoPasskeyServiceIntegrationTest {
             dynamoPasskeyService.savePasskeyIfUnique(passkeyBeforeUpdate);
 
             String lastUsedTime = LocalDateTime.now().plusHours(1).toString();
-            int updatedSignCount = passkeyBeforeUpdate.getPasskeySignCount() + 1;
+            long updatedSignCount = passkeyBeforeUpdate.getPasskeySignCount() + 1;
 
             // When
             var updateResult =

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/Passkey.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/Passkey.java
@@ -21,7 +21,7 @@ public class Passkey extends Authenticator<Passkey> {
 
     private String passkeyAaguid;
     private boolean passkeyIsAttested;
-    private int passkeySignCount;
+    private long passkeySignCount;
     private List<String> passkeyTransports;
     private boolean passkeyBackupEligible;
     private boolean passkeyBackedUp;
@@ -67,15 +67,15 @@ public class Passkey extends Authenticator<Passkey> {
     }
 
     @DynamoDbAttribute(ATTRIBUTE_PASSKEY_SIGN_COUNT)
-    public int getPasskeySignCount() {
+    public long getPasskeySignCount() {
         return passkeySignCount;
     }
 
-    public void setPasskeySignCount(int passkeySignCount) {
+    public void setPasskeySignCount(long passkeySignCount) {
         this.passkeySignCount = passkeySignCount;
     }
 
-    public Passkey withPasskeySignCount(int passkeySignCount) {
+    public Passkey withPasskeySignCount(long passkeySignCount) {
         this.passkeySignCount = passkeySignCount;
         return this;
     }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysRetrieveResponse.java
@@ -14,7 +14,7 @@ public record PasskeysRetrieveResponse(
             @SerializedName("credential") @Expose @Required String credential,
             @SerializedName("aaguid") @Expose @Required String aaguid,
             @SerializedName("isAttested") @Expose @Required boolean isAttested,
-            @SerializedName("signCount") @Expose @Required int signCount,
+            @SerializedName("signCount") @Expose @Required long signCount,
             @SerializedName("transports") @Expose @Required List<String> transports,
             @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysUpdateRequest.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/passkey/PasskeysUpdateRequest.java
@@ -5,5 +5,5 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public record PasskeysUpdateRequest(
-        @SerializedName("signCount") @Expose @Required Integer signCount, // TODO make long
+        @SerializedName("signCount") @Expose @Required Long signCount,
         @SerializedName("lastUsedAt") @Expose @Required String lastUsedAt) {}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/PasskeysTestHelper.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/helpers/PasskeysTestHelper.java
@@ -31,7 +31,7 @@ public class PasskeysTestHelper {
             String passkeyId,
             String aaguid,
             boolean isAttested,
-            int signCount,
+            long signCount,
             List<String> transports,
             boolean backupEligible,
             boolean backedUp,

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/DynamoPasskeyService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/DynamoPasskeyService.java
@@ -40,7 +40,7 @@ public class DynamoPasskeyService extends BaseDynamoService<Passkey> {
     }
 
     public Result<PasskeysUpdateFailureReason, Passkey> updatePasskey(
-            String publicSubjectId, String passkeyId, String lastUsed, int signCount) {
+            String publicSubjectId, String passkeyId, String lastUsed, long signCount) {
         return getPasskeyForUserWithPasskeyId(publicSubjectId, passkeyId)
                 .map(
                         passkey -> {

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
@@ -75,7 +75,7 @@ public class PasskeysService {
     }
 
     public Result<PasskeysUpdateFailureReason, Passkey> updatePasskey(
-            String publicSubjectId, String passkeyId, String lastUsedTime, int updatedSignCount) {
+            String publicSubjectId, String passkeyId, String lastUsedTime, long updatedSignCount) {
         try {
             return dynamoPasskeyService.updatePasskey(
                     publicSubjectId, passkeyId, lastUsedTime, updatedSignCount);

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/PasskeysService.java
@@ -10,7 +10,7 @@ import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.Passke
 import uk.gov.di.authentication.accountdata.entity.passkey.failurereasons.PasskeysUpdateFailureReason;
 import uk.gov.di.authentication.shared.entity.Result;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import static uk.gov.di.authentication.accountdata.helpers.PasskeysHelper.buildSortKey;
@@ -36,7 +36,7 @@ public class PasskeysService {
             PasskeysCreateRequest passkeysCreateRequest, String publicSubjectId) {
 
         var passkeyId = passkeysCreateRequest.passkeyId();
-        var created = LocalDateTime.now().toString();
+        var created = Instant.now().toString();
         var passkey =
                 new Passkey()
                         .withPublicSubjectId(publicSubjectId)

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/PasskeysUpdateHandlerTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,7 +58,7 @@ class PasskeysUpdateHandlerTest {
             var request =
                     passkeysUpdateRequest(
                             SIGN_COUNT, LAST_USED_AT, PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
-            when(passkeysService.updatePasskey(any(), any(), any(), anyInt()))
+            when(passkeysService.updatePasskey(any(), any(), any(), anyLong()))
                     .thenReturn(Result.success(new Passkey()));
 
             // When
@@ -79,7 +79,7 @@ class PasskeysUpdateHandlerTest {
             var request =
                     passkeysUpdateRequest(
                             SIGN_COUNT, LAST_USED_AT, PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
-            when(passkeysService.updatePasskey(any(), any(), any(), anyInt()))
+            when(passkeysService.updatePasskey(any(), any(), any(), anyLong()))
                     .thenReturn(Result.failure(PasskeysUpdateFailureReason.PASSKEY_NOT_FOUND));
 
             // When
@@ -96,7 +96,7 @@ class PasskeysUpdateHandlerTest {
             var request =
                     passkeysUpdateRequest(
                             SIGN_COUNT, LAST_USED_AT, PUBLIC_SUBJECT_ID, PRIMARY_PASSKEY_ID);
-            when(passkeysService.updatePasskey(any(), any(), any(), anyInt()))
+            when(passkeysService.updatePasskey(any(), any(), any(), anyLong()))
                     .thenReturn(
                             Result.failure(PasskeysUpdateFailureReason.FAILED_TO_UPDATE_PASSKEY));
             // When

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysRetrieveResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysRetrieveResponse.java
@@ -14,7 +14,7 @@ public record PasskeysRetrieveResponse(
             @SerializedName("credential") @Expose @Required String credential,
             @SerializedName("aaguid") @Expose @Required String aaguid,
             @SerializedName("isAttested") @Expose @Required boolean isAttested,
-            @SerializedName("signCount") @Expose @Required int signCount,
+            @SerializedName("signCount") @Expose @Required int signCount, // TODO change to long
             @SerializedName("transports") @Expose @Required List<String> transports,
             @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysRetrieveResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/passkeys/PasskeysRetrieveResponse.java
@@ -14,7 +14,7 @@ public record PasskeysRetrieveResponse(
             @SerializedName("credential") @Expose @Required String credential,
             @SerializedName("aaguid") @Expose @Required String aaguid,
             @SerializedName("isAttested") @Expose @Required boolean isAttested,
-            @SerializedName("signCount") @Expose @Required int signCount, // TODO change to long
+            @SerializedName("signCount") @Expose @Required long signCount,
             @SerializedName("transports") @Expose @Required List<String> transports,
             @SerializedName("isBackUpEligible") @Expose @Required boolean isBackUpEligible,
             @SerializedName("isBackedUp") @Expose @Required boolean isBackedUp,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -153,7 +153,7 @@ class AccountDataApiServiceTest {
             // Assert
             assertThat(result.passkeys().size(), equalTo(2));
             assertThat(result.passkeys().get(0).passkeyId(), equalTo("credential-id-123"));
-            assertThat(result.passkeys().get(0).signCount(), equalTo(5));
+            assertThat(result.passkeys().get(0).signCount(), equalTo(5L));
             assertThat(result.passkeys().get(1).passkeyId(), equalTo("credential-id-456"));
             assertThat(result.passkeys().get(1).isAttested(), equalTo(false));
         }


### PR DESCRIPTION
Before we go live with passkeys in prod + integration, we want to tweak two things in the account data authenticators table:

* transform passkeyCount type from int -> long to reflect the data we get back from yubico
* make created at date an instant, not a local date time (the underlying data type remains a string)

Neither of these changes will immediately break any of the existing passkeys since a) nobody reads the created at date and b) no passkey counts are currently bigger than the max int.

We will, however, wipe the databases in the environments that have passkeys turned on to ensure that no data exists that might cause problems in the future if we did e.g. start reading from and parsing the created at date.
