### PR TITLE
AUT-5525: Turn on reauth tests in staging

### DIFF
--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -23,7 +23,7 @@ Mappings:
         or @PasskeysEnabled or @PasskeyUsageEnabled)
     staging:
       tags: >-
-        @UI and not (@under-development or @AccountInterventions or @Reauth or
+        @UI and not (@under-development or @AccountInterventions or @ReauthMultiTabLogout or
         @new-mfa-reset-with-ipv or @AcceptInternationalNumbers
         or @InternationalSmsSendingDisabled or @EnvironmentWithAMCStubDeployed)
 


### PR DESCRIPTION
The api pipeline in staging is now the only place where we don't run reauth tests. There's no reason we can't, so turn these on.

To turn these on, we replace excluding the general @Reauth tag with the more specific @ReauthMultiTabLogout. This turns on the majority of reauth tests while excluding a few tests that we know to be flakey and can block pipelines

