### PR TITLE
ATO-2755: Create IdentitySPOTService

### DIFF
--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityProcessingEndState.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityProcessingEndState.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.identity.entity;
+
+public enum IdentityProcessingEndState {
+    COMPLETED,
+    ERROR,
+    NO_ENTRY,
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityProgressStatus.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityProgressStatus.java
@@ -1,0 +1,8 @@
+package uk.gov.di.orchestration.identity.entity;
+
+public enum IdentityProgressStatus {
+    COMPLETED,
+    PROCESSING,
+    ERROR,
+    NO_ENTRY,
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/LogIds.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/LogIds.java
@@ -1,0 +1,51 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import com.google.gson.annotations.Expose;
+
+public class LogIds {
+
+    @Expose private String sessionId;
+
+    @Expose private String persistentSessionId;
+
+    @Expose private String requestId;
+
+    @Expose private String clientId;
+
+    @Expose private String clientSessionId;
+
+    public LogIds(
+            String sessionId,
+            String persistentSessionId,
+            String requestId,
+            String clientId,
+            String clientSessionId) {
+        this.sessionId = sessionId;
+        this.persistentSessionId = persistentSessionId;
+        this.requestId = requestId;
+        this.clientId = clientId;
+        this.clientSessionId = clientSessionId;
+    }
+
+    public LogIds() {}
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/ProcessingIdentityStatus.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/ProcessingIdentityStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.di.orchestration.identity.entity;
+
+public enum ProcessingIdentityStatus {
+    COMPLETED,
+    PROCESSING,
+    ERROR,
+    NO_ENTRY,
+    INTERVENTION
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/SPOTAuditableEvent.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/SPOTAuditableEvent.java
@@ -1,0 +1,13 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import uk.gov.di.orchestration.shared.domain.AuditableEvent;
+
+public enum SPOTAuditableEvent implements AuditableEvent {
+    IPV_SPOT_REQUESTED, // Not used yet, but this will be the same for IPV and SIS
+    PROCESSING_IDENTITY_REQUEST;
+
+    @Override
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/SPOTClaims.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/SPOTClaims.java
@@ -1,0 +1,55 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.SUB;
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VTM;
+
+public class SPOTClaims {
+
+    private SPOTClaims() {}
+
+    public static SPOTClaimsBuilder builder() {
+        return new SPOTClaimsBuilder();
+    }
+
+    public static class SPOTClaimsBuilder {
+        Map<String, Object> spotClaims = new HashMap<>();
+
+        public SPOTClaimsBuilder withClaims(Map<String, Object> claims) {
+            claims.entrySet().stream()
+                    .filter(SPOTClaimsBuilder::isAddableClaim)
+                    .forEach(c -> spotClaims.put(c.getKey(), c.getValue()));
+            return this;
+        }
+
+        private static boolean isAddableClaim(Map.Entry<String, Object> claim) {
+            return !claim.getKey().equals(SUB.getValue()) && !claim.getKey().equals(VTM.getValue());
+        }
+
+        public SPOTClaimsBuilder withVot(Object vot) {
+            return withClaim(VOT.getValue(), vot);
+        }
+
+        public SPOTClaimsBuilder withVtm(Object vtm) {
+            return withClaim(VTM.getValue(), vtm);
+        }
+
+        public SPOTClaimsBuilder withClaim(String claimName, Object claimValue) {
+            spotClaims.put(claimName, claimValue);
+            return this;
+        }
+
+        public SPOTClaimsBuilder withClaimArray(String claimName, Object claimValues) {
+            spotClaims.put(claimName, claimValues);
+            return this;
+        }
+
+        public Map<String, Object> build() {
+            return Collections.unmodifiableMap(spotClaims);
+        }
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/SPOTRequest.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/SPOTRequest.java
@@ -1,0 +1,84 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+public class SPOTRequest {
+
+    @SerializedName(value = "in_claims")
+    @Expose
+    private Map<String, Object> spotClaims;
+
+    @SerializedName(value = "in_local_account_id")
+    @Expose
+    private String localAccountId;
+
+    @SerializedName(value = "in_salt")
+    @Expose
+    private String salt;
+
+    @SerializedName(value = "in_rp_sector_id")
+    @Expose
+    private String rpSectorId;
+
+    @SerializedName(value = "out_sub")
+    @Expose
+    private String sub;
+
+    @SerializedName(value = "log_ids")
+    @Expose
+    private LogIds logIds;
+
+    @SerializedName(value = "out_audience")
+    @Expose
+    private String audience;
+
+    public SPOTRequest(
+            Map<String, Object> spotClaims,
+            String localAccountId,
+            String salt,
+            String rpSectorId,
+            String sub,
+            LogIds logIds,
+            String audience) {
+        this.spotClaims = spotClaims;
+        this.localAccountId = localAccountId;
+        this.salt = salt;
+        this.rpSectorId = rpSectorId;
+        this.sub = sub;
+        this.logIds = logIds;
+        this.audience = audience;
+    }
+
+    public SPOTRequest() {}
+
+    public Map<String, Object> getSpotClaims() {
+        return spotClaims;
+    }
+
+    public String getLocalAccountId() {
+        return localAccountId;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public String getRpSectorId() {
+        return rpSectorId;
+    }
+
+    public String getSub() {
+        return sub;
+    }
+
+    public LogIds getLogIds() {
+        return logIds;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityProgressService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityProgressService.java
@@ -1,0 +1,89 @@
+package uk.gov.di.orchestration.identity.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
+import uk.gov.di.orchestration.shared.domain.AuditableEvent;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.Metrics;
+
+import java.util.Map;
+
+import static uk.gov.di.orchestration.identity.utils.IdentityProgressUtils.getIdentityProgressStatus;
+
+public class IdentityProgressService {
+
+    private static final Logger LOG = LogManager.getLogger(IdentityProgressService.class);
+    private static final int DELAY_IN_MS = 500;
+    private final ConfigurationService configurationService;
+    private final DynamoIdentityService dynamoIdentityService;
+    private final AuditService auditService;
+    private final Metrics metrics;
+    private final Sleeper sleeper;
+    private final int maxRetries;
+
+    public IdentityProgressService(ConfigurationService configurationService) {
+        this(
+                configurationService,
+                new DynamoIdentityService(configurationService),
+                new AuditService(configurationService),
+                new Metrics(configurationService),
+                Thread::sleep);
+    }
+
+    public IdentityProgressService(
+            ConfigurationService configurationService,
+            DynamoIdentityService dynamoIdentityService,
+            AuditService auditService,
+            Metrics metrics,
+            Sleeper sleeper) {
+        this.configurationService = configurationService;
+        this.dynamoIdentityService = dynamoIdentityService;
+        this.auditService = auditService;
+        this.metrics = metrics;
+        this.sleeper = sleeper;
+        this.maxRetries = (int) (configurationService.getSyncWaitForSpotTimeout() / DELAY_IN_MS);
+    }
+
+    public IdentityProgressStatus pollForStatus(
+            String clientSessionId, AuditContext auditContext, AuditableEvent auditableEvent)
+            throws InterruptedException {
+        var status = IdentityProgressStatus.PROCESSING;
+        var attempts = 1;
+        while (status == IdentityProgressStatus.PROCESSING) {
+            LOG.info(
+                    "Attempting to find identity credentials in dynamo. Attempt {} out of {}",
+                    attempts,
+                    maxRetries);
+            var identityCredentials = dynamoIdentityService.getIdentityCredentials(clientSessionId);
+            status = getIdentityProgressStatus(identityCredentials, attempts);
+            if (status == IdentityProgressStatus.PROCESSING) {
+                if (attempts >= maxRetries) {
+                    LOG.info("Max retries of {} reached. Returning ERROR", maxRetries);
+                    status = IdentityProgressStatus.ERROR;
+                } else {
+                    sleeper.sleep(DELAY_IN_MS);
+                    attempts++;
+                }
+            }
+        }
+        LOG.info("Client session ID {} identity progress status: {}", clientSessionId, status);
+        metrics.increment(
+                "ProcessingIdentity",
+                Map.of(
+                        "Environment",
+                        configurationService.getEnvironment(),
+                        "Status",
+                        status.toString()));
+        auditService.submitAuditEvent(auditableEvent, auditContext);
+
+        return status;
+    }
+
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityProgressService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityProgressService.java
@@ -5,7 +5,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.identity.entity.IdentityProcessingEndState;
 import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
-import uk.gov.di.orchestration.shared.domain.AuditableEvent;
+import uk.gov.di.orchestration.identity.entity.SPOTAuditableEvent;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
@@ -50,8 +50,7 @@ public class IdentityProgressService {
     }
 
     public IdentityProcessingEndState pollForStatus(
-            String clientSessionId, AuditContext auditContext, AuditableEvent auditableEvent)
-            throws InterruptedException {
+            String clientSessionId, AuditContext auditContext) throws InterruptedException {
         var status = IdentityProgressStatus.PROCESSING;
         var attempts = 1;
         while (status == IdentityProgressStatus.PROCESSING) {
@@ -79,7 +78,7 @@ public class IdentityProgressService {
                         configurationService.getEnvironment(),
                         "Status",
                         status.toString()));
-        auditService.submitAuditEvent(auditableEvent, auditContext);
+        auditService.submitAuditEvent(SPOTAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
 
         return IdentityProcessingEndState.valueOf(status.name());
     }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityProgressService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityProgressService.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.identity.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.identity.entity.IdentityProcessingEndState;
 import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.services.AuditService;
@@ -48,7 +49,7 @@ public class IdentityProgressService {
         this.maxRetries = (int) (configurationService.getSyncWaitForSpotTimeout() / DELAY_IN_MS);
     }
 
-    public IdentityProgressStatus pollForStatus(
+    public IdentityProcessingEndState pollForStatus(
             String clientSessionId, AuditContext auditContext, AuditableEvent auditableEvent)
             throws InterruptedException {
         var status = IdentityProgressStatus.PROCESSING;
@@ -80,7 +81,7 @@ public class IdentityProgressService {
                         status.toString()));
         auditService.submitAuditEvent(auditableEvent, auditContext);
 
-        return status;
+        return IdentityProcessingEndState.valueOf(status.name());
     }
 
     interface Sleeper {

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
@@ -1,0 +1,75 @@
+package uk.gov.di.orchestration.identity.service;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.identity.entity.LogIds;
+import uk.gov.di.orchestration.identity.entity.SPOTClaims;
+import uk.gov.di.orchestration.identity.entity.SPOTRequest;
+import uk.gov.di.orchestration.shared.api.OidcAPI;
+import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
+import uk.gov.di.orchestration.shared.entity.IdentityClaims;
+import uk.gov.di.orchestration.shared.services.AwsSqsClient;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.SerializationService;
+
+import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
+
+public class IdentitySPOTService {
+    private static final Logger LOG = LogManager.getLogger(IdentitySPOTService.class);
+    private final ConfigurationService configurationService;
+    private final AwsSqsClient spotSqsClient;
+    private final OidcAPI oidcApi;
+    private final SerializationService objectMapper;
+
+    public IdentitySPOTService(
+            ConfigurationService configurationService,
+            AwsSqsClient spotSqsClient,
+            OidcAPI oidcApi,
+            SerializationService objectMapper) {
+        this.configurationService = configurationService;
+        this.spotSqsClient = spotSqsClient;
+        this.oidcApi = oidcApi;
+        this.objectMapper = objectMapper;
+    }
+
+    public void queueSPOTRequest(
+            LogIds logIds,
+            String sectorIdentifier,
+            UserInfo authUserInfo,
+            Subject pairwiseSubject,
+            UserInfo userIdentityUserInfo,
+            String clientId) {
+        LOG.info("Constructing SPOT request ready to queue");
+        var spotClaimsBuilder =
+                SPOTClaims.builder()
+                        .withClaim(VOT.getValue(), userIdentityUserInfo.getClaim(VOT.getValue()))
+                        .withClaim(
+                                IdentityClaims.CREDENTIAL_JWT.getValue(),
+                                userIdentityUserInfo
+                                        .toJSONObject()
+                                        .get(IdentityClaims.CREDENTIAL_JWT.getValue()))
+                        .withClaim(
+                                IdentityClaims.CORE_IDENTITY.getValue(),
+                                userIdentityUserInfo
+                                        .toJSONObject()
+                                        .get(IdentityClaims.CORE_IDENTITY.getValue()))
+                        .withVtm(oidcApi.trustmarkURI().toString());
+
+        var spotRequest =
+                new SPOTRequest(
+                        spotClaimsBuilder.build(),
+                        authUserInfo.getStringClaim(AuthUserInfoClaims.LOCAL_ACCOUNT_ID.getValue()),
+                        authUserInfo.getStringClaim(AuthUserInfoClaims.SALT.getValue()),
+                        sectorIdentifier,
+                        pairwiseSubject.getValue(),
+                        logIds,
+                        clientId);
+        var spotRequestString = objectMapper.writeValueAsString(spotRequest);
+        if (configurationService.isNewSpotRequestQueueWritingEnabled()) {
+            spotSqsClient.send(spotRequestString);
+        }
+        LOG.info("SPOT request placed on queue");
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
@@ -6,7 +6,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
+import uk.gov.di.orchestration.identity.entity.IdentityProcessingEndState;
 import uk.gov.di.orchestration.identity.entity.LogIds;
 import uk.gov.di.orchestration.identity.entity.SPOTClaims;
 import uk.gov.di.orchestration.identity.entity.SPOTRequest;
@@ -102,18 +102,18 @@ public class IdentitySPOTService {
             var status =
                     identityProgressService.pollForStatus(
                             clientSessionId, auditContext, auditableEvent);
-            if (status == IdentityProgressStatus.NO_ENTRY) {
+            if (status == IdentityProcessingEndState.NO_ENTRY) {
                 return Optional.of(
                         RedirectService.redirectToFrontendErrorPageWithErrorLog(
                                 frontend.errorURI(),
                                 new Error("Identity processing returned NO_ENTRY")));
             }
-            if (status == IdentityProgressStatus.ERROR) {
+            if (status == IdentityProcessingEndState.ERROR) {
                 return Optional.of(
                         RedirectService.redirectToFrontendErrorPageWithErrorLog(
                                 frontend.errorURI(), new Error("Identity processing failed")));
             }
-            if (status == IdentityProgressStatus.COMPLETED) {
+            if (status == IdentityProcessingEndState.COMPLETED) {
                 return Optional.empty();
             }
         } else {

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
@@ -12,10 +12,10 @@ import uk.gov.di.orchestration.identity.entity.SPOTClaims;
 import uk.gov.di.orchestration.identity.entity.SPOTRequest;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
-import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
 import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
+import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
@@ -24,6 +24,7 @@ import uk.gov.di.orchestration.shared.services.SerializationService;
 import java.util.Map;
 import java.util.Optional;
 
+import static uk.gov.di.orchestration.identity.entity.SPOTAuditableEvent.IPV_SPOT_REQUESTED;
 import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
@@ -35,6 +36,7 @@ public class IdentitySPOTService {
     private final SerializationService objectMapper;
     private final IdentityProgressService identityProgressService;
     private final AuthFrontend frontend;
+    private final AuditService auditService;
 
     public IdentitySPOTService(
             ConfigurationService configurationService,
@@ -42,13 +44,15 @@ public class IdentitySPOTService {
             OidcAPI oidcApi,
             SerializationService objectMapper,
             IdentityProgressService identityProgressService,
-            AuthFrontend frontend) {
+            AuthFrontend frontend,
+            AuditService auditService) {
         this.configurationService = configurationService;
         this.spotSqsClient = spotSqsClient;
         this.oidcApi = oidcApi;
         this.objectMapper = objectMapper;
         this.identityProgressService = identityProgressService;
         this.frontend = frontend;
+        this.auditService = auditService;
     }
 
     public void queueSPOTRequest(
@@ -57,7 +61,8 @@ public class IdentitySPOTService {
             UserInfo authUserInfo,
             Subject pairwiseSubject,
             UserInfo userIdentityUserInfo,
-            String clientId) {
+            String clientId,
+            AuditContext auditContext) {
         LOG.info("Constructing SPOT request ready to queue");
         var spotClaimsBuilder =
                 SPOTClaims.builder()
@@ -87,6 +92,7 @@ public class IdentitySPOTService {
         if (configurationService.isNewSpotRequestQueueWritingEnabled()) {
             spotSqsClient.send(spotRequestString);
         }
+        auditService.submitAuditEvent(IPV_SPOT_REQUESTED, auditContext);
         LOG.info("SPOT request placed on queue");
     }
 
@@ -96,12 +102,9 @@ public class IdentitySPOTService {
     // We return an empty optional for a successful sync wait for spot
     //  so we can check for interventions, generate an auth code, and emit audit events + metrics
     public Optional<APIGatewayProxyResponseEvent> waitForSpot(
-            String clientSessionId, AuditContext auditContext, AuditableEvent auditableEvent)
-            throws InterruptedException {
+            String clientSessionId, AuditContext auditContext) throws InterruptedException {
         if (configurationService.isSyncWaitForSpotEnabled()) {
-            var status =
-                    identityProgressService.pollForStatus(
-                            clientSessionId, auditContext, auditableEvent);
+            var status = identityProgressService.pollForStatus(clientSessionId, auditContext);
             if (status == IdentityProcessingEndState.NO_ENTRY) {
                 return Optional.of(
                         RedirectService.redirectToFrontendErrorPageWithErrorLog(

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentitySPOTService.java
@@ -1,20 +1,31 @@
 package uk.gov.di.orchestration.identity.service;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
 import uk.gov.di.orchestration.identity.entity.LogIds;
 import uk.gov.di.orchestration.identity.entity.SPOTClaims;
 import uk.gov.di.orchestration.identity.entity.SPOTRequest;
+import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
+import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
 import uk.gov.di.orchestration.shared.entity.IdentityClaims;
+import uk.gov.di.orchestration.shared.entity.ResponseHeaders;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 
+import java.util.Map;
+import java.util.Optional;
+
 import static uk.gov.di.orchestration.shared.entity.IdentityClaims.VOT;
+import static uk.gov.di.orchestration.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class IdentitySPOTService {
     private static final Logger LOG = LogManager.getLogger(IdentitySPOTService.class);
@@ -22,16 +33,22 @@ public class IdentitySPOTService {
     private final AwsSqsClient spotSqsClient;
     private final OidcAPI oidcApi;
     private final SerializationService objectMapper;
+    private final IdentityProgressService identityProgressService;
+    private final AuthFrontend frontend;
 
     public IdentitySPOTService(
             ConfigurationService configurationService,
             AwsSqsClient spotSqsClient,
             OidcAPI oidcApi,
-            SerializationService objectMapper) {
+            SerializationService objectMapper,
+            IdentityProgressService identityProgressService,
+            AuthFrontend frontend) {
         this.configurationService = configurationService;
         this.spotSqsClient = spotSqsClient;
         this.oidcApi = oidcApi;
         this.objectMapper = objectMapper;
+        this.identityProgressService = identityProgressService;
+        this.frontend = frontend;
     }
 
     public void queueSPOTRequest(
@@ -71,5 +88,45 @@ public class IdentitySPOTService {
             spotSqsClient.send(spotRequestString);
         }
         LOG.info("SPOT request placed on queue");
+    }
+
+    // This method returns error redirects but ALSO returns the immediate
+    // redirect to the frontend spinner page
+    // Hopefully this doesn't exist for much longer so we can remove it soon
+    // We return an empty optional for a successful sync wait for spot
+    //  so we can check for interventions, generate an auth code, and emit audit events + metrics
+    public Optional<APIGatewayProxyResponseEvent> waitForSpot(
+            String clientSessionId, AuditContext auditContext, AuditableEvent auditableEvent)
+            throws InterruptedException {
+        if (configurationService.isSyncWaitForSpotEnabled()) {
+            var status =
+                    identityProgressService.pollForStatus(
+                            clientSessionId, auditContext, auditableEvent);
+            if (status == IdentityProgressStatus.NO_ENTRY) {
+                return Optional.of(
+                        RedirectService.redirectToFrontendErrorPageWithErrorLog(
+                                frontend.errorURI(),
+                                new Error("Identity processing returned NO_ENTRY")));
+            }
+            if (status == IdentityProgressStatus.ERROR) {
+                return Optional.of(
+                        RedirectService.redirectToFrontendErrorPageWithErrorLog(
+                                frontend.errorURI(), new Error("Identity processing failed")));
+            }
+            if (status == IdentityProgressStatus.COMPLETED) {
+                return Optional.empty();
+            }
+        } else {
+            LOG.info("Successful IPV callback. Redirecting to frontend");
+            return Optional.of(
+                    generateApiGatewayProxyResponse(
+                            302,
+                            "",
+                            Map.of(ResponseHeaders.LOCATION, frontend.ipvCallbackURI().toString()),
+                            null));
+        }
+        return Optional.of(
+                RedirectService.redirectToFrontendErrorPageWithErrorLog(
+                        frontend.errorURI(), new Error("Failed to create redirectURI")));
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/utils/IdentityProgressUtils.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/utils/IdentityProgressUtils.java
@@ -1,0 +1,34 @@
+package uk.gov.di.orchestration.identity.utils;
+
+import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
+import uk.gov.di.orchestration.identity.entity.ProcessingIdentityStatus;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class IdentityProgressUtils {
+    private IdentityProgressUtils() {}
+
+    public static ProcessingIdentityStatus getProcessingIdentityStatus(
+            Optional<OrchIdentityCredentials> identityCredentialsOpt, int attempts) {
+        return ProcessingIdentityStatus.valueOf(getStatus(identityCredentialsOpt, attempts));
+    }
+
+    public static IdentityProgressStatus getIdentityProgressStatus(
+            Optional<OrchIdentityCredentials> identityCredentialsOpt, int attempts) {
+        return IdentityProgressStatus.valueOf(getStatus(identityCredentialsOpt, attempts));
+    }
+
+    private static String getStatus(
+            Optional<OrchIdentityCredentials> identityCredentialsOpt, int attempts) {
+        if (identityCredentialsOpt.isEmpty() && attempts == 1) {
+            return "NO_ENTRY";
+        } else if (identityCredentialsOpt.isEmpty()) {
+            return "ERROR";
+        } else if (Objects.nonNull(identityCredentialsOpt.get().getCoreIdentityJWT())) {
+            return "COMPLETED";
+        }
+        return "PROCESSING";
+    }
+}

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityProgressServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityProgressServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.audit.AuditContext;
 import uk.gov.di.orchestration.identity.entity.IdentityProcessingEndState;
+import uk.gov.di.orchestration.identity.entity.SPOTAuditableEvent;
 import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -17,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.orchestration.identity.testsupport.TestAuditEvent.TEST_PROCESSING_IDENTITY_REQUEST;
 import static uk.gov.di.orchestration.sharedtest.helper.Constants.CLIENT_SESSION_ID;
 import static uk.gov.di.orchestration.sharedtest.helper.Constants.ENVIRONMENT;
 
@@ -49,9 +49,7 @@ class IdentityProgressServiceTest {
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(credentialsCompleted());
 
-        var status =
-                identityProgressService.pollForStatus(
-                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+        var status = identityProgressService.pollForStatus(CLIENT_SESSION_ID, auditContext);
 
         assertEquals(IdentityProcessingEndState.COMPLETED, status);
         verifyCloudwatchMetricIncrements(status);
@@ -65,9 +63,7 @@ class IdentityProgressServiceTest {
                 .thenReturn(credentialsProcessing())
                 .thenReturn(credentialsCompleted());
 
-        var status =
-                identityProgressService.pollForStatus(
-                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+        var status = identityProgressService.pollForStatus(CLIENT_SESSION_ID, auditContext);
 
         assertEquals(IdentityProcessingEndState.COMPLETED, status);
         verifyCloudwatchMetricIncrements(status);
@@ -79,9 +75,7 @@ class IdentityProgressServiceTest {
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(credentialsNotFound());
 
-        var status =
-                identityProgressService.pollForStatus(
-                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+        var status = identityProgressService.pollForStatus(CLIENT_SESSION_ID, auditContext);
 
         assertEquals(IdentityProcessingEndState.NO_ENTRY, status);
         verifyCloudwatchMetricIncrements(status);
@@ -94,9 +88,7 @@ class IdentityProgressServiceTest {
                 .thenReturn(credentialsProcessing())
                 .thenReturn(credentialsNotFound());
 
-        var status =
-                identityProgressService.pollForStatus(
-                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+        var status = identityProgressService.pollForStatus(CLIENT_SESSION_ID, auditContext);
 
         assertEquals(IdentityProcessingEndState.ERROR, status);
         verifyCloudwatchMetricIncrements(status);
@@ -108,9 +100,7 @@ class IdentityProgressServiceTest {
         when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
                 .thenReturn(credentialsProcessing());
 
-        var status =
-                identityProgressService.pollForStatus(
-                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+        var status = identityProgressService.pollForStatus(CLIENT_SESSION_ID, auditContext);
 
         assertEquals(IdentityProcessingEndState.ERROR, status);
         verifyCloudwatchMetricIncrements(status);
@@ -141,6 +131,7 @@ class IdentityProgressServiceTest {
     }
 
     private void verifyAuditEventSubmitted() {
-        verify(auditService).submitAuditEvent(TEST_PROCESSING_IDENTITY_REQUEST, auditContext);
+        verify(auditService)
+                .submitAuditEvent(SPOTAuditableEvent.PROCESSING_IDENTITY_REQUEST, auditContext);
     }
 }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityProgressServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityProgressServiceTest.java
@@ -3,7 +3,7 @@ package uk.gov.di.orchestration.identity.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
+import uk.gov.di.orchestration.identity.entity.IdentityProcessingEndState;
 import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -53,7 +53,7 @@ class IdentityProgressServiceTest {
                 identityProgressService.pollForStatus(
                         CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
 
-        assertEquals(IdentityProgressStatus.COMPLETED, status);
+        assertEquals(IdentityProcessingEndState.COMPLETED, status);
         verifyCloudwatchMetricIncrements(status);
         verifyAuditEventSubmitted();
     }
@@ -69,7 +69,7 @@ class IdentityProgressServiceTest {
                 identityProgressService.pollForStatus(
                         CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
 
-        assertEquals(IdentityProgressStatus.COMPLETED, status);
+        assertEquals(IdentityProcessingEndState.COMPLETED, status);
         verifyCloudwatchMetricIncrements(status);
         verifyAuditEventSubmitted();
     }
@@ -83,7 +83,7 @@ class IdentityProgressServiceTest {
                 identityProgressService.pollForStatus(
                         CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
 
-        assertEquals(IdentityProgressStatus.NO_ENTRY, status);
+        assertEquals(IdentityProcessingEndState.NO_ENTRY, status);
         verifyCloudwatchMetricIncrements(status);
         verifyAuditEventSubmitted();
     }
@@ -98,7 +98,7 @@ class IdentityProgressServiceTest {
                 identityProgressService.pollForStatus(
                         CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
 
-        assertEquals(IdentityProgressStatus.ERROR, status);
+        assertEquals(IdentityProcessingEndState.ERROR, status);
         verifyCloudwatchMetricIncrements(status);
         verifyAuditEventSubmitted();
     }
@@ -112,7 +112,7 @@ class IdentityProgressServiceTest {
                 identityProgressService.pollForStatus(
                         CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
 
-        assertEquals(IdentityProgressStatus.ERROR, status);
+        assertEquals(IdentityProcessingEndState.ERROR, status);
         verifyCloudwatchMetricIncrements(status);
         verifyAuditEventSubmitted();
     }
@@ -129,7 +129,7 @@ class IdentityProgressServiceTest {
         return Optional.of(new OrchIdentityCredentials().withCoreIdentityJWT("test-jwt"));
     }
 
-    private void verifyCloudwatchMetricIncrements(IdentityProgressStatus status) {
+    private void verifyCloudwatchMetricIncrements(IdentityProcessingEndState status) {
         verify(metrics)
                 .increment(
                         "ProcessingIdentity",

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityProgressServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityProgressServiceTest.java
@@ -1,0 +1,146 @@
+package uk.gov.di.orchestration.identity.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
+import uk.gov.di.orchestration.shared.services.AuditService;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.DynamoIdentityService;
+import uk.gov.di.orchestration.shared.services.Metrics;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.identity.testsupport.TestAuditEvent.TEST_PROCESSING_IDENTITY_REQUEST;
+import static uk.gov.di.orchestration.sharedtest.helper.Constants.CLIENT_SESSION_ID;
+import static uk.gov.di.orchestration.sharedtest.helper.Constants.ENVIRONMENT;
+
+class IdentityProgressServiceTest {
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoIdentityService dynamoIdentityService = mock(DynamoIdentityService.class);
+    private final AuditService auditService = mock(AuditService.class);
+    private final Metrics metrics = mock(Metrics.class);
+    private final IdentityProgressService.Sleeper sleeper = millis -> {};
+    private final AuditContext auditContext = mock(AuditContext.class);
+    private IdentityProgressService identityProgressService;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getEnvironment()).thenReturn(ENVIRONMENT);
+        when(configurationService.getSyncWaitForSpotTimeout()).thenReturn(5000L);
+        identityProgressService =
+                new IdentityProgressService(
+                        configurationService,
+                        dynamoIdentityService,
+                        auditService,
+                        metrics,
+                        sleeper);
+    }
+
+    @Test
+    void shouldReturnCompletedStatusWhenCredentialsPresentWithCoreIdentityJwtOnFirstAttempt()
+            throws Exception {
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
+                .thenReturn(credentialsCompleted());
+
+        var status =
+                identityProgressService.pollForStatus(
+                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+
+        assertEquals(IdentityProgressStatus.COMPLETED, status);
+        verifyCloudwatchMetricIncrements(status);
+        verifyAuditEventSubmitted();
+    }
+
+    @Test
+    void shouldReturnCompletedStatusWhenCredentialsPresentWithCoreIdentityJwtOnSecondAttempt()
+            throws Exception {
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
+                .thenReturn(credentialsProcessing())
+                .thenReturn(credentialsCompleted());
+
+        var status =
+                identityProgressService.pollForStatus(
+                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+
+        assertEquals(IdentityProgressStatus.COMPLETED, status);
+        verifyCloudwatchMetricIncrements(status);
+        verifyAuditEventSubmitted();
+    }
+
+    @Test
+    void shouldReturnNoEntryStatusWhenNoCredentialsFoundOnFirstAttempt() throws Exception {
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
+                .thenReturn(credentialsNotFound());
+
+        var status =
+                identityProgressService.pollForStatus(
+                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+
+        assertEquals(IdentityProgressStatus.NO_ENTRY, status);
+        verifyCloudwatchMetricIncrements(status);
+        verifyAuditEventSubmitted();
+    }
+
+    @Test
+    void shouldReturnErrorStatusWhenNoCredentialsFoundOnSecondAttempt() throws Exception {
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
+                .thenReturn(credentialsProcessing())
+                .thenReturn(credentialsNotFound());
+
+        var status =
+                identityProgressService.pollForStatus(
+                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+
+        assertEquals(IdentityProgressStatus.ERROR, status);
+        verifyCloudwatchMetricIncrements(status);
+        verifyAuditEventSubmitted();
+    }
+
+    @Test
+    void shouldReturnErrorStatusWhenMaxRetriesHasBeenReached() throws Exception {
+        when(dynamoIdentityService.getIdentityCredentials(CLIENT_SESSION_ID))
+                .thenReturn(credentialsProcessing());
+
+        var status =
+                identityProgressService.pollForStatus(
+                        CLIENT_SESSION_ID, auditContext, TEST_PROCESSING_IDENTITY_REQUEST);
+
+        assertEquals(IdentityProgressStatus.ERROR, status);
+        verifyCloudwatchMetricIncrements(status);
+        verifyAuditEventSubmitted();
+    }
+
+    private static Optional<OrchIdentityCredentials> credentialsNotFound() {
+        return Optional.empty();
+    }
+
+    private static Optional<OrchIdentityCredentials> credentialsProcessing() {
+        return Optional.of(new OrchIdentityCredentials());
+    }
+
+    private static Optional<OrchIdentityCredentials> credentialsCompleted() {
+        return Optional.of(new OrchIdentityCredentials().withCoreIdentityJWT("test-jwt"));
+    }
+
+    private void verifyCloudwatchMetricIncrements(IdentityProgressStatus status) {
+        verify(metrics)
+                .increment(
+                        "ProcessingIdentity",
+                        Map.of(
+                                "Environment",
+                                configurationService.getEnvironment(),
+                                "Status",
+                                status.toString()));
+    }
+
+    private void verifyAuditEventSubmitted() {
+        verify(auditService).submitAuditEvent(TEST_PROCESSING_IDENTITY_REQUEST, auditContext);
+    }
+}

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
@@ -5,10 +5,14 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.audit.AuditContext;
+import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
 import uk.gov.di.orchestration.identity.entity.LogIds;
 import uk.gov.di.orchestration.identity.entity.SPOTRequest;
+import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
@@ -23,14 +27,17 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.identity.testsupport.TestAuditEvent.TEST_PROCESSING_IDENTITY_REQUEST;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 public class IdentitySPOTServiceTest {
@@ -38,6 +45,9 @@ public class IdentitySPOTServiceTest {
     private final AwsSqsClient spotSqsClient = mock(AwsSqsClient.class);
     private final OidcAPI oidcAPI = mock(OidcAPI.class);
     private final SerializationService objectMapper = spy(SerializationService.getInstance());
+    private final IdentityProgressService identityProgressService =
+            mock(IdentityProgressService.class);
+    private final AuthFrontend frontend = mock(AuthFrontend.class);
     private static final URI OIDC_TRUSTMARK_URI = URI.create("https://base-url.com/trustmark");
     private static final UserInfo P2_VOT_USER_IDENTITY_USER_INFO =
             new UserInfo(
@@ -58,6 +68,9 @@ public class IdentitySPOTServiceTest {
             "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes(StandardCharsets.UTF_8);
     private static final String BASE_64_ENCODED_SALT = Base64.getEncoder().encodeToString(salt);
     private static final UserInfo AUTH_USER_INFO = generateAuthUserInfo();
+    private static final AuditContext AUDIT_CONTEXT = mock(AuditContext.class);
+    private static final String FRONTEND_IPV_CALLBACK_URI = "http://frontend/ipv";
+    private static final String FRONTEND_ERROR_URI = "http://frontend/error";
 
     private IdentitySPOTService service;
 
@@ -66,63 +79,139 @@ public class IdentitySPOTServiceTest {
             new CaptureLoggingExtension(IdentitySPOTService.class);
 
     @BeforeEach
-    void setup() {
+    void setup() throws Exception {
         // TODO: We might be able to get rid of this flag?
         when(configurationService.isNewSpotRequestQueueWritingEnabled()).thenReturn(true);
+        when(frontend.ipvCallbackURI()).thenReturn(new URI(FRONTEND_IPV_CALLBACK_URI));
+        when(frontend.errorURI()).thenReturn(new URI(FRONTEND_ERROR_URI));
         service =
-                new IdentitySPOTService(configurationService, spotSqsClient, oidcAPI, objectMapper);
+                new IdentitySPOTService(
+                        configurationService,
+                        spotSqsClient,
+                        oidcAPI,
+                        objectMapper,
+                        identityProgressService,
+                        frontend);
     }
 
-    @Test
-    void shouldQueueSPOTRequestIfValidFormat() {
-        when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);
-        service.queueSPOTRequest(
-                new LogIds(),
-                "sector-identifier",
-                AUTH_USER_INFO,
-                SUBJECT,
-                P2_VOT_USER_IDENTITY_USER_INFO,
-                CLIENT_ID.getValue());
+    @Nested
+    class QueueSpotRequest {
+        @Test
+        void shouldQueueSPOTRequestIfValidFormat() {
+            when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);
+            service.queueSPOTRequest(
+                    new LogIds(),
+                    "sector-identifier",
+                    AUTH_USER_INFO,
+                    SUBJECT,
+                    P2_VOT_USER_IDENTITY_USER_INFO,
+                    CLIENT_ID.getValue());
 
-        assertThat(
-                logging.events(),
-                hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
-        var spotRequestString =
-                "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":\"core-identity\",\"https://vocab.account.gov.uk/v1/credentialJWT\":null,\"vot\":\"P2\",\"vtm\":\"https://base-url.com/trustmark\"},\"in_local_account_id\":\"subject-id\","
-                        + "\"in_salt\":"
-                        + objectMapper.writeValueAsString(BASE_64_ENCODED_SALT)
-                        + ",\"in_rp_sector_id\":\"sector-identifier\",\"out_sub\":\"subject-id\",\"log_ids\":{\"session_id\":null,\"persistent_session_id\":null,\"request_id\":null,\"client_id\":null,\"client_session_id\":null},\"out_audience\":\""
-                        + CLIENT_ID.getValue()
-                        + "\"}";
-        verify(spotSqsClient).send(spotRequestString);
-        assertThat(
-                logging.events(), hasItem(withMessageContaining("SPOT request placed on queue")));
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
+            var spotRequestString =
+                    "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":\"core-identity\",\"https://vocab.account.gov.uk/v1/credentialJWT\":null,\"vot\":\"P2\",\"vtm\":\"https://base-url.com/trustmark\"},\"in_local_account_id\":\"subject-id\","
+                            + "\"in_salt\":"
+                            + objectMapper.writeValueAsString(BASE_64_ENCODED_SALT)
+                            + ",\"in_rp_sector_id\":\"sector-identifier\",\"out_sub\":\"subject-id\",\"log_ids\":{\"session_id\":null,\"persistent_session_id\":null,\"request_id\":null,\"client_id\":null,\"client_session_id\":null},\"out_audience\":\""
+                            + CLIENT_ID.getValue()
+                            + "\"}";
+            verify(spotSqsClient).send(spotRequestString);
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("SPOT request placed on queue")));
+        }
+
+        @Test
+        void shouldThrowJsonExceptionAndDoesNotInteractWithSqsIfCannotMapRequestToJson() {
+            when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);
+            when(objectMapper.writeValueAsString(any(SPOTRequest.class)))
+                    .thenThrow(new Json.JsonException("json-exception"));
+
+            var exception =
+                    assertThrows(
+                            Json.JsonException.class,
+                            () ->
+                                    service.queueSPOTRequest(
+                                            new LogIds(),
+                                            "sector-identifier",
+                                            AUTH_USER_INFO,
+                                            SUBJECT,
+                                            P2_VOT_USER_IDENTITY_USER_INFO,
+                                            CLIENT_ID.getValue()),
+                            "Expected to throw JsonException");
+
+            assertThat(
+                    logging.events(),
+                    hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
+            verifyNoInteractions(spotSqsClient);
+            assertEquals("json-exception", exception.getMessage());
+        }
     }
 
-    @Test
-    void shouldThrowJsonExceptionAndDoesNotInteractWithSqsIfCannotMapRequestToJson() {
-        when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);
-        when(objectMapper.writeValueAsString(any(SPOTRequest.class)))
-                .thenThrow(new Json.JsonException("json-exception"));
+    @Nested
+    class WaitForSPOT {
 
-        var exception =
-                assertThrows(
-                        Json.JsonException.class,
-                        () ->
-                                service.queueSPOTRequest(
-                                        new LogIds(),
-                                        "sector-identifier",
-                                        AUTH_USER_INFO,
-                                        SUBJECT,
-                                        P2_VOT_USER_IDENTITY_USER_INFO,
-                                        CLIENT_ID.getValue()),
-                        "Expected to throw JsonException");
+        @Test
+        void shouldRedirectToFrontendWhenSyncWaitForSPOTDisabled() throws Exception {
+            when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(false);
 
-        assertThat(
-                logging.events(),
-                hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
-        verifyNoInteractions(spotSqsClient);
-        assertEquals("json-exception", exception.getMessage());
+            var redirectOpt =
+                    service.waitForSpot(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+
+            assertTrue(redirectOpt.isPresent());
+            var redirect = redirectOpt.get();
+            assertThat(
+                    redirect.getHeaders().get("Location"), startsWith(FRONTEND_IPV_CALLBACK_URI));
+        }
+
+        @Test
+        void shouldRedirectToFrontendErrorPageWhenSyncWaitForSPOTReturnsError() throws Exception {
+            when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
+            when(identityProgressService.pollForStatus(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
+                    .thenReturn(IdentityProgressStatus.ERROR);
+
+            var redirectOpt =
+                    service.waitForSpot(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+
+            assertTrue(redirectOpt.isPresent());
+            var redirect = redirectOpt.get();
+            assertThat(redirect.getHeaders().get("Location"), startsWith(FRONTEND_ERROR_URI));
+        }
+
+        @Test
+        void shouldRedirectToFrontendErrorPageWhenSyncWaitForSPOTReturnsNoEntry() throws Exception {
+            when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
+            when(identityProgressService.pollForStatus(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
+                    .thenReturn(IdentityProgressStatus.NO_ENTRY);
+
+            var redirectOpt =
+                    service.waitForSpot(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+
+            assertTrue(redirectOpt.isPresent());
+            var redirect = redirectOpt.get();
+            assertThat(redirect.getHeaders().get("Location"), startsWith(FRONTEND_ERROR_URI));
+        }
+
+        @Test
+        void shouldNotRedirectYetWhenSyncWaitForSPOTReturnsCompleted() throws Exception {
+            when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
+            when(identityProgressService.pollForStatus(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
+                    .thenReturn(IdentityProgressStatus.COMPLETED);
+
+            var redirectOpt =
+                    service.waitForSpot(
+                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+
+            assertTrue(redirectOpt.isEmpty());
+        }
     }
 
     private static UserInfo generateAuthUserInfo() {

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
@@ -1,0 +1,145 @@
+package uk.gov.di.orchestration.identity.service;
+
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.orchestration.identity.entity.LogIds;
+import uk.gov.di.orchestration.identity.entity.SPOTRequest;
+import uk.gov.di.orchestration.shared.api.OidcAPI;
+import uk.gov.di.orchestration.shared.serialization.Json;
+import uk.gov.di.orchestration.shared.services.AwsSqsClient;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.sharedtest.logging.CaptureLoggingExtension;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+public class IdentitySPOTServiceTest {
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AwsSqsClient spotSqsClient = mock(AwsSqsClient.class);
+    private final OidcAPI oidcAPI = mock(OidcAPI.class);
+    private final SerializationService objectMapper = spy(SerializationService.getInstance());
+    private static final URI OIDC_TRUSTMARK_URI = URI.create("https://base-url.com/trustmark");
+    private static final UserInfo P2_VOT_USER_IDENTITY_USER_INFO =
+            new UserInfo(
+                    new JSONObject(
+                            Map.of(
+                                    "sub", "sub-val",
+                                    "vot", "P2",
+                                    "vtm", OIDC_TRUSTMARK_URI.toString(),
+                                    "https://vocab.account.gov.uk/v1/coreIdentity", "core-identity",
+                                    "https://vocab.account.gov.uk/v1/passport", "passport")));
+    private static final Subject SUBJECT = new Subject("subject-id");
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final String CLIENT_SESSION_ID = "a-client-session-id";
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_PHONE_NUMBER = "012345678902";
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_ID = "internal-common-subject-id";
+    private static final byte[] salt =
+            "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes(StandardCharsets.UTF_8);
+    private static final String BASE_64_ENCODED_SALT = Base64.getEncoder().encodeToString(salt);
+    private static final UserInfo AUTH_USER_INFO = generateAuthUserInfo();
+
+    private IdentitySPOTService service;
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(IdentitySPOTService.class);
+
+    @BeforeEach
+    void setup() {
+        // TODO: We might be able to get rid of this flag?
+        when(configurationService.isNewSpotRequestQueueWritingEnabled()).thenReturn(true);
+        service =
+                new IdentitySPOTService(configurationService, spotSqsClient, oidcAPI, objectMapper);
+    }
+
+    @Test
+    void shouldQueueSPOTRequestIfValidFormat() {
+        when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);
+        service.queueSPOTRequest(
+                new LogIds(),
+                "sector-identifier",
+                AUTH_USER_INFO,
+                SUBJECT,
+                P2_VOT_USER_IDENTITY_USER_INFO,
+                CLIENT_ID.getValue());
+
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
+        var spotRequestString =
+                "{\"in_claims\":{\"https://vocab.account.gov.uk/v1/coreIdentity\":\"core-identity\",\"https://vocab.account.gov.uk/v1/credentialJWT\":null,\"vot\":\"P2\",\"vtm\":\"https://base-url.com/trustmark\"},\"in_local_account_id\":\"subject-id\","
+                        + "\"in_salt\":"
+                        + objectMapper.writeValueAsString(BASE_64_ENCODED_SALT)
+                        + ",\"in_rp_sector_id\":\"sector-identifier\",\"out_sub\":\"subject-id\",\"log_ids\":{\"session_id\":null,\"persistent_session_id\":null,\"request_id\":null,\"client_id\":null,\"client_session_id\":null},\"out_audience\":\""
+                        + CLIENT_ID.getValue()
+                        + "\"}";
+        verify(spotSqsClient).send(spotRequestString);
+        assertThat(
+                logging.events(), hasItem(withMessageContaining("SPOT request placed on queue")));
+    }
+
+    @Test
+    void shouldThrowJsonExceptionAndDoesNotInteractWithSqsIfCannotMapRequestToJson() {
+        when(oidcAPI.trustmarkURI()).thenReturn(OIDC_TRUSTMARK_URI);
+        when(objectMapper.writeValueAsString(any(SPOTRequest.class)))
+                .thenThrow(new Json.JsonException("json-exception"));
+
+        var exception =
+                assertThrows(
+                        Json.JsonException.class,
+                        () ->
+                                service.queueSPOTRequest(
+                                        new LogIds(),
+                                        "sector-identifier",
+                                        AUTH_USER_INFO,
+                                        SUBJECT,
+                                        P2_VOT_USER_IDENTITY_USER_INFO,
+                                        CLIENT_ID.getValue()),
+                        "Expected to throw JsonException");
+
+        assertThat(
+                logging.events(),
+                hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
+        verifyNoInteractions(spotSqsClient);
+        assertEquals("json-exception", exception.getMessage());
+    }
+
+    private static UserInfo generateAuthUserInfo() {
+        return new UserInfo(
+                new JSONObject(
+                        Map.of(
+                                "sub",
+                                TEST_INTERNAL_COMMON_SUBJECT_ID,
+                                "client_session_id",
+                                CLIENT_SESSION_ID,
+                                "email",
+                                TEST_EMAIL_ADDRESS,
+                                "phone_number",
+                                TEST_PHONE_NUMBER,
+                                "salt",
+                                BASE_64_ENCODED_SALT,
+                                "local_account_id",
+                                SUBJECT.getValue())));
+    }
+}

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.orchestration.audit.AuditContext;
-import uk.gov.di.orchestration.identity.entity.IdentityProgressStatus;
+import uk.gov.di.orchestration.identity.entity.IdentityProcessingEndState;
 import uk.gov.di.orchestration.identity.entity.LogIds;
 import uk.gov.di.orchestration.identity.entity.SPOTRequest;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
@@ -172,7 +172,7 @@ public class IdentitySPOTServiceTest {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
             when(identityProgressService.pollForStatus(
                             CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
-                    .thenReturn(IdentityProgressStatus.ERROR);
+                    .thenReturn(IdentityProcessingEndState.ERROR);
 
             var redirectOpt =
                     service.waitForSpot(
@@ -188,7 +188,7 @@ public class IdentitySPOTServiceTest {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
             when(identityProgressService.pollForStatus(
                             CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
-                    .thenReturn(IdentityProgressStatus.NO_ENTRY);
+                    .thenReturn(IdentityProcessingEndState.NO_ENTRY);
 
             var redirectOpt =
                     service.waitForSpot(
@@ -204,7 +204,7 @@ public class IdentitySPOTServiceTest {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
             when(identityProgressService.pollForStatus(
                             CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
-                    .thenReturn(IdentityProgressStatus.COMPLETED);
+                    .thenReturn(IdentityProcessingEndState.COMPLETED);
 
             var redirectOpt =
                     service.waitForSpot(

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentitySPOTServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.orchestration.identity.entity.SPOTRequest;
 import uk.gov.di.orchestration.shared.api.AuthFrontend;
 import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.serialization.Json;
+import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.AwsSqsClient;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
@@ -37,7 +38,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.orchestration.identity.testsupport.TestAuditEvent.TEST_PROCESSING_IDENTITY_REQUEST;
+import static uk.gov.di.orchestration.identity.entity.SPOTAuditableEvent.IPV_SPOT_REQUESTED;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 public class IdentitySPOTServiceTest {
@@ -48,6 +49,7 @@ public class IdentitySPOTServiceTest {
     private final IdentityProgressService identityProgressService =
             mock(IdentityProgressService.class);
     private final AuthFrontend frontend = mock(AuthFrontend.class);
+    private final AuditService auditService = mock(AuditService.class);
     private static final URI OIDC_TRUSTMARK_URI = URI.create("https://base-url.com/trustmark");
     private static final UserInfo P2_VOT_USER_IDENTITY_USER_INFO =
             new UserInfo(
@@ -91,7 +93,8 @@ public class IdentitySPOTServiceTest {
                         oidcAPI,
                         objectMapper,
                         identityProgressService,
-                        frontend);
+                        frontend,
+                        auditService);
     }
 
     @Nested
@@ -105,7 +108,8 @@ public class IdentitySPOTServiceTest {
                     AUTH_USER_INFO,
                     SUBJECT,
                     P2_VOT_USER_IDENTITY_USER_INFO,
-                    CLIENT_ID.getValue());
+                    CLIENT_ID.getValue(),
+                    AUDIT_CONTEXT);
 
             assertThat(
                     logging.events(),
@@ -121,6 +125,7 @@ public class IdentitySPOTServiceTest {
             assertThat(
                     logging.events(),
                     hasItem(withMessageContaining("SPOT request placed on queue")));
+            verify(auditService).submitAuditEvent(IPV_SPOT_REQUESTED, AUDIT_CONTEXT);
         }
 
         @Test
@@ -139,13 +144,15 @@ public class IdentitySPOTServiceTest {
                                             AUTH_USER_INFO,
                                             SUBJECT,
                                             P2_VOT_USER_IDENTITY_USER_INFO,
-                                            CLIENT_ID.getValue()),
+                                            CLIENT_ID.getValue(),
+                                            AUDIT_CONTEXT),
                             "Expected to throw JsonException");
 
             assertThat(
                     logging.events(),
                     hasItem(withMessageContaining("Constructing SPOT request ready to queue")));
             verifyNoInteractions(spotSqsClient);
+            verifyNoInteractions(auditService);
             assertEquals("json-exception", exception.getMessage());
         }
     }
@@ -157,9 +164,7 @@ public class IdentitySPOTServiceTest {
         void shouldRedirectToFrontendWhenSyncWaitForSPOTDisabled() throws Exception {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(false);
 
-            var redirectOpt =
-                    service.waitForSpot(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+            var redirectOpt = service.waitForSpot(CLIENT_SESSION_ID, AUDIT_CONTEXT);
 
             assertTrue(redirectOpt.isPresent());
             var redirect = redirectOpt.get();
@@ -170,13 +175,10 @@ public class IdentitySPOTServiceTest {
         @Test
         void shouldRedirectToFrontendErrorPageWhenSyncWaitForSPOTReturnsError() throws Exception {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
-            when(identityProgressService.pollForStatus(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
+            when(identityProgressService.pollForStatus(CLIENT_SESSION_ID, AUDIT_CONTEXT))
                     .thenReturn(IdentityProcessingEndState.ERROR);
 
-            var redirectOpt =
-                    service.waitForSpot(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+            var redirectOpt = service.waitForSpot(CLIENT_SESSION_ID, AUDIT_CONTEXT);
 
             assertTrue(redirectOpt.isPresent());
             var redirect = redirectOpt.get();
@@ -186,13 +188,10 @@ public class IdentitySPOTServiceTest {
         @Test
         void shouldRedirectToFrontendErrorPageWhenSyncWaitForSPOTReturnsNoEntry() throws Exception {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
-            when(identityProgressService.pollForStatus(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
+            when(identityProgressService.pollForStatus(CLIENT_SESSION_ID, AUDIT_CONTEXT))
                     .thenReturn(IdentityProcessingEndState.NO_ENTRY);
 
-            var redirectOpt =
-                    service.waitForSpot(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+            var redirectOpt = service.waitForSpot(CLIENT_SESSION_ID, AUDIT_CONTEXT);
 
             assertTrue(redirectOpt.isPresent());
             var redirect = redirectOpt.get();
@@ -202,13 +201,10 @@ public class IdentitySPOTServiceTest {
         @Test
         void shouldNotRedirectYetWhenSyncWaitForSPOTReturnsCompleted() throws Exception {
             when(configurationService.isSyncWaitForSpotEnabled()).thenReturn(true);
-            when(identityProgressService.pollForStatus(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST))
+            when(identityProgressService.pollForStatus(CLIENT_SESSION_ID, AUDIT_CONTEXT))
                     .thenReturn(IdentityProcessingEndState.COMPLETED);
 
-            var redirectOpt =
-                    service.waitForSpot(
-                            CLIENT_SESSION_ID, AUDIT_CONTEXT, TEST_PROCESSING_IDENTITY_REQUEST);
+            var redirectOpt = service.waitForSpot(CLIENT_SESSION_ID, AUDIT_CONTEXT);
 
             assertTrue(redirectOpt.isEmpty());
         }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/testsupport/TestAuditEvent.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/testsupport/TestAuditEvent.java
@@ -4,7 +4,8 @@ import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 
 public enum TestAuditEvent implements AuditableEvent {
     TEST_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-    TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
+    TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+    TEST_PROCESSING_IDENTITY_REQUEST;
 
     @Override
     public AuditableEvent parseFromName(String name) {

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/testsupport/TestAuditEvent.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/testsupport/TestAuditEvent.java
@@ -4,8 +4,7 @@ import uk.gov.di.orchestration.shared.domain.AuditableEvent;
 
 public enum TestAuditEvent implements AuditableEvent {
     TEST_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-    TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-    TEST_PROCESSING_IDENTITY_REQUEST;
+    TEST_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
 
     @Override
     public AuditableEvent parseFromName(String name) {

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityProgressUtilsTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityProgressUtilsTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.orchestration.identity.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.identity.entity.ProcessingIdentityStatus;
+import uk.gov.di.orchestration.shared.entity.OrchIdentityCredentials;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.orchestration.identity.utils.IdentityProgressUtils.getProcessingIdentityStatus;
+
+class IdentityProgressUtilsTest {
+    @Test
+    void shouldReturnCompletedStatusWhenIdentityCredentialsPresentWithCoreIdentityJwt() {
+        assertEquals(
+                ProcessingIdentityStatus.COMPLETED,
+                getProcessingIdentityStatus(credentialsCompleted(), 1));
+    }
+
+    @Test
+    void shouldReturnNoEntryWhenIdentityCredentialsMissingOnFirstAttempt() {
+        assertEquals(
+                ProcessingIdentityStatus.NO_ENTRY,
+                getProcessingIdentityStatus(credentialsNotFound(), 1));
+    }
+
+    @Test
+    void shouldReturnErrorWhenIdentityCredentialsMissingOnSecondAttempt() {
+        assertEquals(
+                ProcessingIdentityStatus.ERROR,
+                getProcessingIdentityStatus(credentialsNotFound(), 2));
+    }
+
+    @Test
+    void shouldReturnProcessingWhenIdentityCredentialsPresentButMissingCoreIdentityJwt() {
+        assertEquals(
+                ProcessingIdentityStatus.PROCESSING,
+                getProcessingIdentityStatus(credentialsProcessing(), 1));
+    }
+
+    private static Optional<OrchIdentityCredentials> credentialsNotFound() {
+        return Optional.empty();
+    }
+
+    private static Optional<OrchIdentityCredentials> credentialsProcessing() {
+        return Optional.of(new OrchIdentityCredentials());
+    }
+
+    private static Optional<OrchIdentityCredentials> credentialsCompleted() {
+        return Optional.of(new OrchIdentityCredentials().withCoreIdentityJWT("test-jwt"));
+    }
+}


### PR DESCRIPTION
### Wider context of change

This is part of the work to consolidate the identity callback code so it can be shared between IPV and SIS

### What’s changed

This PR adds a service to send SPOT requests and wait for a SPOT response. This has been copied from IPVCallbackHelper.

I will remove the copied code once we use these new shared identity methods in IPVCallbackHandler

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
