### PR TITLE
AUT-5652: Implement self re-invocation for inactive account data export lambda

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -39,6 +39,22 @@ Resources:
               !Ref Environment,
               inactiveAccountExportMaxRetries,
             ]
+          INACTIVE_ACCOUNT_EXPORT_LAMBDA_NAME: !Sub
+            - "${EnvironmentName}-inactive-account-data-export-lambda"
+            - EnvironmentName:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          INACTIVE_ACCOUNT_EXPORT_MAX_ITEMS_PER_SEGMENT:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              inactiveAccountExportMaxItemsPerSegment,
+            ]
+          INACTIVE_ACCOUNT_EXPORT_PAUSE_BETWEEN_INVOCATIONS_MS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              inactiveAccountExportPauseBetweenInvocationsMs,
+            ]
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy

--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -60,6 +60,7 @@ Resources:
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoCredentialReadAccessPolicy
         - !Ref CloudWatchLogsKmsAccessPolicy
+        - !Ref InactiveAccountDataExportSelfInvokePolicy
       AutoPublishAlias: live
       LoggingConfig:
         LogGroup: !Ref InactiveAccountDataExportLogGroup
@@ -105,3 +106,16 @@ Resources:
       LogGroupName: !Ref InactiveAccountDataExportLogGroup
       FilterPattern: ""
       DestinationArn: !Ref LoggingSubscriptionEndpointArn
+
+  InactiveAccountDataExportSelfInvokePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: lambda:InvokeFunction
+            Resource: !Sub
+              - "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${EnvironmentName}-inactive-account-data-export-lambda"
+              - EnvironmentName:
+                  !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -171,6 +171,8 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportPauseBetweenInvocationsMs: "15000"
 
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
@@ -206,6 +208,8 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportPauseBetweenInvocationsMs: "15000"
 
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
@@ -241,6 +245,8 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportPauseBetweenInvocationsMs: "15000"
 
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
@@ -276,6 +282,8 @@ Mappings:
       inactiveAccountExportParallelism: "3"
       inactiveAccountExportTotalSegments: "5"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "10"
+      inactiveAccountExportPauseBetweenInvocationsMs: "15000"
 
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
@@ -311,6 +319,8 @@ Mappings:
       inactiveAccountExportParallelism: "200"
       inactiveAccountExportTotalSegments: "200"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportPauseBetweenInvocationsMs: "60000"
 
     staging:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
@@ -346,6 +356,8 @@ Mappings:
       inactiveAccountExportParallelism: "200"
       inactiveAccountExportTotalSegments: "200"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportPauseBetweenInvocationsMs: "60000"
 
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
@@ -381,6 +393,8 @@ Mappings:
       inactiveAccountExportParallelism: "200"
       inactiveAccountExportTotalSegments: "200"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportPauseBetweenInvocationsMs: "60000"
 
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
@@ -416,6 +430,8 @@ Mappings:
       inactiveAccountExportParallelism: "200"
       inactiveAccountExportTotalSegments: "200"
       inactiveAccountExportMaxRetries: "3"
+      inactiveAccountExportMaxItemsPerSegment: "7500"
+      inactiveAccountExportPauseBetweenInvocationsMs: "60000"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -238,6 +238,23 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 System.getenv().getOrDefault("INACTIVE_ACCOUNT_EXPORT_MAX_RETRIES", "3"));
     }
 
+    public String getInactiveAccountExportLambdaName() {
+        return System.getenv().getOrDefault("INACTIVE_ACCOUNT_EXPORT_LAMBDA_NAME", "");
+    }
+
+    public int getInactiveAccountExportMaxItemsPerSegment() {
+        return Integer.parseInt(
+                System.getenv()
+                        .getOrDefault("INACTIVE_ACCOUNT_EXPORT_MAX_ITEMS_PER_SEGMENT", "7500"));
+    }
+
+    public long getInactiveAccountExportPauseBetweenInvocationsMs() {
+        return Long.parseLong(
+                System.getenv()
+                        .getOrDefault(
+                                "INACTIVE_ACCOUNT_EXPORT_PAUSE_BETWEEN_INVOCATIONS_MS", "60000"));
+    }
+
     public String getTicfCRILambdaIdentifier() {
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_IDENTIFIER", "");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
@@ -37,8 +37,7 @@ public class LambdaInvokerService implements LambdaInvoker {
         try {
             payload = SdkBytes.fromUtf8String(jsonPayload);
         } catch (Exception e) {
-            LOG.error(
-                    "Could not convert payload for {} into SdkBytes: {}", lambdaName, jsonPayload);
+            LOG.error("Could not convert payload for {} into SdkBytes", lambdaName);
             return;
         }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -208,6 +208,22 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void getInactiveAccountExportLambdaNameShouldDefault() {
+        assertEquals("", configurationService.getInactiveAccountExportLambdaName());
+    }
+
+    @Test
+    void getInactiveAccountExportMaxItemsPerSegmentShouldDefault() {
+        assertEquals(7500, configurationService.getInactiveAccountExportMaxItemsPerSegment());
+    }
+
+    @Test
+    void getInactiveAccountExportPauseBetweenInvocationsMsShouldDefault() {
+        assertEquals(
+                60000, configurationService.getInactiveAccountExportPauseBetweenInvocationsMs());
+    }
+
+    @Test
     void getTicfCRILambdaNameShouldDefault() {
         assertEquals("", configurationService.getTicfCRILambdaIdentifier());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
@@ -86,6 +86,6 @@ class LambdaInvokerServiceTest {
                         withMessage(
                                 "Could not convert payload for "
                                         + functionName
-                                        + " into SdkBytes: null")));
+                                        + " into SdkBytes")));
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportRequest.java
@@ -1,3 +1,10 @@
 package uk.gov.di.authentication.utils.entity;
 
-public record InactiveAccountDataExportRequest() {}
+import com.google.gson.annotations.Expose;
+
+import java.util.Map;
+
+public record InactiveAccountDataExportRequest(
+        @Expose Map<Integer, Map<String, String>> segmentKeys,
+        @Expose Long processedCount,
+        @Expose Long writtenCount) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportResponse.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountDataExportResponse.java
@@ -2,4 +2,5 @@ package uk.gov.di.authentication.utils.entity;
 
 import com.google.gson.annotations.Expose;
 
-public record InactiveAccountDataExportResponse(@Expose long totalItemsScanned) {}
+public record InactiveAccountDataExportResponse(
+        @Expose long processedCount, @Expose long writtenCount) {}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -75,11 +75,18 @@ public class InactiveAccountDataExportHandler
         int maxRetries = configurationService.getInactiveAccountExportMaxRetries();
         int maxItemsPerSegment = configurationService.getInactiveAccountExportMaxItemsPerSegment();
 
+        if (maxItemsPerSegment <= 0) {
+            throw new IllegalStateException(
+                    "INACTIVE_ACCOUNT_EXPORT_MAX_ITEMS_PER_SEGMENT must be greater than 0");
+        }
+
         long processedCount =
                 request != null && request.processedCount() != null ? request.processedCount() : 0L;
         long writtenCount =
                 request != null && request.writtenCount() != null ? request.writtenCount() : 0L;
 
+        Map<Integer, Map<String, AttributeValue>> activeSegments =
+                resolveActiveSegments(request, totalSegments);
 
         LOG.info(
                 "Inactive account data export: parallelism={}, totalSegments={}, maxRetries={}, "
@@ -91,50 +98,117 @@ public class InactiveAccountDataExportHandler
                 activeSegments.size(),
                 processedCount);
 
-        List<ForkJoinTask<SegmentResult>> tasks = new ArrayList<>();
+        List<SegmentTask> segmentTasks = new ArrayList<>();
         ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism);
 
         try {
-            for (int segment = 0; segment < totalSegments; segment++) {
-                final int currentSegment = segment;
-                tasks.add(
-                        forkJoinPool.submit(
-                                () -> scanSegment(currentSegment, totalSegments, maxRetries)));
+            for (var entry : activeSegments.entrySet()) {
+                int segment = entry.getKey();
+                Map<String, AttributeValue> startKey = entry.getValue();
+                segmentTasks.add(
+                        new SegmentTask(
+                                segment,
+                                forkJoinPool.submit(
+                                        () ->
+                                                scanSegment(
+                                                        segment,
+                                                        totalSegments,
+                                                        maxRetries,
+                                                        maxItemsPerSegment,
+                                                        startKey))));
             }
 
             gracefulPoolShutdown(forkJoinPool);
 
             long totalItemsScanned = 0;
             long totalMissingCredentials = 0;
-            for (ForkJoinTask<SegmentResult> task : tasks) {
-                SegmentResult result = task.join();
+            Map<Integer, Map<String, String>> remainingSegmentKeys = new HashMap<>();
+
+            for (SegmentTask segmentTask : segmentTasks) {
+                SegmentResult result = segmentTask.task().join();
                 totalItemsScanned += result.itemsScanned();
                 totalMissingCredentials += result.missingCredentialsCount();
+
+                if (result.lastEvaluatedKey() != null && !result.lastEvaluatedKey().isEmpty()) {
+                    remainingSegmentKeys.put(
+                            segmentTask.segment(), toSerialisableKeys(result.lastEvaluatedKey()));
+                }
             }
 
-            LOG.info(
-                    "Scan completed: {} total items scanned, {} missing credentials",
-                    totalItemsScanned,
-                    totalMissingCredentials);
+            processedCount += totalItemsScanned;
 
-            return new InactiveAccountDataExportResponse(totalItemsScanned);
+            LOG.info(
+                    "Invocation complete: {} items scanned this invocation, {} missing credentials, "
+                            + "{} total processed, {} segments remaining",
+                    totalItemsScanned,
+                    totalMissingCredentials,
+                    processedCount,
+                    remainingSegmentKeys.size());
+
+            return new InactiveAccountDataExportResponse(processedCount, writtenCount);
         } finally {
             forcePoolShutdown(forkJoinPool);
         }
     }
 
-    private SegmentResult scanSegment(int segment, int totalSegments, int maxRetries) {
-        Map<String, AttributeValue> lastKey = null;
+    private Map<Integer, Map<String, AttributeValue>> resolveActiveSegments(
+            InactiveAccountDataExportRequest request, int totalSegments) {
+        Map<Integer, Map<String, AttributeValue>> activeSegments = new HashMap<>();
+
+        if (request == null || request.segmentKeys() == null) {
+            for (int i = 0; i < totalSegments; i++) {
+                activeSegments.put(i, null);
+            }
+        } else {
+            for (var entry : request.segmentKeys().entrySet()) {
+                activeSegments.put(entry.getKey(), toDynamoKeys(entry.getValue()));
+            }
+        }
+
+        return activeSegments;
+    }
+
+    private Map<String, AttributeValue> toDynamoKeys(Map<String, String> serialisedKey) {
+        if (serialisedKey == null || serialisedKey.isEmpty()) {
+            return null;
+        }
+        Map<String, AttributeValue> key = new HashMap<>();
+        for (var entry : serialisedKey.entrySet()) {
+            key.put(entry.getKey(), AttributeValue.builder().s(entry.getValue()).build());
+        }
+        return key;
+    }
+
+    private Map<String, String> toSerialisableKeys(Map<String, AttributeValue> key) {
+        Map<String, String> serialised = new HashMap<>();
+        for (var entry : key.entrySet()) {
+            serialised.put(entry.getKey(), entry.getValue().s());
+        }
+        return serialised;
+    }
+
+    SegmentResult scanSegment(
+            int segment,
+            int totalSegments,
+            int maxRetries,
+            int maxItemsPerSegment,
+            Map<String, AttributeValue> exclusiveStartKey) {
+        Map<String, AttributeValue> lastKey = exclusiveStartKey;
         long itemsScanned = 0;
         long missingCredentialsCount = 0;
         List<Map<String, AttributeValue>> currentBatch = new ArrayList<>();
 
         do {
+            if (itemsScanned >= maxItemsPerSegment) {
+                break;
+            }
+
             ScanRequest.Builder requestBuilder =
                     ScanRequest.builder()
                             .tableName(userProfileTableName)
                             .segment(segment)
                             .totalSegments(totalSegments)
+                            .limit(maxItemsPerSegment)
                             .projectionExpression(USER_PROFILE_PROJECTION_EXPRESSION)
                             .expressionAttributeNames(USER_PROFILE_EXPRESSION_ATTRIBUTE_NAMES);
 
@@ -154,7 +228,7 @@ public class InactiveAccountDataExportHandler
                 throw e;
             }
 
-            for (Map<String, AttributeValue> item : response.items()) {
+            for (var item : response.items()) {
                 itemsScanned++;
                 currentBatch.add(item);
 
@@ -172,13 +246,17 @@ public class InactiveAccountDataExportHandler
             currentBatch.clear();
         }
 
+        Map<String, AttributeValue> finalKey =
+                (lastKey != null && !lastKey.isEmpty()) ? lastKey : null;
+
         LOG.info(
-                "Segment {} completed: {} items scanned, {} missing credentials",
+                "Segment {} completed: {} items scanned, {} missing credentials, segmentExhausted={}",
                 segment,
                 itemsScanned,
-                missingCredentialsCount);
+                missingCredentialsCount,
+                finalKey == null);
 
-        return new SegmentResult(itemsScanned, missingCredentialsCount);
+        return new SegmentResult(itemsScanned, missingCredentialsCount, finalKey);
     }
 
     private long batchGetUserCredentials(
@@ -246,7 +324,12 @@ public class InactiveAccountDataExportHandler
         return allResults;
     }
 
-    private record SegmentResult(long itemsScanned, long missingCredentialsCount) {}
+    record SegmentTask(int segment, ForkJoinTask<SegmentResult> task) {}
+
+    record SegmentResult(
+            long itemsScanned,
+            long missingCredentialsCount,
+            Map<String, AttributeValue> lastEvaluatedKey) {}
 
     private static void gracefulPoolShutdown(ForkJoinPool forkJoinPool) {
         forkJoinPool.shutdown();

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -11,8 +11,12 @@ import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import uk.gov.di.authentication.shared.helpers.LambdaPauseHelper;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.LambdaInvokerService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportResponse;
 
@@ -48,13 +52,18 @@ public class InactiveAccountDataExportHandler
 
     private final DynamoDbClient client;
     private final ConfigurationService configurationService;
+    private final LambdaInvokerService lambdaInvokerService;
+    private final Json objectMapper = SerializationService.getInstance();
     private final String userProfileTableName;
     private final String userCredentialsTableName;
 
     public InactiveAccountDataExportHandler(
-            ConfigurationService configurationService, DynamoDbClient client) {
+            ConfigurationService configurationService,
+            DynamoDbClient client,
+            LambdaInvokerService lambdaInvokerService) {
         this.client = client;
         this.configurationService = configurationService;
+        this.lambdaInvokerService = lambdaInvokerService;
         this.userProfileTableName =
                 TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService);
         this.userCredentialsTableName =
@@ -64,7 +73,8 @@ public class InactiveAccountDataExportHandler
     public InactiveAccountDataExportHandler() {
         this(
                 ConfigurationService.getInstance(),
-                createDynamoClient(ConfigurationService.getInstance()));
+                createDynamoClient(ConfigurationService.getInstance()),
+                new LambdaInvokerService(ConfigurationService.getInstance()));
     }
 
     @Override
@@ -145,6 +155,10 @@ public class InactiveAccountDataExportHandler
                     processedCount,
                     remainingSegmentKeys.size());
 
+            if (!remainingSegmentKeys.isEmpty()) {
+                selfInvoke(remainingSegmentKeys, processedCount, writtenCount);
+            }
+
             return new InactiveAccountDataExportResponse(processedCount, writtenCount);
         } finally {
             forcePoolShutdown(forkJoinPool);
@@ -166,6 +180,44 @@ public class InactiveAccountDataExportHandler
         }
 
         return activeSegments;
+    }
+
+    private void selfInvoke(
+            Map<Integer, Map<String, String>> remainingSegmentKeys,
+            long processedCount,
+            long writtenCount) {
+        long pauseMs = configurationService.getInactiveAccountExportPauseBetweenInvocationsMs();
+        String lambdaName = configurationService.getInactiveAccountExportLambdaName();
+
+        if (lambdaName == null || lambdaName.isEmpty()) {
+            throw new RuntimeException(
+                    "INACTIVE_ACCOUNT_EXPORT_LAMBDA_NAME not set, cannot self-invoke");
+        }
+
+        LambdaPauseHelper.pauseBetweenInvocations(pauseMs);
+
+        var continuationRequest =
+                new InactiveAccountDataExportRequest(
+                        remainingSegmentKeys, processedCount, writtenCount);
+
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsStringCamelCase(continuationRequest);
+        } catch (Json.JsonException e) {
+            throw new RuntimeException("Failed to serialise continuation request", e);
+        }
+
+        LOG.info(
+                "Self-invoking with {} remaining segments, processedCount={}",
+                remainingSegmentKeys.size(),
+                processedCount);
+
+        try {
+            lambdaInvokerService.invokeAsyncWithPayload(payload, lambdaName);
+        } catch (Exception e) {
+            LOG.error("Self-invocation failed", e);
+            throw new RuntimeException("Failed to self-invoke lambda: " + lambdaName, e);
+        }
     }
 
     private Map<String, AttributeValue> toDynamoKeys(Map<String, String> serialisedKey) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -73,12 +73,23 @@ public class InactiveAccountDataExportHandler
         int parallelism = configurationService.getInactiveAccountExportParallelism();
         int totalSegments = configurationService.getInactiveAccountExportTotalSegments();
         int maxRetries = configurationService.getInactiveAccountExportMaxRetries();
+        int maxItemsPerSegment = configurationService.getInactiveAccountExportMaxItemsPerSegment();
+
+        long processedCount =
+                request != null && request.processedCount() != null ? request.processedCount() : 0L;
+        long writtenCount =
+                request != null && request.writtenCount() != null ? request.writtenCount() : 0L;
+
 
         LOG.info(
-                "Inactive account data export request: parallelism={}, totalSegments={}, maxRetries={}",
+                "Inactive account data export: parallelism={}, totalSegments={}, maxRetries={}, "
+                        + "maxItemsPerSegment={}, activeSegments={}, processedCount={}",
                 parallelism,
                 totalSegments,
-                maxRetries);
+                maxRetries,
+                maxItemsPerSegment,
+                activeSegments.size(),
+                processedCount);
 
         List<ForkJoinTask<SegmentResult>> tasks = new ArrayList<>();
         ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism);

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 
 import java.nio.ByteBuffer;
@@ -31,6 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -46,6 +49,7 @@ class InactiveAccountDataExportHandlerTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoDbClient client = mock(DynamoDbClient.class);
+    private final LambdaInvokerService lambdaInvokerService = mock(LambdaInvokerService.class);
     private final Context context = mock(Context.class);
 
     @BeforeEach
@@ -54,11 +58,16 @@ class InactiveAccountDataExportHandlerTest {
         when(configurationService.getInactiveAccountExportParallelism()).thenReturn(4);
         when(configurationService.getInactiveAccountExportTotalSegments()).thenReturn(1);
         when(configurationService.getInactiveAccountExportMaxRetries()).thenReturn(3);
-        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(7500);
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(100000);
+        when(configurationService.getInactiveAccountExportLambdaName())
+                .thenReturn("test-inactive-account-data-export-lambda");
+        when(configurationService.getInactiveAccountExportPauseBetweenInvocationsMs())
+                .thenReturn(0L);
     }
 
     private InactiveAccountDataExportHandler createHandler() {
-        return new InactiveAccountDataExportHandler(configurationService, client);
+        return new InactiveAccountDataExportHandler(
+                configurationService, client, lambdaInvokerService);
     }
 
     @Test
@@ -436,6 +445,153 @@ class InactiveAccountDataExportHandlerTest {
         assertNull(deserialised.segmentKeys());
         assertNull(deserialised.processedCount());
         assertNull(deserialised.writtenCount());
+    }
+
+    @Test
+    void shouldSelfInvokeWhenSegmentsRemainAfterProcessing() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        handler.handleRequest(request, context);
+
+        verify(lambdaInvokerService)
+                .invokeAsyncWithPayload(
+                        any(String.class), eq("test-inactive-account-data-export-lambda"));
+    }
+
+    @Test
+    void shouldNotSelfInvokeWhenAllSegmentsExhausted() {
+        int totalItems = 5;
+        mockScanWithPagination(totalItems, totalItems);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        handler.handleRequest(request, context);
+
+        verify(lambdaInvokerService, never()).invokeAsyncWithPayload(any(), any());
+    }
+
+    @Test
+    void shouldPassCorrectContinuationStateInSelfInvocation() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, 100L, 0L);
+
+        handler.handleRequest(request, context);
+
+        var payloadCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(lambdaInvokerService)
+                .invokeAsyncWithPayload(
+                        payloadCaptor.capture(), eq("test-inactive-account-data-export-lambda"));
+
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+        var continuation =
+                gson.fromJson(payloadCaptor.getValue(), InactiveAccountDataExportRequest.class);
+
+        assertNotNull(continuation.segmentKeys());
+        assertEquals(105, continuation.processedCount());
+        assertEquals(0, continuation.writtenCount());
+    }
+
+    @Test
+    void shouldSelfInvokeWithOnlyRemainingSegments() {
+        when(configurationService.getInactiveAccountExportTotalSegments()).thenReturn(2);
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+
+        // First segment exhausts (5 items, no more pages), second has more
+        AtomicInteger scanCallCount = new AtomicInteger(0);
+        when(client.scan(any(ScanRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            ScanRequest req = invocation.getArgument(0);
+                            int segment = req.segment();
+                            int call = scanCallCount.getAndIncrement();
+
+                            List<Map<String, AttributeValue>> items = new ArrayList<>();
+                            for (int i = 1; i <= 5; i++) {
+                                items.add(createItem(segment * 100 + i));
+                            }
+
+                            ScanResponse.Builder builder =
+                                    ScanResponse.builder().items(items).count(5).scannedCount(5);
+
+                            if (segment == 1) {
+                                builder.lastEvaluatedKey(
+                                        Map.of(
+                                                UserProfile.ATTRIBUTE_EMAIL,
+                                                AttributeValue.builder()
+                                                        .s("continue@example.com")
+                                                        .build()));
+                            }
+
+                            return builder.build();
+                        });
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        handler.handleRequest(request, context);
+
+        var payloadCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(lambdaInvokerService)
+                .invokeAsyncWithPayload(
+                        payloadCaptor.capture(), eq("test-inactive-account-data-export-lambda"));
+
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+        var continuation =
+                gson.fromJson(payloadCaptor.getValue(), InactiveAccountDataExportRequest.class);
+
+        // Only segment 1 should remain
+        assertEquals(1, continuation.segmentKeys().size());
+        assertNotNull(continuation.segmentKeys().get(1));
+        assertNull(continuation.segmentKeys().get(0));
+    }
+
+    @Test
+    void shouldThrowWhenSelfInvocationFails() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        doThrow(new RuntimeException("Invoke failed"))
+                .when(lambdaInvokerService)
+                .invokeAsyncWithPayload(any(), any());
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        assertThrows(RuntimeException.class, () -> handler.handleRequest(request, context));
+    }
+
+    @Test
+    void shouldThrowWhenLambdaNameNotConfigured() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        when(configurationService.getInactiveAccountExportLambdaName()).thenReturn("");
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        assertThrows(RuntimeException.class, () -> handler.handleRequest(request, context));
     }
 
     private Map<String, AttributeValue> createItem(int index) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -64,7 +64,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -80,7 +80,7 @@ class InactiveAccountDataExportHandlerTest {
                                 .build());
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         assertThrows(DynamoDbException.class, () -> handler.handleRequest(request, context));
     }
@@ -92,7 +92,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -148,7 +148,7 @@ class InactiveAccountDataExportHandlerTest {
                         });
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -203,7 +203,7 @@ class InactiveAccountDataExportHandlerTest {
                         });
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -217,7 +217,7 @@ class InactiveAccountDataExportHandlerTest {
         mockScanWithPagination(0, 1);
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -232,7 +232,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -247,7 +247,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 
@@ -265,7 +265,7 @@ class InactiveAccountDataExportHandlerTest {
         mockBatchGetItemWithFullMatch();
 
         var handler = createHandler();
-        var request = new InactiveAccountDataExportRequest();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
 
         var response = handler.handleRequest(request, context);
 

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.utils.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -25,6 +27,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -50,10 +54,37 @@ class InactiveAccountDataExportHandlerTest {
         when(configurationService.getInactiveAccountExportParallelism()).thenReturn(4);
         when(configurationService.getInactiveAccountExportTotalSegments()).thenReturn(1);
         when(configurationService.getInactiveAccountExportMaxRetries()).thenReturn(3);
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(7500);
     }
 
     private InactiveAccountDataExportHandler createHandler() {
         return new InactiveAccountDataExportHandler(configurationService, client);
+    }
+
+    @Test
+    void shouldHandleNullRequest() {
+        mockScanWithPagination(0, 1);
+
+        var handler = createHandler();
+        var response = handler.handleRequest(null, context);
+
+        assertEquals(0, response.processedCount());
+        assertEquals(0, response.writtenCount());
+    }
+
+    @Test
+    void shouldHandleEmptyRequest() {
+        int itemCount = 5;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(itemCount, response.processedCount());
+        assertEquals(0, response.writtenCount());
     }
 
     @Test
@@ -68,7 +99,7 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
     }
 
     @Test
@@ -96,7 +127,7 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
         verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
     }
 
@@ -152,7 +183,7 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
         verify(client, times(2)).batchGetItem(any(BatchGetItemRequest.class));
     }
 
@@ -207,7 +238,7 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
         // Initial call + 2 retries = 3 calls
         verify(client, times(3)).batchGetItem(any(BatchGetItemRequest.class));
     }
@@ -221,7 +252,7 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(0, response.totalItemsScanned());
+        assertEquals(0, response.processedCount());
         verify(client, never()).batchGetItem(any(BatchGetItemRequest.class));
     }
 
@@ -236,7 +267,7 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
         verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
     }
 
@@ -251,14 +282,13 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
         // 101 items = batch of 100 + final batch of 1 = 2 calls
         verify(client, times(2)).batchGetItem(any(BatchGetItemRequest.class));
     }
 
     @Test
     void shouldAccumulateItemsAcrossPagesBeforeBatching() {
-        // 25 items across 5 pages of 5 items each — all in one batch at the end
         int itemCount = 25;
         int pageSize = 5;
         mockScanWithPagination(itemCount, pageSize);
@@ -269,9 +299,143 @@ class InactiveAccountDataExportHandlerTest {
 
         var response = handler.handleRequest(request, context);
 
-        assertEquals(itemCount, response.totalItemsScanned());
+        assertEquals(itemCount, response.processedCount());
         // 25 items < 100 so only final partial batch = 1 call
         verify(client, times(1)).batchGetItem(any(BatchGetItemRequest.class));
+    }
+
+    @Test
+    void shouldStopScanningSegmentWhenItemLimitReached() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(10);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, null, null);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(10, response.processedCount());
+    }
+
+    @Test
+    void shouldReturnLastEvaluatedKeyWhenItemLimitStopsSegmentEarly() {
+        when(configurationService.getInactiveAccountExportMaxItemsPerSegment()).thenReturn(5);
+        int totalItems = 25;
+        int pageSize = 5;
+        mockScanWithPagination(totalItems, pageSize);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+
+        var result = handler.scanSegment(0, 1, 3, 5, null);
+
+        assertEquals(5, result.itemsScanned());
+        assertNotNull(result.lastEvaluatedKey());
+    }
+
+    @Test
+    void shouldReturnNullLastEvaluatedKeyWhenSegmentFullyExhausted() {
+        int totalItems = 5;
+        mockScanWithPagination(totalItems, totalItems);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+
+        var result = handler.scanSegment(0, 1, 3, 7500, null);
+
+        assertEquals(5, result.itemsScanned());
+        assertNull(result.lastEvaluatedKey());
+    }
+
+    @Test
+    void shouldResumeFromStartKeyWhenProvided() {
+        int totalItems = 10;
+        int pageSize = 5;
+        List<ScanResponse> pages = buildPages(totalItems, pageSize);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        when(client.scan(any(ScanRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            ScanRequest req = invocation.getArgument(0);
+                            assertNotNull(req.exclusiveStartKey());
+                            return pages.get(callCount.getAndIncrement() + 1);
+                        });
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        Map<String, AttributeValue> startKey =
+                Map.of("Email", AttributeValue.builder().s("lastKey-5").build());
+
+        var result = handler.scanSegment(0, 1, 3, 7500, startKey);
+
+        assertEquals(5, result.itemsScanned());
+        assertNull(result.lastEvaluatedKey());
+    }
+
+    @Test
+    void shouldOnlyScanActiveSegmentsFromContinuationState() {
+        when(configurationService.getInactiveAccountExportTotalSegments()).thenReturn(3);
+        mockScanWithPagination(5, 5);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        Map<Integer, Map<String, String>> segmentKeys = new HashMap<>();
+        segmentKeys.put(1, Map.of("Email", "user5@example.com"));
+
+        var request = new InactiveAccountDataExportRequest(segmentKeys, 100L, 0L);
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(105, response.processedCount());
+        assertEquals(0, response.writtenCount());
+        verify(client, times(1)).scan(any(ScanRequest.class));
+    }
+
+    @Test
+    void shouldAccumulateProcessedCountFromPreviousInvocations() {
+        int itemCount = 5;
+        mockScanWithPagination(itemCount, itemCount);
+        mockBatchGetItemWithFullMatch();
+
+        var handler = createHandler();
+        var request = new InactiveAccountDataExportRequest(null, 500L, 0L);
+
+        var response = handler.handleRequest(request, context);
+
+        assertEquals(505, response.processedCount());
+        assertEquals(0, response.writtenCount());
+    }
+
+    @Test
+    void shouldSerialiseContinuationStateAsJson() {
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+        var request =
+                new InactiveAccountDataExportRequest(
+                        Map.of(0, Map.of("Email", "user5@example.com")), 100L, 0L);
+
+        String json = gson.toJson(request);
+        var deserialised = gson.fromJson(json, InactiveAccountDataExportRequest.class);
+
+        assertEquals(request.processedCount(), deserialised.processedCount());
+        assertEquals(request.writtenCount(), deserialised.writtenCount());
+        assertEquals(
+                request.segmentKeys().get(0).get("Email"),
+                deserialised.segmentKeys().get(0).get("Email"));
+    }
+
+    @Test
+    void shouldDeserialiseEmptyPayloadAsFirstInvocation() {
+        Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+        var deserialised = gson.fromJson("{}", InactiveAccountDataExportRequest.class);
+
+        assertNull(deserialised.segmentKeys());
+        assertNull(deserialised.processedCount());
+        assertNull(deserialised.writtenCount());
     }
 
     private Map<String, AttributeValue> createItem(int index) {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

**Utils lambda changes only**

Implements self re-invocation for the inactive account data export lambda to avoid hitting the 15-minute Lambda timeout when scanning the full `user-profile` and `user-credentials` tables (large item counts in production).

Previously, the handler scanned all DynamoDB segments to completion in a single invocation using a parallel segmented scan. This would put sustained high load on DynamoDB and exceed the Lambda execution time limit on tables with large item counts (as we do in production).

The handler now adopts a "low and slow" approach:
- Each invocation scans all segments in parallel (distributing load evenly across partitions) but limits each segment to `maxItemsPerSegment` items, for a single invocation.
- If segments still have data remaining, the handler pauses then re-invokes itself asynchronously with continuation state (per-segment `lastEvaluatedKey` and accumulated counts).
- Segments that are fully exhausted drop out of subsequent invocations.
- When all segments are exhausted, the final invocation returns the completed response.

Diagram of this "low and slow" approach:

```mermaid
sequenceDiagram
    participant Trigger
    participant Inv1 as Invocation 1
    participant Inv2 as Invocation 2
    participant InvN as Invocation N (final)
    participant DDB as DynamoDB

    Trigger->>Inv1: {} (empty payload, defaults)
    Inv1->>DDB: Scan all segments (parallel, max X items each)
    Inv1->>Inv1: Pause
    Inv1->>Inv2: re-invoke({segmentKeys: {0: lastEvaluatedKey, 1: lastEvaluatedKey, ...}, processedCount: Y, writtenCount: 0})
    Inv2->>DDB: Scan remaining segments (parallel, max X items each)
    Inv2->>Inv2: Pause
    Inv2->>InvN: re-invoke({segmentKeys: {3: lastEvaluatedKey, 7: lastEvaluatedKey}, processedCount: Z, writtenCount: 0})
    InvN->>DDB: Scan final segments (exhaust them)
    InvN-->>InvN: All segments exhausted, return final response
```

Note that `writtenCount` is set to 0 for the time being - AUT-5658 and AUT-5653 will handle persisting some of this data in a separate table and will update this count.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy the `utils` module to a dev environment and make a test request to the `*-inactive-account-data-export-lambda` Lambda to scan the dev tables, ensure this work is split over multiple invocations, that there are no errors, and that the expected number of items are scanned through the logs.
    - I have followed these steps - see "Testing" section below

## Testing

Deployed the `utils` module to authdev1 and made a test request to the `authdev1-inactive-account-data-export-lambda` Lambda to scan the dev table with an empty payload (`{}`).

Observed the scan happening over multiple Lambda invocations, no errors seen, and verified that the correct number of items (all in the `user-profile` table) were scanned and that there were no missing user credentials items based off the final executions output:


<details>

<summary>AWS Log Analytics query (to get log output below)</summary>

```
SOURCE "arn:aws:logs:eu-west-2:975050272416:log-group:/aws/lambda/authdev1-inactive-account-data-export-lambda" START=-900s END=0s |
fields @timestamp, message
| filter ispresent(message)
| filter message not like /^(Environment variable AWS_XRAY_DAEMON_ADDRESS|Overriding contextMissingStrategy)/
| sort @timestamp asc
| display message
| limit 100
```

</details>

<details>

<summary>Log output (using the above query)</summary>

In ascending order. One line per log event. Note the lines starting with "Inactive account data export" indicate a new Lambda execution.

```
Inactive account data export: parallelism=3, totalSegments=3, maxRetries=3, maxItemsPerSegment=100, activeSegments=3, processedCount=0
Segment 2 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 0 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Invocation complete: 300 items scanned this invocation, 1 missing credentials, 300 total processed, 3 segments remaining
Segment 1 completed: 100 items scanned, 1 missing credentials, segmentExhausted=false
Pausing between Lambda invocations for: 7500 ms
Pause between Lambda invocations complete.
Self-invoking with 3 remaining segments, processedCount=300

Inactive account data export: parallelism=3, totalSegments=3, maxRetries=3, maxItemsPerSegment=100, activeSegments=3, processedCount=300
Segment 1 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 2 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 0 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Pausing between Lambda invocations for: 7500 ms
Invocation complete: 300 items scanned this invocation, 0 missing credentials, 600 total processed, 3 segments remaining
Pause between Lambda invocations complete.
Self-invoking with 3 remaining segments, processedCount=600

Inactive account data export: parallelism=3, totalSegments=3, maxRetries=3, maxItemsPerSegment=100, activeSegments=3, processedCount=600
Segment 2 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 0 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 1 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Invocation complete: 300 items scanned this invocation, 0 missing credentials, 900 total processed, 3 segments remaining
Pausing between Lambda invocations for: 7500 ms
Pause between Lambda invocations complete.
Self-invoking with 3 remaining segments, processedCount=900

Inactive account data export: parallelism=3, totalSegments=3, maxRetries=3, maxItemsPerSegment=100, activeSegments=3, processedCount=900
Segment 2 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 1 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Segment 0 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Invocation complete: 300 items scanned this invocation, 0 missing credentials, 1200 total processed, 3 segments remaining
Pausing between Lambda invocations for: 7500 ms
Pause between Lambda invocations complete.
Self-invoking with 3 remaining segments, processedCount=1200

Inactive account data export: parallelism=3, totalSegments=3, maxRetries=3, maxItemsPerSegment=100, activeSegments=3, processedCount=1200
Segment 0 completed: 61 items scanned, 0 missing credentials, segmentExhausted=true
Segment 2 completed: 70 items scanned, 0 missing credentials, segmentExhausted=true
Segment 1 completed: 100 items scanned, 0 missing credentials, segmentExhausted=false
Pausing between Lambda invocations for: 7500 ms
Invocation complete: 231 items scanned this invocation, 0 missing credentials, 1431 total processed, 1 segments remaining
Self-invoking with 1 remaining segments, processedCount=1431
Pause between Lambda invocations complete.

Inactive account data export: parallelism=3, totalSegments=3, maxRetries=3, maxItemsPerSegment=100, activeSegments=1, processedCount=1431
Segment 1 completed: 9 items scanned, 0 missing credentials, segmentExhausted=true
Invocation complete: 9 items scanned this invocation, 0 missing credentials, 1440 total processed, 0 segments remaining
```

</details>

<details>

<summary>Lambda env var config (for reference)</summary>

```
INACTIVE_ACCOUNT_EXPORT_LAMBDA_NAME | authdev1-inactive-account-data-export-lambda
INACTIVE_ACCOUNT_EXPORT_MAX_ITEMS_PER_SEGMENT | 100
INACTIVE_ACCOUNT_EXPORT_MAX_RETRIES | 3
INACTIVE_ACCOUNT_EXPORT_PARALLELISM | 3
INACTIVE_ACCOUNT_EXPORT_PAUSE_BETWEEN_INVOCATIONS_MS | 7500
INACTIVE_ACCOUNT_EXPORT_TOTAL_SEGMENTS | 3
```

</details>

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A, utils lambda**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #8586
- #8597
- #8619
