### PR TITLE
Aut 5684/add failure reason to metric

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/JourneyOutcomeResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/JourneyOutcomeResponse.java
@@ -11,8 +11,8 @@ public record JourneyOutcomeResponse(
     public record Action(
             @Expose String action, @Expose boolean success, @Expose ActionDetails details) {}
 
-    public record ActionDetails(@Expose ActionError error) {}
+    public record ActionDetails(@Expose Error error) {}
 
-    public record ActionError(
+    public record Error(
             @Expose int code, @Expose @SerializedName("description") String description) {}
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandler.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_ACCOUNT_ACTIONS;
@@ -227,13 +228,24 @@ public class AMCCallbackHandler extends BaseFrontendHandler<AMCCallbackRequest>
     }
 
     private void emitAuthorisationReceivedMetric(JourneyOutcomeResponse journeyOutcomeResponse) {
-        var metricDimensions =
-                Map.ofEntries(
-                        Map.entry(ENVIRONMENT.getValue(), configurationService.getEnvironment()),
-                        Map.entry(
-                                AMC_AUTHORISATION_OVERALL_SUCCESS.getValue(),
-                                String.valueOf(journeyOutcomeResponse.success())),
-                        Map.entry(AMC_SCOPE.getValue(), journeyOutcomeResponse.scope()));
+        var metricDimensions = new HashMap<String, String>();
+        metricDimensions.put(ENVIRONMENT.getValue(), configurationService.getEnvironment());
+        metricDimensions.put(
+                AMC_AUTHORISATION_OVERALL_SUCCESS.getValue(),
+                String.valueOf(journeyOutcomeResponse.success()));
+        metricDimensions.put(AMC_SCOPE.getValue(), journeyOutcomeResponse.scope());
+        // this logic will need to be updated for sfad
+        var optionalFailureReason =
+                journeyOutcomeResponse.actions().stream()
+                        .filter(
+                                action ->
+                                        Objects.equals(action.action(), "passkey-create")
+                                                && !Objects.isNull(action.details().error()))
+                        .findFirst()
+                        .map(action -> action.details().error().description());
+        if (optionalFailureReason.isPresent()) {
+            metricDimensions.put(FAILURE_REASON.getValue(), optionalFailureReason.get());
+        }
         cloudwatchMetricsService.incrementCounter(AMC_AUTHORISATION_RECEIVED, metricDimensions);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
@@ -492,7 +492,8 @@ class AMCCallbackHandlerTest {
                 Map.ofEntries(
                         Map.entry("Environment", ENV),
                         Map.entry("AMCAuthorisationOverallSuccess", "false"),
-                        Map.entry("AMCScope", "passkey-create"));
+                        Map.entry("AMCScope", "passkey-create"),
+                        Map.entry("FailureReason", "UserBackedOutOfJourney"));
         verify(cloudwatchMetricsService)
                 .incrementCounter(
                         CloudwatchMetrics.AMC_AUTHORISATION_RECEIVED, expectedMetricsDimensions);


### PR DESCRIPTION
When a failure comes back from amc in the amc callback, we should add the failure reason to the metric to allow for better visibility.

Currently just done for passkey create journeys, will need a bit of a rethink for sfad.