### PR TITLE
AUT-5658: Add initial IAD tracker entity

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -1,0 +1,140 @@
+package uk.gov.di.authentication.utils.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class InactiveAccountTrackerItem {
+
+    private String dateForDeletion;
+    private String commonSubjectId;
+    private String publicSubjectId;
+    private String emailAddress;
+    private String userLastActive;
+    private String status = "pending";
+    private String statusLastUpdated;
+    private String source = "AUTH_BACKFILL";
+    private String sourceId;
+
+    public InactiveAccountTrackerItem() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("DateForDeletion")
+    public String getDateForDeletion() {
+        return dateForDeletion;
+    }
+
+    public void setDateForDeletion(String dateForDeletion) {
+        this.dateForDeletion = dateForDeletion;
+    }
+
+    public InactiveAccountTrackerItem withDateForDeletion(String dateForDeletion) {
+        this.dateForDeletion = dateForDeletion;
+        return this;
+    }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("CommonSubjectId")
+    public String getCommonSubjectId() {
+        return commonSubjectId;
+    }
+
+    public void setCommonSubjectId(String commonSubjectId) {
+        this.commonSubjectId = commonSubjectId;
+    }
+
+    public InactiveAccountTrackerItem withCommonSubjectId(String commonSubjectId) {
+        this.commonSubjectId = commonSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute("PublicSubjectId")
+    public String getPublicSubjectId() {
+        return publicSubjectId;
+    }
+
+    public void setPublicSubjectId(String publicSubjectId) {
+        this.publicSubjectId = publicSubjectId;
+    }
+
+    public InactiveAccountTrackerItem withPublicSubjectId(String publicSubjectId) {
+        this.publicSubjectId = publicSubjectId;
+        return this;
+    }
+
+    @DynamoDbAttribute("EmailAddress")
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    public InactiveAccountTrackerItem withEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+        return this;
+    }
+
+    @DynamoDbAttribute("UserLastActive")
+    public String getUserLastActive() {
+        return userLastActive;
+    }
+
+    public void setUserLastActive(String userLastActive) {
+        this.userLastActive = userLastActive;
+    }
+
+    public InactiveAccountTrackerItem withUserLastActive(String userLastActive) {
+        this.userLastActive = userLastActive;
+        return this;
+    }
+
+    @DynamoDbAttribute("Status")
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @DynamoDbAttribute("StatusLastUpdated")
+    public String getStatusLastUpdated() {
+        return statusLastUpdated;
+    }
+
+    public void setStatusLastUpdated(String statusLastUpdated) {
+        this.statusLastUpdated = statusLastUpdated;
+    }
+
+    public InactiveAccountTrackerItem withStatusLastUpdated(String statusLastUpdated) {
+        this.statusLastUpdated = statusLastUpdated;
+        return this;
+    }
+
+    @DynamoDbAttribute("Source")
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @DynamoDbAttribute("SourceId")
+    public String getSourceId() {
+        return sourceId;
+    }
+
+    public void setSourceId(String sourceId) {
+        this.sourceId = sourceId;
+    }
+
+    public InactiveAccountTrackerItem withSourceId(String sourceId) {
+        this.sourceId = sourceId;
+        return this;
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -6,7 +6,10 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,6 +19,8 @@ public class InactiveAccountDataExportHelper {
 
     private static final Logger LOG = LogManager.getLogger(InactiveAccountDataExportHelper.class);
     private static final long BASE_BACKOFF_MS = 100;
+
+    public record LastActiveDate(String timestamp, String source) {}
 
     private InactiveAccountDataExportHelper() {}
 
@@ -59,5 +64,56 @@ public class InactiveAccountDataExportHelper {
 
     public static long countMissingCredentials(int requestedCount, int returnedCount) {
         return Math.max(0, requestedCount - returnedCount);
+    }
+
+    public static LastActiveDate calculateLastActiveDate(
+            Map<String, AttributeValue> userProfileItem,
+            Map<String, AttributeValue> userCredentialsItem) {
+        String timestamp = getStringAttribute(userProfileItem, "Updated");
+
+        // TODO: THIS PR: Use other attributes too to determine latest timestamp.
+
+        if (timestamp == null) {
+            return null;
+        }
+
+        return new LastActiveDate(timestamp, "user_profile.updated");
+    }
+
+    public static String calculateDateForDeletion(String lastActiveDate) {
+        if (lastActiveDate == null || lastActiveDate.isBlank()) {
+            return null;
+        }
+        return LocalDateTime.parse(lastActiveDate).toLocalDate().plusYears(5).toString();
+    }
+
+    public static InactiveAccountTrackerItem buildTrackerItem(
+            Map<String, AttributeValue> userProfileItem,
+            Map<String, AttributeValue> userCredentialsItem) {
+        String subjectId = getStringAttribute(userProfileItem, "SubjectID");
+        String publicSubjectId = getStringAttribute(userProfileItem, "PublicSubjectID");
+        String email = getStringAttribute(userProfileItem, "Email");
+
+        LastActiveDate lastActiveDate =
+                calculateLastActiveDate(userProfileItem, userCredentialsItem);
+        String lastActiveTimestamp = lastActiveDate != null ? lastActiveDate.timestamp() : null;
+        String lastActiveSource = lastActiveDate != null ? lastActiveDate.source() : null;
+
+        String dateForDeletion = calculateDateForDeletion(lastActiveTimestamp);
+
+        return new InactiveAccountTrackerItem()
+                .withDateForDeletion(dateForDeletion)
+                .withCommonSubjectId(subjectId)
+                .withPublicSubjectId(publicSubjectId)
+                .withEmailAddress(email)
+                .withUserLastActive(lastActiveTimestamp)
+                .withStatusLastUpdated(NowHelper.toTimestampString(NowHelper.now()))
+                .withSourceId(lastActiveSource);
+    }
+
+    private static String getStringAttribute(
+            Map<String, AttributeValue> item, String attributeName) {
+        AttributeValue value = item.get(attributeName);
+        return value != null ? value.s() : null;
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -69,16 +69,72 @@ public class InactiveAccountDataExportHelper {
     public static LastActiveDate calculateLastActiveDate(
             Map<String, AttributeValue> userProfileItem,
             Map<String, AttributeValue> userCredentialsItem) {
-        String timestamp = getStringAttribute(userProfileItem, "Updated");
+        List<TimestampCandidate> candidates =
+                buildTimestampCandidates(userProfileItem, userCredentialsItem);
 
-        // TODO: THIS PR: Use other attributes too to determine latest timestamp.
+        LocalDateTime mostRecent = null;
+        String mostRecentSource = null;
 
-        if (timestamp == null) {
+        for (TimestampCandidate candidate : candidates) {
+            if (candidate.timestamp() == null) {
+                continue;
+            }
+
+            try {
+                LocalDateTime parsed = LocalDateTime.parse(candidate.timestamp());
+                if (mostRecent == null || parsed.isAfter(mostRecent)) {
+                    mostRecent = parsed;
+                    mostRecentSource = candidate.source();
+                }
+            } catch (Exception e) {
+                LOG.warn(
+                        "Failed to parse timestamp '{}' from source '{}': {}",
+                        candidate.timestamp(),
+                        candidate.source(),
+                        e.getMessage());
+            }
+        }
+
+        if (mostRecent == null) {
             return null;
         }
 
-        return new LastActiveDate(timestamp, "user_profile.updated");
+        return new LastActiveDate(mostRecent.toString(), mostRecentSource);
     }
+
+    private static List<TimestampCandidate> buildTimestampCandidates(
+            Map<String, AttributeValue> userProfileItem,
+            Map<String, AttributeValue> userCredentialsItem) {
+        List<TimestampCandidate> candidates = new ArrayList<>();
+
+        if (userProfileItem != null) {
+            candidates.add(
+                    new TimestampCandidate(
+                            getStringAttribute(userProfileItem, "Created"), "UserProfile.Created"));
+            candidates.add(
+                    new TimestampCandidate(
+                            getStringAttribute(userProfileItem, "Updated"), "UserProfile.Updated"));
+            candidates.add(
+                    new TimestampCandidate(
+                            getTermsAndConditionsTimestamp(userProfileItem),
+                            "UserProfile.termsAndConditions.timestamp"));
+        }
+
+        if (userCredentialsItem != null) {
+            candidates.add(
+                    new TimestampCandidate(
+                            getStringAttribute(userCredentialsItem, "Created"),
+                            "UserCredentials.Created"));
+            candidates.add(
+                    new TimestampCandidate(
+                            getStringAttribute(userCredentialsItem, "Updated"),
+                            "UserCredentials.Updated"));
+        }
+
+        return candidates;
+    }
+
+    private record TimestampCandidate(String timestamp, String source) {}
 
     public static String calculateDateForDeletion(String lastActiveDate) {
         if (lastActiveDate == null || lastActiveDate.isBlank()) {
@@ -101,6 +157,13 @@ public class InactiveAccountDataExportHelper {
 
         String dateForDeletion = calculateDateForDeletion(lastActiveTimestamp);
 
+        if (dateForDeletion == null) {
+            LOG.warn(
+                    "Skipping tracker item for public subject ID '{}': could not determine dateForDeletion (lastActiveDate was null)",
+                    publicSubjectId);
+            return null;
+        }
+
         return new InactiveAccountTrackerItem()
                 .withDateForDeletion(dateForDeletion)
                 .withCommonSubjectId(subjectId)
@@ -109,6 +172,14 @@ public class InactiveAccountDataExportHelper {
                 .withUserLastActive(lastActiveTimestamp)
                 .withStatusLastUpdated(NowHelper.toTimestampString(NowHelper.now()))
                 .withSourceId(lastActiveSource);
+    }
+
+    private static String getTermsAndConditionsTimestamp(Map<String, AttributeValue> item) {
+        AttributeValue tcMap = item.get("termsAndConditions");
+        if (tcMap == null || !tcMap.hasM()) {
+            return null;
+        }
+        return getStringAttribute(tcMap.m(), "timestamp");
     }
 
     private static String getStringAttribute(

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -139,7 +139,7 @@ class InactiveAccountDataExportHelperTest {
                         "Email",
                         AttributeValue.builder().s("test@example.com").build(),
                         "Updated",
-                        AttributeValue.builder().s("2021-07-17T10:30:00.000000").build());
+                        AttributeValue.builder().s("2021-07-17T10:30:00.123456").build());
 
         Map<String, AttributeValue> userCredentialsItem =
                 Map.of("Email", AttributeValue.builder().s("test@example.com").build());
@@ -150,27 +150,21 @@ class InactiveAccountDataExportHelperTest {
         assertEquals("subject-123", result.getCommonSubjectId());
         assertEquals("public-456", result.getPublicSubjectId());
         assertEquals("test@example.com", result.getEmailAddress());
-        assertEquals("2021-07-17T10:30:00.000000", result.getUserLastActive());
+        assertEquals("2021-07-17T10:30:00.123456", result.getUserLastActive());
         assertEquals("pending", result.getStatus());
         assertEquals("AUTH_BACKFILL", result.getSource());
-        assertEquals("user_profile.updated", result.getSourceId());
+        assertEquals("UserProfile.Updated", result.getSourceId());
         assertNotNull(result.getStatusLastUpdated());
     }
 
     @Test
-    void buildTrackerItemShouldHandleMissingUpdatedAttribute() {
+    void buildTrackerItemShouldReturnNullWhenNoTimestampsAvailable() {
         Map<String, AttributeValue> userProfileItem =
                 Map.of("SubjectID", AttributeValue.builder().s("subject-789").build());
 
         InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
 
-        assertNull(result.getDateForDeletion());
-        assertEquals("subject-789", result.getCommonSubjectId());
-        assertNull(result.getPublicSubjectId());
-        assertNull(result.getEmailAddress());
-        assertNull(result.getUserLastActive());
-        assertNull(result.getSourceId());
-        assertNotNull(result.getStatusLastUpdated());
+        assertNull(result);
     }
 
     @Test
@@ -186,29 +180,107 @@ class InactiveAccountDataExportHelperTest {
 
         InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
 
-        assertEquals("user_profile.updated", result.getSourceId());
+        assertEquals("UserProfile.Updated", result.getSourceId());
         assertEquals("my-subject-id", result.getCommonSubjectId());
     }
 
     @Test
-    void calculateLastActiveDateShouldReturnUpdatedFromUserProfile() {
+    void calculateLastActiveDateShouldReturnMostRecentAcrossAllAttributes() {
         Map<String, AttributeValue> userProfileItem =
-                Map.of("Updated", AttributeValue.builder().s("2023-05-10T14:30:00.000000").build());
+                Map.of(
+                        "Created",
+                        AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2023-05-10T14:30:00.222222").build(),
+                        "termsAndConditions",
+                        AttributeValue.builder()
+                                .m(
+                                        Map.of(
+                                                "timestamp",
+                                                AttributeValue.builder()
+                                                        .s("2024-11-20T09:15:00.123456")
+                                                        .build()))
+                                .build());
 
-        LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of(
+                        "Created",
+                        AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2024-06-01T08:00:00.333333").build());
 
-        assertEquals("2023-05-10T14:30:00.000000", result.timestamp());
-        assertEquals("user_profile.updated", result.source());
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
+
+        assertEquals("2024-11-20T09:15:00.123456", result.timestamp());
+        assertEquals("UserProfile.termsAndConditions.timestamp", result.source());
     }
 
     @Test
-    void calculateLastActiveDateShouldReturnNullWhenUpdatedMissing() {
+    void calculateLastActiveDateShouldReturnCredentialsUpdatedWhenMostRecent() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        "Created",
+                        AttributeValue.builder().s("2020-01-01T00:00:00.111111").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2021-06-15T12:00:00.222222").build());
+
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of(
+                        "Created",
+                        AttributeValue.builder().s("2020-01-01T00:00:00.111111").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2025-03-20T16:45:00.552352138").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
+
+        assertEquals("2025-03-20T16:45:00.552352138", result.timestamp());
+        assertEquals("UserCredentials.Updated", result.source());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldReturnProfileCreatedWhenOnlyAttributePresent() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of("Created", AttributeValue.builder().s("2023-05-10T14:30:00.123456").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
+
+        assertEquals("2023-05-10T14:30:00.123456", result.timestamp());
+        assertEquals("UserProfile.Created", result.source());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldReturnNullWhenNoTimestampAttributesPresent() {
         Map<String, AttributeValue> userProfileItem =
                 Map.of("Email", AttributeValue.builder().s("test@example.com").build());
 
         LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
 
         assertNull(result);
+    }
+
+    @Test
+    void calculateLastActiveDateShouldReturnNullWhenBothItemsNull() {
+        LastActiveDate result = calculateLastActiveDate(null, null);
+
+        assertNull(result);
+    }
+
+    @Test
+    void calculateLastActiveDateShouldHandleOnlyCredentialsItemProvided() {
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of(
+                        "Created",
+                        AttributeValue.builder().s("2022-08-01T09:00:00.111111").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2023-12-25T18:30:00.654321").build());
+
+        Map<String, AttributeValue> userProfileItem =
+                Map.of("Email", AttributeValue.builder().s("test@example.com").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
+
+        assertEquals("2023-12-25T18:30:00.654321", result.timestamp());
+        assertEquals("UserCredentials.Updated", result.source());
     }
 
     @Test

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -4,13 +4,20 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
+import uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.LastActiveDate;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildCredentialKeys;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildTrackerItem;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.calculateDateForDeletion;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.calculateLastActiveDate;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
 
@@ -119,5 +126,103 @@ class InactiveAccountDataExportHelperTest {
     @Test
     void countMissingCredentialsShouldReturnZeroForZeroInputs() {
         assertEquals(0, countMissingCredentials(0, 0));
+    }
+
+    @Test
+    void buildTrackerItemShouldMapAllFieldsFromUserProfileItem() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        "SubjectID",
+                        AttributeValue.builder().s("subject-123").build(),
+                        "PublicSubjectID",
+                        AttributeValue.builder().s("public-456").build(),
+                        "Email",
+                        AttributeValue.builder().s("test@example.com").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2021-07-17T10:30:00.000000").build());
+
+        Map<String, AttributeValue> userCredentialsItem =
+                Map.of("Email", AttributeValue.builder().s("test@example.com").build());
+
+        InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, userCredentialsItem);
+
+        assertEquals("2026-07-17", result.getDateForDeletion());
+        assertEquals("subject-123", result.getCommonSubjectId());
+        assertEquals("public-456", result.getPublicSubjectId());
+        assertEquals("test@example.com", result.getEmailAddress());
+        assertEquals("2021-07-17T10:30:00.000000", result.getUserLastActive());
+        assertEquals("pending", result.getStatus());
+        assertEquals("AUTH_BACKFILL", result.getSource());
+        assertEquals("user_profile.updated", result.getSourceId());
+        assertNotNull(result.getStatusLastUpdated());
+    }
+
+    @Test
+    void buildTrackerItemShouldHandleMissingUpdatedAttribute() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of("SubjectID", AttributeValue.builder().s("subject-789").build());
+
+        InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
+
+        assertNull(result.getDateForDeletion());
+        assertEquals("subject-789", result.getCommonSubjectId());
+        assertNull(result.getPublicSubjectId());
+        assertNull(result.getEmailAddress());
+        assertNull(result.getUserLastActive());
+        assertNull(result.getSourceId());
+        assertNotNull(result.getStatusLastUpdated());
+    }
+
+    @Test
+    void buildTrackerItemShouldSetSourceIdToSubjectId() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of(
+                        "SubjectID",
+                        AttributeValue.builder().s("my-subject-id").build(),
+                        "Email",
+                        AttributeValue.builder().s("user@gov.uk").build(),
+                        "Updated",
+                        AttributeValue.builder().s("2020-01-01T00:00:00.000000").build());
+
+        InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
+
+        assertEquals("user_profile.updated", result.getSourceId());
+        assertEquals("my-subject-id", result.getCommonSubjectId());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldReturnUpdatedFromUserProfile() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of("Updated", AttributeValue.builder().s("2023-05-10T14:30:00.000000").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
+
+        assertEquals("2023-05-10T14:30:00.000000", result.timestamp());
+        assertEquals("user_profile.updated", result.source());
+    }
+
+    @Test
+    void calculateLastActiveDateShouldReturnNullWhenUpdatedMissing() {
+        Map<String, AttributeValue> userProfileItem =
+                Map.of("Email", AttributeValue.builder().s("test@example.com").build());
+
+        LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
+
+        assertNull(result);
+    }
+
+    @Test
+    void calculateDateForDeletionShouldAddFiveYearsToDate() {
+        assertEquals("2029-03-15", calculateDateForDeletion("2024-03-15T10:30:00.000000"));
+    }
+
+    @Test
+    void calculateDateForDeletionShouldReturnNullForNullInput() {
+        assertNull(calculateDateForDeletion(null));
+    }
+
+    @Test
+    void calculateDateForDeletionShouldReturnNullForBlankInput() {
+        assertNull(calculateDateForDeletion(""));
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -598,8 +598,8 @@ class InactiveAccountDataExportHandlerTest {
         var profile =
                 new UserProfile()
                         .withEmail("user" + index + "@example.com")
-                        .withCreated("2024-01-15")
-                        .withUpdated("2024-06-20")
+                        .withCreated("2024-01-15T09:01:02.345678")
+                        .withUpdated("2024-06-20T10:03:04.567890")
                         .withPublicSubjectID("public-subject-" + index)
                         .withSubjectID("subject-" + index)
                         .withSalt(ByteBuffer.wrap(new byte[] {(byte) index, 42}))
@@ -611,8 +611,8 @@ class InactiveAccountDataExportHandlerTest {
     private Map<String, AttributeValue> createCredentialItem(String email) {
         Map<String, AttributeValue> item = new HashMap<>();
         item.put("Email", AttributeValue.builder().s(email).build());
-        item.put("Created", AttributeValue.builder().s("2024-01-15").build());
-        item.put("Updated", AttributeValue.builder().s("2024-06-20").build());
+        item.put("Created", AttributeValue.builder().s("2024-01-15T09:01:02.345678").build());
+        item.put("Updated", AttributeValue.builder().s("2024-06-20T10:03:04.567890").build());
         item.put("MigratedPassword", AttributeValue.builder().s("migrated-hash").build());
         return item;
     }


### PR DESCRIPTION
## What

* Introduced the `InactiveAccountTrackerItem` DynamoDB entity and added helper logic to construct it from partial database items.
* Updated the active date calculation to evaluate all timestamp attributes across user profile and user credentials to determine the most recent activity timestamp.
* Added logic to automatically calculate a deletion date (five years after the last active date) and fixed date formats in test data to match production.

NOTE: Work around `shouldNotify` boolean on this item has been split out to AUT-5691 - awaiting clarification on these changes from another team.

## How to review

1. Static code review

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A**