### PR TITLE
BAU: Move IAD config params into constants

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -51,23 +51,34 @@ public class InactiveAccountDataExportHandler
             "Email,Created,Updated,MigratedPassword";
 
     private final DynamoDbClient client;
-    private final ConfigurationService configurationService;
     private final LambdaInvokerService lambdaInvokerService;
     private final Json objectMapper = SerializationService.getInstance();
     private final String userProfileTableName;
     private final String userCredentialsTableName;
+    private final int parallelism;
+    private final int totalSegments;
+    private final int maxRetries;
+    private final int maxItemsPerSegment;
+    private final long pauseBetweenInvocationsMs;
+    private final String lambdaName;
 
     public InactiveAccountDataExportHandler(
             ConfigurationService configurationService,
             DynamoDbClient client,
             LambdaInvokerService lambdaInvokerService) {
         this.client = client;
-        this.configurationService = configurationService;
         this.lambdaInvokerService = lambdaInvokerService;
         this.userProfileTableName =
                 TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService);
         this.userCredentialsTableName =
                 TableNameHelper.getFullTableName(USER_CREDENTIALS_TABLE, configurationService);
+        this.parallelism = configurationService.getInactiveAccountExportParallelism();
+        this.totalSegments = configurationService.getInactiveAccountExportTotalSegments();
+        this.maxRetries = configurationService.getInactiveAccountExportMaxRetries();
+        this.maxItemsPerSegment = configurationService.getInactiveAccountExportMaxItemsPerSegment();
+        this.pauseBetweenInvocationsMs =
+                configurationService.getInactiveAccountExportPauseBetweenInvocationsMs();
+        this.lambdaName = configurationService.getInactiveAccountExportLambdaName();
     }
 
     public InactiveAccountDataExportHandler() {
@@ -80,11 +91,6 @@ public class InactiveAccountDataExportHandler
     @Override
     public InactiveAccountDataExportResponse handleRequest(
             InactiveAccountDataExportRequest request, Context context) {
-        int parallelism = configurationService.getInactiveAccountExportParallelism();
-        int totalSegments = configurationService.getInactiveAccountExportTotalSegments();
-        int maxRetries = configurationService.getInactiveAccountExportMaxRetries();
-        int maxItemsPerSegment = configurationService.getInactiveAccountExportMaxItemsPerSegment();
-
         if (maxItemsPerSegment <= 0) {
             throw new IllegalStateException(
                     "INACTIVE_ACCOUNT_EXPORT_MAX_ITEMS_PER_SEGMENT must be greater than 0");
@@ -186,15 +192,12 @@ public class InactiveAccountDataExportHandler
             Map<Integer, Map<String, String>> remainingSegmentKeys,
             long processedCount,
             long writtenCount) {
-        long pauseMs = configurationService.getInactiveAccountExportPauseBetweenInvocationsMs();
-        String lambdaName = configurationService.getInactiveAccountExportLambdaName();
-
         if (lambdaName == null || lambdaName.isEmpty()) {
             throw new RuntimeException(
                     "INACTIVE_ACCOUNT_EXPORT_LAMBDA_NAME not set, cannot self-invoke");
         }
 
-        LambdaPauseHelper.pauseBetweenInvocations(pauseMs);
+        LambdaPauseHelper.pauseBetweenInvocations(pauseBetweenInvocationsMs);
 
         var continuationRequest =
                 new InactiveAccountDataExportRequest(


### PR DESCRIPTION
## What

Moved Inactive Account Data (IAD) configuration parameter retrievals into the class constructor, assigned configuration values to `final` class fields and removed local variable declarations.

Addresses [PR comment here](https://github.com/govuk-one-login/authentication-api/pull/8624#discussion_r3613670574)

## How to review

1. Static code review

## Checklist

- [x] Deployment of this PR will not break active user journeys **- N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A**