### PR TITLE
BAU: Enforce Https so moving to curl to download rain version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,7 +55,8 @@ jobs:
         env:
           RAIN_VERSION: v1.20.1
         run: |
-          wget -q "https://github.com/aws-cloudformation/rain/releases/download/${RAIN_VERSION}/rain-${RAIN_VERSION}_linux-amd64.zip"
+          curl -sSL --proto '=https' --tlsv1.2 -o "rain-${RAIN_VERSION}_linux-amd64.zip" \
+            "https://github.com/aws-cloudformation/rain/releases/download/${RAIN_VERSION}/rain-${RAIN_VERSION}_linux-amd64.zip"
           unzip "rain-${RAIN_VERSION}_linux-amd64.zip"
           chmod +x "rain-${RAIN_VERSION}_linux-amd64/rain"
           mv "rain-${RAIN_VERSION}_linux-amd64/rain" /usr/local/bin/rain


### PR DESCRIPTION
## What

Fixing Sonar Issue "Not disabling redirects might allow for redirections to insecure websites. Make sure it is safe here."

By enforcing Https so moving to curl to download rain version

## How to review

1. Code Review


