### PR TITLE
BAU: Log additional message metrics

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.message.ObjectMessage;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.ipv.entity.SPOTStatus;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
@@ -22,6 +24,7 @@ import uk.gov.di.orchestration.shared.services.SerializationService;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED;
@@ -87,6 +90,8 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                         logIds.getClientSessionId() != null
                                 && !logIds.getClientSessionId().isBlank());
 
+                logMessageMetadata(msg);
+
                 if (spotResponse.getStatus().equals(SPOTStatus.ACCEPTED)) {
                     LOG.info(
                             "SPOTResponse Status is {}. Adding CoreIdentityJWT to Dynamo",
@@ -140,6 +145,58 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                     Map.of());
         } catch (Exception e) {
             LOG.warn("Failed to emit SPOT latency metric, continuing as normal", e);
+        }
+    }
+
+    private void logMessageMetadata(SQSMessage msg) {
+        try {
+            var timeNowMs = NowHelper.now().toInstant().toEpochMilli();
+            var approximateFirstReceiveTimestampMs =
+                    Optional.ofNullable(
+                                    msg.getAttributes()
+                                            .get(
+                                                    MessageSystemAttributeName
+                                                            .APPROXIMATE_FIRST_RECEIVE_TIMESTAMP
+                                                            .toString()))
+                            .map(Long::parseLong)
+                            .orElse(0L);
+            var sentTimestampMs =
+                    Optional.ofNullable(
+                                    msg.getAttributes()
+                                            .get(
+                                                    MessageSystemAttributeName.SENT_TIMESTAMP
+                                                            .toString()))
+                            .map(Long::parseLong)
+                            .orElse(0L);
+            var approxReceiveCount =
+                    Optional.ofNullable(
+                                    msg.getAttributes()
+                                            .get(
+                                                    MessageSystemAttributeName
+                                                            .APPROXIMATE_RECEIVE_COUNT
+                                                            .toString()))
+                            .map(Long::parseLong)
+                            .orElse(1L);
+            var timeToDeliver = timeNowMs - sentTimestampMs;
+            var timeInQueue = timeNowMs - approximateFirstReceiveTimestampMs;
+
+            LOG.info(
+                    new ObjectMessage(
+                            Map.of(
+                                    "messageId",
+                                    msg.getMessageId(),
+                                    "ApproximateFirstReceiveTimestampMs",
+                                    approximateFirstReceiveTimestampMs,
+                                    "SentTimestampMs",
+                                    sentTimestampMs,
+                                    "ApproximateReceiveCount",
+                                    approxReceiveCount,
+                                    "deliveryTimeMs",
+                                    timeToDeliver,
+                                    "queuedTimeMs",
+                                    timeInQueue)));
+        } catch (Exception e) {
+            LOG.warn("Failed to emit SPOT message metadata log", e);
         }
     }
 }


### PR DESCRIPTION
### Wider context of change

Our interactions with SPOT are asynchronous and queue based, meaning we poll a queue and await the response. SQS provides a lot of information in the form of SQS message metadata, which we can use to derive information about where latency exists in the interaction between us and SPOT.

This emits a log message with this metadata, including the following:
 - messageId
 - ApproximateFirstReceiveTimestampMs
 - SentTimestampMs
 - ApproximateReceiveCount

And a couple of metrics I have derived from doing calculations on the metadata timestamps such as:
  - deliveryTimeMs (time recieved by lambda - time sent)
  - queuedTimeMs ( time received by lambda - time received by queue)

### What’s changed

Adds a log message containing the above metrics, emitted as a 

### Manual testing

Deployed to dev, check that the SPOT response works fine and the log is present


## Example log message:

<img width="670" height="274" alt="Screenshot 2026-07-21 at 11 32 01" src="https://github.com/user-attachments/assets/e5169cab-8429-4268-813a-6291d5663a2e" />


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
