### PR TITLE
ATO-2771: Create IdentityTokenService and test

### DIFF
--- a/identity-shared/build.gradle
+++ b/identity-shared/build.gradle
@@ -9,6 +9,7 @@ version = "unspecified"
 dependencies {
     compileOnly libs.bundles.awsLambda,
             libs.awsSqs,
+            libs.awsKms,
             libs.bundles.awsDynamoDb
 
     implementation libs.gson,
@@ -27,6 +28,7 @@ dependencies {
             project(":orchestration-shared-test"),
             libs.bundles.awsLambda,
             libs.awsSqs,
+            libs.awsKms,
             libs.bundles.awsDynamoDb
 
     testRuntimeOnly libs.bundles.testRuntime

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityTokenService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityTokenService.java
@@ -1,7 +1,0 @@
-package uk.gov.di.orchestration.identity.entity;
-
-import com.nimbusds.oauth2.sdk.TokenResponse;
-
-public interface IdentityTokenService {
-    TokenResponse getToken(String authCode);
-}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelper.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelper.java
@@ -3,7 +3,7 @@ package uk.gov.di.orchestration.identity.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.identity.entity.AuditEventConfiguration;
-import uk.gov.di.orchestration.identity.entity.IdentityTokenService;
+import uk.gov.di.orchestration.identity.service.IdentityTokenService;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.services.AuditService;
 import uk.gov.di.orchestration.shared.services.RedirectService;

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityTokenService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityTokenService.java
@@ -1,0 +1,150 @@
+package uk.gov.di.orchestration.identity.service;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.orchestration.shared.helpers.ConstructUriHelper;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.temporal.ChronoUnit;
+
+import static java.util.Collections.singletonList;
+
+public class IdentityTokenService {
+
+    private static final Logger LOG = LogManager.getLogger(IdentityTokenService.class);
+    private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
+    private static final Long PRIVATE_KEY_JWT_EXPIRY = 5L;
+    private final KmsConnectionService kmsService;
+    private final URI callbackUri;
+    private final URI tokenUri;
+    private final String clientId;
+    private final String audience;
+    private final JWK signingJwk;
+    private final String signingKeyAlias;
+
+    public IdentityTokenService(
+            KmsConnectionService kmsService,
+            URI callbackUri,
+            URI backendUri,
+            String clientId,
+            String audience,
+            JWK signingJwk,
+            String signingKeyAlias) {
+        this.kmsService = kmsService;
+        this.callbackUri = callbackUri;
+        this.tokenUri = ConstructUriHelper.buildURI(backendUri.toString(), "token");
+        this.clientId = clientId;
+        this.audience = audience;
+        this.signingJwk = signingJwk;
+        this.signingKeyAlias = signingKeyAlias;
+    }
+
+    public TokenResponse getToken(String authCode) {
+        int count = 0;
+        int maxTries = 2;
+        TokenResponse tokenResponse;
+        do {
+            if (count > 0) LOG.warn("Retrying access token request");
+            count++;
+            // We must generate a new token request every time:
+            // private_key_jwt client auth JWTs are not reusable
+            var tokenRequest = constructTokenRequest(authCode);
+            tokenResponse = sendTokenRequest(tokenRequest);
+            if (!tokenResponse.indicatesSuccess()) {
+                HTTPResponse response = tokenResponse.toHTTPResponse();
+                LOG.warn(
+                        "Unsuccessful {} response from token endpoint on attempt {}: {} ",
+                        response.getStatusCode(),
+                        count,
+                        response.getBody());
+            }
+        } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+
+        return tokenResponse;
+    }
+
+    public TokenRequest constructTokenRequest(String authCode) {
+        LOG.info("Constructing token request");
+        var codeGrant = new AuthorizationCodeGrant(new AuthorizationCode(authCode), callbackUri);
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(clientId),
+                        singletonList(new Audience(audience)),
+                        NowHelper.nowPlus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES),
+                        NowHelper.now(),
+                        NowHelper.now(),
+                        new JWTID());
+        return new TokenRequest.Builder(tokenUri, generatePrivateKeyJwt(claimsSet), codeGrant)
+                .customParameter("client_id", clientId)
+                .build();
+    }
+
+    public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
+        try {
+            LOG.info("Sending token request");
+            return TokenResponse.parse(tokenRequest.toHTTPRequest().send());
+        } catch (IOException e) {
+            LOG.error("Error whilst sending TokenRequest", e);
+            throw new RuntimeException(e);
+        } catch (ParseException e) {
+            LOG.error("Error whilst parsing TokenResponse", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PrivateKeyJWT generatePrivateKeyJwt(JWTAuthenticationClaimsSet claimsSet) {
+        try {
+            var jwsHeader =
+                    new JWSHeader.Builder(TOKEN_ALGORITHM).keyID(signingJwk.getKeyID()).build();
+            var encodedHeader = jwsHeader.toBase64URL();
+            var encodedClaims = Base64URL.encode(claimsSet.toJWTClaimsSet().toString());
+            var message = encodedHeader + "." + encodedClaims;
+            var signRequest =
+                    SignRequest.builder()
+                            .message(
+                                    SdkBytes.fromByteArray(
+                                            message.getBytes(StandardCharsets.UTF_8)))
+                            .keyId(signingKeyAlias)
+                            .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                            .build();
+
+            var signResponse = kmsService.sign(signRequest);
+            LOG.info("PrivateKeyJWT has been signed successfully");
+            var signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResponse.signature().asByteArray(),
+                                            ECDSA.getSignatureByteArrayLength(TOKEN_ALGORITHM)))
+                            .toString();
+            return new PrivateKeyJWT(SignedJWT.parse(message + "." + signature));
+        } catch (JOSEException | java.text.ParseException e) {
+            LOG.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelperTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/helpers/IdentityCallbackHelperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
 import uk.gov.di.orchestration.identity.entity.AuditEventConfiguration;
-import uk.gov.di.orchestration.identity.entity.IdentityTokenService;
+import uk.gov.di.orchestration.identity.service.IdentityTokenService;
 import uk.gov.di.orchestration.identity.testsupport.TestAuditEvent;
 import uk.gov.di.orchestration.shared.api.CommonFrontend;
 import uk.gov.di.orchestration.shared.domain.AuditableEvent;

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityTokenServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityTokenServiceTest.java
@@ -1,0 +1,205 @@
+package uk.gov.di.orchestration.identity.service;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.KmsConnectionService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.time.temporal.ChronoUnit;
+
+import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.orchestration.sharedtest.exceptions.Unchecked.unchecked;
+
+public class IdentityTokenServiceTest {
+
+    private final ConfigurationService configService = mock(ConfigurationService.class);
+    private final KmsConnectionService kmsService = mock(KmsConnectionService.class);
+
+    private static final URI BACKEND_URI = URI.create("http://identity-backend/");
+    private static final URI REDIRECT_URI = URI.create("http://redirect");
+    private static final ClientID CLIENT_ID = new ClientID("some-client-id");
+    private static final String KEY_ID = "14342354354353";
+    private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
+    private IdentityTokenService tokenService;
+    private ECKey ecPrivateKey;
+
+    @BeforeEach
+    void setUp() throws JOSEException {
+        var signingJWK =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        ecPrivateKey = signingJWK.toECKey();
+        tokenService =
+                spy(
+                        new IdentityTokenService(
+                                kmsService,
+                                REDIRECT_URI,
+                                BACKEND_URI,
+                                CLIENT_ID.getValue(),
+                                BACKEND_URI.toString(),
+                                signingJWK,
+                                KEY_ID));
+        when(configService.getAccessTokenExpiry()).thenReturn(300L);
+    }
+
+    @Test
+    void shouldConstructTokenRequest() throws Exception {
+        mockKmsSigningJwt();
+        TokenRequest tokenRequest = tokenService.constructTokenRequest(AUTH_CODE.getValue());
+        assertThat(tokenRequest.getEndpointURI().toString(), equalTo(BACKEND_URI + "token"));
+        assertThat(
+                tokenRequest.getClientAuthentication().getMethod().getValue(),
+                equalTo("private_key_jwt"));
+        assertThat(
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("redirect_uri").get(0),
+                equalTo(REDIRECT_URI.toString()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("grant_type").get(0),
+                equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("client_id").get(0),
+                equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getBodyAsFormParameters().get("resource"),
+                equalTo(null));
+        assertSignRequestHeaderEquals(
+                new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(KEY_ID).build());
+    }
+
+    @Nested
+    class SendTokenRequest {
+        private final HTTPRequest httpRequest = mock(HTTPRequest.class);
+        private final TokenRequest tokenRequest = mock(TokenRequest.class);
+
+        @Test
+        void shouldCallTokenEndpointAndReturn200() throws IOException {
+            when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+            when(tokenRequest.toHTTPRequest().send()).thenReturn(getSuccessfulTokenHttpResponse());
+
+            var tokenResponse = tokenService.sendTokenRequest(tokenRequest);
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+        }
+
+        @Test
+        void shouldRetryTokenEndpointOnceAndParseSuccessfulSecondResponse() throws Exception {
+            mockKmsSigningJwt();
+            when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
+            when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+            when(tokenRequest.toHTTPRequest().send())
+                    .thenReturn(new HTTPResponse(500))
+                    .thenReturn(getSuccessfulTokenHttpResponse());
+
+            var tokenResponse = tokenService.getToken(AUTH_CODE.getValue());
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+            verify(tokenService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
+        }
+
+        @Test
+        void shouldReturnUnsuccessfulResponseIfTwoCallsToTokenEndpointFail() throws Exception {
+            mockKmsSigningJwt();
+            when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
+            when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+            when(tokenRequest.toHTTPRequest().send()).thenReturn(new HTTPResponse(500));
+
+            var tokenResponse = tokenService.getToken(AUTH_CODE.getValue());
+
+            assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+            verify(tokenService, times(2)).constructTokenRequest(AUTH_CODE.getValue());
+            verify(tokenRequest.toHTTPRequest(), times(2)).send();
+        }
+
+        public HTTPResponse getSuccessfulTokenHttpResponse() {
+            var tokenResponseContent =
+                    "{"
+                            + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                            + "  \"token_type\": \"bearer\","
+                            + "  \"expires_in\": \"3600\""
+                            + "}";
+            var tokenHTTPResponse = new HTTPResponse(200);
+            tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
+            tokenHTTPResponse.setBody(tokenResponseContent);
+
+            return tokenHTTPResponse;
+        }
+    }
+
+    private void assertSignRequestHeaderEquals(JWSHeader expectedHeader) throws ParseException {
+        var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
+        verify(kmsService).sign(signRequestCaptor.capture());
+        var request = signRequestCaptor.getValue();
+        var message = request.message().asString(StandardCharsets.UTF_8);
+        var actualHeaderString = message.split("\\.")[0];
+        var actualHeader = JWSHeader.parse(Base64URL.from(actualHeaderString));
+        assertThat(actualHeader.toJSONObject(), equalTo(expectedHeader.toJSONObject()));
+    }
+
+    private void mockKmsSigningJwt() throws JOSEException {
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(CLIENT_ID),
+                        singletonList(new Audience(buildURI(BACKEND_URI.toString(), "token"))),
+                        NowHelper.nowPlus(5, ChronoUnit.MINUTES),
+                        null,
+                        NowHelper.now(),
+                        new JWTID());
+        var ecdsaSigner = new ECDSASigner(ecPrivateKey);
+        var jwsHeader =
+                new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(ecPrivateKey.getKeyID()).build();
+        var signedJWT = new SignedJWT(jwsHeader, claimsSet.toJWTClaimsSet());
+        unchecked(signedJWT::sign).accept(ecdsaSigner);
+        byte[] idTokenSignatureDer =
+                ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
+        var signResult =
+                SignResponse.builder()
+                        .signature(SdkBytes.fromByteArray(idTokenSignatureDer))
+                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                        .keyId(KEY_ID)
+                        .build();
+
+        when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
+    }
+}


### PR DESCRIPTION
### Wider context of change

This is part of the work to consolidate the identity callback code so it can be shared between IPV and SIS

### What’s changed

This PR copies IPVTokenService and parameterises the fields that would change between IPV and SIS. The tests are also copied. 
I've removed the `sendUserIdentityRequest` method from the new class as it felt a bit out of place. There's another PR to add this to a utils class here: https://github.com/govuk-one-login/authentication-api/pull/8613

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

