### PR TITLE
AUT-5556: Read supportPasskeyUsage from request instead of backend config

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsRequest.java
@@ -1,8 +1,14 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class CheckUserExistsRequest extends BaseFrontendRequest {
+
+    @Expose
+    @SerializedName("supportPasskeyUsage")
+    private boolean supportPasskeyUsage;
 
     public CheckUserExistsRequest() {}
 
@@ -10,8 +16,23 @@ public class CheckUserExistsRequest extends BaseFrontendRequest {
         this.email = email;
     }
 
+    public CheckUserExistsRequest(String email, boolean supportPasskeyUsage) {
+        this.email = email;
+        this.supportPasskeyUsage = supportPasskeyUsage;
+    }
+
+    public boolean isSupportPasskeyUsage() {
+        return supportPasskeyUsage;
+    }
+
     @Override
     public String toString() {
-        return "CheckUserExistsRequest{" + "email='" + email + '\'' + '}';
+        return "CheckUserExistsRequest{"
+                + "email='"
+                + email
+                + '\''
+                + ", supportPasskeyUsage="
+                + supportPasskeyUsage
+                + '}';
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -207,7 +207,11 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         configurationService.isForcedMFAResetAfterMFACheckEnabled()
                                 && requiresMfaResetForInternationalNumber(
                                         authSession, userCredentials, userProfile);
-                hasActivePasskey = hasActivePasskey(userProfile.getPublicSubjectID(), authSession);
+                hasActivePasskey =
+                        hasActivePasskey(
+                                userProfile.getPublicSubjectID(),
+                                authSession,
+                                request.isSupportPasskeyUsage());
                 shouldSuppressPasskeyRegistrationPrompt =
                         PasskeyRegistrationPromptHelper.shouldSuppressPasskeyRegistrationPrompt(
                                 userProfile);
@@ -261,8 +265,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
     }
 
     private Optional<Boolean> hasActivePasskey(
-            String publicSubjectId, AuthSessionItem authSession) {
-        if (configurationService.supportPasskeys()) {
+            String publicSubjectId, AuthSessionItem authSession, boolean supportPasskeyUsage) {
+        if (supportPasskeyUsage) {
             LOG.info("Checking if user has active passkey");
 
             var hasActivePasskeyResult =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -56,7 +56,7 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
         LOG.debug("received request to TICF CRI Handler");
         var environmentForMetrics = Map.entry("Environment", configurationService.getEnvironment());
         try {
-            var response = sendRequest(input, configurationService.supportPasskeys());
+            var response = sendRequest(input);
             var statusCode = response.statusCode();
             var logMessage =
                     format("Response received from TICF CRI Service with status %s", statusCode);
@@ -96,11 +96,9 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
                 metric, Map.of("Environment", configurationService.getEnvironment()));
     }
 
-    private HttpResponse<String> sendRequest(
-            InternalTICFCRIRequest internalTICFCRIRequest, boolean supportPasskeys)
+    private HttpResponse<String> sendRequest(InternalTICFCRIRequest internalTICFCRIRequest)
             throws IOException, InterruptedException {
-        var externalRequest =
-                ExternalTICFCRIRequest.fromInternalRequest(internalTICFCRIRequest, supportPasskeys);
+        var externalRequest = ExternalTICFCRIRequest.fromInternalRequest(internalTICFCRIRequest);
         var body = serialisationService.writeValueAsStringNoNulls(externalRequest);
         var timeoutInMilliseconds =
                 Duration.ofMillis(configurationService.getTicfCriServiceCallTimeout());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -147,7 +147,6 @@ class CheckUserExistsHandlerTest {
         when(configurationService.getMaxPasswordRetries()).thenReturn(5);
         when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(false);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
-        when(configurationService.supportPasskeys()).thenReturn(false);
 
         handler =
                 new CheckUserExistsHandler(
@@ -293,13 +292,12 @@ class CheckUserExistsHandlerTest {
         @ParameterizedTest
         void shouldIncludeWhetherTheUserHasAnActivePasskeyOnAuthCheckUserKnownEmail(
                 Boolean hasActivePasskey) {
-            when(configurationService.supportPasskeys()).thenReturn(true);
             when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID))
                     .thenReturn(Result.success((hasActivePasskey)));
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of()));
 
-            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS, true), context);
 
             assertThat(result, hasStatus(200));
             verify(auditService)
@@ -647,17 +645,15 @@ class CheckUserExistsHandlerTest {
 
         @ParameterizedTest
         @ValueSource(booleans = {true, false})
-        void shouldReturnResultOfHasActivePasskeysWhenFeatureFlagIsOn(boolean hasActivePasskey)
-                throws Json.JsonException {
-            when(configurationService.supportPasskeys()).thenReturn(true);
-
+        void shouldReturnResultOfHasActivePasskeysWhenSupportPasskeyUsageIsTrue(
+                boolean hasActivePasskey) throws Json.JsonException {
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
             when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID))
                     .thenReturn(Result.success(hasActivePasskey));
 
-            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS, true), context);
 
             assertThat(result, hasStatus(200));
             var checkUserExistsResponse =
@@ -692,8 +688,6 @@ class CheckUserExistsHandlerTest {
         @Test
         void shouldReturnNullForHasActivePasskeyIfPasskeysServiceReturnsFailure()
                 throws Json.JsonException {
-            when(configurationService.supportPasskeys()).thenReturn(true);
-
             MFAMethod mfaMethod = verifiedMfaMethod(MFAMethodType.SMS, true);
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of(mfaMethod)));
@@ -703,7 +697,7 @@ class CheckUserExistsHandlerTest {
                             Result.failure(
                                     PasskeyRetrieveError.ERROR_RESPONSE_FROM_PASSKEY_RETRIEVE));
 
-            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS, true), context);
 
             assertThat(result, hasStatus(200));
             var checkUserExistsResponse =
@@ -734,6 +728,150 @@ class CheckUserExistsHandlerTest {
                             AUDIT_CONTEXT.withSubjectId(getExpectedInternalPairwiseId()),
                             pair("number_of_attempts_user_allowed_to_login", 5));
         }
+    }
+
+    @Test
+    void shouldLowercaseEmailFromRequestBeforeLookup() throws Json.JsonException {
+        authSessionExists();
+        var mixedCaseEmail = "Joe.Bloggs@Digital.Cabinet-Office.Gov.UK";
+        setupUserProfileAndClient(Optional.empty());
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody(
+                                format(
+                                        "{\"email\": \"%s\", \"supportPasskeyUsage\": false}",
+                                        mixedCaseEmail))
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        var checkUserExistsResponse =
+                objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+        assertThat(checkUserExistsResponse.email(), equalTo(EMAIL_ADDRESS));
+        verify(authenticationService).getUserProfileByEmailMaybe(EMAIL_ADDRESS);
+    }
+
+    @Test
+    void shouldDefaultSupportPasskeyUsageToFalseWhenNotInRequestBody() throws Json.JsonException {
+        authSessionExists();
+        var userProfile =
+                generateUserProfile().withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER);
+        setupUserProfileAndClient(Optional.of(userProfile));
+        when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody(format("{\"email\": \"%s\"}", EMAIL_ADDRESS))
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        var checkUserExistsResponse =
+                objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+        assertNull(checkUserExistsResponse.hasActivePasskey());
+        verifyNoInteractions(passkeysService);
+    }
+
+    @Test
+    void shouldReturn400WhenRequestBodyIsNull() {
+        authSessionExists();
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody(null)
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.REQUEST_MISSING_PARAMS));
+    }
+
+    @Test
+    void shouldReturn400WhenRequestBodyIsEmptyJsonObject() {
+        authSessionExists();
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody("{}")
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.REQUEST_MISSING_PARAMS));
+    }
+
+    @Test
+    void shouldReturn400WhenRequestHasEmptyStringEmail() {
+        authSessionExists();
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody("{\"email\": \"\"}")
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.EMAIL_ADDRESS_EMPTY));
+    }
+
+    @Test
+    void shouldCallPasskeysServiceWhenSupportPasskeyUsageIsTrue() throws Json.JsonException {
+        authSessionExists();
+        var userProfile =
+                generateUserProfile().withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER);
+        setupUserProfileAndClient(Optional.of(userProfile));
+        when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+        when(passkeysService.hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID))
+                .thenReturn(Result.success(true));
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody(
+                                format(
+                                        "{\"email\": \"%s\", \"supportPasskeyUsage\": true}",
+                                        EMAIL_ADDRESS))
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        verify(passkeysService).hasActivePasskey(userProfile.getPublicSubjectID(), SESSION_ID);
+    }
+
+    @Test
+    void shouldAcceptRequestWithUnknownFieldsAndProcessSuccessfully() throws Json.JsonException {
+        authSessionExists();
+        setupUserProfileAndClient(Optional.empty());
+
+        var event =
+                new APIGatewayProxyRequestEvent()
+                        .withHeaders(VALID_HEADERS)
+                        .withBody(
+                                format(
+                                        "{\"email\": \"%s\", \"supportPasskeyUsage\": false, \"unknownField\": \"value\"}",
+                                        EMAIL_ADDRESS))
+                        .withRequestContext(contextWithSourceIp(IP_ADDRESS));
+
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        var checkUserExistsResponse =
+                objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+        assertThat(checkUserExistsResponse.email(), equalTo(EMAIL_ADDRESS));
     }
 
     @Test
@@ -846,9 +984,17 @@ class CheckUserExistsHandlerTest {
     }
 
     private APIGatewayProxyRequestEvent userExistsRequest(String email) {
+        return userExistsRequest(email, false);
+    }
+
+    private APIGatewayProxyRequestEvent userExistsRequest(
+            String email, boolean supportPasskeyUsage) {
         return new APIGatewayProxyRequestEvent()
                 .withHeaders(VALID_HEADERS)
-                .withBody(format("{\"email\": \"%s\" }", email))
+                .withBody(
+                        format(
+                                "{\"email\": \"%s\", \"supportPasskeyUsage\": %s}",
+                                email, supportPasskeyUsage))
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandlerTest.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonArray;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -346,41 +345,6 @@ class TicfCriHandlerTest {
         when(httpResponse.statusCode()).thenReturn(200);
         when(httpClient.send(any(), any())).thenReturn(httpResponse);
         when(configurationService.supportPasskeys()).thenReturn(true);
-        handler.handleRequest(ticfRequest, context);
-
-        var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(httpClient).send(httpRequestCaptor.capture(), ArgumentMatchers.any());
-
-        var actualRequestBody =
-                bodyPublisherToString(httpRequestCaptor.getValue().bodyPublisher().get());
-
-        var expectedUri = URI.create(SERVICE_URI + "/auth");
-        assertEquals(expectedUri, httpRequestCaptor.getValue().uri());
-        assertEquals(expectedRequestBody, actualRequestBody);
-    }
-
-    @Test
-    void shouldNotIncludePasskeyInCallToTicfIfPasskeysNotEnabled()
-            throws IOException, InterruptedException, ExecutionException {
-        var ticfRequest =
-                new InternalTICFCRIRequest(
-                        COMMON_SUBJECTID,
-                        VECTORS_OF_TRUST,
-                        JOURNEY_ID,
-                        true,
-                        EXISTING_ACCOUNT_STATE,
-                        NA_RESET_PASSWORD_STATE,
-                        NA_RESET_MFA_STATE,
-                        NA_USED_MFA_METHOD_TYPE,
-                        true);
-        var expectedRequestBody =
-                format(
-                        "{\"sub\":\"%s\",\"vtr\":%s,\"govuk_signin_journey_id\":\"%s\",\"authenticated\":\"%s\"}",
-                        COMMON_SUBJECTID, jsonArrayFrom(VECTORS_OF_TRUST), JOURNEY_ID, "Y");
-
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(httpClient.send(any(), any())).thenReturn(httpResponse);
-        when(configurationService.supportPasskeys()).thenReturn(false);
         handler.handleRequest(ticfRequest, context);
 
         var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -634,7 +634,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                             .withStatus(200)
                                             .withBody(passkeysResponseWithActivePasskey)));
 
-            var request = new CheckUserExistsRequest(TEST_EMAIL_1);
+            var request = new CheckUserExistsRequest(TEST_EMAIL_1, true);
             var response =
                     makeRequest(
                             Optional.of(request),

--- a/shared/src/main/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequest.java
@@ -23,7 +23,7 @@ public record ExternalTICFCRIRequest(
         @Expose String passkey) {
 
     public static ExternalTICFCRIRequest fromInternalRequest(
-            InternalTICFCRIRequest internalRequest, boolean supportPasskeys) {
+            InternalTICFCRIRequest internalRequest) {
         boolean passwordResetSuccess =
                 internalRequest.resetPasswordState().equals(ResetPasswordState.SUCCEEDED);
         boolean reportablePasswordAttempted =
@@ -56,7 +56,7 @@ public record ExternalTICFCRIRequest(
                 sanitisedMfaMethodType != null
                         ? Collections.singletonList(sanitisedMfaMethodType)
                         : null,
-                internalRequest.hasVerifiedWithPasskey() && supportPasskeys ? "Y" : null);
+                internalRequest.hasVerifiedWithPasskey() ? "Y" : null);
     }
 
     @Override

--- a/shared/src/test/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequestTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/entity/ExternalTICFCRIRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.entity;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -368,38 +367,6 @@ class ExternalTICFCRIRequestTest {
     @MethodSource("ticfParametersSource")
     void shouldCorrectlyBeConstructedFromInternalRequest(
             InternalTICFCRIRequest provided, ExternalTICFCRIRequest expected) {
-        assertEquals(expected, ExternalTICFCRIRequest.fromInternalRequest(provided, true));
-    }
-
-    @Test
-    void shouldNotSendPasskeyIfPasskeysNotSupported() {
-        var userSignedInWithPasskeyInternalTicfRequest =
-                new InternalTICFCRIRequest(
-                        "test-sub",
-                        List.of("Cl.Cm"),
-                        "test-journey-id",
-                        true,
-                        AccountState.EXISTING,
-                        ResetPasswordState.NONE,
-                        ResetMfaState.NONE,
-                        MFAMethodType.NONE,
-                        true);
-
-        var expectedExternalTicfCriRequest =
-                new ExternalTICFCRIRequest(
-                        "test-sub",
-                        List.of("Cl.Cm"),
-                        "test-journey-id",
-                        "Y",
-                        null,
-                        null,
-                        null,
-                        null,
-                        null);
-
-        assertEquals(
-                ExternalTICFCRIRequest.fromInternalRequest(
-                        userSignedInWithPasskeyInternalTicfRequest, false),
-                expectedExternalTicfCriRequest);
+        assertEquals(expected, ExternalTICFCRIRequest.fromInternalRequest(provided));
     }
 }


### PR DESCRIPTION

## What

Read supportPasskeyUsage from request instead of backend config

PR no 2 of 2 ([PR1](https://github.com/govuk-one-login/authentication-frontend/pull/3564))

- Remove use of the passkeys feature switch in CheckUserExistsHandler and TicfCriHandler
- Means the backend switch can be retired and only the frontend switches are required for go-live
- Backend deployment time would add complexity to the release so easier to remove the switch entirely
- Adds a new "supportPasskeyUsage" attribute to the 'check-user-exists' request

To be merged only after the frontend change: https://github.com/govuk-one-login/authentication-frontend/pull/3564

## How to review

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure the journeys work correctly with the frontend passkey sign in switch both on and off

Tested on authdev1 with 

```
{
          "name": "SUPPORT_PASSKEY_USAGE",
          "value": "1"
},
```

See the following log message:

```
"loggerName": "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler",
"message": "Checking if user has active passkey",
```

When

```
{
          "name": "SUPPORT_PASSKEY_USAGE",
          "value": "0"
},
```

The above message does not appear, meaning the new api attribute is working correctly, but see **hasVerifiedWithPasskey = 'false'**

```
{
    "instant": {
        "epochSecond": 1784895691,
        "nanoOfSecond": 821985835
    },
    "level": "INFO",
    "loggerName": "uk.gov.di.authentication.shared.services.AuthSessionService",
    "message": "Updating auth session item AuthSessionItem{sessionId = 'nnWEwmvHNNgP3BmD5WDZWQoZnPY', verifiedMfaMethodType = 'SMS', timeToLive = '1784899275', isNewAccount = 'EXISTING', resetPasswordState = 'NONE', resetMfaState = 'NONE', internalCommonSubjectId = 'urn:fdc:gov.uk:2022:', upliftRequired = 'false', hasVerifiedWithPassword = 'true', hasVerifiedWithMfa = 'true', **hasVerifiedWithPasskey = 'false'**}}",
    "session-id": "nnWEwmvHNNgP3BmD5WDZWQoZnPY",
    "persistent-session-id": "9jFjRUVmmSuH7KMSFhhugKATx1I--1784105817381",
    "client-session-id": "yq-eEPtBPVqzJ4gVpxMVnwyDs64",
    "govuk_signin_journey_id": "yq-eEPtBPVqzJ4gVpxMVnwyDs64",
    "client-id": "skwdHH2y6ERjJWTPSoAFbSt8lX04OgtI",
    "trace-id": "d20c410347af26ff98809ca827b680c7"
}
```

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3564
