### PR TITLE
BAU: Prevent sign-up race conditions by using a conditional create

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -249,7 +250,6 @@ class DynamoServiceIntegrationTest {
         @MethodSource("existingMFAs")
         @ParameterizedTest
         void shouldDeleteAllMigratedMfaMethods(MFAMethod mfaMethod, MFAMethod mfaMethod2) {
-            userStore.signUp(TEST_EMAIL, "password-1", new Subject("1111"));
             userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, mfaMethod);
             if (mfaMethod2 != null) {
                 userStore.addMfaMethodSupportingMultiple(TEST_EMAIL, mfaMethod2);
@@ -975,6 +975,15 @@ class DynamoServiceIntegrationTest {
         assertFalse(userProfileAfterUpdate.isMfaMethodsMigrated());
         assertTrue(userProfileAfterUpdate.isPhoneNumberVerified());
         assertEquals(phoneNumber, userProfileAfterUpdate.getPhoneNumber());
+    }
+
+    @Test
+    void shouldThrowErrorOnSignUpForADuplicateEmailAddress() {
+        userStore.signUp("duplicate@example.com", "password-1");
+
+        assertThrows(
+                ConditionalCheckFailedException.class,
+                () -> userStore.signUp("duplicate@example.com", "password-2"));
     }
 
     private void signUpWithPhoneNumber(String email, String subjectId, String phoneNumber) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -52,6 +52,7 @@ import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.warmUp;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.BACKUP;
 import static uk.gov.di.authentication.shared.entity.PriorityIdentifier.DEFAULT;
+import static uk.gov.di.authentication.shared.entity.UserCredentials.ATTRIBUTE_EMAIL;
 import static uk.gov.di.authentication.shared.helpers.NoDefaultMfaMethodLogHelper.logDebugIfAnyMfaMethodHasNullPriority;
 import static uk.gov.di.authentication.shared.helpers.NoDefaultMfaMethodLogHelper.logDebugIfMfaMethodHasNullPriority;
 
@@ -129,7 +130,15 @@ public class DynamoService implements AuthenticationService {
             userProfile.setTestUser(1);
         }
 
-        dynamoUserCredentialsTable.putItem(userCredentials);
+        dynamoUserCredentialsTable.putItem(
+                (builder) ->
+                        builder.item(userCredentials)
+                                .conditionExpression(
+                                        Expression.builder()
+                                                .expression(
+                                                        "attribute_not_exists(%s)"
+                                                                .formatted(ATTRIBUTE_EMAIL))
+                                                .build()));
         dynamoUserProfileTable.putItem(userProfile);
         return new User(userProfile, userCredentials);
     }


### PR DESCRIPTION
## What

Added a conditional check when signing up. Although there is a check earlier in the flow, this prevents any race condition allowing a user to sign up with a duplicate email address.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)
