### PR TITLE
Aut 5660/emit enhanced auth code protection metric

### DIFF
--- a/ci/cloudformation/auth/function/orch-auth-code.yaml
+++ b/ci/cloudformation/auth/function/orch-auth-code.yaml
@@ -230,6 +230,62 @@ Resources:
           DefaultValue: 10,
         ]
 
+  EnhancedAuthCodeProtectionCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !If
+            - IsProduction
+            - "{{resolve:ssm:/deploy/production/auth_notifications_channel_topic_arn}}"
+            - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "30 or more journeys have been blocked by the enhanced auth code protection in the last 24 hours in ${Env}."
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      AlarmName: !Sub
+        - ${Env}-enhanced-auth-code-protection-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 30
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: m1
+          ReturnData: true
+          MetricStat:
+            Metric:
+              Namespace: Authentication
+              MetricName: EnhancedAuthCodeBlocked
+              Dimensions:
+                - Name: Environment
+                  Value: !If
+                    - UseSubEnvironment
+                    - !Ref SubEnvironment
+                    - !Ref Environment
+                - Name: LogGroup
+                  Value: !Sub
+                    - /aws/lambda/${Env}-orch-auth-code-lambda
+                    - Env:
+                        !If [
+                          UseSubEnvironment,
+                          !Ref SubEnvironment,
+                          !Ref Environment,
+                        ]
+                - Name: ServiceName
+                  Value: !Sub
+                    - ${Env}-orch-auth-code-lambda
+                    - Env:
+                        !If [
+                          UseSubEnvironment,
+                          !Ref SubEnvironment,
+                          !Ref Environment,
+                        ]
+                - Name: ServiceType
+                  Value: "AWS::Lambda::Function"
+            Period: 86400 # 24 hours
+            Stat: Sum
+
   OrchAuthCodeFunctionSubscriptionFilter:
     Condition: IsSplunkEnabled
     Type: AWS::Logs::SubscriptionFilter

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -107,6 +107,9 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                 LOG.warn("Not permitted to issue auth code");
 
                 if (configurationService.isEnhancedAuthCodeProtectionEnabled()) {
+                    cloudwatchMetricsService.incrementCounter(
+                            CloudwatchMetrics.ENHANCED_AUTH_CODE_BLOCKED.getValue(),
+                            Map.of(ENVIRONMENT.getValue(), configurationService.getEnvironment()));
                     return generateApiGatewayProxyErrorResponse(
                             500, ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR);
                 } else {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -424,6 +424,8 @@ class AuthenticationAuthCodeHandlerTest {
                 hasBody(
                         objectMapper.writeValueAsString(
                                 ErrorResponse.UNEXPECTED_INTERNAL_API_ERROR)));
+        verify(cloudwatchMetricsService, times(1))
+                .incrementCounter("EnhancedAuthCodeBlocked", Map.of("Environment", "test"));
         verify(dynamoAuthCodeService, never())
                 .saveAuthCode(any(), any(), any(), anyBoolean(), any(), anyBoolean(), any(), any());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -43,7 +43,8 @@ public enum CloudwatchMetrics {
     AMC_FAILURE_GETTING_AUTHORISATION("AMCFailureGettingAuthorisation"),
     PASSKEY_DELETION_SUCCESSFUL("PasskeyDeletionSuccessful"),
     PASSKEY_DELETION_FAILED("PasskeyDeletionFailed"),
-    PASSWORD_REHASH_COMPLETED("PasswordRehashCompleted");
+    PASSWORD_REHASH_COMPLETED("PasswordRehashCompleted"),
+    ENHANCED_AUTH_CODE_BLOCKED("EnhancedAuthCodeBlocked");
 
     private String value;
 


### PR DESCRIPTION
## What

- If the enhanced auth code feature flag is turned on and
  the `canIssueAuthCode()` returns false, the
  "EnhancedAuthCodeBlocked" metric
- Alarms when 30 or more journeys are blocked by the enhanced
  auth code protection in a 24-hour period
- Sends notifications to #di-authentication-notifications via
  SSM parameter:
  - NB: the existing `slack_alert_notification_topic_arn` is
    hooked to #di-2nd-line in production, but
    #di-authentication-notifications in integration and
    nothing in lower environments
  - There is no topic currently hooked to
    #di-authentication-notifications in production, so one
    has been created in authentication-infrastructure, the
    ARN of which is contained in the
    `auth_notifications_channel_topic_arn` SSM parameter

## How to review

1. Code Review
2. Run through a sign in journey in dev up to the register passkey step, go to auth session table in di-auth-development, set achieved credential to `LOW_LEVEL`, click skip, see error on `/auth-code` - you should see the count incremented for `EnhancedAuthCodeBlocked` 
3. We can't test full integration with the alert in production, but when this is in production we can increment the metric >30 times using the AWS CLI; this will trigger the alarm, proving the other part of the flow works

## Related PRs

https://github.com/govuk-one-login/authentication-infrastructure/pull/164
