### PR TITLE
AUT-5528: Storing skipped passkey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
@@ -12,25 +12,14 @@ public class UpdateProfileRequest extends BaseFrontendRequest {
     @Required
     private UpdateProfileType updateProfileType;
 
-    @SerializedName("profileInformation")
-    @Expose
-    @Required
-    private String profileInformation;
-
     public UpdateProfileRequest() {}
 
-    public UpdateProfileRequest(
-            String email, UpdateProfileType updateProfileType, String profileInformation) {
+    public UpdateProfileRequest(String email, UpdateProfileType updateProfileType) {
         this.email = email;
         this.updateProfileType = updateProfileType;
-        this.profileInformation = profileInformation;
     }
 
     public UpdateProfileType getUpdateProfileType() {
         return updateProfileType;
-    }
-
-    public String getProfileInformation() {
-        return profileInformation;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileType.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileType.java
@@ -1,7 +1,5 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
 public enum UpdateProfileType {
-    ADD_PHONE_NUMBER,
     UPDATE_TERMS_CONDS,
-    REGISTER_AUTH_APP,
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileType.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileType.java
@@ -2,4 +2,5 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 public enum UpdateProfileType {
     UPDATE_TERMS_CONDS,
+    SKIP_ADDING_PASSKEY,
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -8,7 +8,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
-import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -106,7 +105,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                             userContext.getClientSessionId(), userContext.getTxmaAuditEncoded()));
         }
 
-        AuditableEvent auditableEvent;
         String auditablePhoneNumber =
                 userContext
                         .getUserProfile()
@@ -124,10 +122,10 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         if (request.getUpdateProfileType().equals(UPDATE_TERMS_CONDS)) {
             authenticationService.updateTermsAndConditions(
                     request.getEmail(), configurationService.getTermsAndConditionsVersion());
-            auditableEvent = AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE;
             LOG.info(
                     "Updated terms and conditions for Version: {}",
                     configurationService.getTermsAndConditionsVersion());
+            auditService.submitAuditEvent(AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE, auditContext);
         } else {
             LOG.error(
                     "Encountered unexpected error while processing session: {}",
@@ -135,7 +133,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             return generateErrorResponse(ErrorResponse.INVALID_UPDATE_PROFILE_TYPE, auditContext);
         }
 
-        auditService.submitAuditEvent(auditableEvent, auditContext);
         return generateEmptySuccessApiGatewayResponse();
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -119,18 +119,24 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         auditablePhoneNumber,
                         persistentSessionId);
 
-        if (request.getUpdateProfileType().equals(UPDATE_TERMS_CONDS)) {
-            authenticationService.updateTermsAndConditions(
-                    request.getEmail(), configurationService.getTermsAndConditionsVersion());
-            LOG.info(
-                    "Updated terms and conditions for Version: {}",
-                    configurationService.getTermsAndConditionsVersion());
-            auditService.submitAuditEvent(AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE, auditContext);
-        } else {
-            LOG.error(
-                    "Encountered unexpected error while processing session: {}",
-                    userContext.getAuthSession().getSessionId());
-            return generateErrorResponse(ErrorResponse.INVALID_UPDATE_PROFILE_TYPE, auditContext);
+        switch (request.getUpdateProfileType()) {
+            case UPDATE_TERMS_CONDS -> {
+                authenticationService.updateTermsAndConditions(
+                        request.getEmail(), configurationService.getTermsAndConditionsVersion());
+                LOG.info(
+                        "Updated terms and conditions for Version: {}",
+                        configurationService.getTermsAndConditionsVersion());
+                auditService.submitAuditEvent(
+                        AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE, auditContext);
+            }
+            default -> {
+                LOG.error(
+                        "Unexpected UpdateProfileType '{}' while processing session '{}'",
+                        request.getUpdateProfileType().toString(),
+                        userContext.getAuthSession().getSessionId());
+                return generateErrorResponse(
+                        ErrorResponse.INVALID_UPDATE_PROFILE_TYPE, auditContext);
+            }
         }
 
         return generateEmptySuccessApiGatewayResponse();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -110,6 +110,11 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 auditService.submitAuditEvent(
                         AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE, auditContext);
             }
+            case SKIP_ADDING_PASSKEY -> {
+                authenticationService.renewLastSkippedAddingPasskeyTimestamp(request.getEmail());
+                LOG.info("Renewed lastSkippedAddingPasskey timestamp");
+                // TODO - AUT-5464 - Add the audit event here
+            }
             default -> {
                 LOG.error(
                         "Unexpected UpdateProfileType '{}' while processing session '{}'",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.NonNull;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
@@ -26,7 +27,6 @@ import static uk.gov.di.audit.AuditContext.emptyAuditContext;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_ERROR;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE;
-import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 
@@ -87,15 +87,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             UserContext userContext) {
 
         AuthSessionItem authSession = userContext.getAuthSession();
-
-        String persistentSessionId =
-                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
-
         LogLineHelper.attachSessionIdToLogs(userContext.getAuthSession().getSessionId());
-
         LOG.info("Processing request");
-
-        String ipAddress = IpAddressHelper.extractIpAddress(input);
 
         if (!authSession.validateSession(request.getEmail())) {
             LOG.info("Invalid session");
@@ -105,19 +98,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                             userContext.getClientSessionId(), userContext.getTxmaAuditEncoded()));
         }
 
-        String auditablePhoneNumber =
-                userContext
-                        .getUserProfile()
-                        .map(UserProfile::getPhoneNumber)
-                        .orElse(AuditService.UNKNOWN);
-        var auditContext =
-                auditContextFromUserContext(
-                        userContext,
-                        authSession.getInternalCommonSubjectId(),
-                        authSession.getEmailAddress(),
-                        ipAddress,
-                        auditablePhoneNumber,
-                        persistentSessionId);
+        var auditContext = buildAuditContext(input, userContext, authSession);
 
         switch (request.getUpdateProfileType()) {
             case UPDATE_TERMS_CONDS -> {
@@ -140,6 +121,30 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         }
 
         return generateEmptySuccessApiGatewayResponse();
+    }
+
+    private static @NonNull AuditContext buildAuditContext(
+            APIGatewayProxyRequestEvent input,
+            UserContext userContext,
+            AuthSessionItem authSession) {
+        String persistentSessionId =
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
+
+        String ipAddress = IpAddressHelper.extractIpAddress(input);
+
+        String auditablePhoneNumber =
+                userContext
+                        .getUserProfile()
+                        .map(UserProfile::getPhoneNumber)
+                        .orElse(AuditService.UNKNOWN);
+
+        return auditContextFromUserContext(
+                userContext,
+                authSession.getInternalCommonSubjectId(),
+                authSession.getEmailAddress(),
+                ipAddress,
+                auditablePhoneNumber,
+                persistentSessionId);
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -29,8 +29,8 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_ERROR;
@@ -53,11 +53,9 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class UpdateProfileHandlerTest {
 
-    private static final boolean UPDATED_TERMS_AND_CONDITIONS_VALUE = true;
     private static final String SESSION_ID = "a-session-id";
     private static final ClientID CLIENT_ID = new ClientID("client-one");
     private static final String INTERNAL_SUBJECT = new Subject().getValue();
-    private static final String COOKIE = "Cookie";
 
     private final Context context = mock(Context.class);
     private UpdateProfileHandler handler;
@@ -127,8 +125,8 @@ class UpdateProfileHandlerTest {
 
         var body =
                 format(
-                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
-                        EMAIL, UPDATE_TERMS_CONDS, UPDATED_TERMS_AND_CONDITIONS_VALUE);
+                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
+                        EMAIL, UPDATE_TERMS_CONDS);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
@@ -152,8 +150,8 @@ class UpdateProfileHandlerTest {
 
         var body =
                 format(
-                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
-                        EMAIL, UPDATE_TERMS_CONDS, UPDATED_TERMS_AND_CONDITIONS_VALUE);
+                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
+                        EMAIL, UPDATE_TERMS_CONDS);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
 
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
@@ -175,17 +173,13 @@ class UpdateProfileHandlerTest {
     void shouldReturn400WhenRequestIsMissingParameters() {
         usingValidSession();
 
-        var body =
-                format(
-                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\"}",
-                        EMAIL, UPDATE_TERMS_CONDS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.REQUEST_MISSING_PARAMS));
-        verify(authenticationService, never())
-                .updatePhoneNumber(eq(EMAIL), eq(CommonTestVariables.UK_MOBILE_NUMBER));
+        verifyNoInteractions(authenticationService);
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_REQUEST_RECEIVED, auditContextWithOnlyClientSession);
@@ -197,10 +191,7 @@ class UpdateProfileHandlerTest {
     @Test
     void checkUpdateProfileRequestErrorAuditEventStillEmittedWhenTICFHeaderNotProvided() {
         usingValidSession();
-        var body =
-                format(
-                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\"}",
-                        EMAIL, UPDATE_TERMS_CONDS);
+        var body = format("{ \"email\": \"%s\" }", EMAIL);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
 
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
@@ -225,8 +216,7 @@ class UpdateProfileHandlerTest {
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
-        var response = handler.handleRequest(event, context);
-        return response;
+        return handler.handleRequest(event, context);
     }
 
     private UserProfile generateUserProfile() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditContext;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_ERROR;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE;
+import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.SKIP_ADDING_PASSKEY;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
 import static uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper.apiRequestEventWithHeadersAndBody;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.CLIENT_SESSION_ID;
@@ -117,56 +119,92 @@ class UpdateProfileHandlerTest {
                         authSessionService);
     }
 
-    @Test
-    void shouldReturn204WhenUpdatingTermsAndConditions() {
-        usingValidSession();
-        when(authenticationService.getUserProfileFromEmail(EMAIL))
-                .thenReturn(Optional.of(generateUserProfile()));
+    @Nested
+    class UpdateTermsConds {
+        @Test
+        void shouldReturn204WhenUpdatingTermsAndConditions() {
+            usingValidSession();
+            when(authenticationService.getUserProfileFromEmail(EMAIL))
+                    .thenReturn(Optional.of(generateUserProfile()));
 
-        var body =
-                format(
-                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
-                        EMAIL, UPDATE_TERMS_CONDS);
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
+            var body =
+                    format(
+                            "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
+                            EMAIL, UPDATE_TERMS_CONDS);
+            var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
-        APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
+            APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
-        verify(authenticationService)
-                .updateTermsAndConditions(eq(EMAIL), eq(TERMS_AND_CONDITIONS_VERSION));
-        assertThat(result, hasStatus(204));
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_UPDATE_PROFILE_REQUEST_RECEIVED, auditContextWithOnlyClientSession);
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE, auditContextWithAllUserInfo);
+            verify(authenticationService)
+                    .updateTermsAndConditions(eq(EMAIL), eq(TERMS_AND_CONDITIONS_VERSION));
+            assertThat(result, hasStatus(204));
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
+                            auditContextWithOnlyClientSession);
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
+                            auditContextWithAllUserInfo);
+        }
+
+        @Test
+        void
+                checkUpdateProfileTermsCondsAcceptanceAuditEventStillEmittedWhenTICFHeaderNotProvided() {
+            usingValidSession();
+            when(authenticationService.getUserProfileFromEmail(EMAIL))
+                    .thenReturn(Optional.of(generateUserProfile()));
+
+            var body =
+                    format(
+                            "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
+                            EMAIL, UPDATE_TERMS_CONDS);
+            var event =
+                    apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
+
+            APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
+
+            assertThat(result, hasStatus(204));
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
+                            auditContextWithOnlyClientSession.withTxmaAuditEncoded(
+                                    AuditService.UNKNOWN));
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
+                            auditContextWithAllUserInfo.withTxmaAuditEncoded(AuditService.UNKNOWN));
+        }
     }
 
-    @Test
-    void checkUpdateProfileTermsCondsAcceptanceAuditEventStillEmittedWhenTICFHeaderNotProvided() {
-        usingValidSession();
-        when(authenticationService.getUserProfileFromEmail(EMAIL))
-                .thenReturn(Optional.of(generateUserProfile()));
+    @Nested
+    class SkipAddingPasskey {
+        @Test
+        void shouldReturn204WhenRenewingLastSkippedAddingPasskeyTimestamp() {
+            usingValidSession();
+            when(authenticationService.getUserProfileFromEmail(EMAIL))
+                    .thenReturn(Optional.of(generateUserProfile()));
 
-        var body =
-                format(
-                        "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
-                        EMAIL, UPDATE_TERMS_CONDS);
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
+            var body =
+                    format(
+                            "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
+                            EMAIL, SKIP_ADDING_PASSKEY);
+            var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
-        APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
+            APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
-        assertThat(result, hasStatus(204));
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
-                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(
-                                AuditService.UNKNOWN));
+            verify(authenticationService).renewLastSkippedAddingPasskeyTimestamp(eq(EMAIL));
+            assertThat(result, hasStatus(204));
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
+                            auditContextWithOnlyClientSession);
+            // TODO - AUT-5464 - Verify AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED audit event
+        }
 
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                        auditContextWithAllUserInfo.withTxmaAuditEncoded(AuditService.UNKNOWN));
+        // TODO - AUT-5464 - Add test
+        // checkUpdateProfileRenewLastSkippedAddingPasskeyAuditEventStillEmittedWhenTICFHeaderNotProvided
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -48,7 +48,6 @@ import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.INT
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.UK_MOBILE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS;
-import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.VALID_HEADERS_WITHOUT_AUDIT_ENCODED;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -147,35 +146,6 @@ class UpdateProfileHandlerTest {
                             AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
                             auditContextWithAllUserInfo);
         }
-
-        @Test
-        void
-                checkUpdateProfileTermsCondsAcceptanceAuditEventStillEmittedWhenTICFHeaderNotProvided() {
-            usingValidSession();
-            when(authenticationService.getUserProfileFromEmail(EMAIL))
-                    .thenReturn(Optional.of(generateUserProfile()));
-
-            var body =
-                    format(
-                            "{ \"email\": \"%s\", \"updateProfileType\": \"%s\" }",
-                            EMAIL, UPDATE_TERMS_CONDS);
-            var event =
-                    apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
-
-            APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
-
-            assertThat(result, hasStatus(204));
-            verify(auditService)
-                    .submitAuditEvent(
-                            AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
-                            auditContextWithOnlyClientSession.withTxmaAuditEncoded(
-                                    AuditService.UNKNOWN));
-
-            verify(auditService)
-                    .submitAuditEvent(
-                            AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                            auditContextWithAllUserInfo.withTxmaAuditEncoded(AuditService.UNKNOWN));
-        }
     }
 
     @Nested
@@ -202,9 +172,6 @@ class UpdateProfileHandlerTest {
                             auditContextWithOnlyClientSession);
             // TODO - AUT-5464 - Verify AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED audit event
         }
-
-        // TODO - AUT-5464 - Add test
-        // checkUpdateProfileRenewLastSkippedAddingPasskeyAuditEventStillEmittedWhenTICFHeaderNotProvided
     }
 
     @Test
@@ -224,27 +191,6 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTH_UPDATE_PROFILE_REQUEST_ERROR, auditContextWithOnlyClientSession);
-    }
-
-    @Test
-    void checkUpdateProfileRequestErrorAuditEventStillEmittedWhenTICFHeaderNotProvided() {
-        usingValidSession();
-        var body = format("{ \"email\": \"%s\" }", EMAIL);
-        var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
-
-        APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
-
-        assertThat(result, hasStatus(400));
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
-                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(
-                                AuditService.UNKNOWN));
-        verify(auditService)
-                .submitAuditEvent(
-                        AUTH_UPDATE_PROFILE_REQUEST_ERROR,
-                        auditContextWithOnlyClientSession.withTxmaAuditEncoded(
-                                AuditService.UNKNOWN));
     }
 
     private void usingValidSession() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE;
+import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.SKIP_ADDING_PASSKEY;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -48,6 +49,26 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 List.of(
                         AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
                         AUTH_UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE));
+    }
+
+    @Test
+    void shouldCallUpdateProfileToRenewLastSkippedAddingPasskeyTimestampAndReturn204() {
+        String sessionId = IdGenerator.generate();
+        String clientSessionId = IdGenerator.generate();
+        setUpTest(sessionId);
+
+        UpdateProfileRequest request = new UpdateProfileRequest(EMAIL_ADDRESS, SKIP_ADDING_PASSKEY);
+
+        var response =
+                makeRequest(
+                        Optional.of(request),
+                        constructFrontendHeaders(sessionId, clientSessionId),
+                        Map.of());
+
+        assertThat(response, hasStatus(204));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTH_UPDATE_PROFILE_REQUEST_RECEIVED));
+        // TODO - AUT-5464 - Add AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED to List
     }
 
     private void setUpTest(String sessionId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -34,8 +34,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         String clientSessionId = IdGenerator.generate();
         setUpTest(sessionId);
 
-        UpdateProfileRequest request =
-                new UpdateProfileRequest(EMAIL_ADDRESS, UPDATE_TERMS_CONDS, String.valueOf(true));
+        UpdateProfileRequest request = new UpdateProfileRequest(EMAIL_ADDRESS, UPDATE_TERMS_CONDS);
 
         var response =
                 makeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
@@ -21,6 +22,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -37,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 
 class DynamoServiceIntegrationTest {
 
@@ -984,6 +988,30 @@ class DynamoServiceIntegrationTest {
         assertThrows(
                 ConditionalCheckFailedException.class,
                 () -> userStore.signUp("duplicate@example.com", "password-2"));
+    }
+
+    @Test
+    void shouldUpdateLastSkippedAddingPasskeyToTimestampNow() {
+        // Arrange
+        userStore.signUp(TEST_EMAIL, "password-1", new Subject());
+        LocalDateTime fixedDateTime = LocalDateTime.of(2026, 1, 1, 0, 0);
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime =
+                mockStatic(LocalDateTime.class, CALLS_REAL_METHODS)) {
+            mockedLocalDateTime
+                    .when(() -> LocalDateTime.now(ZoneId.of("UTC")))
+                    .thenReturn(fixedDateTime);
+
+            // Act
+            dynamoService.renewLastSkippedAddingPasskeyTimestamp(TEST_EMAIL);
+
+            // Assert
+            UserProfile updatedUserProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
+
+            assertThat(
+                    updatedUserProfile.getLastSkippedAddingPasskey(),
+                    equalTo(fixedDateTime.toString()));
+        }
     }
 
     private void signUpWithPhoneNumber(String email, String subjectId, String phoneNumber) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -27,6 +27,7 @@ public class UserProfile {
     public static final String ATTRIBUTE_TEST_USER = "testUser";
     public static final String ATTRIBUTE_MFA_METHODS_MIGRATED = "mfaMethodsMigrated";
     public static final String ATTRIBUTE_MFA_IDENTIFIER = "MFAIdentifier";
+    public static final String ATTRIBUTE_LAST_SKIPPED_ADDING_PASSKEY = "LastSkippedAddingPasskey";
 
     private String email;
     private String subjectID;
@@ -43,6 +44,7 @@ public class UserProfile {
     private int testUser;
     private boolean mfaMethodsMigrated;
     private String mfaIdentifier;
+    private String lastSkippedAddingPasskey;
 
     public UserProfile() {}
 
@@ -258,6 +260,20 @@ public class UserProfile {
 
     public UserProfile withMfaIdentifier(String mfaIdentifier) {
         this.mfaIdentifier = mfaIdentifier;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_LAST_SKIPPED_ADDING_PASSKEY)
+    public String getLastSkippedAddingPasskey() {
+        return lastSkippedAddingPasskey;
+    }
+
+    public void setLastSkippedAddingPasskey(String lastSkippedAddingPasskey) {
+        this.lastSkippedAddingPasskey = lastSkippedAddingPasskey;
+    }
+
+    public UserProfile withLastSkippedAddingPasskey(String lastSkippedAddingPasskey) {
+        this.lastSkippedAddingPasskey = lastSkippedAddingPasskey;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -107,4 +107,6 @@ public interface AuthenticationService {
             String email, String mfaMethodIdentifier);
 
     void setMfaIdentifierForNonMigratedSmsMethod(String email, String smsMfaIdentifier);
+
+    void renewLastSkippedAddingPasskeyTimestamp(String email);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -1065,4 +1065,16 @@ public class DynamoService implements AuthenticationService {
     private static String hashPassword(String password) {
         return Argon2EncoderHelper.argon2Hash(password);
     }
+
+    @Override
+    public void renewLastSkippedAddingPasskeyTimestamp(String email) {
+        dynamoUserProfileTable.updateItem(
+                dynamoUserProfileTable
+                        .getItem(
+                                Key.builder()
+                                        .partitionValue(email.toLowerCase(Locale.ROOT))
+                                        .build())
+                        .withLastSkippedAddingPasskey(
+                                LocalDateTime.now(ZoneId.of("UTC")).toString()));
+    }
 }


### PR DESCRIPTION
## What

Added a new `SKIP_ADDING_PASSKEY` function to the `UpdateProfileHandler`. Calling this function will update the `LastSkippedAddingPasskey` field on the UserProfile with the current timestamp.

Also did some refactoring in the handler to make it cleaner to add this feature.

Have left some TODOs in the code for where we need to add the audit event-related code as part of AUT-5464 in the future.

## How to review

1. Code Review
1. Test in authdev2 and ensure that
    1. The new `SKIP_ADDING_PASSKEY` logic is setting the timestamp correctly (this will have to be done by calling the endpoint via API Gateway as the frontend isn't hooked up yet)
    2. The existing `UPDATE_TERMS_CONDS` logic is still working as intended (this can be done by performing a journey in the frontend)