### PR TITLE
AUT-5681: Switch on the passkeys acceptance tests in build

### DIFF
--- a/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
+++ b/ci/cloudformation/auth/parameters/acceptance-test-tags.yaml
@@ -19,8 +19,7 @@ Mappings:
     build:
       tags: >-
         @UI and not (@under-development or @ReauthMultiTabLogout or
-        @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
-        or @PasskeysEnabled or @PasskeyUsageEnabled)
+        @AcceptInternationalNumbers or @InternationalSmsSendingDisabled)
     staging:
       tags: >-
         @UI and not (@under-development or @AccountInterventions or @ReauthMultiTabLogout or


### PR DESCRIPTION
## What

Run passkeys acceptance tests in build

- Switch on passkeys in build and run the passkeys acceptance tests
- Proves that the tests will run green when we ship for live proving and go-live

## How to review

1. Code Review


## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)


<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3568
