### PR TITLE
ATO-2785: Add flag to send `update_identity` claim to IPV

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -136,7 +136,8 @@ public class IPVAuthorisationService {
             String clientSessionId,
             String emailAddress,
             List<String> vtr,
-            Boolean reproveIdentity) {
+            Boolean reproveIdentity,
+            boolean userRequestedUpdate) {
         LOG.info("Generating request JWT");
         var jwtID = IdGenerator.generate();
         var expiryDate = nowClock.nowPlus(3, ChronoUnit.MINUTES);
@@ -163,6 +164,9 @@ public class IPVAuthorisationService {
         if (configurationService.isAccountInterventionServiceActionEnabled()
                 && reproveIdentity != null) {
             claimsBuilder.claim("reprove_identity", reproveIdentity);
+        }
+        if (userRequestedUpdate) {
+            claimsBuilder.claim("update_identity", true);
         }
         claimsBuilder.claim("claims", claimsRequest.toJSONObject());
         LOG.info("Encrypted request JWT has been generated");

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -319,7 +319,8 @@ class IPVAuthorisationServiceTest {
                         "journey-id",
                         "test@test.com",
                         List.of("P2", "P1"),
-                        true);
+                        true,
+                        false);
             }
             var captor = ArgumentCaptor.forClass(JWTClaimsSet.class);
             verify(orchJwtService)
@@ -359,6 +360,7 @@ class IPVAuthorisationServiceTest {
                         "",
                         "",
                         emptyList(),
+                        false,
                         false);
             }
             verify(orchJwtService)
@@ -391,6 +393,7 @@ class IPVAuthorisationServiceTest {
                         "",
                         "",
                         emptyList(),
+                        false,
                         false);
             }
             verify(orchJwtService)
@@ -413,11 +416,34 @@ class IPVAuthorisationServiceTest {
                         "",
                         "",
                         emptyList(),
-                        null);
+                        null,
+                        false);
             }
             verify(orchJwtService)
                     .signAndEncryptJWT(
                             argThat(claims -> !claims.getClaims().containsKey("reprove_identity")),
+                            eq(IPV_SIGNING_KEY_ID),
+                            eq(publicEncKey.toRSAPublicKey()));
+        }
+
+        @Test
+        void shouldConstructJWTWithUpdateIdentityClaimIfUpdateIdentityIsTrue() throws Exception {
+            try (var mockIdGenerator = mockStatic(IdGenerator.class)) {
+                mockIdGenerator.when(IdGenerator::generate).thenReturn("test-jti");
+                authorisationService.constructRequestJWT(
+                        new State("state"),
+                        new Scope(OIDCScopeValue.OPENID),
+                        new Subject("subject"),
+                        new ClaimsSetRequest(),
+                        "",
+                        "",
+                        emptyList(),
+                        false,
+                        true);
+            }
+            verify(orchJwtService)
+                    .signAndEncryptJWT(
+                            argThat(claims -> claims.getClaims().containsKey("update_identity")),
                             eq(IPV_SIGNING_KEY_ID),
                             eq(publicEncKey.toRSAPublicKey()));
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -511,7 +511,8 @@ public class AuthenticationCallbackHandler
                             persistentSessionId,
                             reproveIdentity,
                             VectorOfTrust.getRequestedLevelsOfConfidence(
-                                    orchClientSession.getVtrList()));
+                                    orchClientSession.getVtrList()),
+                            false);
                 }
 
                 URI clientRedirectURI = authenticationRequest.getRedirectionURI();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -93,7 +93,8 @@ public class InitiateIPVAuthorisationService {
                         Optional.ofNullable(clientSessionId).orElse("unknown"),
                         userInfo.getEmailAddress(),
                         levelsOfConfidence,
-                        reproveIdentity);
+                        reproveIdentity,
+                        false);
 
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -71,7 +71,8 @@ public class InitiateIPVAuthorisationService {
             String clientSessionId,
             String persistentSessionCookieId,
             Boolean reproveIdentity,
-            List<String> levelsOfConfidence) {
+            List<String> levelsOfConfidence,
+            boolean updateIdentity) {
         if (!configurationService.isIdentityEnabled()) {
             LOG.error("Identity is not enabled");
             throw new RuntimeException("Identity is not enabled");
@@ -94,7 +95,7 @@ public class InitiateIPVAuthorisationService {
                         userInfo.getEmailAddress(),
                         levelsOfConfidence,
                         reproveIdentity,
-                        false);
+                        updateIdentity);
 
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -973,7 +973,8 @@ class AuthenticationCallbackHandlerTest {
                                 any(),
                                 any(),
                                 eq(reproveIdentity),
-                                any());
+                                any(),
+                                eq(false));
                 verifyNoInteractions(logoutService);
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
@@ -1025,7 +1026,8 @@ class AuthenticationCallbackHandlerTest {
                                 any(),
                                 any(),
                                 eq(reproveIdentity),
-                                any());
+                                any(),
+                                eq(false));
                 verifyNoInteractions(logoutService);
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));
@@ -1077,7 +1079,8 @@ class AuthenticationCallbackHandlerTest {
                                 any(),
                                 any(),
                                 eq(reproveIdentity),
-                                any());
+                                any(),
+                                eq(false));
                 verifyNoInteractions(logoutService);
                 verify(orchSessionService, times(2))
                         .updateSession(argThat(OrchSessionItem::getAuthenticated));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -42,8 +42,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -165,9 +163,10 @@ public class InitiateIPVAuthorisationServiceTest {
                         any(Subject.class),
                         eq(claimsSetRequest),
                         eq(CLIENT_SESSION_ID),
-                        anyString(),
+                        eq(EMAIL_ADDRESS),
                         eq(List.of("P0", "P2")),
-                        anyBoolean()))
+                        eq(false),
+                        eq(false)))
                 .thenReturn(encryptedJWT);
 
         var response =
@@ -200,7 +199,8 @@ public class InitiateIPVAuthorisationServiceTest {
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL_ADDRESS),
                         eq(List.of("P0", "P2")),
-                        eq(REPROVE_IDENTITY));
+                        eq(REPROVE_IDENTITY),
+                        eq(false));
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
@@ -249,7 +249,8 @@ public class InitiateIPVAuthorisationServiceTest {
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL_ADDRESS),
                         eq(List.of("P0", "P2")),
-                        eq(REPROVE_IDENTITY));
+                        eq(REPROVE_IDENTITY),
+                        eq(false));
 
         assertEquals(
                 claimsSetRequestWithStorageTokenClaim.toJSONString(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -69,6 +69,7 @@ public class InitiateIPVAuthorisationServiceTest {
     private static final String RP_PAIRWISE_ID = "urn:fdc:gov.uk:2022:dkjfshsdkjh";
     private static final String IP_ADDRESS = "123.123.123.123";
     private static final Boolean REPROVE_IDENTITY = true;
+    private static final boolean UPDATE_IDENTITY = false;
     private static final String SERIALIZED_JWT =
             "eyJraWQiOiIwOWRkYjY1ZWIzY2U0MWEzYjczYTJhOTM0ZTM5NDg4NmQyYTIyYjU0ZmQwMzVmYWJlZWM3YWMxYzllYzliNzBiIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOlsiaHR0cHM6Ly9jcmVkZW50aWFsLXN0b3JlLnRlc3QuYWNjb3VudC5nb3YudWsiLCJodHRwczovL2lkZW50aXR5LnRlc3QuYWNjb3VudC5nb3YudWsiXSwic3ViIjoia3NFUjVWcDRuZU1ONWM2WHJlSV9uUDhGNFZuc2VqS2x1b3BOX05mZjlfNCIsImlzcyI6Imh0dHBzOi8vb2lkYy50ZXN0LmFjY291bnQuZ292LnVrLyIsImV4cCI6MTcwOTA1MTE2MywiaWF0IjoxNzA5MDQ3NTYzLCJqdGkiOiJkZmNjZjc1MS1iZTU1LTRkZjQtYWEzZi1hOTkzMTkzZDUyMTYifQ.rpZ2IqMwlFLbZ8a7En-EuQ480zcorvNd-GZcwjlxlK3Twq9J1GNiuj9teSLINP_zmeirx7Y8p3DUYWk_hyRhww";
 
@@ -146,7 +147,8 @@ public class InitiateIPVAuthorisationServiceTest {
                                         CLIENT_SESSION_ID,
                                         PERSISTENT_SESSION_ID,
                                         REPROVE_IDENTITY,
-                                        LEVELS_OF_CONFIDENCE),
+                                        LEVELS_OF_CONFIDENCE,
+                                        UPDATE_IDENTITY),
                         "Expected to throw exception");
 
         assertThat(exception.getMessage(), equalTo("Identity is not enabled"));
@@ -165,7 +167,7 @@ public class InitiateIPVAuthorisationServiceTest {
                         eq(CLIENT_SESSION_ID),
                         eq(EMAIL_ADDRESS),
                         eq(List.of("P0", "P2")),
-                        eq(false),
+                        eq(true),
                         eq(false)))
                 .thenReturn(encryptedJWT);
 
@@ -180,7 +182,8 @@ public class InitiateIPVAuthorisationServiceTest {
                         CLIENT_SESSION_ID,
                         PERSISTENT_SESSION_ID,
                         REPROVE_IDENTITY,
-                        LEVELS_OF_CONFIDENCE);
+                        LEVELS_OF_CONFIDENCE,
+                        UPDATE_IDENTITY);
 
         assertThat(response, hasStatus(302));
         String redirectLocation = response.getHeaders().get("Location");
@@ -234,7 +237,8 @@ public class InitiateIPVAuthorisationServiceTest {
                         CLIENT_SESSION_ID,
                         PERSISTENT_SESSION_ID,
                         REPROVE_IDENTITY,
-                        LEVELS_OF_CONFIDENCE);
+                        LEVELS_OF_CONFIDENCE,
+                        UPDATE_IDENTITY);
 
         assertThat(response, hasStatus(302));
         verify(tokenService).generateStorageToken(any(Subject.class));


### PR DESCRIPTION
### Wider context of change

We would like to send the `update_identity` claim to IPV if SIS returns an error with the `record_update_identity` error code. 

### What’s changed

This PR adds a new flag (similar to the `reproveIdentity` flag), which, if true, adds the `update_identity` claim to the IPV authorise request.

I've also tidied up some `any()` arg matchers in the tests

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.
