### PR TITLE
AUT-5681: Update amcStateTableEncryptionKey for build, int and prod

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -483,7 +483,7 @@ Mappings:
       userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/13c5043c-3c9e-4370-bff6-b70c2d8bc609
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
       internationalNumberSendCountTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/29a0ed62-d58d-4361-8f5d-8f2580848d03
-      amcStateTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c8a62e1f-eec6-47c3-b4e3-b7b455b58b75
+      amcStateTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/c8a62e1f-eec6-47c3-b4e3-b7b455b58b75
       frontendApiFMSTagValue: "authfrontendbuild"
       frontendBaseUrl: https://signin.build.account.gov.uk
       internalApiNewInternationalSmsEnabled: false
@@ -634,7 +634,7 @@ Mappings:
       internalApiNewInternationalSmsEnabled: false
       internationalSmsSendingEnabled: true
       idReverificationStateTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/0fd64c49-cd23-4e0b-9061-8c8cf65954d5
-      amcStateTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/0d7dd107-1937-4573-ac38-1abb8f58cc0c
+      amcStateTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/0d7dd107-1937-4573-ac38-1abb8f58cc0c
       IPVApiEnabled: true
       IsSplunkEnabled: "Yes"
       lambdaMaxConcurrency: 10
@@ -708,7 +708,7 @@ Mappings:
       internalApiNewInternationalSmsEnabled: false
       internationalSmsSendingEnabled: true
       idReverificationStateTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/c9ebf851-6ee0-437f-a11c-51e5e01ae38e
-      amcStateTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/102bf244-2608-49f8-94f7-5faffa346c9e
+      amcStateTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/102bf244-2608-49f8-94f7-5faffa346c9e
       IPVApiEnabled: true
       IsSplunkEnabled: "Yes"
       lambdaMaxConcurrency: 10


### PR DESCRIPTION

## What

Update amcStateTableEncryptionKey for build, int and prod

Account numbers in the urn were incorrect

This configuration is not currently in use in integration and production so will have no adverse impact

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

#5320 
#5324 0885c257