### PR TITLE
Bau/errors in finish assertion

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandler.java
@@ -194,11 +194,24 @@ public class FinishPasskeyAssertionHandler
                         .build();
         userActionsManager.incorrectPasskeyReceived(null, permissionContext);
 
-        var metricsDimensions =
-                Map.ofEntries(
-                        Map.entry(ENVIRONMENT.getValue(), configurationService.getEnvironment()),
-                        Map.entry(FAILURE_REASON.getValue(), failureReason.getValue()));
-        cloudwatchMetricsService.incrementCounter(PASSKEY_VERIFICATION_FAILED, metricsDimensions);
+        switch (failureReason) {
+            case ASSERTION_FAILED_ERROR -> {
+                LOG.info("Passkey verification failed due to assertion failure");
+                var metricsDimensions =
+                        Map.ofEntries(
+                                Map.entry(
+                                        ENVIRONMENT.getValue(),
+                                        configurationService.getEnvironment()),
+                                Map.entry(FAILURE_REASON.getValue(), failureReason.getValue()));
+                cloudwatchMetricsService.incrementCounter(
+                        PASSKEY_VERIFICATION_FAILED, metricsDimensions);
+            }
+            case PARSING_PKC_ERROR,
+                    ERROR_UPDATING_PASSKEY_RECORD,
+                    PARSING_ASSERTION_REQUEST_ERROR -> LOG.error(
+                    "Unexpected error when attempting to verify passkey assertion, {}",
+                    failureReason.getValue());
+        }
 
         return null;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -68,8 +68,6 @@ public class PasskeyAssertionService {
         try {
             credential = jsonParser.parsePublicKeyCredential(publicKeyCredentialJson);
         } catch (Exception e) {
-            var failureReason = "Public key credential in request failed to parse";
-            emitAuthPasskeyVerificationFailedEvent(auditContext, failureReason, Optional.empty());
             return Result.failure(FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR);
         }
 
@@ -77,9 +75,6 @@ public class PasskeyAssertionService {
         try {
             assertionRequest = jsonParser.parseAssertionRequest(assertionRequestJson);
         } catch (Exception e) {
-            var failureReason = "Assertion request stored in session failed to parse";
-            emitAuthPasskeyVerificationFailedEvent(
-                    auditContext, failureReason, Optional.of(credential));
             return Result.failure(
                     FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR);
         }
@@ -110,19 +105,6 @@ public class PasskeyAssertionService {
                 auditContext, assertionRequest, assertionResult, credential, publicSubjectId);
 
         return Result.success(assertionResult);
-    }
-
-    private void emitAuthPasskeyVerificationFailedEvent(
-            AuditContext auditContext,
-            String failureReason,
-            Optional<
-                            PublicKeyCredential<
-                                    AuthenticatorAssertionResponse,
-                                    ClientAssertionExtensionOutputs>>
-                    maybePublicKeyCredential) {
-        var passkeyDetail = PasskeyDetail.verificationCouldNotProceed(failureReason);
-        var credentialId = maybePublicKeyCredential.map(c -> c.getId().getBase64Url()).orElse(null);
-        emitVerificationFailedEvent(auditContext, null, credentialId, passkeyDetail);
     }
 
     private void emitAuthPasskeyVerificationFailedEventForAssertionError(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionService.java
@@ -140,9 +140,9 @@ public class PasskeyAssertionService {
                         assertionResult.isBackedUp(),
                         passkeyCredentialDeviceTypeFrom(assertionResult),
                         "Passkey assertion result was not successful");
-        var alllowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
+        var allowedCredentials = passkeyAllowedCredentialsFrom(assertionRequest);
         var credentialId = publicKeyCredential.getId().getBase64Url();
-        emitVerificationFailedEvent(auditContext, alllowedCredentials, credentialId, passkeyDetail);
+        emitVerificationFailedEvent(auditContext, allowedCredentials, credentialId, passkeyDetail);
     }
 
     @SuppressWarnings("deprecation")

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/FinishPasskeyAssertionHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.FinishPasskeyAssertionFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.passkeys.PasskeyUpdateError;
 import uk.gov.di.authentication.frontendapi.services.passkeys.PasskeysService;
@@ -28,6 +28,7 @@ import uk.gov.di.authentication.userpermissions.UserActionsManager;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -320,11 +321,10 @@ class FinishPasskeyAssertionHandlerTest {
             assertThat(response, hasJsonBody(ErrorResponse.PASSKEY_ASSERTION_FAILED));
         }
 
-        @ParameterizedTest
-        @EnumSource(FinishPasskeyAssertionFailureReason.class)
-        void shouldEmitVerificationFailureMetricWhenAssertionFailsForAnyReason(
-                FinishPasskeyAssertionFailureReason failureReason) {
+        @Test
+        void shouldEmitVerificationFailureMetricWhenAssertionFails() {
             // Given
+            var failureReason = FinishPasskeyAssertionFailureReason.ASSERTION_FAILED_ERROR;
             when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
                     .thenReturn(Result.failure(failureReason));
 
@@ -348,6 +348,30 @@ class FinishPasskeyAssertionHandlerTest {
             verify(cloudwatchMetricsService, never())
                     .incrementCounter(eq(PASSKEY_VERIFICATION_SUCCESSFUL), anyMap());
         }
+    }
+
+    private static Stream<FinishPasskeyAssertionFailureReason>
+            unexpectedPasskeyVerificationFailures() {
+        return Stream.of(
+                FinishPasskeyAssertionFailureReason.ERROR_UPDATING_PASSKEY_RECORD,
+                FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR,
+                FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR);
+    }
+
+    @ParameterizedTest
+    @MethodSource("unexpectedPasskeyVerificationFailures")
+    void shouldNotEmitVerificationFailureMetricWhenAssertionFailsForUnexpectedReason(
+            FinishPasskeyAssertionFailureReason failureReason) {
+        // Given
+        when(passkeyAssertionService.finishAssertion(any(), any(), any(), any()))
+                .thenReturn(Result.failure(failureReason));
+
+        // When
+        handler.handleRequest(finishPasskeyAssertionRequest(), context);
+
+        // Then
+        verify(cloudwatchMetricsService, never())
+                .incrementCounter(eq(PASSKEY_VERIFICATION_FAILED), anyMap());
     }
 
     private APIGatewayProxyRequestEvent finishPasskeyAssertionRequest(String body) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/webauthn/PasskeyAssertionServiceTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -210,32 +211,13 @@ class PasskeyAssertionServiceTest {
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.PARSING_ASSERTION_REQUEST_ERROR,
                         actualFailureReason);
-
-                verifyAuditEventEmittedWithName(VERIFICATION_FAILED_EVENT_NAME);
-            }
-
-            @Test
-            void shouldEmitAuditEventWhenAssertionRequestParsingFails()
-                    throws IOException, Base64UrlException {
-                // Given
-                var pkc = setupPublicKeyCredential(CREDENTIAL_ID);
-                when(jsonParser.parsePublicKeyCredential(any())).thenReturn(pkc);
-                when(jsonParser.parseAssertionRequest(any()))
-                        .thenThrow(JsonProcessingException.class);
-
-                // When
-                passkeyAssertionService
-                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
-                        .getFailure();
-
-                // Then
-                var expectedPasskeyDetail =
-                        PasskeyDetail.verificationCouldNotProceed(
-                                "Assertion request stored in session failed to parse");
-                var expectedRestrictedPasskeySection =
-                        new RestrictedPasskeySection(null, CREDENTIAL_ID);
-                verifyVerificationFailedAuditEventEmitted(
-                        expectedPasskeyDetail, expectedRestrictedPasskeySection);
+                verify(structuredAuditService, never())
+                        .submitAuditEvent(
+                                argThat(
+                                        auditEvent ->
+                                                auditEvent
+                                                        .eventName()
+                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
             }
 
             @Test
@@ -254,28 +236,13 @@ class PasskeyAssertionServiceTest {
                 // Then
                 assertEquals(
                         FinishPasskeyAssertionFailureReason.PARSING_PKC_ERROR, actualFailureReason);
-                verifyAuditEventEmittedWithName(VERIFICATION_FAILED_EVENT_NAME);
-            }
-
-            @Test
-            void shouldEmitRelevantAuditEventWhenPKCParsingFails() throws IOException {
-                // Given
-                when(jsonParser.parseAssertionRequest(any()))
-                        .thenReturn(mock(AssertionRequest.class));
-                when(jsonParser.parsePublicKeyCredential(any())).thenThrow(IOException.class);
-
-                // When
-                passkeyAssertionService
-                        .finishAssertion("", "", AUDIT_CONTEXT, TEST_PUBLIC_SUBJECT_ID)
-                        .getFailure();
-
-                // Then
-                var expectedPasskeyDetail =
-                        PasskeyDetail.verificationCouldNotProceed(
-                                "Public key credential in request failed to parse");
-                var expectedRestrictedPasskeySection = new RestrictedPasskeySection(null, null);
-                verifyVerificationFailedAuditEventEmitted(
-                        expectedPasskeyDetail, expectedRestrictedPasskeySection);
+                verify(structuredAuditService, never())
+                        .submitAuditEvent(
+                                argThat(
+                                        auditEvent ->
+                                                auditEvent
+                                                        .eventName()
+                                                        .equals(VERIFICATION_FAILED_EVENT_NAME)));
             }
 
             @Test


### PR DESCRIPTION
Narrow down the scope of things that can trigger the PASSKEY_VERIFICATION_FAILED event and metric to just verification failures, rather than anything that can cause the finish passkey assertion to fail (including unexpected errors).

This is so that our metrics and audit events better reflect things that are actually verification failures.

Also adds some logging.
