### PR TITLE
Bau: stop emitting audit event for technical error

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -143,85 +143,6 @@ public class MFAMethodsCreateHandler
                 () -> mfaMethodsHandler(input, context));
     }
 
-    private Result<APIGatewayProxyResponseEvent, UserProfile>
-            getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
-        var subject = input.getPathParameters().get("publicSubjectId");
-
-        if (subject == null) {
-            LOG.error("Subject missing from request prevents request being handled.");
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(400, REQUEST_MISSING_PARAMS));
-        }
-
-        Optional<UserProfile> maybeUserProfile =
-                dynamoService.getOptionalUserProfileFromPublicSubject(subject);
-        if (maybeUserProfile.isEmpty()) {
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND));
-        }
-
-        UserProfile userProfile = maybeUserProfile.get();
-
-        Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-
-        if (PrincipalValidationHelper.principalIsInvalid(
-                userProfile,
-                configurationService.getInternalSectorUri(),
-                dynamoService,
-                authorizerParams)) {
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(401, ErrorResponse.INVALID_PRINCIPAL));
-        }
-
-        return Result.success(userProfile);
-    }
-
-    private Result<ErrorResponse, MfaMethodCreateRequest> validateRequest(
-            APIGatewayProxyRequestEvent input, UserProfile userProfile, AuditContext auditContext) {
-        MfaMethodCreateRequest mfaMethodCreateRequest = null;
-
-        try {
-            mfaMethodCreateRequest = readMfaMethodCreateRequest(input);
-        } catch (Json.JsonException e) {
-            LOG.error("Invalid request to create an MFA method: ", e);
-            return Result.failure(REQUEST_MISSING_PARAMS);
-        }
-
-        if (mfaMethodCreateRequest.mfaMethod().priorityIdentifier() == PriorityIdentifier.DEFAULT) {
-            LOG.error(DEFAULT_MFA_ALREADY_EXISTS.name());
-            return Result.failure(DEFAULT_MFA_ALREADY_EXISTS);
-        }
-
-        if (mfaMethodCreateRequest.mfaMethod().method()
-                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
-
-            var invalidPhoneNumber =
-                    ValidationHelper.validatePhoneNumber(
-                            requestSmsMfaDetail.phoneNumber(),
-                            PRODUCTION.name(),
-                            false,
-                            configurationService.isAccountManagementInternationalSmsEnabled());
-
-            if (invalidPhoneNumber.isPresent()) {
-                sendAuditEvent(AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
-                return Result.failure(invalidPhoneNumber.get());
-            }
-
-            boolean isValidOtpCode =
-                    codeStorageService.isValidOtpCode(
-                            userProfile.getEmail(),
-                            requestSmsMfaDetail.otp(),
-                            NotificationType.VERIFY_PHONE_NUMBER);
-            if (!isValidOtpCode) {
-                LOG.info("Invalid OTP presented.");
-                sendAuditEvent(AUTH_INVALID_CODE_SENT, auditContext, mfaMethodCreateRequest);
-                return Result.failure(INVALID_OTP);
-            }
-        }
-
-        return Result.success(mfaMethodCreateRequest);
-    }
-
     private APIGatewayProxyResponseEvent mfaMethodsHandler(
             APIGatewayProxyRequestEvent input, Context context) {
 
@@ -340,6 +261,85 @@ public class MFAMethodsCreateHandler
             LOG.error("Failed to build successful response: ", e);
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
+    }
+
+    private Result<APIGatewayProxyResponseEvent, UserProfile>
+            getUserProfileWhenGuardConditionsPassed(APIGatewayProxyRequestEvent input) {
+        var subject = input.getPathParameters().get("publicSubjectId");
+
+        if (subject == null) {
+            LOG.error("Subject missing from request prevents request being handled.");
+            return Result.failure(
+                    generateApiGatewayProxyErrorResponse(400, REQUEST_MISSING_PARAMS));
+        }
+
+        Optional<UserProfile> maybeUserProfile =
+                dynamoService.getOptionalUserProfileFromPublicSubject(subject);
+        if (maybeUserProfile.isEmpty()) {
+            return Result.failure(
+                    generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND));
+        }
+
+        UserProfile userProfile = maybeUserProfile.get();
+
+        Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
+
+        if (PrincipalValidationHelper.principalIsInvalid(
+                userProfile,
+                configurationService.getInternalSectorUri(),
+                dynamoService,
+                authorizerParams)) {
+            return Result.failure(
+                    generateApiGatewayProxyErrorResponse(401, ErrorResponse.INVALID_PRINCIPAL));
+        }
+
+        return Result.success(userProfile);
+    }
+
+    private Result<ErrorResponse, MfaMethodCreateRequest> validateRequest(
+            APIGatewayProxyRequestEvent input, UserProfile userProfile, AuditContext auditContext) {
+        MfaMethodCreateRequest mfaMethodCreateRequest = null;
+
+        try {
+            mfaMethodCreateRequest = readMfaMethodCreateRequest(input);
+        } catch (Json.JsonException e) {
+            LOG.error("Invalid request to create an MFA method: ", e);
+            return Result.failure(REQUEST_MISSING_PARAMS);
+        }
+
+        if (mfaMethodCreateRequest.mfaMethod().priorityIdentifier() == PriorityIdentifier.DEFAULT) {
+            LOG.error(DEFAULT_MFA_ALREADY_EXISTS.name());
+            return Result.failure(DEFAULT_MFA_ALREADY_EXISTS);
+        }
+
+        if (mfaMethodCreateRequest.mfaMethod().method()
+                instanceof RequestSmsMfaDetail requestSmsMfaDetail) {
+
+            var invalidPhoneNumber =
+                    ValidationHelper.validatePhoneNumber(
+                            requestSmsMfaDetail.phoneNumber(),
+                            PRODUCTION.name(),
+                            false,
+                            configurationService.isAccountManagementInternationalSmsEnabled());
+
+            if (invalidPhoneNumber.isPresent()) {
+                sendAuditEvent(AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
+                return Result.failure(invalidPhoneNumber.get());
+            }
+
+            boolean isValidOtpCode =
+                    codeStorageService.isValidOtpCode(
+                            userProfile.getEmail(),
+                            requestSmsMfaDetail.otp(),
+                            NotificationType.VERIFY_PHONE_NUMBER);
+            if (!isValidOtpCode) {
+                LOG.info("Invalid OTP presented.");
+                sendAuditEvent(AUTH_INVALID_CODE_SENT, auditContext, mfaMethodCreateRequest);
+                return Result.failure(INVALID_OTP);
+            }
+        }
+
+        return Result.success(mfaMethodCreateRequest);
     }
 
     private static APIGatewayProxyResponseEvent handleCreateBackupMfaFailure(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -246,12 +246,6 @@ public class MFAMethodsCreateHandler
 
         if (backupMfaMethodAsResponse.isFailure()) {
             LOG.error(backupMfaMethodAsResponse.getFailure());
-            var addFailedAuditStatus =
-                    sendAuditEvent(
-                            AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
-            if (addFailedAuditStatus.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(500, addFailedAuditStatus.getFailure());
-            }
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -207,18 +207,6 @@ public class MFAMethodsCreateHandler
         }
 
         var backupMfaMethod = addBackupMfaResult.getSuccess();
-        var backupMfaMethodAsResponse = MfaMethodResponse.from(backupMfaMethod);
-
-        if (backupMfaMethodAsResponse.isFailure()) {
-            LOG.error(backupMfaMethodAsResponse.getFailure());
-            var addFailedAuditStatus =
-                    sendAuditEvent(
-                            AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
-            if (addFailedAuditStatus.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(500, addFailedAuditStatus.getFailure());
-            }
-            return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
-        }
 
         var auditResult =
                 sendSuccessfulAddEvents(auditContext, mfaMethodCreateRequest, backupMfaMethod);
@@ -253,6 +241,19 @@ public class MFAMethodsCreateHandler
                 ACCOUNT_MANAGEMENT,
                 mfaMethodCreateRequest.mfaMethod().method().mfaMethodType().toString(),
                 PriorityIdentifier.BACKUP);
+
+        var backupMfaMethodAsResponse = MfaMethodResponse.from(backupMfaMethod);
+
+        if (backupMfaMethodAsResponse.isFailure()) {
+            LOG.error(backupMfaMethodAsResponse.getFailure());
+            var addFailedAuditStatus =
+                    sendAuditEvent(
+                            AUTH_MFA_METHOD_ADD_FAILED, auditContext, mfaMethodCreateRequest);
+            if (addFailedAuditStatus.isFailure()) {
+                return generateApiGatewayProxyErrorResponse(500, addFailedAuditStatus.getFailure());
+            }
+            return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
+        }
 
         try {
             return generateApiGatewayProxyResponse(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -829,7 +829,17 @@ class MFAMethodsCreateHandlerTest {
 
             assertThat(result, hasStatus(500));
             assertThat(result, hasJsonBody(ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR));
-            verifyNoInteractions(sqsClient);
+
+            // We still emit add completed here, as we did add a method to the database,
+            // regardless of whether the overall api request returns an error in this case.
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_MFA_METHOD_ADD_COMPLETED,
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
+                            pair("mfa-type", AUTH_APP.toString()),
+                            pair("mfa-method", BACKUP.name().toLowerCase()));
 
             verify(auditService)
                     .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -840,15 +840,6 @@ class MFAMethodsCreateHandlerTest {
                             pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", AUTH_APP.toString()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
-
-            verify(auditService)
-                    .submitAuditEvent(
-                            AUTH_MFA_METHOD_ADD_FAILED,
-                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
-                            AUDIT_EVENT_COMPONENT_ID_HOME,
-                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
-                            pair("mfa-type", AUTH_APP.toString()),
-                            pair("mfa-method", BACKUP.name().toLowerCase()));
         }
 
         @Test


### PR DESCRIPTION
Previously, in the case of a failure to generate a valid mfa response in the mfa create handler, we were emitting the add failed audit event. This is despite:

a) it being a very very unlikely edge case that should never happen in theory (it would only happen if the method we added didn't have a known type, but we already validate this on the request validation so it shouldn't ever happen in practice); and
b) in these cases, we would have actually added the mfa method in the database, and in theory it would be useable, so it's more appropriate to emit the add created event.

This enables us to simplify the code and move the creation of the response closer to where it's used, which reduces the level of complexity in the handler.

It's a step towards making the logic in this handler in general more comprehensible, as currently it's difficult to follow.

## How to review
1. Code review
