### PR TITLE
AUT-5603: Create IAD/ADAPI Account Delete Handler

### DIFF
--- a/account-data-api-integration-tests/build.gradle
+++ b/account-data-api-integration-tests/build.gradle
@@ -44,6 +44,7 @@ test {
     environment "AWS_SECRET_ACCESS_KEY", "mocksecretkey"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "ENVIRONMENT", "local"
+    environment "INTERNAL_SECTOR_URI", "https://test.account.gov.uk"
 
     testLogging {
         showStandardStreams = false

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/AccountDeleteHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/AccountDeleteHandlerIntegrationTest.java
@@ -1,0 +1,100 @@
+package uk.gov.di.accountdata.lambda;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.accountdata.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.accountdata.lambda.AccountDeleteHandler;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
+import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.services.DynamoService;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AccountDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String PUBLIC_SUBJECT_ID_KEY = "publicSubjectId";
+    private static final String TEST_EMAIL = "account-delete-test@example.com";
+    private static final String TEST_PASSWORD = "password-1";
+    private static final Subject TEST_SUBJECT = new Subject();
+
+    private final ConfigurationService configurationService = new ConfigurationService();
+    private final DynamoService dynamoService = new DynamoService(configurationService);
+
+    @BeforeEach
+    void setUp() {
+        handler = new AccountDeleteHandler(configurationService, dynamoService);
+    }
+
+    @Test
+    void shouldReturn204WhenUserExists() {
+        var user =
+                dynamoService.signUp(
+                        TEST_EMAIL,
+                        TEST_PASSWORD,
+                        TEST_SUBJECT,
+                        new TermsAndConditions("1.0", "2024-01-01T00:00:00.000Z"));
+        var publicSubjectId = user.getUserProfile().getPublicSubjectID();
+
+        var result =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of(PUBLIC_SUBJECT_ID_KEY, publicSubjectId),
+                        Collections.emptyMap());
+
+        assertThat(result.getStatusCode(), equalTo(204));
+    }
+
+    @Test
+    void shouldReturn404WhenUserDoesNotExist() {
+        var result =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of(PUBLIC_SUBJECT_ID_KEY, "non-existent-subject-id"),
+                        Collections.emptyMap());
+
+        assertEquals(
+                "{\"code\":1056,\"message\":\"User not found or no match\"}", result.getBody());
+        assertThat(result.getStatusCode(), equalTo(404));
+    }
+
+    @Test
+    void shouldReturn400WhenPublicSubjectIdMissing() {
+        var result =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        assertEquals(
+                "{\"code\":1001,\"message\":\"Request is missing parameters\"}", result.getBody());
+        assertThat(result.getStatusCode(), equalTo(400));
+    }
+
+    @Test
+    void shouldReturn400WhenPublicSubjectIdEmpty() {
+        var result =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of(PUBLIC_SUBJECT_ID_KEY, ""),
+                        Collections.emptyMap());
+
+        assertEquals(
+                "{\"code\":1001,\"message\":\"Request is missing parameters\"}", result.getBody());
+        assertThat(result.getStatusCode(), equalTo(400));
+    }
+}

--- a/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/AccountDeleteHandlerIntegrationTest.java
+++ b/account-data-api-integration-tests/src/test/java/uk/gov/di/accountdata/lambda/AccountDeleteHandlerIntegrationTest.java
@@ -3,10 +3,16 @@ package uk.gov.di.accountdata.lambda;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountdata.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.accountdata.extensions.AuthenticatorExtension;
 import uk.gov.di.authentication.accountdata.lambda.AccountDeleteHandler;
+import uk.gov.di.authentication.accountdata.services.AccountDeleteDynamoService;
 import uk.gov.di.authentication.accountdata.services.ConfigurationService;
+import uk.gov.di.authentication.accountdata.services.DynamoPasskeyService;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.Collections;
@@ -16,6 +22,9 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.accountdata.helpers.PasskeysTestHelper.buildGenericPasskeyForUserWithSubjectId;
 
 class AccountDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -26,14 +35,63 @@ class AccountDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     private final ConfigurationService configurationService = new ConfigurationService();
     private final DynamoService dynamoService = new DynamoService(configurationService);
+    private final DynamoPasskeyService dynamoPasskeyService =
+            new DynamoPasskeyService(configurationService);
+    private final DynamoAccountModifiersService dynamoAccountModifiersService =
+            new DynamoAccountModifiersService(configurationService);
+    private final AccountDeleteDynamoService accountDeleteDynamoService =
+            new AccountDeleteDynamoService(configurationService);
+
+    @RegisterExtension
+    protected static final AuthenticatorExtension authenticatorExtension =
+            new AuthenticatorExtension();
 
     @BeforeEach
     void setUp() {
-        handler = new AccountDeleteHandler(configurationService, dynamoService);
+        handler =
+                new AccountDeleteHandler(
+                        configurationService, dynamoService, accountDeleteDynamoService);
     }
 
     @Test
-    void shouldReturn204WhenUserExists() {
+    void shouldReturn204AndDeleteAllUserData() {
+        var user =
+                dynamoService.signUp(
+                        TEST_EMAIL,
+                        TEST_PASSWORD,
+                        TEST_SUBJECT,
+                        new TermsAndConditions("1.0", "2024-01-01T00:00:00.000Z"));
+        var userProfile = user.getUserProfile();
+        var publicSubjectId = userProfile.getPublicSubjectID();
+        var salt = dynamoService.getOrGenerateSalt(userProfile);
+
+        var internalPairwiseId =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        TEST_SUBJECT.getValue(), "test.account.gov.uk", salt);
+
+        dynamoAccountModifiersService.setAccountRecoveryBlock(internalPairwiseId, true);
+        dynamoPasskeyService.savePasskeyIfUnique(
+                buildGenericPasskeyForUserWithSubjectId(publicSubjectId, "credential-1"));
+        dynamoPasskeyService.savePasskeyIfUnique(
+                buildGenericPasskeyForUserWithSubjectId(publicSubjectId, "credential-2"));
+
+        var result =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of(PUBLIC_SUBJECT_ID_KEY, publicSubjectId),
+                        Collections.emptyMap());
+
+        assertThat(result.getStatusCode(), equalTo(204));
+        assertNull(dynamoService.getUserProfileByEmail(TEST_EMAIL));
+        assertNull(dynamoService.getUserCredentialsFromEmail(TEST_EMAIL));
+        assertTrue(dynamoAccountModifiersService.getAccountModifiers(internalPairwiseId).isEmpty());
+        assertTrue(dynamoPasskeyService.getPasskeysForUser(publicSubjectId).isEmpty());
+    }
+
+    @Test
+    void shouldReturn204WhenNoAccountModifiersOrAuthenticators() {
         var user =
                 dynamoService.signUp(
                         TEST_EMAIL,
@@ -51,6 +109,8 @@ class AccountDeleteHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTe
                         Collections.emptyMap());
 
         assertThat(result.getStatusCode(), equalTo(204));
+        assertNull(dynamoService.getUserProfileByEmail(TEST_EMAIL));
+        assertNull(dynamoService.getUserCredentialsFromEmail(TEST_EMAIL));
     }
 
     @Test

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/AuthenticatorItemKey.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/entity/AuthenticatorItemKey.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.accountdata.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class AuthenticatorItemKey {
+
+    private static final String ATTRIBUTE_PUBLIC_SUBJECT_ID = "PublicSubjectID";
+    private static final String ATTRIBUTE_SORT_KEY = "SK";
+
+    private String publicSubjectId;
+    private String sortKey;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_PUBLIC_SUBJECT_ID)
+    public String getPublicSubjectId() {
+        return publicSubjectId;
+    }
+
+    public void setPublicSubjectId(String publicSubjectId) {
+        this.publicSubjectId = publicSubjectId;
+    }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute(ATTRIBUTE_SORT_KEY)
+    public String getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(String sortKey) {
+        this.sortKey = sortKey;
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandler.java
@@ -7,9 +7,11 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.accountdata.services.AccountDeleteDynamoService;
 import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.Optional;
@@ -24,18 +26,23 @@ public class AccountDeleteHandler
 
     private final ConfigurationService configurationService;
     private final DynamoService dynamoService;
+    private final AccountDeleteDynamoService accountDeleteDynamoService;
 
     private static final Logger LOG = LogManager.getLogger(AccountDeleteHandler.class);
 
     public AccountDeleteHandler(
-            ConfigurationService configurationService, DynamoService dynamoService) {
+            ConfigurationService configurationService,
+            DynamoService dynamoService,
+            AccountDeleteDynamoService accountDeleteDynamoService) {
         this.configurationService = configurationService;
         this.dynamoService = dynamoService;
+        this.accountDeleteDynamoService = accountDeleteDynamoService;
     }
 
     public AccountDeleteHandler() {
         this.configurationService = new ConfigurationService();
         this.dynamoService = new DynamoService(configurationService);
+        this.accountDeleteDynamoService = new AccountDeleteDynamoService(configurationService);
     }
 
     @Override
@@ -62,6 +69,22 @@ public class AccountDeleteHandler
 
         if (maybeUserProfile.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND);
+        }
+        UserProfile userProfile = maybeUserProfile.get();
+
+        try {
+            String internalPairwiseSubject =
+                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                    userProfile,
+                                    configurationService.getInternalSectorUri(),
+                                    dynamoService)
+                            .getValue();
+
+            accountDeleteDynamoService.deleteAccount(
+                    userProfile.getEmail(), internalPairwiseSubject, publicSubjectId);
+        } catch (Exception e) {
+            LOG.error("Failed to delete account", e);
+            return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
         }
 
         return generateEmptySuccessApiGatewayResponse();

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandler.java
@@ -7,16 +7,36 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.DynamoService;
 
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class AccountDeleteHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    private static final String PUBLIC_SUBJECT_ID_KEY = "publicSubjectId";
+
+    private final ConfigurationService configurationService;
+    private final DynamoService dynamoService;
 
     private static final Logger LOG = LogManager.getLogger(AccountDeleteHandler.class);
 
-    public AccountDeleteHandler() {}
+    public AccountDeleteHandler(
+            ConfigurationService configurationService, DynamoService dynamoService) {
+        this.configurationService = configurationService;
+        this.dynamoService = dynamoService;
+    }
+
+    public AccountDeleteHandler() {
+        this.configurationService = new ConfigurationService();
+        this.dynamoService = new DynamoService(configurationService);
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
@@ -30,6 +50,20 @@ public class AccountDeleteHandler
     public APIGatewayProxyResponseEvent accountDeleteHandler(
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("AccountDeleteHandler called");
+
+        String publicSubjectId = input.getPathParameters().get(PUBLIC_SUBJECT_ID_KEY);
+
+        if (publicSubjectId == null || publicSubjectId.isEmpty()) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.REQUEST_MISSING_PARAMS);
+        }
+
+        Optional<UserProfile> maybeUserProfile =
+                dynamoService.getOptionalUserProfileFromPublicSubject(publicSubjectId);
+
+        if (maybeUserProfile.isEmpty()) {
+            return generateApiGatewayProxyErrorResponse(404, ErrorResponse.USER_NOT_FOUND);
+        }
+
         return generateEmptySuccessApiGatewayResponse();
     }
 }

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandler.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandler.java
@@ -1,0 +1,35 @@
+package uk.gov.di.authentication.accountdata.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class AccountDeleteHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(AccountDeleteHandler.class);
+
+    public AccountDeleteHandler() {}
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        ThreadContext.clearMap();
+        return segmentedFunctionCall(
+                "account-data-api::" + getClass().getSimpleName(),
+                () -> accountDeleteHandler(input, context));
+    }
+
+    public APIGatewayProxyResponseEvent accountDeleteHandler(
+            APIGatewayProxyRequestEvent input, Context context) {
+        LOG.info("AccountDeleteHandler called");
+        return generateEmptySuccessApiGatewayResponse();
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/AccountDeleteDynamoService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/AccountDeleteDynamoService.java
@@ -1,0 +1,157 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import uk.gov.di.authentication.accountdata.entity.AuthenticatorItemKey;
+import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
+import uk.gov.di.authentication.shared.entity.AccountModifiers;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.TableNameHelper;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.warmUp;
+
+public class AccountDeleteDynamoService {
+
+    private static final Logger LOG = LogManager.getLogger(AccountDeleteDynamoService.class);
+    private static final int DYNAMO_TRANSACTION_LIMIT = 100;
+    private static final int GUARANTEED_TRANSACTION_ITEMS = 2;
+
+    private static final String USER_PROFILE_TABLE = "user-profile";
+    private static final String USER_CREDENTIALS_TABLE = "user-credentials";
+    private static final String ACCOUNT_MODIFIERS_TABLE = "account-modifiers";
+    private static final String AUTHENTICATOR_TABLE = "authenticator";
+
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final DynamoDbTable<UserProfile> userProfileTable;
+    private final DynamoDbTable<UserCredentials> userCredentialsTable;
+    private final DynamoDbTable<AccountModifiers> accountModifiersTable;
+    private final DynamoDbTable<AuthenticatorItemKey> authenticatorTable;
+
+    public AccountDeleteDynamoService(ConfigurationService configurationService) {
+        this.dynamoDbEnhancedClient =
+                DynamoClientHelper.createDynamoEnhancedClient(configurationService);
+
+        this.userProfileTable =
+                dynamoDbEnhancedClient.table(
+                        TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService),
+                        TableSchema.fromBean(UserProfile.class));
+        this.userCredentialsTable =
+                dynamoDbEnhancedClient.table(
+                        TableNameHelper.getFullTableName(
+                                USER_CREDENTIALS_TABLE, configurationService),
+                        TableSchema.fromBean(UserCredentials.class));
+        this.accountModifiersTable =
+                dynamoDbEnhancedClient.table(
+                        TableNameHelper.getFullTableName(
+                                ACCOUNT_MODIFIERS_TABLE, configurationService),
+                        TableSchema.fromBean(AccountModifiers.class));
+        this.authenticatorTable =
+                dynamoDbEnhancedClient.table(
+                        TableNameHelper.getFullTableName(AUTHENTICATOR_TABLE, configurationService),
+                        TableSchema.fromBean(AuthenticatorItemKey.class));
+
+        warmUp(userProfileTable);
+        warmUp(userCredentialsTable);
+        warmUp(accountModifiersTable);
+        warmUp(authenticatorTable);
+    }
+
+    public AccountDeleteDynamoService(
+            DynamoDbEnhancedClient dynamoDbEnhancedClient,
+            DynamoDbTable<UserProfile> userProfileTable,
+            DynamoDbTable<UserCredentials> userCredentialsTable,
+            DynamoDbTable<AccountModifiers> accountModifiersTable,
+            DynamoDbTable<AuthenticatorItemKey> authenticatorTable) {
+        this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
+        this.userProfileTable = userProfileTable;
+        this.userCredentialsTable = userCredentialsTable;
+        this.accountModifiersTable = accountModifiersTable;
+        this.authenticatorTable = authenticatorTable;
+    }
+
+    public void deleteAccount(String email, String internalSubPairwiseId, String publicSubjectId) {
+        var transactionBuilder =
+                TransactWriteItemsEnhancedRequest.builder()
+                        .addDeleteItem(
+                                userCredentialsTable,
+                                Key.builder()
+                                        .partitionValue(email.toLowerCase(Locale.ROOT))
+                                        .build())
+                        .addDeleteItem(
+                                userProfileTable,
+                                Key.builder()
+                                        .partitionValue(email.toLowerCase(Locale.ROOT))
+                                        .build());
+
+        var accountModifiers =
+                Optional.ofNullable(
+                        accountModifiersTable.getItem(
+                                Key.builder().partitionValue(internalSubPairwiseId).build()));
+
+        accountModifiers.ifPresent(
+                item ->
+                        transactionBuilder.addDeleteItem(
+                                accountModifiersTable,
+                                Key.builder()
+                                        .partitionValue(item.getInternalCommonSubjectIdentifier())
+                                        .build()));
+
+        var authenticatorItems = getAuthenticatorItems(publicSubjectId);
+        int transactionItemCount =
+                GUARANTEED_TRANSACTION_ITEMS + (accountModifiers.isPresent() ? 1 : 0);
+        int availableTransactionCapacity = DYNAMO_TRANSACTION_LIMIT - transactionItemCount;
+
+        if (authenticatorItems.size() <= availableTransactionCapacity) {
+            authenticatorItems.forEach(
+                    item ->
+                            transactionBuilder.addDeleteItem(
+                                    authenticatorTable,
+                                    Key.builder()
+                                            .partitionValue(item.getPublicSubjectId())
+                                            .sortValue(item.getSortKey())
+                                            .build()));
+        } else {
+            LOG.warn(
+                    "User has {} authenticator items which exceeds transaction capacity of {}. "
+                            + "Deleting authenticator items prior to the main account "
+                            + "deletion transaction.",
+                    authenticatorItems.size(),
+                    availableTransactionCapacity);
+            deleteAuthenticatorItemsIndividually(authenticatorItems);
+        }
+
+        dynamoDbEnhancedClient.transactWriteItems(transactionBuilder.build());
+    }
+
+    private List<AuthenticatorItemKey> getAuthenticatorItems(String publicSubjectId) {
+        var queryConditional =
+                QueryConditional.keyEqualTo(Key.builder().partitionValue(publicSubjectId).build());
+        return authenticatorTable
+                .query(QueryEnhancedRequest.builder().queryConditional(queryConditional).build())
+                .items()
+                .stream()
+                .toList();
+    }
+
+    private void deleteAuthenticatorItemsIndividually(List<AuthenticatorItemKey> items) {
+        for (AuthenticatorItemKey item : items) {
+            authenticatorTable.deleteItem(
+                    Key.builder()
+                            .partitionValue(item.getPublicSubjectId())
+                            .sortValue(item.getSortKey())
+                            .build());
+        }
+    }
+}

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
@@ -2,12 +2,13 @@ package uk.gov.di.authentication.accountdata.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 
-public class ConfigurationService {
+public class ConfigurationService implements DynamoConfiguration {
     private static final Logger LOG =
             LogManager.getLogger(
                     uk.gov.di.authentication.shared.services.ConfigurationService.class);

--- a/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
+++ b/account-data-api/src/main/java/uk/gov/di/authentication/accountdata/services/ConfigurationService.java
@@ -53,4 +53,8 @@ public class ConfigurationService implements DynamoConfiguration {
     public String getAuthToAccountDataApiAudience() {
         return System.getenv().getOrDefault("AUTH_TO_ACCOUNT_DATA_API_AUDIENCE", "");
     }
+
+    public String getInternalSectorUri() {
+        return System.getenv().getOrDefault("INTERNAL_SECTOR_URI", "");
+    }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandlerTest.java
@@ -2,23 +2,80 @@ package uk.gov.di.authentication.accountdata.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.accountdata.services.ConfigurationService;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.DynamoService;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AccountDeleteHandlerTest {
+    private static final String TEST_PUBLIC_SUBJECT = new Subject().getValue();
+    private static final UserProfile TEST_USER_PROFILE =
+            new UserProfile().withPublicSubjectID(TEST_PUBLIC_SUBJECT);
+    private static final String PUBLIC_SUBJECT_ID_KEY = "publicSubjectId";
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoService dynamoService = mock(DynamoService.class);
 
     private final Context context = mock(Context.class);
-    private final AccountDeleteHandler handler = new AccountDeleteHandler();
+    private final AccountDeleteHandler handler =
+            new AccountDeleteHandler(configurationService, dynamoService);
 
     @Test
     void shouldReturn204() {
-        var request = new APIGatewayProxyRequestEvent();
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(TEST_USER_PROFILE));
+
+        var request =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters(Map.of(PUBLIC_SUBJECT_ID_KEY, TEST_PUBLIC_SUBJECT));
 
         var result = handler.handleRequest(request, context);
 
         assertThat(result, hasStatus(204));
+    }
+
+    @Test
+    void shouldReturn404WhenUserProfileNotFoundForPublicSubject() {
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.empty());
+
+        var request =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters(Map.of(PUBLIC_SUBJECT_ID_KEY, TEST_PUBLIC_SUBJECT));
+
+        var result = handler.handleRequest(request, context);
+
+        assertEquals(
+                "{\"code\":1056,\"message\":\"User not found or no match\"}", result.getBody());
+        assertThat(result, hasStatus(404));
+    }
+
+    private static Stream<Map<String, String>> invalidPathParameters() {
+        return Stream.of(Map.of("publicSubjectId", ""), Map.of());
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidPathParameters")
+    void shouldReturn400IfPathParameterIsInvalid(Map<String, String> pathParameters) {
+        var request = new APIGatewayProxyRequestEvent().withPathParameters(pathParameters);
+
+        var result = handler.handleRequest(request, context);
+
+        assertEquals(
+                "{\"code\":1001,\"message\":\"Request is missing parameters\"}", result.getBody());
+        assertThat(result, hasStatus(400));
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandlerTest.java
@@ -6,37 +6,63 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.accountdata.services.AccountDeleteDynamoService;
 import uk.gov.di.authentication.accountdata.services.ConfigurationService;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
+import java.net.URI;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AccountDeleteHandlerTest {
     private static final String TEST_PUBLIC_SUBJECT = new Subject().getValue();
-    private static final UserProfile TEST_USER_PROFILE =
-            new UserProfile().withPublicSubjectID(TEST_PUBLIC_SUBJECT);
+    private static final String TEST_INTERNAL_SUBJECT = new Subject().getValue();
+    private static final String TEST_EMAIL = "test@test.com";
     private static final String PUBLIC_SUBJECT_ID_KEY = "publicSubjectId";
+    private static final byte[] TEST_SALT = SaltHelper.generateNewSalt();
+    private static final UserProfile TEST_USER_PROFILE =
+            new UserProfile()
+                    .withEmail(TEST_EMAIL)
+                    .withPublicSubjectID(TEST_PUBLIC_SUBJECT)
+                    .withSubjectID(TEST_INTERNAL_SUBJECT)
+                    .withSalt(ByteBuffer.wrap(TEST_SALT));
+    private static final String TEST_INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private static final String TEST_INTERNAL_PAIRWISE_SUBJECT =
+            ClientSubjectHelper.calculatePairwiseIdentifier(
+                    TEST_INTERNAL_SUBJECT,
+                    URI.create(TEST_INTERNAL_SECTOR_URI).getHost(),
+                    TEST_SALT);
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
+    private final AccountDeleteDynamoService accountDeleteDynamoService =
+            mock(AccountDeleteDynamoService.class);
 
     private final Context context = mock(Context.class);
     private final AccountDeleteHandler handler =
-            new AccountDeleteHandler(configurationService, dynamoService);
+            new AccountDeleteHandler(
+                    configurationService, dynamoService, accountDeleteDynamoService);
 
     @Test
-    void shouldReturn204() {
+    void shouldReturn204AndCallAccountDelete() {
         when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
                 .thenReturn(Optional.of(TEST_USER_PROFILE));
+        when(configurationService.getInternalSectorUri()).thenReturn(TEST_INTERNAL_SECTOR_URI);
+        when(dynamoService.getOrGenerateSalt(TEST_USER_PROFILE)).thenReturn(TEST_SALT);
 
         var request =
                 new APIGatewayProxyRequestEvent()
@@ -44,6 +70,8 @@ class AccountDeleteHandlerTest {
 
         var result = handler.handleRequest(request, context);
 
+        verify(accountDeleteDynamoService)
+                .deleteAccount(TEST_EMAIL, TEST_INTERNAL_PAIRWISE_SUBJECT, TEST_PUBLIC_SUBJECT);
         assertThat(result, hasStatus(204));
     }
 
@@ -77,5 +105,25 @@ class AccountDeleteHandlerTest {
         assertEquals(
                 "{\"code\":1001,\"message\":\"Request is missing parameters\"}", result.getBody());
         assertThat(result, hasStatus(400));
+    }
+
+    @Test
+    void shouldReturn500WhenDeleteAccountThrowsException() {
+        when(dynamoService.getOptionalUserProfileFromPublicSubject(TEST_PUBLIC_SUBJECT))
+                .thenReturn(Optional.of(TEST_USER_PROFILE));
+        when(configurationService.getInternalSectorUri()).thenReturn(TEST_INTERNAL_SECTOR_URI);
+        when(dynamoService.getOrGenerateSalt(TEST_USER_PROFILE)).thenReturn(TEST_SALT);
+        doThrow(new RuntimeException("DynamoDB transaction failed"))
+                .when(accountDeleteDynamoService)
+                .deleteAccount(anyString(), anyString(), anyString());
+
+        var request =
+                new APIGatewayProxyRequestEvent()
+                        .withPathParameters(Map.of(PUBLIC_SUBJECT_ID_KEY, TEST_PUBLIC_SUBJECT));
+
+        var result = handler.handleRequest(request, context);
+
+        assertEquals("{\"code\":5000,\"message\":\"Internal server error\"}", result.getBody());
+        assertThat(result, hasStatus(500));
     }
 }

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandlerTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/lambda/AccountDeleteHandlerTest.java
@@ -1,0 +1,24 @@
+package uk.gov.di.authentication.accountdata.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static uk.gov.di.authentication.accountdata.helpers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AccountDeleteHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final AccountDeleteHandler handler = new AccountDeleteHandler();
+
+    @Test
+    void shouldReturn204() {
+        var request = new APIGatewayProxyRequestEvent();
+
+        var result = handler.handleRequest(request, context);
+
+        assertThat(result, hasStatus(204));
+    }
+}

--- a/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/AccountDeleteDynamoServiceTest.java
+++ b/account-data-api/src/test/java/uk/gov/di/authentication/accountdata/services/AccountDeleteDynamoServiceTest.java
@@ -1,0 +1,146 @@
+package uk.gov.di.authentication.accountdata.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import uk.gov.di.authentication.accountdata.entity.AuthenticatorItemKey;
+import uk.gov.di.authentication.shared.entity.AccountModifiers;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.enhanced.dynamodb.TableSchema.fromBean;
+
+@SuppressWarnings("unchecked")
+class AccountDeleteDynamoServiceTest {
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_INTERNAL_PAIRWISE_ID = "urn:fdc:gov.uk:2022:test-pairwise-id";
+    private static final String TEST_PUBLIC_SUBJECT_ID = "test-public-subject-id";
+
+    private final DynamoDbTable<UserProfile> userProfileTable = mock(DynamoDbTable.class);
+    private final DynamoDbTable<UserCredentials> userCredentialsTable = mock(DynamoDbTable.class);
+    private final DynamoDbTable<AccountModifiers> accountModifiersTable = mock(DynamoDbTable.class);
+    private final DynamoDbTable<AuthenticatorItemKey> authenticatorTable =
+            mock(DynamoDbTable.class);
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient =
+            mock(DynamoDbEnhancedClient.class);
+
+    private final AccountDeleteDynamoService service =
+            new AccountDeleteDynamoService(
+                    dynamoDbEnhancedClient,
+                    userProfileTable,
+                    userCredentialsTable,
+                    accountModifiersTable,
+                    authenticatorTable);
+
+    private final ArgumentCaptor<TransactWriteItemsEnhancedRequest> transactionCaptor =
+            ArgumentCaptor.forClass(TransactWriteItemsEnhancedRequest.class);
+
+    @BeforeEach
+    void setUp() {
+        when(userProfileTable.tableSchema()).thenReturn(fromBean(UserProfile.class));
+        when(userProfileTable.tableName()).thenReturn("test-user-profile");
+        when(userCredentialsTable.tableSchema()).thenReturn(fromBean(UserCredentials.class));
+        when(userCredentialsTable.tableName()).thenReturn("test-user-credentials");
+        when(accountModifiersTable.tableSchema()).thenReturn(fromBean(AccountModifiers.class));
+        when(accountModifiersTable.tableName()).thenReturn("test-account-modifiers");
+        when(authenticatorTable.tableSchema()).thenReturn(fromBean(AuthenticatorItemKey.class));
+        when(authenticatorTable.tableName()).thenReturn("test-authenticator");
+    }
+
+    @Test
+    void shouldIncludeAuthenticatorItemsInTransactionWhenAtExactCapacity() {
+        when(accountModifiersTable.getItem(any(Key.class))).thenReturn(null);
+        mockAuthenticatorQuery(buildAuthenticatorItems(98));
+
+        service.deleteAccount(TEST_EMAIL, TEST_INTERNAL_PAIRWISE_ID, TEST_PUBLIC_SUBJECT_ID);
+
+        verify(dynamoDbEnhancedClient).transactWriteItems(transactionCaptor.capture());
+        assertThat(transactionCaptor.getValue().transactWriteItems().size(), equalTo(100));
+        verify(authenticatorTable, never()).deleteItem(any(Key.class));
+    }
+
+    @Test
+    void shouldDeleteAuthenticatorItemsIndividuallyWhenExceedingCapacity() {
+        when(accountModifiersTable.getItem(any(Key.class))).thenReturn(null);
+        mockAuthenticatorQuery(buildAuthenticatorItems(99));
+
+        service.deleteAccount(TEST_EMAIL, TEST_INTERNAL_PAIRWISE_ID, TEST_PUBLIC_SUBJECT_ID);
+
+        verify(authenticatorTable, times(99)).deleteItem(any(Key.class));
+        verify(dynamoDbEnhancedClient).transactWriteItems(transactionCaptor.capture());
+        assertThat(transactionCaptor.getValue().transactWriteItems().size(), equalTo(2));
+    }
+
+    @Test
+    void shouldReduceAvailableCapacityWhenAccountModifiersPresent() {
+        var accountModifiers =
+                new AccountModifiers()
+                        .withInternalCommonSubjectIdentifier(TEST_INTERNAL_PAIRWISE_ID);
+        when(accountModifiersTable.getItem(any(Key.class))).thenReturn(accountModifiers);
+
+        // 97 items fits: 2 (profile+creds) + 1 (modifiers) + 97 = 100
+        mockAuthenticatorQuery(buildAuthenticatorItems(97));
+
+        service.deleteAccount(TEST_EMAIL, TEST_INTERNAL_PAIRWISE_ID, TEST_PUBLIC_SUBJECT_ID);
+
+        verify(dynamoDbEnhancedClient).transactWriteItems(transactionCaptor.capture());
+        assertThat(transactionCaptor.getValue().transactWriteItems().size(), equalTo(100));
+        verify(authenticatorTable, never()).deleteItem(any(Key.class));
+    }
+
+    @Test
+    void shouldOverflowWhenAccountModifiersPresentAndAuthenticatorItemsExceedReducedCapacity() {
+        var accountModifiers =
+                new AccountModifiers()
+                        .withInternalCommonSubjectIdentifier(TEST_INTERNAL_PAIRWISE_ID);
+        when(accountModifiersTable.getItem(any(Key.class))).thenReturn(accountModifiers);
+
+        // 98 items exceeds: 2 (profile+creds) + 1 (modifiers) + 98 = 101 > 100
+        mockAuthenticatorQuery(buildAuthenticatorItems(98));
+
+        service.deleteAccount(TEST_EMAIL, TEST_INTERNAL_PAIRWISE_ID, TEST_PUBLIC_SUBJECT_ID);
+
+        verify(authenticatorTable, times(98)).deleteItem(any(Key.class));
+        verify(dynamoDbEnhancedClient).transactWriteItems(transactionCaptor.capture());
+        assertThat(transactionCaptor.getValue().transactWriteItems().size(), equalTo(3));
+    }
+
+    private List<AuthenticatorItemKey> buildAuthenticatorItems(int count) {
+        var items = new ArrayList<AuthenticatorItemKey>();
+        for (int i = 0; i < count; i++) {
+            var item = new AuthenticatorItemKey();
+            item.setPublicSubjectId(TEST_PUBLIC_SUBJECT_ID);
+            item.setSortKey("PASSKEY#credential-" + i);
+            items.add(item);
+        }
+        return items;
+    }
+
+    private void mockAuthenticatorQuery(List<AuthenticatorItemKey> items) {
+        PageIterable<AuthenticatorItemKey> pageIterable = mock(PageIterable.class);
+        doReturn(pageIterable).when(authenticatorTable).query(any(QueryEnhancedRequest.class));
+        SdkIterable<AuthenticatorItemKey> itemsIterable = mock(SdkIterable.class);
+        doReturn(itemsIterable).when(pageIterable).items();
+        when(itemsIterable.stream()).thenReturn(items.stream());
+    }
+}

--- a/ci/cloudformation/account-data/function/account-delete.yaml
+++ b/ci/cloudformation/account-data/function/account-delete.yaml
@@ -23,11 +23,24 @@ Resources:
                   !Ref Environment,
                   dataStoreAccountId,
                 ]
+          INTERNAL_SECTOR_URI: !If
+            - IsNotProduction
+            - !If
+              - UseSubEnvironment
+              - !Sub "https://identity.${SubEnvironment}.${Environment}.account.gov.uk"
+              - !Sub "https://identity.${Environment}.account.gov.uk"
+            - "https://identity.account.gov.uk"
       LoggingConfig:
         LogGroup: !Ref AccountDeleteFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserProfileTableReadAccessPolicy
+        - !Ref DynamoUserProfileDeleteAccessPolicy
+        - !Ref DynamoUserCredentialsDeleteAccessPolicy
+        - !Ref DynamoAccountModifiersReadAccessPolicy
+        - !Ref DynamoAccountModifiersDeleteAccessPolicy
+        - !Ref DynamoAuthenticatorTableReadAccessPolicy
+        - !Ref DynamoAuthenticatorTableDeleteAccessPolicy
       SnapStart:
         ApplyOn: PublishedVersions
       VpcConfig:

--- a/ci/cloudformation/account-data/function/account-delete.yaml
+++ b/ci/cloudformation/account-data/function/account-delete.yaml
@@ -1,0 +1,213 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AccountDeleteFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub
+        - ${Env}-account-data-account-delete-lambda
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      AutoPublishAlias: active
+      CodeUri: ./account-data-api/build/distributions/account-data-api.zip
+      Handler: uk.gov.di.authentication.accountdata.lambda.AccountDeleteHandler::handleRequest
+      Environment:
+        Variables:
+          ENVIRONMENT: !Sub
+            - "${env}"
+            - env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      LoggingConfig:
+        LogGroup: !Ref AccountDeleteFunctionLogGroup
+      Policies:
+        - !Ref LambdaBasicExecutionPolicy
+      SnapStart:
+        ApplyOn: PublishedVersions
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+
+  AccountDeleteFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt AccountDeleteFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  AccountDeleteFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref AccountDeleteFunction.Alias
+      Principal: apigateway.amazonaws.com
+
+  AccountDeleteFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - /aws/lambda/${Env}-account-data-account-delete-lambda
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      KmsKeyId: !GetAtt MainKmsKey.Arn
+      RetentionInDays:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          cloudwatchLogRetentionInDays,
+        ]
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-AccountDeleteFunctionLogGroup"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Source
+          Value: govuk-one-login/authentication-api/ci/cloudformation/account-data/function/account-delete.yaml
+
+  AccountDeleteFunctionErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterName: !Sub
+        - ${Env}-account-data-account-delete-errors
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      FilterPattern: '{($.level = "ERROR")}'
+      LogGroupName: !Ref AccountDeleteFunctionLogGroup
+      MetricTransformations:
+        - MetricName: !Sub
+            - ${Env}-account-data-account-delete-error-count
+            - Env:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          MetricNamespace: LambdaErrorsNamespace
+          MetricValue: 1
+
+  AccountDeleteFunctionErrorCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "${AlarmThreshold} or more number of errors have occurred in the ${Env}-account-data-account-delete-lambda function. ${RunbookLink}"
+        - AlarmThreshold:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              lambdaLogAlarmThreshold,
+              DefaultValue: 5,
+            ]
+          Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          RunbookLink:
+            !FindInMap [
+              LambdaConfiguration,
+              "account-delete",
+              RunbookLink,
+              DefaultValue: "",
+            ]
+      AlarmName: !Sub
+        - ${Env}-account-data-account-delete-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub
+        - ${Env}-account-data-account-delete-error-count
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      Namespace: LambdaErrorsNamespace
+      Period: 3600
+      Statistic: Sum
+      Threshold:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          lambdaLogAlarmThreshold,
+          DefaultValue: 5,
+        ]
+
+  AccountDeleteFunctionErrorRateCloudwatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: !If
+        - UseAlarmActions
+        - - !Sub "{{resolve:ssm:/deploy/${Environment}/slack_alert_notification_topic_arn}}"
+        - []
+      AlarmDescription: !Sub
+        - "Lambda error rate of ${ErrorRateThreshold}% has been reached in the ${Env}-account-data-account-delete-lambda. ${RunbookLink}"
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          ErrorRateThreshold:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              lambdaLogAlarmErrorRateThreshold,
+              DefaultValue: 10,
+            ]
+          RunbookLink:
+            !FindInMap [
+              LambdaConfiguration,
+              "account-delete",
+              RunbookLink,
+              DefaultValue: "",
+            ]
+      AlarmName: !Sub
+        - ${Env}-account-data-account-delete-error-rate-alarm
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Metrics:
+        - Id: e1
+          Label: "Error Rate"
+          ReturnData: true
+          Expression: (m2/m1)*100
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub
+                    - ${Env}-account-data-account-delete-lambda
+                    - Env:
+                        !If [
+                          UseSubEnvironment,
+                          !Ref SubEnvironment,
+                          !Ref Environment,
+                        ]
+            Period: 60
+            Stat: Sum
+            Unit: Count
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Errors
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub
+                    - ${Env}-account-data-account-delete-lambda
+                    - Env:
+                        !If [
+                          UseSubEnvironment,
+                          !Ref SubEnvironment,
+                          !Ref Environment,
+                        ]
+            Period: 60
+            Stat: Sum
+            Unit: Count
+      Threshold:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          lambdaLogAlarmErrorRateThreshold,
+          DefaultValue: 10,
+        ]
+
+  AccountDeleteFunctionSubscriptionFilter:
+    Condition: IsSplunkEnabled
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref LoggingSubscriptionEndpointArn
+      FilterPattern: ""
+      LogGroupName: !Ref AccountDeleteFunctionLogGroup

--- a/ci/cloudformation/account-data/function/account-delete.yaml
+++ b/ci/cloudformation/account-data/function/account-delete.yaml
@@ -15,10 +15,19 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          DYNAMO_ARN_PREFIX: !Sub
+            - "arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/"
+            - DataStoreAccountId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dataStoreAccountId,
+                ]
       LoggingConfig:
         LogGroup: !Ref AccountDeleteFunctionLogGroup
       Policies:
         - !Ref LambdaBasicExecutionPolicy
+        - !Ref DynamoUserProfileTableReadAccessPolicy
       SnapStart:
         ApplyOn: PublishedVersions
       VpcConfig:

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -113,18 +113,27 @@ Mappings:
     authdev1:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/d41a1b95-0291-4477-93f7-f1428ceef646
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f7c048d2-6e3c-46a3-b4eb-39fb964bee4f
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5d6c761d-797a-45f7-a3cc-0bd9c10acb28
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/07ded8ad-6627-4827-adc6-5be6b0227b9b
       accountDataJwksUrl: https://5fgwu5kpd2.execute-api.eu-west-2.amazonaws.com/authdev1/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev1.dev.account.gov.uk
       amcClientId: auth
     authdev2:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/88707a9b-53c9-4ad6-ab54-b03b1bf21321
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/7d25305d-ff63-42ed-827b-83141db54866
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/a99e39a4-0a63-4816-b222-6e7c6c318b32
       accountDataJwksUrl: https://nw0dah7bxk.execute-api.eu-west-2.amazonaws.com/authdev2/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev2.dev.account.gov.uk
       amcClientId: auth
     authdev3:
       cloudwatchLogRetentionInDays: 1
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/3a47bbdd-4144-4d1a-959f-56b928fcfe3c
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/9fde06f2-7014-4a13-a57e-7562157bf657
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ce9680d3-953a-4b6a-9098-a0380d0afc70
       accountDataJwksUrl: https://y3s69ubaz5.execute-api.eu-west-2.amazonaws.com/authdev3/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.authdev3.dev.account.gov.uk
       amcClientId: auth
@@ -134,6 +143,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UseAlarmActions: "No"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/c6a2fb5e-c92b-4129-bc0c-d75b2b72bae8
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5e64dd3f-adb6-4a3c-8737-0da6e76b2d95
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4b475855-e71a-43a5-a836-c6cb37e9cb22
       dataStoreAccountId: 653994557586
       accountDataJwksUrl: https://tze402cnbk.execute-api.eu-west-2.amazonaws.com/dev/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.dev.account.gov.uk
@@ -144,6 +156,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UseAlarmActions: "Yes"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/3c2113fe-9f53-4bed-a46f-c53f02f6c117
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/13c5043c-3c9e-4370-bff6-b70c2d8bc609
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/4932c4d3-bf86-4f39-a32c-b82faf9a2574
       dataStoreAccountId: 761723964695
       accountDataJwksUrl: https://7ecg8e1o73.execute-api.eu-west-2.amazonaws.com/build/.well-known/ad-jwks.json
       frontendBaseUrl: https://signin.build.account.gov.uk
@@ -154,6 +169,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UseAlarmActions: "Yes"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/ed6c6a2d-866f-4e2e-9ebd-c499ce9513c6
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/36434b6d-1d77-4cee-af4b-70cf39109e52
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/01f3d1a6-e66f-4eb7-a3d7-412437c8f01d
       dataStoreAccountId: 758531536632
       accountComponentsVpcEndpointId: vpce-04ae8d53b32b38278
       accountDataJwksUrl: https://z02rnzbqw8.execute-api.eu-west-2.amazonaws.com/staging/.well-known/ad-jwks.json
@@ -165,6 +183,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UseAlarmActions: "Yes"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/743b2818-03fd-4414-bfaf-6aa8a4bb4e45
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/2f7fd1cc-c0e1-40f5-a747-2ed29e02427d
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
       dataStoreAccountId: 761723964695
       accountComponentsVpcEndpointId: vpce-0553cfc8fc1aeb970
       accountDataJwksUrl: https://db10ia9pr6.execute-api.eu-west-2.amazonaws.com/integration/.well-known/ad-jwks.json
@@ -176,6 +197,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       UseAlarmActions: "Yes"
       authenticatorTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/b380ea74-d240-4500-b02b-f5c3d414e34e
+      userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
+      userCredentialsTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/7f36e093-d4c1-4b18-8cf3-0c11a59e6d67
+      accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/075774c2-b836-452f-9684-dcd742146f81
       dataStoreAccountId: 172348255554
       accountComponentsVpcEndpointId: vpce-0d6fa47d5c9ae876d
       accountDataJwksUrl: https://86n9innl95.execute-api.eu-west-2.amazonaws.com/production/.well-known/ad-jwks.json
@@ -406,6 +430,25 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
+          - Sid: AllowDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    userProfileTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    userProfileTableEncryptionKey,
+                  ]
           - Sid: AllowReadAccessToUserProfileTable
             Effect: Allow
             Action:
@@ -413,6 +456,7 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:Get*
               - dynamodb:Query
+              - dynamodb:UpdateItem
             Resource:
               - !Sub
                 - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-user-profile
@@ -430,6 +474,204 @@ Resources:
                     ]
               - !Sub
                 - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-user-profile/index/*
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+
+  DynamoUserProfileDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing delete permissions to the Dynamo User Profile table"
+      Path: !Sub
+        - /${Env}/ad/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    userProfileTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    userProfileTableEncryptionKey,
+                  ]
+          - Sid: AllowDeleteAccessToUserProfileTable
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-user-profile
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+
+  DynamoUserCredentialsDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing delete permissions to the Dynamo User Credentials table"
+      Path: !Sub
+        - /${Env}/ad/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    userCredentialsTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    userCredentialsTableEncryptionKey,
+                  ]
+          - Sid: AllowDeleteAccessToUserCredentialsTable
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+              - dynamodb:DescribeTable
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-user-credentials
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+
+  DynamoAccountModifiersReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing read permissions to the Dynamo Account Modifiers table"
+      Path: !Sub
+        - /${Env}/ad/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    accountModifiersTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    accountModifiersTableEncryptionKey,
+                  ]
+          - Sid: AllowReadAccessToAccountModifiersTable
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:GetItem
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-account-modifiers
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+
+  DynamoAccountModifiersDeleteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing delete permissions to the Dynamo Account Modifiers table"
+      Path: !Sub
+        - /${Env}/ad/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowEncryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - !If
+                - UseSubEnvironment
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref SubEnvironment,
+                    accountModifiersTableEncryptionKey,
+                  ]
+                - !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    accountModifiersTableEncryptionKey,
+                  ]
+          - Sid: AllowDeleteAccessToAccountModifiersTable
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-account-modifiers
                 - DataStoreAccountId:
                     !FindInMap [
                       EnvironmentConfiguration,

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -396,6 +396,53 @@ Resources:
         - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       TargetKeyId: !Ref MainKmsKey
 
+  DynamoUserProfileTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "IAM policy for managing read permissions to the Dynamo User Profile table"
+      Path: !Sub
+        - /${Env}/ad/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowReadAccessToUserProfileTable
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+              - dynamodb:Query
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-user-profile
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${Env}-user-profile/index/*
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      dataStoreAccountId,
+                    ]
+                  Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+
   DynamoAuthenticatorTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -182,6 +182,8 @@ Mappings:
       frontendBaseUrl: https://signin.account.gov.uk
       amcClientId: auth
   LambdaConfiguration:
+    account-delete:
+      RunbookLink: "" # TODO: must be populated when runbook is created
     passkeys-create:
       RunbookLink: "https://govukverify.atlassian.net/wiki/x/GICdkgE"
     passkeys-retrieve:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/DynamoConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/DynamoConfiguration.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.shared.configuration;
+
+import java.util.Optional;
+
+public interface DynamoConfiguration extends BaseLambdaConfiguration {
+
+    Optional<String> getDynamoArnPrefix();
+
+    Optional<String> getDynamoEndpointUri();
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
@@ -6,12 +6,12 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 
 import java.net.URI;
 
 public class DynamoClientHelper {
-    public static DynamoDbClient createDynamoClient(ConfigurationService configurationService) {
+    public static DynamoDbClient createDynamoClient(DynamoConfiguration configurationService) {
         var dynamoDbClientBuilder =
                 DynamoDbClient.builder()
                         .credentialsProvider(DefaultCredentialsProvider.builder().build())
@@ -24,7 +24,7 @@ public class DynamoClientHelper {
     }
 
     public static DynamoDbEnhancedClient createDynamoEnhancedClient(
-            ConfigurationService configurationService) {
+            DynamoConfiguration configurationService) {
         var dynamoDbClient = createDynamoClient(configurationService);
         return DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TableNameHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TableNameHelper.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 
 import java.util.Optional;
 
@@ -9,7 +9,7 @@ public class TableNameHelper {
     private TableNameHelper() {}
 
     public static String getFullTableName(
-            String tableName, ConfigurationService configurationService) {
+            String tableName, DynamoConfiguration configurationService) {
         Optional<String> authDynamoArnPrefix = configurationService.getDynamoArnPrefix();
         if (authDynamoArnPrefix.isPresent()) {
             return authDynamoArnPrefix.get()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BaseDynamoService.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 
 import java.util.Optional;
@@ -23,7 +24,7 @@ public class BaseDynamoService<T> {
     private final DynamoDbClient client;
 
     public BaseDynamoService(
-            Class<T> objectClass, String table, ConfigurationService configurationService) {
+            Class<T> objectClass, String table, DynamoConfiguration configurationService) {
         var tableName = TableNameHelper.getFullTableName(table, configurationService);
         client = createDynamoClient(configurationService);
         var enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.ssm.model.Parameter;
 import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
 import uk.gov.di.authentication.shared.exceptions.MissingEnvVariableException;
 
@@ -31,7 +32,8 @@ import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.entity.Environment.INTEGRATION;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
 
-public class ConfigurationService implements BaseLambdaConfiguration, AuditPublisherConfiguration {
+public class ConfigurationService
+        implements BaseLambdaConfiguration, AuditPublisherConfiguration, DynamoConfiguration {
 
     private static final Logger LOG = LogManager.getLogger(ConfigurationService.class);
     public static final String FEATURE_SWITCH_OFF = "false";

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAccountModifiersService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAccountModifiersService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 import uk.gov.di.authentication.shared.entity.AccountModifiers;
 import uk.gov.di.authentication.shared.entity.AccountRecovery;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -8,7 +9,7 @@ import java.util.Optional;
 
 public class DynamoAccountModifiersService extends BaseDynamoService<AccountModifiers> {
 
-    public DynamoAccountModifiersService(ConfigurationService configurationService) {
+    public DynamoAccountModifiersService(DynamoConfiguration configurationService) {
         super(AccountModifiers.class, "account-modifiers", configurationService);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.authentication.shared.configuration.DynamoConfiguration;
 import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -65,7 +66,7 @@ public class DynamoService implements AuthenticationService {
     private static final String TEST_USER_INDEX_NAME = "TestUserIndex";
     private static final Logger LOG = LogManager.getLogger(DynamoService.class);
 
-    public DynamoService(ConfigurationService configurationService) {
+    public DynamoService(DynamoConfiguration configurationService) {
         String userProfileTableName =
                 TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService);
         String userCredentialsTableName =


### PR DESCRIPTION
## What

Creates AccountDeleteHandler and supporting infrastructure to delete:
- User profile
- User credentials
- Account modifiers (if present)
- Authenticators (if present)

API gateway integration is to be created in a subsequent ticket

## How to review

1. Code Review commit-by-commit
2. Test: 
     - Deploy to a dev environment 
     - Create an account with account modifiers and authenticators. I copied existing records in `{env}-account-modifiers` and `{env}-authenticator`, having my internal pairwise subject (calculated using the `export-ics.sh` script in the authentication-api) and publicSubjectId (retrieved from the `user-profile` table) as the partition key respectively for ease
     - Invoke the lambda in the AWS console lambda test area, see all records deleted (note: lambda will exist in new account [`di-authentication-development`], dynamo tables exist in old account [`di-auth-development`])

Test request object:
```
{
  "resource": "/account/{publicSubjectId}",
  "path": "/account/<publicSubjectId>",
  "httpMethod": "DELETE",
  "pathParameters": {
    "publicSubjectId": "<publicSubjectId>"
  },
  "requestContext": {
    "requestId": "test-123",
    "identity": {}
  },
  "headers": {},
  "multiValueHeaders": {},
  "queryStringParameters": null,
  "multiValueQueryStringParameters": null,
  "body": null,
  "isBase64Encoded": false
}
```

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [x] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

