### PR TITLE
Aut 5705: Emit Update auth app event in create handler

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
-import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.mfa.request.MfaMethodCreateRequest;
 import uk.gov.di.authentication.shared.entity.mfa.request.RequestSmsMfaDetail;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
@@ -60,12 +59,14 @@ import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_MFA_TYPE;
 import static uk.gov.di.authentication.shared.domain.AuditableEvent.AUDIT_EVENT_EXTENSIONS_NOTIFICATION_TYPE;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.entity.AuthenticationMethod.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.DEFAULT_MFA_ALREADY_EXISTS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.INVALID_OTP;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.REQUEST_MISSING_PARAMS;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.UNEXPECTED_ACCT_MGMT_ERROR;
 import static uk.gov.di.authentication.shared.entity.JourneyType.ACCOUNT_MANAGEMENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.mfa.MFAMethodType.SMS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -458,39 +459,27 @@ public class MFAMethodsCreateHandler
 
     private Result<APIGatewayProxyResponseEvent, Void> sendSuccessfulAddEvents(
             AuditContext auditContext,
-            MfaMethodCreateRequest mfaMethodCreateRequest,
+            MfaMethodCreateRequest createRequest,
             MFAMethod addedMethod) {
-        var addCompletedResult =
-                sendAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext, mfaMethodCreateRequest);
-
-        if (addCompletedResult.isFailure()) {
-            return Result.failure(
-                    generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure()));
-        }
-
-        if (addedMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            var updatePhoneNumberResult =
-                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, auditContext, mfaMethodCreateRequest);
-
-            if (updatePhoneNumberResult.isFailure()) {
-                return Result.failure(
-                        generateApiGatewayProxyErrorResponse(
-                                500, updatePhoneNumberResult.getFailure()));
-            }
-        }
-
-        if (addedMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.AUTH_APP.name())) {
-            var updateAuthAppResult =
-                    sendAuditEvent(
-                            AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, mfaMethodCreateRequest);
-
-            if (updateAuthAppResult.isFailure()) {
-                return Result.failure(
-                        generateApiGatewayProxyErrorResponse(
-                                500, updateAuthAppResult.getFailure()));
-            }
-        }
-        return Result.emptySuccess();
+        return sendAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext, createRequest)
+                .flatMap(
+                        success -> {
+                            var mfaMethodType = addedMethod.getMfaMethodType();
+                            if (mfaMethodType.equalsIgnoreCase(SMS.name())) {
+                                return sendAuditEvent(
+                                        AUTH_UPDATE_PHONE_NUMBER, auditContext, createRequest);
+                            } else if (mfaMethodType.equalsIgnoreCase(AUTH_APP.name())) {
+                                return sendAuditEvent(
+                                        AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, createRequest);
+                            } else {
+                                LOG.warn(
+                                        "Attempted to send success event for unknown mfa type {}",
+                                        mfaMethodType);
+                                return Result.emptySuccess();
+                            }
+                        })
+                .mapFailure(
+                        errorResponse -> generateApiGatewayProxyErrorResponse(500, errorResponse));
     }
 
     private Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandler.java
@@ -50,6 +50,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR;
 import static uk.gov.di.accountmanagement.helpers.AuditHelper.accountManagementAuditContext;
 import static uk.gov.di.authentication.entity.Environment.PRODUCTION;
@@ -297,21 +298,11 @@ public class MFAMethodsCreateHandler
             return generateApiGatewayProxyErrorResponse(500, UNEXPECTED_ACCT_MGMT_ERROR);
         }
 
-        var addCompletedResult =
-                sendAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext, mfaMethodCreateRequest);
+        var auditResult =
+                sendSuccessfulAddEvents(auditContext, mfaMethodCreateRequest, backupMfaMethod);
 
-        if (addCompletedResult.isFailure()) {
-            return generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure());
-        }
-
-        if (backupMfaMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
-            var updatePhoneNumberResult =
-                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, auditContext, mfaMethodCreateRequest);
-
-            if (updatePhoneNumberResult.isFailure()) {
-                return generateApiGatewayProxyErrorResponse(
-                        500, updatePhoneNumberResult.getFailure());
-            }
+        if (auditResult.isFailure()) {
+            return auditResult.getFailure();
         }
 
         LocaleHelper.SupportedLanguage userLanguage =
@@ -377,7 +368,8 @@ public class MFAMethodsCreateHandler
             case AUTH_MFA_METHOD_ADD_COMPLETED,
                     AUTH_UPDATE_PHONE_NUMBER,
                     AUTH_MFA_METHOD_ADD_FAILED,
-                    AUTH_INVALID_CODE_SENT -> new AuditService.MetadataPair[] {
+                    AUTH_INVALID_CODE_SENT,
+                    AUTH_UPDATE_PROFILE_AUTH_APP -> new AuditService.MetadataPair[] {
                 ACCOUNT_MANAGEMENT_JOURNEY_TYPE_PAIR, mfaTypePair, mfaMethodPair
             };
             case AUTH_CODE_VERIFIED -> {
@@ -462,6 +454,43 @@ public class MFAMethodsCreateHandler
         }
 
         return Result.success(null);
+    }
+
+    private Result<APIGatewayProxyResponseEvent, Void> sendSuccessfulAddEvents(
+            AuditContext auditContext,
+            MfaMethodCreateRequest mfaMethodCreateRequest,
+            MFAMethod addedMethod) {
+        var addCompletedResult =
+                sendAuditEvent(AUTH_MFA_METHOD_ADD_COMPLETED, auditContext, mfaMethodCreateRequest);
+
+        if (addCompletedResult.isFailure()) {
+            return Result.failure(
+                    generateApiGatewayProxyErrorResponse(500, addCompletedResult.getFailure()));
+        }
+
+        if (addedMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.SMS.name())) {
+            var updatePhoneNumberResult =
+                    sendAuditEvent(AUTH_UPDATE_PHONE_NUMBER, auditContext, mfaMethodCreateRequest);
+
+            if (updatePhoneNumberResult.isFailure()) {
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                500, updatePhoneNumberResult.getFailure()));
+            }
+        }
+
+        if (addedMethod.getMfaMethodType().equalsIgnoreCase(MFAMethodType.AUTH_APP.name())) {
+            var updateAuthAppResult =
+                    sendAuditEvent(
+                            AUTH_UPDATE_PROFILE_AUTH_APP, auditContext, mfaMethodCreateRequest);
+
+            if (updateAuthAppResult.isFailure()) {
+                return Result.failure(
+                        generateApiGatewayProxyErrorResponse(
+                                500, updateAuthAppResult.getFailure()));
+            }
+        }
+        return Result.emptySuccess();
     }
 
     private Result<ErrorResponse, Void> sendAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/MFAMethodsCreateHandlerTest.java
@@ -62,12 +62,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.constants.AccountManagementConstants.AUDIT_EVENT_COMPONENT_ID_HOME;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_INVALID_CODE_SENT;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_COMPLETED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.IP_ADDRESS;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.PERSISTENT_ID;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.SESSION_ID;
@@ -315,6 +317,8 @@ class MFAMethodsCreateHandlerTest {
                             pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
                             pair("mfa-type", SMS.name()),
                             pair("mfa-method", BACKUP.name().toLowerCase()));
+
+            verifyNoMoreInteractions(auditService);
         }
 
         @Test
@@ -399,14 +403,28 @@ class MFAMethodsCreateHandlerTest {
             assertEquals(expectedExtensions, authCodeVerifiedEvent.extensions());
             assertEquals(AUDIT_EVENT_COMPONENT_ID_HOME, authCodeVerifiedEvent.componentId());
 
+            var expectedMetadataPairs =
+                    List.of(
+                                    pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
+                                    pair("mfa-type", AUTH_APP.name()),
+                                    pair("mfa-method", BACKUP.name().toLowerCase()))
+                            .toArray(AuditService.MetadataPair[]::new);
+
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_MFA_METHOD_ADD_COMPLETED,
                             BASE_AUDIT_CONTEXT.withPhoneNumber(null),
                             AUDIT_EVENT_COMPONENT_ID_HOME,
-                            pair("journey-type", ACCOUNT_MANAGEMENT.getValue()),
-                            pair("mfa-type", AUTH_APP.name()),
-                            pair("mfa-method", BACKUP.name().toLowerCase()));
+                            expectedMetadataPairs);
+
+            verify(auditService)
+                    .submitAuditEvent(
+                            AUTH_UPDATE_PROFILE_AUTH_APP,
+                            BASE_AUDIT_CONTEXT.withPhoneNumber(null),
+                            AUDIT_EVENT_COMPONENT_ID_HOME,
+                            expectedMetadataPairs);
+
+            verifyNoMoreInteractions(auditService);
         }
 
         @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/MFAMethodsCreateHandlerIntegrationTest.java
@@ -46,6 +46,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_ADD_FAILED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_MFA_METHOD_MIGRATION_ATTEMPTED;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PHONE_NUMBER;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.AUTH_UPDATE_PROFILE_AUTH_APP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.BACKUP_METHOD_ADDED;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_JOURNEY_TYPE;
 import static uk.gov.di.accountmanagement.testsupport.AuditTestConstants.EXTENSIONS_MFA_METHOD;
@@ -373,7 +374,8 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                     List.of(
                             AUTH_CODE_VERIFIED,
                             AUTH_MFA_METHOD_MIGRATION_ATTEMPTED,
-                            AUTH_MFA_METHOD_ADD_COMPLETED);
+                            AUTH_MFA_METHOD_ADD_COMPLETED,
+                            AUTH_UPDATE_PROFILE_AUTH_APP);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 
@@ -392,6 +394,13 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             addCompletedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             addCompletedAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
             eventExpectations.put(AUTH_MFA_METHOD_ADD_COMPLETED.name(), addCompletedAttributes);
+
+            Map<String, String> updateProfileAuthAppAttributes = new HashMap<>();
+            updateProfileAuthAppAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+            updateProfileAuthAppAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
+            updateProfileAuthAppAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
+            eventExpectations.put(
+                    AUTH_UPDATE_PROFILE_AUTH_APP.name(), updateProfileAuthAppAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
         }
@@ -449,7 +458,10 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             assertEquals(expectedResponse, response.getBody());
 
             List<AuditableEvent> expectedEvents =
-                    List.of(AUTH_CODE_VERIFIED, AUTH_MFA_METHOD_ADD_COMPLETED);
+                    List.of(
+                            AUTH_CODE_VERIFIED,
+                            AUTH_MFA_METHOD_ADD_COMPLETED,
+                            AUTH_UPDATE_PROFILE_AUTH_APP);
 
             Map<String, Map<String, String>> eventExpectations = new HashMap<>();
 
@@ -464,6 +476,13 @@ class MFAMethodsCreateHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
             addCompletedAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
             addCompletedAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
             eventExpectations.put(AUTH_MFA_METHOD_ADD_COMPLETED.name(), addCompletedAttributes);
+
+            Map<String, String> updateProfileAuthAppAttributes = new HashMap<>();
+            updateProfileAuthAppAttributes.put(EXTENSIONS_JOURNEY_TYPE, ACCOUNT_MANAGEMENT.name());
+            updateProfileAuthAppAttributes.put(EXTENSIONS_MFA_TYPE, AUTH_APP.name());
+            updateProfileAuthAppAttributes.put(EXTENSIONS_MFA_METHOD, BACKUP.name().toLowerCase());
+            eventExpectations.put(
+                    AUTH_UPDATE_PROFILE_AUTH_APP.name(), updateProfileAuthAppAttributes);
 
             verifyAuditEvents(expectedEvents, eventExpectations);
         }


### PR DESCRIPTION
We don't currently emit the AUTH_UPDATE_PROFILE_AUTH_APP event in the mfa methods create handler when the backup method we're creating is an auth app.

This was missed when implementing the event originally for the new mfa methods api. It is emitted in the put handler, but not the create handler.

## How to review

Code review
