### PR TITLE
AUT-5694: Update IAD tracker item attribute naming

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -13,6 +13,7 @@ public class InactiveAccountTrackerItem {
     private String publicSubjectId;
     private String emailAddress;
     private String emailAddressLastUpdated;
+    private String emailAddressSource = "AUTH_BACKFILL";
     private String userLastActive;
     private String status = "pending";
     private String statusLastUpdated;
@@ -92,6 +93,15 @@ public class InactiveAccountTrackerItem {
     public InactiveAccountTrackerItem withEmailAddressLastUpdated(String emailAddressLastUpdated) {
         this.emailAddressLastUpdated = emailAddressLastUpdated;
         return this;
+    }
+
+    @DynamoDbAttribute("emailAddressSource")
+    public String getEmailAddressSource() {
+        return emailAddressSource;
+    }
+
+    public void setEmailAddressSource(String emailAddressSource) {
+        this.emailAddressSource = emailAddressSource;
     }
 
     @DynamoDbAttribute("status")

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -12,6 +12,7 @@ public class InactiveAccountTrackerItem {
     private String commonSubjectId;
     private String publicSubjectId;
     private String emailAddress;
+    private String emailAddressLastUpdated;
     private String userLastActive;
     private String status = "pending";
     private String statusLastUpdated;
@@ -76,6 +77,20 @@ public class InactiveAccountTrackerItem {
 
     public InactiveAccountTrackerItem withEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
+        return this;
+    }
+
+    @DynamoDbAttribute("emailAddressLastUpdated")
+    public String getEmailAddressLastUpdated() {
+        return emailAddressLastUpdated;
+    }
+
+    public void setEmailAddressLastUpdated(String emailAddressLastUpdated) {
+        this.emailAddressLastUpdated = emailAddressLastUpdated;
+    }
+
+    public InactiveAccountTrackerItem withEmailAddressLastUpdated(String emailAddressLastUpdated) {
+        this.emailAddressLastUpdated = emailAddressLastUpdated;
         return this;
     }
 

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -15,7 +15,7 @@ public class InactiveAccountTrackerItem {
     private String userLastActive;
     private String status = "pending";
     private String statusLastUpdated;
-    private String source = "AUTH_BACKFILL";
+    private String userLastActiveSource = "AUTH_BACKFILL";
     private String sourceId;
 
     public InactiveAccountTrackerItem() {}
@@ -78,20 +78,6 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("userLastActive")
-    public String getUserLastActive() {
-        return userLastActive;
-    }
-
-    public void setUserLastActive(String userLastActive) {
-        this.userLastActive = userLastActive;
-    }
-
-    public InactiveAccountTrackerItem withUserLastActive(String userLastActive) {
-        this.userLastActive = userLastActive;
-        return this;
-    }
-
     @DynamoDbAttribute("status")
     public String getStatus() {
         return status;
@@ -115,13 +101,27 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("source")
-    public String getSource() {
-        return source;
+    @DynamoDbAttribute("userLastActive")
+    public String getUserLastActive() {
+        return userLastActive;
     }
 
-    public void setSource(String source) {
-        this.source = source;
+    public void setUserLastActive(String userLastActive) {
+        this.userLastActive = userLastActive;
+    }
+
+    public InactiveAccountTrackerItem withUserLastActive(String userLastActive) {
+        this.userLastActive = userLastActive;
+        return this;
+    }
+
+    @DynamoDbAttribute("userLastActiveSource")
+    public String getUserLastActiveSource() {
+        return userLastActiveSource;
+    }
+
+    public void setUserLastActiveSource(String userLastActiveSource) {
+        this.userLastActiveSource = userLastActiveSource;
     }
 
     @DynamoDbAttribute("sourceId")

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -17,6 +17,7 @@ public class InactiveAccountTrackerItem {
     private String statusLastUpdated;
     private String userLastActiveSource = "AUTH_BACKFILL";
     private String userLastActiveSourceId;
+    private String userLastActiveUpdated;
 
     public InactiveAccountTrackerItem() {}
 
@@ -135,6 +136,20 @@ public class InactiveAccountTrackerItem {
 
     public InactiveAccountTrackerItem withUserLastActiveSourceId(String userLastActiveSourceId) {
         this.userLastActiveSourceId = userLastActiveSourceId;
+        return this;
+    }
+
+    @DynamoDbAttribute("userLastActiveUpdated")
+    public String getUserLastActiveUpdated() {
+        return userLastActiveUpdated;
+    }
+
+    public void setUserLastActiveUpdated(String userLastActiveUpdated) {
+        this.userLastActiveUpdated = userLastActiveUpdated;
+    }
+
+    public InactiveAccountTrackerItem withUserLastActiveUpdated(String userLastActiveUpdated) {
+        this.userLastActiveUpdated = userLastActiveUpdated;
         return this;
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -21,7 +21,7 @@ public class InactiveAccountTrackerItem {
     public InactiveAccountTrackerItem() {}
 
     @DynamoDbPartitionKey
-    @DynamoDbAttribute("DateForDeletion")
+    @DynamoDbAttribute("dateForDeletion")
     public String getDateForDeletion() {
         return dateForDeletion;
     }
@@ -36,7 +36,7 @@ public class InactiveAccountTrackerItem {
     }
 
     @DynamoDbSortKey
-    @DynamoDbAttribute("CommonSubjectId")
+    @DynamoDbAttribute("commonSubjectId")
     public String getCommonSubjectId() {
         return commonSubjectId;
     }
@@ -50,7 +50,7 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("PublicSubjectId")
+    @DynamoDbAttribute("publicSubjectId")
     public String getPublicSubjectId() {
         return publicSubjectId;
     }
@@ -64,7 +64,7 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("EmailAddress")
+    @DynamoDbAttribute("emailAddress")
     public String getEmailAddress() {
         return emailAddress;
     }
@@ -78,7 +78,7 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("UserLastActive")
+    @DynamoDbAttribute("userLastActive")
     public String getUserLastActive() {
         return userLastActive;
     }
@@ -92,7 +92,7 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("Status")
+    @DynamoDbAttribute("status")
     public String getStatus() {
         return status;
     }
@@ -101,7 +101,7 @@ public class InactiveAccountTrackerItem {
         this.status = status;
     }
 
-    @DynamoDbAttribute("StatusLastUpdated")
+    @DynamoDbAttribute("statusLastUpdated")
     public String getStatusLastUpdated() {
         return statusLastUpdated;
     }
@@ -115,7 +115,7 @@ public class InactiveAccountTrackerItem {
         return this;
     }
 
-    @DynamoDbAttribute("Source")
+    @DynamoDbAttribute("source")
     public String getSource() {
         return source;
     }
@@ -124,7 +124,7 @@ public class InactiveAccountTrackerItem {
         this.source = source;
     }
 
-    @DynamoDbAttribute("SourceId")
+    @DynamoDbAttribute("sourceId")
     public String getSourceId() {
         return sourceId;
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -16,7 +16,7 @@ public class InactiveAccountTrackerItem {
     private String status = "pending";
     private String statusLastUpdated;
     private String userLastActiveSource = "AUTH_BACKFILL";
-    private String sourceId;
+    private String userLastActiveSourceId;
 
     public InactiveAccountTrackerItem() {}
 
@@ -124,17 +124,17 @@ public class InactiveAccountTrackerItem {
         this.userLastActiveSource = userLastActiveSource;
     }
 
-    @DynamoDbAttribute("sourceId")
-    public String getSourceId() {
-        return sourceId;
+    @DynamoDbAttribute("userLastActiveSourceId")
+    public String getUserLastActiveSourceId() {
+        return userLastActiveSourceId;
     }
 
-    public void setSourceId(String sourceId) {
-        this.sourceId = sourceId;
+    public void setUserLastActiveSourceId(String userLastActiveSourceId) {
+        this.userLastActiveSourceId = userLastActiveSourceId;
     }
 
-    public InactiveAccountTrackerItem withSourceId(String sourceId) {
-        this.sourceId = sourceId;
+    public InactiveAccountTrackerItem withUserLastActiveSourceId(String userLastActiveSourceId) {
+        this.userLastActiveSourceId = userLastActiveSourceId;
         return this;
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -14,6 +14,7 @@ public class InactiveAccountTrackerItem {
     private String emailAddress;
     private String emailAddressLastUpdated;
     private String emailAddressSource = "AUTH_BACKFILL";
+    private String emailAddressSourceId = "UserProfile.Email";
     private String userLastActive;
     private String status = "pending";
     private String statusLastUpdated;
@@ -102,6 +103,15 @@ public class InactiveAccountTrackerItem {
 
     public void setEmailAddressSource(String emailAddressSource) {
         this.emailAddressSource = emailAddressSource;
+    }
+
+    @DynamoDbAttribute("emailAddressSourceId")
+    public String getEmailAddressSourceId() {
+        return emailAddressSourceId;
+    }
+
+    public void setEmailAddressSourceId(String emailAddressSourceId) {
+        this.emailAddressSourceId = emailAddressSourceId;
     }
 
     @DynamoDbAttribute("status")

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -165,12 +165,14 @@ public class InactiveAccountDataExportHelper {
         }
 
         var currentTimestamp = NowHelper.toTimestampString(NowHelper.now());
+        String profileUpdated = getStringAttribute(userProfileItem, "Updated");
 
         return new InactiveAccountTrackerItem()
                 .withDateForDeletion(dateForDeletion)
                 .withCommonSubjectId(subjectId)
                 .withPublicSubjectId(publicSubjectId)
                 .withEmailAddress(email)
+                .withEmailAddressLastUpdated(profileUpdated)
                 .withStatusLastUpdated(currentTimestamp)
                 .withUserLastActive(lastActiveTimestamp)
                 .withUserLastActiveSourceId(lastActiveSourceId)

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -153,7 +153,7 @@ public class InactiveAccountDataExportHelper {
         LastActiveDate lastActiveDate =
                 calculateLastActiveDate(userProfileItem, userCredentialsItem);
         String lastActiveTimestamp = lastActiveDate != null ? lastActiveDate.timestamp() : null;
-        String lastActiveSource = lastActiveDate != null ? lastActiveDate.source() : null;
+        String lastActiveSourceId = lastActiveDate != null ? lastActiveDate.source() : null;
 
         String dateForDeletion = calculateDateForDeletion(lastActiveTimestamp);
 
@@ -171,7 +171,7 @@ public class InactiveAccountDataExportHelper {
                 .withEmailAddress(email)
                 .withUserLastActive(lastActiveTimestamp)
                 .withStatusLastUpdated(NowHelper.toTimestampString(NowHelper.now()))
-                .withSourceId(lastActiveSource);
+                .withUserLastActiveSourceId(lastActiveSourceId);
     }
 
     private static String getTermsAndConditionsTimestamp(Map<String, AttributeValue> item) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
@@ -110,10 +111,12 @@ public class InactiveAccountDataExportHelper {
         if (userProfileItem != null) {
             candidates.add(
                     new TimestampCandidate(
-                            getStringAttribute(userProfileItem, "Created"), "UserProfile.Created"));
+                            getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_CREATED),
+                            "UserProfile.Created"));
             candidates.add(
                     new TimestampCandidate(
-                            getStringAttribute(userProfileItem, "Updated"), "UserProfile.Updated"));
+                            getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_UPDATED),
+                            "UserProfile.Updated"));
             candidates.add(
                     new TimestampCandidate(
                             getTermsAndConditionsTimestamp(userProfileItem),
@@ -123,11 +126,13 @@ public class InactiveAccountDataExportHelper {
         if (userCredentialsItem != null) {
             candidates.add(
                     new TimestampCandidate(
-                            getStringAttribute(userCredentialsItem, "Created"),
+                            getStringAttribute(
+                                    userCredentialsItem, UserCredentials.ATTRIBUTE_CREATED),
                             "UserCredentials.Created"));
             candidates.add(
                     new TimestampCandidate(
-                            getStringAttribute(userCredentialsItem, "Updated"),
+                            getStringAttribute(
+                                    userCredentialsItem, UserCredentials.ATTRIBUTE_UPDATED),
                             "UserCredentials.Updated"));
         }
 
@@ -146,9 +151,10 @@ public class InactiveAccountDataExportHelper {
     public static InactiveAccountTrackerItem buildTrackerItem(
             Map<String, AttributeValue> userProfileItem,
             Map<String, AttributeValue> userCredentialsItem) {
-        String subjectId = getStringAttribute(userProfileItem, "SubjectID");
-        String publicSubjectId = getStringAttribute(userProfileItem, "PublicSubjectID");
-        String email = getStringAttribute(userProfileItem, "Email");
+        String subjectId = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_SUBJECT_ID);
+        String publicSubjectId =
+                getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID);
+        String email = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_EMAIL);
 
         LastActiveDate lastActiveDate =
                 calculateLastActiveDate(userProfileItem, userCredentialsItem);
@@ -165,7 +171,7 @@ public class InactiveAccountDataExportHelper {
         }
 
         var currentTimestamp = NowHelper.toTimestampString(NowHelper.now());
-        String profileUpdated = getStringAttribute(userProfileItem, "Updated");
+        String profileUpdated = getStringAttribute(userProfileItem, UserProfile.ATTRIBUTE_UPDATED);
 
         return new InactiveAccountTrackerItem()
                 .withDateForDeletion(dateForDeletion)
@@ -180,7 +186,7 @@ public class InactiveAccountDataExportHelper {
     }
 
     private static String getTermsAndConditionsTimestamp(Map<String, AttributeValue> item) {
-        AttributeValue tcMap = item.get("termsAndConditions");
+        AttributeValue tcMap = item.get(UserProfile.ATTRIBUTE_TERMS_AND_CONDITIONS);
         if (tcMap == null || !tcMap.hasM()) {
             return null;
         }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -164,14 +164,17 @@ public class InactiveAccountDataExportHelper {
             return null;
         }
 
+        var currentTimestamp = NowHelper.toTimestampString(NowHelper.now());
+
         return new InactiveAccountTrackerItem()
                 .withDateForDeletion(dateForDeletion)
                 .withCommonSubjectId(subjectId)
                 .withPublicSubjectId(publicSubjectId)
                 .withEmailAddress(email)
+                .withStatusLastUpdated(currentTimestamp)
                 .withUserLastActive(lastActiveTimestamp)
-                .withStatusLastUpdated(NowHelper.toTimestampString(NowHelper.now()))
-                .withUserLastActiveSourceId(lastActiveSourceId);
+                .withUserLastActiveSourceId(lastActiveSourceId)
+                .withUserLastActiveUpdated(currentTimestamp);
     }
 
     private static String getTermsAndConditionsTimestamp(Map<String, AttributeValue> item) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -152,7 +152,7 @@ class InactiveAccountDataExportHelperTest {
         assertEquals("test@example.com", result.getEmailAddress());
         assertEquals("2021-07-17T10:30:00.123456", result.getUserLastActive());
         assertEquals("pending", result.getStatus());
-        assertEquals("AUTH_BACKFILL", result.getSource());
+        assertEquals("AUTH_BACKFILL", result.getUserLastActiveSource());
         assertEquals("UserProfile.Updated", result.getSourceId());
         assertNotNull(result.getStatusLastUpdated());
     }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -150,6 +150,9 @@ class InactiveAccountDataExportHelperTest {
         assertEquals("subject-123", result.getCommonSubjectId());
         assertEquals("public-456", result.getPublicSubjectId());
         assertEquals("test@example.com", result.getEmailAddress());
+        assertEquals("2021-07-17T10:30:00.123456", result.getEmailAddressLastUpdated());
+        assertEquals("AUTH_BACKFILL", result.getEmailAddressSource());
+        assertEquals("UserProfile.Email", result.getEmailAddressSourceId());
         assertEquals("2021-07-17T10:30:00.123456", result.getUserLastActive());
         assertEquals("pending", result.getStatus());
         assertEquals("AUTH_BACKFILL", result.getUserLastActiveSource());

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -155,6 +155,7 @@ class InactiveAccountDataExportHelperTest {
         assertEquals("AUTH_BACKFILL", result.getUserLastActiveSource());
         assertEquals("UserProfile.Updated", result.getUserLastActiveSourceId());
         assertNotNull(result.getStatusLastUpdated());
+        assertNotNull(result.getUserLastActiveUpdated());
     }
 
     @Test

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 import uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.LastActiveDate;
 
@@ -29,16 +31,22 @@ class InactiveAccountDataExportHelperTest {
     void buildCredentialKeysShouldExtractEmailKeysFromProfileItems() {
         List<Map<String, AttributeValue>> profileItems =
                 List.of(
-                        Map.of("Email", AttributeValue.builder().s("a@example.com").build()),
-                        Map.of("Email", AttributeValue.builder().s("b@example.com").build()),
-                        Map.of("Email", AttributeValue.builder().s("c@example.com").build()));
+                        Map.of(
+                                UserCredentials.ATTRIBUTE_EMAIL,
+                                AttributeValue.builder().s("a@example.com").build()),
+                        Map.of(
+                                UserCredentials.ATTRIBUTE_EMAIL,
+                                AttributeValue.builder().s("b@example.com").build()),
+                        Map.of(
+                                UserCredentials.ATTRIBUTE_EMAIL,
+                                AttributeValue.builder().s("c@example.com").build()));
 
         var keys = buildCredentialKeys(profileItems);
 
         assertEquals(3, keys.size());
-        assertEquals("a@example.com", keys.get(0).get("Email").s());
-        assertEquals("b@example.com", keys.get(1).get("Email").s());
-        assertEquals("c@example.com", keys.get(2).get("Email").s());
+        assertEquals("a@example.com", keys.get(0).get(UserCredentials.ATTRIBUTE_EMAIL).s());
+        assertEquals("b@example.com", keys.get(1).get(UserCredentials.ATTRIBUTE_EMAIL).s());
+        assertEquals("c@example.com", keys.get(2).get(UserCredentials.ATTRIBUTE_EMAIL).s());
     }
 
     @Test
@@ -70,7 +78,8 @@ class InactiveAccountDataExportHelperTest {
                                                 .keys(
                                                         List.of(
                                                                 Map.of(
-                                                                        "Email",
+                                                                        UserCredentials
+                                                                                .ATTRIBUTE_EMAIL,
                                                                         AttributeValue.builder()
                                                                                 .s("x@example.com")
                                                                                 .build())))
@@ -86,8 +95,12 @@ class InactiveAccountDataExportHelperTest {
     void extractUnprocessedKeysShouldReturnKeysWhenPresent() {
         List<Map<String, AttributeValue>> unprocessed =
                 List.of(
-                        Map.of("Email", AttributeValue.builder().s("a@example.com").build()),
-                        Map.of("Email", AttributeValue.builder().s("b@example.com").build()));
+                        Map.of(
+                                UserCredentials.ATTRIBUTE_EMAIL,
+                                AttributeValue.builder().s("a@example.com").build()),
+                        Map.of(
+                                UserCredentials.ATTRIBUTE_EMAIL,
+                                AttributeValue.builder().s("b@example.com").build()));
 
         var response =
                 BatchGetItemResponse.builder()
@@ -132,17 +145,19 @@ class InactiveAccountDataExportHelperTest {
     void buildTrackerItemShouldMapAllFieldsFromUserProfileItem() {
         Map<String, AttributeValue> userProfileItem =
                 Map.of(
-                        "SubjectID",
+                        UserProfile.ATTRIBUTE_SUBJECT_ID,
                         AttributeValue.builder().s("subject-123").build(),
-                        "PublicSubjectID",
+                        UserProfile.ATTRIBUTE_PUBLIC_SUBJECT_ID,
                         AttributeValue.builder().s("public-456").build(),
-                        "Email",
+                        UserProfile.ATTRIBUTE_EMAIL,
                         AttributeValue.builder().s("test@example.com").build(),
-                        "Updated",
+                        UserProfile.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2021-07-17T10:30:00.123456").build());
 
         Map<String, AttributeValue> userCredentialsItem =
-                Map.of("Email", AttributeValue.builder().s("test@example.com").build());
+                Map.of(
+                        UserCredentials.ATTRIBUTE_EMAIL,
+                        AttributeValue.builder().s("test@example.com").build());
 
         InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, userCredentialsItem);
 
@@ -164,7 +179,9 @@ class InactiveAccountDataExportHelperTest {
     @Test
     void buildTrackerItemShouldReturnNullWhenNoTimestampsAvailable() {
         Map<String, AttributeValue> userProfileItem =
-                Map.of("SubjectID", AttributeValue.builder().s("subject-789").build());
+                Map.of(
+                        UserProfile.ATTRIBUTE_SUBJECT_ID,
+                        AttributeValue.builder().s("subject-789").build());
 
         InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
 
@@ -175,11 +192,11 @@ class InactiveAccountDataExportHelperTest {
     void buildTrackerItemShouldSetSourceIdToSubjectId() {
         Map<String, AttributeValue> userProfileItem =
                 Map.of(
-                        "SubjectID",
+                        UserProfile.ATTRIBUTE_SUBJECT_ID,
                         AttributeValue.builder().s("my-subject-id").build(),
-                        "Email",
+                        UserProfile.ATTRIBUTE_EMAIL,
                         AttributeValue.builder().s("user@gov.uk").build(),
-                        "Updated",
+                        UserProfile.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2020-01-01T00:00:00.000000").build());
 
         InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
@@ -192,11 +209,11 @@ class InactiveAccountDataExportHelperTest {
     void calculateLastActiveDateShouldReturnMostRecentAcrossAllAttributes() {
         Map<String, AttributeValue> userProfileItem =
                 Map.of(
-                        "Created",
+                        UserProfile.ATTRIBUTE_CREATED,
                         AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
-                        "Updated",
+                        UserProfile.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2023-05-10T14:30:00.222222").build(),
-                        "termsAndConditions",
+                        UserProfile.ATTRIBUTE_TERMS_AND_CONDITIONS,
                         AttributeValue.builder()
                                 .m(
                                         Map.of(
@@ -208,9 +225,9 @@ class InactiveAccountDataExportHelperTest {
 
         Map<String, AttributeValue> userCredentialsItem =
                 Map.of(
-                        "Created",
+                        UserCredentials.ATTRIBUTE_CREATED,
                         AttributeValue.builder().s("2022-01-01T10:00:00.111111").build(),
-                        "Updated",
+                        UserCredentials.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2024-06-01T08:00:00.333333").build());
 
         LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
@@ -223,16 +240,16 @@ class InactiveAccountDataExportHelperTest {
     void calculateLastActiveDateShouldReturnCredentialsUpdatedWhenMostRecent() {
         Map<String, AttributeValue> userProfileItem =
                 Map.of(
-                        "Created",
+                        UserProfile.ATTRIBUTE_CREATED,
                         AttributeValue.builder().s("2020-01-01T00:00:00.111111").build(),
-                        "Updated",
+                        UserProfile.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2021-06-15T12:00:00.222222").build());
 
         Map<String, AttributeValue> userCredentialsItem =
                 Map.of(
-                        "Created",
+                        UserCredentials.ATTRIBUTE_CREATED,
                         AttributeValue.builder().s("2020-01-01T00:00:00.111111").build(),
-                        "Updated",
+                        UserCredentials.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2025-03-20T16:45:00.552352138").build());
 
         LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
@@ -244,7 +261,9 @@ class InactiveAccountDataExportHelperTest {
     @Test
     void calculateLastActiveDateShouldReturnProfileCreatedWhenOnlyAttributePresent() {
         Map<String, AttributeValue> userProfileItem =
-                Map.of("Created", AttributeValue.builder().s("2023-05-10T14:30:00.123456").build());
+                Map.of(
+                        UserProfile.ATTRIBUTE_CREATED,
+                        AttributeValue.builder().s("2023-05-10T14:30:00.123456").build());
 
         LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
 
@@ -255,7 +274,9 @@ class InactiveAccountDataExportHelperTest {
     @Test
     void calculateLastActiveDateShouldReturnNullWhenNoTimestampAttributesPresent() {
         Map<String, AttributeValue> userProfileItem =
-                Map.of("Email", AttributeValue.builder().s("test@example.com").build());
+                Map.of(
+                        UserProfile.ATTRIBUTE_EMAIL,
+                        AttributeValue.builder().s("test@example.com").build());
 
         LastActiveDate result = calculateLastActiveDate(userProfileItem, null);
 
@@ -273,13 +294,15 @@ class InactiveAccountDataExportHelperTest {
     void calculateLastActiveDateShouldHandleOnlyCredentialsItemProvided() {
         Map<String, AttributeValue> userCredentialsItem =
                 Map.of(
-                        "Created",
+                        UserCredentials.ATTRIBUTE_CREATED,
                         AttributeValue.builder().s("2022-08-01T09:00:00.111111").build(),
-                        "Updated",
+                        UserCredentials.ATTRIBUTE_UPDATED,
                         AttributeValue.builder().s("2023-12-25T18:30:00.654321").build());
 
         Map<String, AttributeValue> userProfileItem =
-                Map.of("Email", AttributeValue.builder().s("test@example.com").build());
+                Map.of(
+                        UserProfile.ATTRIBUTE_EMAIL,
+                        AttributeValue.builder().s("test@example.com").build());
 
         LastActiveDate result = calculateLastActiveDate(userProfileItem, userCredentialsItem);
 

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -153,7 +153,7 @@ class InactiveAccountDataExportHelperTest {
         assertEquals("2021-07-17T10:30:00.123456", result.getUserLastActive());
         assertEquals("pending", result.getStatus());
         assertEquals("AUTH_BACKFILL", result.getUserLastActiveSource());
-        assertEquals("UserProfile.Updated", result.getSourceId());
+        assertEquals("UserProfile.Updated", result.getUserLastActiveSourceId());
         assertNotNull(result.getStatusLastUpdated());
     }
 
@@ -180,7 +180,7 @@ class InactiveAccountDataExportHelperTest {
 
         InactiveAccountTrackerItem result = buildTrackerItem(userProfileItem, null);
 
-        assertEquals("UserProfile.Updated", result.getSourceId());
+        assertEquals("UserProfile.Updated", result.getUserLastActiveSourceId());
         assertEquals("my-subject-id", result.getCommonSubjectId());
     }
 


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The home team have shared a more finalised schema for Inactive Account Deletion (IAD) tracker items ([link](https://github.com/govuk-one-login/di-account-management-backend/compare/bau-new-schema-for-iad?expand=1#diff-c75d4577dfd3917f1ab8a90add5858387bfe15c1b6a840762a830f41d693386d)).

This PR updates the naming around existing attributes, and adds a few other simple attributes now present on the home interface (linked above).

Note that `hasSetupMfa` is out of scope of this ticket and will be covered by AUT-5691.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required) **- N/A**