### PR TITLE
ATO-2800: Create IdentityContextService

### DIFF
--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/CrossBrowserException.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/CrossBrowserException.java
@@ -1,0 +1,15 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
+
+public class CrossBrowserException extends Exception {
+    private final transient CrossBrowserEntity entity;
+
+    public CrossBrowserException(CrossBrowserEntity entity) {
+        this.entity = entity;
+    }
+
+    public CrossBrowserEntity getEntity() {
+        return entity;
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/CrossBrowserNoSessionException.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/CrossBrowserNoSessionException.java
@@ -1,0 +1,9 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
+
+public class CrossBrowserNoSessionException extends CrossBrowserException {
+    public CrossBrowserNoSessionException(CrossBrowserEntity entity) {
+        super(entity);
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/CrossBrowserStateMismatchException.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/CrossBrowserStateMismatchException.java
@@ -1,0 +1,9 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
+
+public class CrossBrowserStateMismatchException extends CrossBrowserException {
+    public CrossBrowserStateMismatchException(CrossBrowserEntity entity) {
+        super(entity);
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityContext.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/entity/IdentityContext.java
@@ -1,0 +1,14 @@
+package uk.gov.di.orchestration.identity.entity;
+
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
+
+public record IdentityContext(
+        OrchSessionItem orchSessionItem,
+        OrchClientSessionItem orchClientSessionItem,
+        ClientRegistry clientRegistry,
+        UserInfo authUserInfo,
+        AuthenticationRequest authRequest) {}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/exceptions/IdentityCallbackException.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/exceptions/IdentityCallbackException.java
@@ -1,6 +1,6 @@
 package uk.gov.di.orchestration.identity.exceptions;
 
-public class IdentityCallbackException extends RuntimeException {
+public class IdentityCallbackException extends Exception {
     public IdentityCallbackException(String message) {
         super(message);
     }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.identity.service;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
+import uk.gov.di.orchestration.identity.entity.CrossBrowserStateMismatchException;
 import uk.gov.di.orchestration.identity.entity.IdentityContext;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
@@ -34,7 +35,9 @@ public class IdentityContextService {
     }
 
     public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
-            throws CrossBrowserNoSessionException, NoSessionException {
+            throws CrossBrowserNoSessionException,
+                    NoSessionException,
+                    CrossBrowserStateMismatchException {
         var sessionCookiesIds = CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
         if (Objects.isNull(sessionCookiesIds)) {
             var noSessionEntity =
@@ -63,6 +66,13 @@ public class IdentityContextService {
                 orchClientSessionService
                         .getClientSession(clientSessionId)
                         .orElseThrow(() -> new NoSessionException("ClientSession not found"));
+
+        var mismatchedEntity =
+                crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
+                        input.getQueryStringParameters(), clientSessionId, orchSession);
+        if (mismatchedEntity.isPresent()) {
+            throw new CrossBrowserStateMismatchException(mismatchedEntity.get());
+        }
         return null;
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -1,0 +1,31 @@
+package uk.gov.di.orchestration.identity.service;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
+import uk.gov.di.orchestration.identity.entity.IdentityContext;
+import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
+import uk.gov.di.orchestration.shared.helpers.CookieHelper;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+
+import java.util.Objects;
+
+public class IdentityContextService {
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
+
+    public IdentityContextService(
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
+        this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
+    }
+
+    public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
+            throws CrossBrowserNoSessionException, NoSessionException {
+        var sessionCookiesIds = CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
+        if (Objects.isNull(sessionCookiesIds)) {
+            var noSessionEntity =
+                    crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
+                            input.getQueryStringParameters());
+            throw new CrossBrowserNoSessionException(noSessionEntity);
+        }
+        return null;
+    }
+}

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -11,6 +11,7 @@ import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
@@ -30,16 +31,19 @@ public class IdentityContextService {
     private final OrchSessionService orchSessionService;
     private final OrchClientSessionService orchClientSessionService;
     private final DynamoClientService clientService;
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService;
 
     public IdentityContextService(
             CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             OrchSessionService orchSessionService,
             OrchClientSessionService orchClientSessionService,
-            DynamoClientService clientService) {
+            DynamoClientService clientService,
+            AuthenticationUserInfoStorageService authUserInfoStorageService) {
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.orchSessionService = orchSessionService;
         this.orchClientSessionService = orchClientSessionService;
         this.clientService = clientService;
+        this.authUserInfoStorageService = authUserInfoStorageService;
     }
 
     public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
@@ -95,6 +99,12 @@ public class IdentityContextService {
                                 () ->
                                         new IdentityCallbackException(
                                                 "Client registry not found with given clientId"));
+
+        var authUserInfo =
+                authUserInfoStorageService
+                        .getAuthenticationUserInfo(
+                                orchSession.getInternalCommonSubjectId(), clientSessionId)
+                        .orElseThrow(() -> new IdentityCallbackException("authUserInfo not found"));
         return null;
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -1,6 +1,8 @@
 package uk.gov.di.orchestration.identity.service;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserStateMismatchException;
 import uk.gov.di.orchestration.identity.entity.IdentityContext;
@@ -14,6 +16,7 @@ import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
 import java.util.Objects;
 
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
@@ -37,7 +40,8 @@ public class IdentityContextService {
     public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
             throws CrossBrowserNoSessionException,
                     NoSessionException,
-                    CrossBrowserStateMismatchException {
+                    CrossBrowserStateMismatchException,
+                    ParseException {
         var sessionCookiesIds = CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
         if (Objects.isNull(sessionCookiesIds)) {
             var noSessionEntity =
@@ -73,6 +77,10 @@ public class IdentityContextService {
         if (mismatchedEntity.isPresent()) {
             throw new CrossBrowserStateMismatchException(mismatchedEntity.get());
         }
+
+        var authRequest = AuthenticationRequest.parse(orchClientSession.getAuthRequestParams());
+        var clientId = authRequest.getClientID().getValue();
+        attachLogFieldToLogs(CLIENT_ID, clientId);
         return null;
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -105,6 +105,7 @@ public class IdentityContextService {
                         .getAuthenticationUserInfo(
                                 orchSession.getInternalCommonSubjectId(), clientSessionId)
                         .orElseThrow(() -> new IdentityCallbackException("authUserInfo not found"));
-        return null;
+        return new IdentityContext(
+                orchSession, orchClientSession, clientRegistry, authUserInfo, authRequest);
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -6,11 +6,13 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserStateMismatchException;
 import uk.gov.di.orchestration.identity.entity.IdentityContext;
+import uk.gov.di.orchestration.identity.exceptions.IdentityCallbackException;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
@@ -27,21 +29,25 @@ public class IdentityContextService {
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final OrchSessionService orchSessionService;
     private final OrchClientSessionService orchClientSessionService;
+    private final DynamoClientService clientService;
 
     public IdentityContextService(
             CrossBrowserOrchestrationService crossBrowserOrchestrationService,
             OrchSessionService orchSessionService,
-            OrchClientSessionService orchClientSessionService) {
+            OrchClientSessionService orchClientSessionService,
+            DynamoClientService clientService) {
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.orchSessionService = orchSessionService;
         this.orchClientSessionService = orchClientSessionService;
+        this.clientService = clientService;
     }
 
     public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
             throws CrossBrowserNoSessionException,
                     NoSessionException,
                     CrossBrowserStateMismatchException,
-                    ParseException {
+                    ParseException,
+                    IdentityCallbackException {
         var sessionCookiesIds = CookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
         if (Objects.isNull(sessionCookiesIds)) {
             var noSessionEntity =
@@ -81,6 +87,14 @@ public class IdentityContextService {
         var authRequest = AuthenticationRequest.parse(orchClientSession.getAuthRequestParams());
         var clientId = authRequest.getClientID().getValue();
         attachLogFieldToLogs(CLIENT_ID, clientId);
+
+        var clientRegistry =
+                clientService
+                        .getClient(clientId)
+                        .orElseThrow(
+                                () ->
+                                        new IdentityCallbackException(
+                                                "Client registry not found with given clientId"));
         return null;
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -6,22 +6,31 @@ import uk.gov.di.orchestration.identity.entity.IdentityContext;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
+import uk.gov.di.orchestration.shared.helpers.PersistentIdHelper;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
 import java.util.Objects;
 
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
 public class IdentityContextService {
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
     private final OrchSessionService orchSessionService;
+    private final OrchClientSessionService orchClientSessionService;
 
     public IdentityContextService(
             CrossBrowserOrchestrationService crossBrowserOrchestrationService,
-            OrchSessionService orchSessionService) {
+            OrchSessionService orchSessionService,
+            OrchClientSessionService orchClientSessionService) {
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
         this.orchSessionService = orchSessionService;
+        this.orchClientSessionService = orchClientSessionService;
     }
 
     public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
@@ -43,6 +52,17 @@ public class IdentityContextService {
                                         new NoSessionException(
                                                 "Orchestration session not found in DynamoDB"));
         attachSessionIdToLogs(sessionId);
+
+        var persistentId =
+                PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
+        attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
+        var clientSessionId = sessionCookiesIds.getClientSessionId();
+        attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+        attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+        var orchClientSession =
+                orchClientSessionService
+                        .getClientSession(clientSessionId)
+                        .orElseThrow(() -> new NoSessionException("ClientSession not found"));
         return null;
     }
 }

--- a/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
+++ b/identity-shared/src/main/java/uk/gov/di/orchestration/identity/service/IdentityContextService.java
@@ -3,18 +3,25 @@ package uk.gov.di.orchestration.identity.service;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
 import uk.gov.di.orchestration.identity.entity.IdentityContext;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.CookieHelper;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
 import java.util.Objects;
 
+import static uk.gov.di.orchestration.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+
 public class IdentityContextService {
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService;
+    private final OrchSessionService orchSessionService;
 
     public IdentityContextService(
-            CrossBrowserOrchestrationService crossBrowserOrchestrationService) {
+            CrossBrowserOrchestrationService crossBrowserOrchestrationService,
+            OrchSessionService orchSessionService) {
         this.crossBrowserOrchestrationService = crossBrowserOrchestrationService;
+        this.orchSessionService = orchSessionService;
     }
 
     public IdentityContext buildContext(APIGatewayProxyRequestEvent input)
@@ -26,6 +33,16 @@ public class IdentityContextService {
                             input.getQueryStringParameters());
             throw new CrossBrowserNoSessionException(noSessionEntity);
         }
+
+        var sessionId = sessionCookiesIds.getSessionId();
+        OrchSessionItem orchSession =
+                orchSessionService
+                        .getSession(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new NoSessionException(
+                                                "Orchestration session not found in DynamoDB"));
+        attachSessionIdToLogs(sessionId);
         return null;
     }
 }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.orchestration.identity.service;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -144,6 +145,15 @@ public class IdentityContextServiceTest {
         assertThrows(CrossBrowserStateMismatchException.class, () -> service.buildContext(request));
     }
 
+    @Test
+    void shouldThrowParseExceptionWhenClientSessionHasInvalidAuthRequestParams() {
+        usingValidSession();
+        usingClientSession(orchClientSession.withAuthRequestParams(Map.of()));
+        var request = createRequestEvent();
+
+        assertThrows(ParseException.class, () -> service.buildContext(request));
+    }
+
     private APIGatewayProxyRequestEvent createRequestEvent() {
         return createRequestEvent(Map.of());
     }
@@ -190,8 +200,12 @@ public class IdentityContextServiceTest {
     }
 
     private void usingValidClientSession() {
+        usingClientSession(orchClientSession);
+    }
+
+    private void usingClientSession(OrchClientSessionItem clientSession) {
         when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(Optional.of(orchClientSession));
+                .thenReturn(Optional.of(clientSession));
     }
 
     private void mockCrossBrowserReturningNoSessionEntity(APIGatewayProxyRequestEvent request)

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
 import java.util.HashMap;
@@ -27,6 +29,8 @@ public class IdentityContextServiceTest {
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
             mock(CrossBrowserOrchestrationService.class);
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
+    private final OrchClientSessionService orchClientSessionService =
+            mock(OrchClientSessionService.class);
 
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
@@ -34,12 +38,22 @@ public class IdentityContextServiceTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String PERSISTENT_SESSION_ID = IdGenerator.generate() + "--1700558480962";
     private static final State STATE = new State();
+    private static final String TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
+            "urn:fdc:gov.uk:2022:0VzHWj9aaJpyHXJX8B5QJ-UOUibweHmkSg1GjF6w9yM";
+
+    private final OrchSessionItem orchSession =
+            new OrchSessionItem("test-session-id")
+                    .withInternalCommonSubjectId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
 
     private IdentityContextService service;
 
     @BeforeEach
     void setup() {
-        service = new IdentityContextService(crossBrowserOrchestrationService, orchSessionService);
+        service =
+                new IdentityContextService(
+                        crossBrowserOrchestrationService,
+                        orchSessionService,
+                        orchClientSessionService);
     }
 
     @Test
@@ -71,6 +85,16 @@ public class IdentityContextServiceTest {
         assertThrows(NoSessionException.class, () -> service.buildContext(request));
     }
 
+    @Test
+    void shouldThrowNoSessionExceptionWhenNoClientSessionFoundWithClientSessionId() {
+        usingValidSession();
+        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.empty());
+        var request = createRequestEvent();
+
+        assertThrows(NoSessionException.class, () -> service.buildContext(request));
+    }
+
     private APIGatewayProxyRequestEvent createRequestEvent() {
         return createRequestEvent(Map.of());
     }
@@ -95,6 +119,10 @@ public class IdentityContextServiceTest {
                 3600,
                 "Secure; HttpOnly;",
                 PERSISTENT_SESSION_ID);
+    }
+
+    private void usingValidSession() {
+        when(orchSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(orchSession));
     }
 
     private void mockCrossBrowserReturningNoSessionEntity(APIGatewayProxyRequestEvent request)

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -18,11 +18,13 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserStateMismatchException;
 import uk.gov.di.orchestration.identity.exceptions.IdentityCallbackException;
+import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.shared.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
@@ -35,6 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,6 +49,8 @@ public class IdentityContextServiceTest {
     private final OrchClientSessionService orchClientSessionService =
             mock(OrchClientSessionService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private final AuthenticationUserInfoStorageService authUserInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
 
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
@@ -73,6 +78,13 @@ public class IdentityContextServiceTest {
                             List.of(),
                             "test-client-name")
                     .withRpPairwiseId(RP_PAIRWISE_SUBJECT);
+    private final ClientRegistry client =
+            new ClientRegistry()
+                    .withClientID(CLIENT_ID.getValue())
+                    .withClientName("test-client")
+                    .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                    .withSectorIdentifierUri("https://test.com")
+                    .withSubjectType("pairwise");
 
     private IdentityContextService service;
 
@@ -83,7 +95,8 @@ public class IdentityContextServiceTest {
                         crossBrowserOrchestrationService,
                         orchSessionService,
                         orchClientSessionService,
-                        dynamoClientService);
+                        dynamoClientService,
+                        authUserInfoStorageService);
     }
 
     @Test
@@ -168,6 +181,19 @@ public class IdentityContextServiceTest {
         assertThrows(IdentityCallbackException.class, () -> service.buildContext(request));
     }
 
+    @Test
+    void shouldThrowIdentityCallbackExceptionWhenAuthUserInfoIsNotFound() throws Exception {
+        usingValidSession();
+        usingValidClientSession();
+        usingValidClient();
+        when(authUserInfoStorageService.getAuthenticationUserInfo(
+                        TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER, CLIENT_SESSION_ID))
+                .thenReturn(Optional.empty());
+
+        var request = createRequestEvent();
+        assertThrows(IdentityCallbackException.class, () -> service.buildContext(request));
+    }
+
     private APIGatewayProxyRequestEvent createRequestEvent() {
         return createRequestEvent(Map.of());
     }
@@ -220,6 +246,10 @@ public class IdentityContextServiceTest {
     private void usingClientSession(OrchClientSessionItem clientSession) {
         when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
+    }
+
+    private void usingValidClient() {
+        when(dynamoClientService.getClient(CLIENT_ID.getValue())).thenReturn(Optional.of(client));
     }
 
     private void mockCrossBrowserReturningNoSessionEntity(APIGatewayProxyRequestEvent request)

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -3,10 +3,19 @@ package uk.gov.di.orchestration.identity.service;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
+import uk.gov.di.orchestration.identity.entity.CrossBrowserStateMismatchException;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
@@ -16,7 +25,9 @@ import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
+import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,12 +49,26 @@ public class IdentityContextServiceTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String PERSISTENT_SESSION_ID = IdGenerator.generate() + "--1700558480962";
     private static final State STATE = new State();
+    private static final URI REDIRECT_URI = URI.create("test-uri");
+    private static final State RP_STATE = new State();
+    private static final ClientID CLIENT_ID = new ClientID("test-client-id");
     private static final String TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER =
             "urn:fdc:gov.uk:2022:0VzHWj9aaJpyHXJX8B5QJ-UOUibweHmkSg1GjF6w9yM";
+    private static final String RP_PAIRWISE_SUBJECT =
+            "urn:fdc:gov.uk:2022:_WJvfEzqmWo6vnDwSqgMPTC-aK8n_fkgZsNF-a4OxxU";
 
     private final OrchSessionItem orchSession =
             new OrchSessionItem("test-session-id")
                     .withInternalCommonSubjectId(TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER);
+    private final AuthenticationRequest authRequest = generateAuthRequest(new OIDCClaimsRequest());
+    private final OrchClientSessionItem orchClientSession =
+            new OrchClientSessionItem(
+                            CLIENT_SESSION_ID,
+                            authRequest.toParameters(),
+                            null,
+                            List.of(),
+                            "test-client-name")
+                    .withRpPairwiseId(RP_PAIRWISE_SUBJECT);
 
     private IdentityContextService service;
 
@@ -95,6 +120,30 @@ public class IdentityContextServiceTest {
         assertThrows(NoSessionException.class, () -> service.buildContext(request));
     }
 
+    @Test
+    void shouldThrowNoSessionExceptionWhenStateParamFieldIsNotPresent() throws Exception {
+        usingValidSession();
+        usingValidClientSession();
+        var request = createRequestEvent();
+        when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
+                        request.getQueryStringParameters(), CLIENT_SESSION_ID, orchSession))
+                .thenThrow(new NoSessionException("test"));
+
+        assertThrows(NoSessionException.class, () -> service.buildContext(request));
+    }
+
+    @Test
+    void
+            shouldThrowCrossBrowserStateMismatchExceptionWhenStateInParamsDoesNotMatchStateFromClientSession()
+                    throws Exception {
+        usingValidSession();
+        usingValidClientSession();
+        var request = createRequestEvent();
+        mockStateMismatch(request);
+
+        assertThrows(CrossBrowserStateMismatchException.class, () -> service.buildContext(request));
+    }
+
     private APIGatewayProxyRequestEvent createRequestEvent() {
         return createRequestEvent(Map.of());
     }
@@ -121,8 +170,28 @@ public class IdentityContextServiceTest {
                 PERSISTENT_SESSION_ID);
     }
 
+    public static AuthenticationRequest generateAuthRequest(OIDCClaimsRequest oidcClaimsRequest) {
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        Scope scope = new Scope();
+        Nonce nonce = new Nonce();
+        scope.add(OIDCScopeValue.OPENID);
+        scope.add("phone");
+        scope.add("email");
+        return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
+                .state(RP_STATE)
+                .nonce(nonce)
+                .claims(oidcClaimsRequest)
+                .responseMode(ResponseMode.QUERY)
+                .build();
+    }
+
     private void usingValidSession() {
         when(orchSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(orchSession));
+    }
+
+    private void usingValidClientSession() {
+        when(orchClientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(orchClientSession));
     }
 
     private void mockCrossBrowserReturningNoSessionEntity(APIGatewayProxyRequestEvent request)
@@ -141,5 +210,16 @@ public class IdentityContextServiceTest {
         when(crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
                         request.getQueryStringParameters()))
                 .thenThrow(new NoSessionException("test"));
+    }
+
+    private void mockStateMismatch(APIGatewayProxyRequestEvent request) throws Exception {
+        var crossBrowserEntity =
+                new CrossBrowserEntity(
+                        "test-csid-2",
+                        new ErrorObject("test-error"),
+                        new OrchClientSessionItem("test-csid-2"));
+        when(crossBrowserOrchestrationService.generateEntityForMismatchInClientSessionId(
+                        request.getQueryStringParameters(), CLIENT_SESSION_ID, orchSession))
+                .thenReturn(Optional.of(crossBrowserEntity));
     }
 }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -17,12 +17,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserStateMismatchException;
+import uk.gov.di.orchestration.identity.exceptions.IdentityCallbackException;
 import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.entity.OrchSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+import uk.gov.di.orchestration.shared.services.DynamoClientService;
 import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
@@ -43,6 +45,7 @@ public class IdentityContextServiceTest {
     private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
     private final OrchClientSessionService orchClientSessionService =
             mock(OrchClientSessionService.class);
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
 
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
@@ -79,7 +82,8 @@ public class IdentityContextServiceTest {
                 new IdentityContextService(
                         crossBrowserOrchestrationService,
                         orchSessionService,
-                        orchClientSessionService);
+                        orchClientSessionService,
+                        dynamoClientService);
     }
 
     @Test
@@ -152,6 +156,16 @@ public class IdentityContextServiceTest {
         var request = createRequestEvent();
 
         assertThrows(ParseException.class, () -> service.buildContext(request));
+    }
+
+    @Test
+    void shouldThrowIdentityCallbackExceptionWhenClientDoesNotExistWithClientId() {
+        usingValidSession();
+        usingValidClientSession();
+        when(dynamoClientService.getClient(CLIENT_ID.getValue())).thenReturn(Optional.empty());
+        var request = createRequestEvent();
+
+        assertThrows(IdentityCallbackException.class, () -> service.buildContext(request));
     }
 
     private APIGatewayProxyRequestEvent createRequestEvent() {

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -9,10 +9,13 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
@@ -38,6 +41,8 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,6 +70,7 @@ public class IdentityContextServiceTest {
             "urn:fdc:gov.uk:2022:0VzHWj9aaJpyHXJX8B5QJ-UOUibweHmkSg1GjF6w9yM";
     private static final String RP_PAIRWISE_SUBJECT =
             "urn:fdc:gov.uk:2022:_WJvfEzqmWo6vnDwSqgMPTC-aK8n_fkgZsNF-a4OxxU";
+    private static final UserInfo AUTH_USER_INFO = generateAuthUserInfo();
 
     private final OrchSessionItem orchSession =
             new OrchSessionItem("test-session-id")
@@ -194,6 +200,23 @@ public class IdentityContextServiceTest {
         assertThrows(IdentityCallbackException.class, () -> service.buildContext(request));
     }
 
+    @Test
+    void shouldReturnIdentityContext() throws Exception {
+        usingValidSession();
+        usingValidClientSession();
+        usingValidClient();
+        usingValidAuthUserInfo();
+
+        var request = createRequestEvent();
+        var result = service.buildContext(request);
+
+        assertThat(result.orchSessionItem(), equalTo(orchSession));
+        assertThat(result.orchClientSessionItem(), equalTo(orchClientSession));
+        assertThat(result.clientRegistry(), equalTo(client));
+        assertThat(result.authUserInfo(), equalTo(AUTH_USER_INFO));
+        assertThat(result.authRequest().toParameters(), equalTo(authRequest.toParameters()));
+    }
+
     private APIGatewayProxyRequestEvent createRequestEvent() {
         return createRequestEvent(Map.of());
     }
@@ -235,6 +258,24 @@ public class IdentityContextServiceTest {
                 .build();
     }
 
+    private static UserInfo generateAuthUserInfo() {
+        return new UserInfo(
+                new JSONObject(
+                        Map.of(
+                                "sub",
+                                TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER,
+                                "client_session_id",
+                                CLIENT_SESSION_ID,
+                                "email",
+                                "test-email-address",
+                                "phone_number",
+                                "012345678902",
+                                "salt",
+                                "TW1jNDhpbUV1TzVra1ZXN050WFZ0eDVoMG1iQ1RmWHNxWGRXdmJSTXpkdz0=",
+                                "local_account_id",
+                                new Subject().getValue())));
+    }
+
     private void usingValidSession() {
         when(orchSessionService.getSession(SESSION_ID)).thenReturn(Optional.of(orchSession));
     }
@@ -250,6 +291,12 @@ public class IdentityContextServiceTest {
 
     private void usingValidClient() {
         when(dynamoClientService.getClient(CLIENT_ID.getValue())).thenReturn(Optional.of(client));
+    }
+
+    private void usingValidAuthUserInfo() throws ParseException {
+        when(authUserInfoStorageService.getAuthenticationUserInfo(
+                        TEST_INTERNAL_COMMON_SUBJECT_IDENTIFIER, CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(AUTH_USER_INFO));
     }
 
     private void mockCrossBrowserReturningNoSessionEntity(APIGatewayProxyRequestEvent request)

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -1,0 +1,106 @@
+package uk.gov.di.orchestration.identity.service;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.orchestration.identity.entity.CrossBrowserNoSessionException;
+import uk.gov.di.orchestration.shared.entity.CrossBrowserEntity;
+import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
+import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IdentityContextServiceTest {
+    private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
+            mock(CrossBrowserOrchestrationService.class);
+
+    private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
+    private static final String COOKIE = "Cookie";
+    private static final String SESSION_ID = "a-session-id";
+    private static final String CLIENT_SESSION_ID = "a-client-session-id";
+    private static final String PERSISTENT_SESSION_ID = IdGenerator.generate() + "--1700558480962";
+    private static final State STATE = new State();
+
+    private IdentityContextService service;
+
+    @BeforeEach
+    void setup() {
+        service = new IdentityContextService(crossBrowserOrchestrationService);
+    }
+
+    @Test
+    void
+            shouldThrowCrossBrowserNoSessionExceptionWhenNoSessionCookiesAreSetAndSessionFoundUsingState()
+                    throws Exception {
+        var request = createRequestEvent();
+        request.setHeaders(Map.of(COOKIE, ""));
+        mockCrossBrowserReturningNoSessionEntity(request);
+
+        assertThrows(CrossBrowserNoSessionException.class, () -> service.buildContext(request));
+    }
+
+    @Test
+    void shouldThrowNoSessionExceptionWhenNoSessionCookiesAreSetAndSessionNotFoundUsingState()
+            throws Exception {
+        var request = createRequestEvent();
+        request.setHeaders(Map.of(COOKIE, ""));
+        mockNoSessionFoundFromState(request);
+
+        assertThrows(NoSessionException.class, () -> service.buildContext(request));
+    }
+
+    private APIGatewayProxyRequestEvent createRequestEvent() {
+        return createRequestEvent(Map.of());
+    }
+
+    private APIGatewayProxyRequestEvent createRequestEvent(Map<String, String> extraParams) {
+        Map<String, String> responseParams = new HashMap<>();
+        responseParams.put("code", AUTH_CODE.getValue());
+        responseParams.put("state", STATE.getValue());
+        responseParams.putAll(extraParams);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setQueryStringParameters(responseParams);
+        event.setHeaders(Map.of(COOKIE, buildCookieString()));
+        return event;
+    }
+
+    private static String buildCookieString() {
+        return format(
+                "%s=%s.%s; Max-Age=%d; %s di-persistent-session-id=%s; Max-Age=34190000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
+                "gs",
+                SESSION_ID,
+                CLIENT_SESSION_ID,
+                3600,
+                "Secure; HttpOnly;",
+                PERSISTENT_SESSION_ID);
+    }
+
+    private void mockCrossBrowserReturningNoSessionEntity(APIGatewayProxyRequestEvent request)
+            throws Exception {
+        var noSessionCrossBrowserEntity =
+                new CrossBrowserEntity(
+                        "test-csid",
+                        new ErrorObject("test-error", "Test Description"),
+                        new OrchClientSessionItem("test-csid"));
+        when(crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
+                        request.getQueryStringParameters()))
+                .thenReturn(noSessionCrossBrowserEntity);
+    }
+
+    private void mockNoSessionFoundFromState(APIGatewayProxyRequestEvent request) throws Exception {
+        when(crossBrowserOrchestrationService.generateNoSessionOrchestrationEntity(
+                        request.getQueryStringParameters()))
+                .thenThrow(new NoSessionException("test"));
+    }
+}

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/service/IdentityContextServiceTest.java
@@ -12,9 +12,11 @@ import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
 import uk.gov.di.orchestration.shared.exceptions.NoSessionException;
 import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 import uk.gov.di.orchestration.shared.services.CrossBrowserOrchestrationService;
+import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,6 +26,7 @@ import static org.mockito.Mockito.when;
 public class IdentityContextServiceTest {
     private final CrossBrowserOrchestrationService crossBrowserOrchestrationService =
             mock(CrossBrowserOrchestrationService.class);
+    private final OrchSessionService orchSessionService = mock(OrchSessionService.class);
 
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
@@ -36,7 +39,7 @@ public class IdentityContextServiceTest {
 
     @BeforeEach
     void setup() {
-        service = new IdentityContextService(crossBrowserOrchestrationService);
+        service = new IdentityContextService(crossBrowserOrchestrationService, orchSessionService);
     }
 
     @Test
@@ -56,6 +59,14 @@ public class IdentityContextServiceTest {
         var request = createRequestEvent();
         request.setHeaders(Map.of(COOKIE, ""));
         mockNoSessionFoundFromState(request);
+
+        assertThrows(NoSessionException.class, () -> service.buildContext(request));
+    }
+
+    @Test
+    void shouldThrowNoSessionExceptionWhenNoSessionFoundWithSessionId() {
+        when(orchSessionService.getSession(SESSION_ID)).thenReturn(Optional.empty());
+        var request = createRequestEvent();
 
         assertThrows(NoSessionException.class, () -> service.buildContext(request));
     }

--- a/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtilsTest.java
+++ b/identity-shared/src/test/java/uk/gov/di/orchestration/identity/utils/IdentityCallbackUtilsTest.java
@@ -121,7 +121,8 @@ class IdentityCallbackUtilsTest {
     class ValidateUserIdentityResponse {
 
         @Test
-        void shouldReturnAccessDeniedIfVotIsNotContainedInRequestedLoCs() {
+        void shouldReturnAccessDeniedIfVotIsNotContainedInRequestedLoCs()
+                throws IdentityCallbackException {
             var userInfo = new UserInfo(SUBJECT);
             userInfo.setClaim("vot", LevelOfConfidence.MEDIUM_LEVEL.getValue());
 
@@ -149,7 +150,8 @@ class IdentityCallbackUtilsTest {
         }
 
         @Test
-        void shouldNotReturnErrorIfVotIsInRequestedLoCsAndVtmMatchesTrustmarkUrl() {
+        void shouldNotReturnErrorIfVotIsInRequestedLoCsAndVtmMatchesTrustmarkUrl()
+                throws IdentityCallbackException {
             var userInfo = new UserInfo(SUBJECT);
             userInfo.setClaim("vot", LevelOfConfidence.MEDIUM_LEVEL.getValue());
             userInfo.setClaim("vtm", TRUSTMARK_URL);


### PR DESCRIPTION
### Wider context of change

There was a lot of setup code in the IPVCallbackHandler which was just fetching data ready to be used by the handler. Moving this setup code into its own service would not only make it easier to test but also make it shared with SISCallbackHandler in the future.

### What’s changed

This PR creates a service which builds an `IdentityContext`. This new context record contains all the information that the IPVCallbackHandler needs to process a journey. 


### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
- [x] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

