### PR TITLE
BAU: Ignore deprecated java17 linting check

### DIFF
--- a/ci/cloudformation/account-data/parent.yaml
+++ b/ci/cloudformation/account-data/parent.yaml
@@ -12,6 +12,7 @@ Metadata:
         - E1011
         - W8001
         - W2531
+        - E2531
 
 Description: >
   SAM template for deploying account-data-api

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -12,6 +12,7 @@ Metadata:
         - E1011
         - W8001
         - W2531
+        - E2531
 
 Description: >
   SAM template for deploying account-management API

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -11,6 +11,7 @@ Metadata:
         - W8003
         - E1011
         - W2531
+        - E2531
 
 Description: >
   SAM template for deploying auth-external-api and auth-internal-api

--- a/ci/cloudformation/stubs/parent.yaml
+++ b/ci/cloudformation/stubs/parent.yaml
@@ -12,6 +12,7 @@ Metadata:
         - E1011
         - W8001
         - W2531
+        - E2531
 
 Description: >
   SAM template for deploying Auth Ticf Stub  and Account-Interventions stub Api

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -11,6 +11,7 @@ Metadata:
         - W8003
         - E1011
         - W2531
+        - E2531
 
 Description: >
   SAM template for deploying utility Lambda functions and supporting infrastructure


### PR DESCRIPTION
## What

- As of 30/07/2026 AWS has marked the java17 runtime as deprecated
- The check is blocking deployment, so adding to ignore_checks for now
- Will remove from ignore_checks after upgrading java

## How to review

1. Code Review
2. See deployment now succeeds: https://github.com/govuk-one-login/authentication-api/actions/runs/30792442403/job/91618651987


## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Assessed the impact on active user sessions and confirmed no breaking changes

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Orch and Auth mutual dependencies have been checked for breaking changes

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] Stub-orchestration has been updated (or no changes required)

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed (or no review required)

<!-- Pairing
We want to make sure ensemble commits are correctly attributed to the contributors, so everyone who is not the committer should have a separate `Co-authored-by` line in the trailer of the commit.

See this page for more information: https://gds-way.digital.cabinet-office.gov.uk/standards/pair-programming.html#pair-programming-and-version-control
-->

- [ ] Co-authors have been attributed in commits (using one or more `Co-authored-by` lines) where pairing or mobbing has taken place (or none required)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
