### PR TITLE
AUT-5661: Enable enhanced auth code protection in all environments

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -526,7 +526,7 @@ Mappings:
       amcJourneyOutcomeUri: https://amcstub.signin.build.account.gov.uk/journeyoutcome
       amcClientId: auth
       accountDataApiId: ac3znt5m23
-      enhancedAuthCodeProtectionEnabled: false
+      enhancedAuthCodeProtectionEnabled: true
       supportPasskeys: false
       amcCreatePasskeyRedirectUri: https://signin.build.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"
@@ -600,7 +600,7 @@ Mappings:
       amcJourneyOutcomeUri: https://2hdyiuvtug.execute-api.eu-west-2.amazonaws.com/v1/journeyoutcome
       amcClientId: auth
       accountDataApiId: 7xgl7lexy4
-      enhancedAuthCodeProtectionEnabled: false
+      enhancedAuthCodeProtectionEnabled: true
       supportPasskeys: true
       amcCreatePasskeyRedirectUri: https://signin.staging.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "true"
@@ -674,7 +674,7 @@ Mappings:
       amcJourneyOutcomeUri: https://votf1tvl36.execute-api.eu-west-2.amazonaws.com/v1/journeyoutcome
       amcClientId: auth
       accountDataApiId: hoidt6wujb
-      enhancedAuthCodeProtectionEnabled: false
+      enhancedAuthCodeProtectionEnabled: true
       supportPasskeys: false
       amcCreatePasskeyRedirectUri: https://signin.integration.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"
@@ -748,7 +748,7 @@ Mappings:
       amcJourneyOutcomeUri: https://h06vqhfzgi.execute-api.eu-west-2.amazonaws.com/v1/journeyoutcome
       amcClientId: auth
       accountDataApiId: 0218o1p9tj
-      enhancedAuthCodeProtectionEnabled: false
+      enhancedAuthCodeProtectionEnabled: true
       supportPasskeys: false
       amcCreatePasskeyRedirectUri: https://signin.account.gov.uk/create-passkey-callback
       bulkEmailSendingEnabled: "false"


### PR DESCRIPTION
This adds additional protection into the auth estate, by ensuring that the backend cannot issue an auth code when it hasn't recorded sufficient user actions.