### PR TITLE
Bau: Add more projects to ignore-paths

### DIFF
--- a/.github/workflows/deploy-api-account-data-sp.yml
+++ b/.github/workflows/deploy-api-account-data-sp.yml
@@ -27,6 +27,17 @@ on:
       - "ticf-cri-stub/**"
       - "interventions-api-stub/**"
       - "sis-api/**"
+      - "orchestration-*/**"
+      - "doc-checking-app-api/**"
+      - "delivery-receipts-api/**"
+      - "client-registry-api/**"
+      - "auth-external-api/**"
+      - "account-data-api-integration-tests/**"
+      - "oidc-api-integration-tests/**"
+      - "ipv-api-integration-tests/**"
+      - "identity-shared/**"
+      - "http/**"
+      - "user-permissions/**"
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/deploy-api-account-management-sp.yml
+++ b/.github/workflows/deploy-api-account-management-sp.yml
@@ -27,6 +27,16 @@ on:
       - "ticf-cri-stub/**"
       - "interventions-api-stub/**"
       - "sis-api/**"
+      - "orchestration-*/**"
+      - "doc-checking-app-api/**"
+      - "delivery-receipts-api/**"
+      - "client-registry-api/**"
+      - "auth-external-api/**"
+      - "oidc-api-integration-tests/**"
+      - "ipv-api-integration-tests/**"
+      - "identity-shared/**"
+      - "http/**"
+      - "tools/**"
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/deploy-api-auth-sp.yml
+++ b/.github/workflows/deploy-api-auth-sp.yml
@@ -26,6 +26,14 @@ on:
       - "ticf-cri-stub/**"
       - "interventions-api-stub/**"
       - "oidc-api/**"
+      - "orchestration-*/**"
+      - "doc-checking-app-api/**"
+      - "client-registry-api/**"
+      - "oidc-api-integration-tests/**"
+      - "ipv-api-integration-tests/**"
+      - "identity-shared/**"
+      - "http/**"
+      - "tools/**"
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/deploy-api-stubs-sp.yml
+++ b/.github/workflows/deploy-api-stubs-sp.yml
@@ -27,6 +27,16 @@ on:
       - "ipv-api/**"
       - "oidc-api/**"
       - "sis-api/**"
+      - "orchestration-*/**"
+      - "doc-checking-app-api/**"
+      - "delivery-receipts-api/**"
+      - "client-registry-api/**"
+      - "auth-external-api/**"
+      - "oidc-api-integration-tests/**"
+      - "ipv-api-integration-tests/**"
+      - "identity-shared/**"
+      - "http/**"
+      - "tools/**"
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/deploy-api-utils-sp.yml
+++ b/.github/workflows/deploy-api-utils-sp.yml
@@ -28,6 +28,15 @@ on:
       - "ipv-api/**"
       - "oidc-api/**"
       - "sis-api/**"
+      - "orchestration-*/**"
+      - "doc-checking-app-api/**"
+      - "client-registry-api/**"
+      - "auth-external-api/**"
+      - "oidc-api-integration-tests/**"
+      - "ipv-api-integration-tests/**"
+      - "identity-shared/**"
+      - "http/**"
+      - "tools/**"
 
 env:
   AWS_REGION: eu-west-2


### PR DESCRIPTION
Trigger fewer deploys per pipeline by adding more items to auth deploy templates' ignore paths (changes to matching files will not trigger pipeline runs).


Rationale for added ignore items:
| Ignored path | Where ignored | Rationale |
|-----|----|---|
|"orchestration-*/**" | everywhere in auth deploy files | not ever related |
| "doc-checking-app-api/**" | everywhere in auth deploy files | not ever related (orch) |
| "client-registry-api/**" | everwhere in auth deploy files | not ever related (orch) |
| "http/**" | everywhere | documentation for local running / testing  rather than prod code |
| "account-data-api-integration-tests/**" | everywhere | not prod code (arguably we should ignore "*-integration-tests/** everywhere) |
|  "oidc-api-integration-tests/**" | everywhere | orch stuff and also not prod code |
| "ipv-api-integration-tests/**" | everywhere | orch stuff and also not prod code |
| "identity-shared/**" | everywhere | orch code |
| "user-permissions/**" | account data api | think very unlikely we'll add user permissions into the account data api as meant to be a fairly thin database layer with business logic in the code that calls this api |
| "delivery-receipts-api/**| account data api, account management api, stubs | not entirely sure where this is deployed but definitely not in these |
| "auth-external-api | everywhere except deploy-api-auth-sp.yml  | only trigger in the pipeline where this api is actually deployed |