### PR TITLE
AUT-5653: Add a stub IAD tracker DynamoDB table for dev and build

### DIFF
--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -136,6 +136,18 @@ Conditions:
                 ]
               - "0"
 
+  InactiveAccountTrackerStubEnabled: !Not
+    - !Or
+      - !Equals
+        - !Ref Environment
+        - staging
+      - !Equals
+        - !Ref Environment
+        - integration
+      - !Equals
+        - !Ref Environment
+        - production
+
 Mappings:
   EnvironmentConfiguration:
     authdev1:
@@ -1640,3 +1652,52 @@ Resources:
             Condition:
               Bool:
                 "aws:SecureTransport": "false"
+
+  # ============================================================================
+  # DynamoDB Tables
+  # ============================================================================
+
+  # Stub inactive account tracker table for dev/build environments
+  InactiveAccountTrackerStubKmsKey:
+    Type: AWS::KMS::Key
+    Condition: InactiveAccountTrackerStubEnabled
+    Properties:
+      Description: KMS key for the inactive account tracker stub table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+
+  InactiveAccountTrackerStubTable:
+    Type: AWS::DynamoDB::Table
+    Condition: InactiveAccountTrackerStubEnabled
+    Properties:
+      TableName: !Sub
+        - ${Env}-stub-inactive-account-tracker
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: dateForDeletion
+          AttributeType: S
+        - AttributeName: commonSubjectId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: dateForDeletion
+          KeyType: HASH
+        - AttributeName: commonSubjectId
+          KeyType: RANGE
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt InactiveAccountTrackerStubKmsKey.Arn
+      DeletionProtectionEnabled: false
+      Tags:
+        - Key: Environment
+          Value: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+        - Key: Service
+          Value: inactive-account-data-export


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The home-owned table will only be used in staging/int/prod, we therefore require a stub table in dev/build for testing.

A subsequent PR will handle adding write functionality and policies to the IAD data export utils Lambda.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy the utils module to a dev env and check that the resources have been created
    a. [I've done this - see testing section below]

## Testing

Deployed the utils module to authdev1 and checked that the DynamoDB and KMS resources were created as expected

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Assessed the impact on active user sessions and confirmed no breaking changes **- N/A, utils lambda only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Orch and Auth mutual dependencies have been checked for breaking changes **- N/A, utils lambda only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] Stub-orchestration has been updated (or no changes required) **- N/A**
