### PR TITLE
ATO-2708: integration cloudfront cutover params

### DIFF
--- a/ci/stack-orchestration/configuration/integration/cloudfront-tls-certificate/parameters.json
+++ b/ci/stack-orchestration/configuration/integration/cloudfront-tls-certificate/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "HostedZoneID",
-    "ParameterValue": "TODO"
+    "ParameterValue": "Z0258845ILN01OIWADX9"
   },
   {
     "ParameterKey": "DomainName",

--- a/ci/stack-orchestration/configuration/integration/integration-oidc-cloudfront/alternative-with-live-cert-parameters.json
+++ b/ci/stack-orchestration/configuration/integration/integration-oidc-cloudfront/alternative-with-live-cert-parameters.json
@@ -5,7 +5,7 @@
   },
   {
     "ParameterKey": "CloudFrontCertArn",
-    "ParameterValue": "TODO"
+    "ParameterValue": "arn:aws:acm:us-east-1:058264132019:certificate/eb73b64a-f996-4594-bc65-ab638bd7f641"
   },
   {
     "ParameterKey": "FraudHeaderEnabled",

--- a/ci/stack-orchestration/configuration/integration/integration-oidc-cloudfront/live-with-rollback-parameters.json
+++ b/ci/stack-orchestration/configuration/integration/integration-oidc-cloudfront/live-with-rollback-parameters.json
@@ -5,7 +5,7 @@
   },
   {
     "ParameterKey": "CloudFrontCertArn",
-    "ParameterValue": "TODO"
+    "ParameterValue": "arn:aws:acm:us-east-1:058264132019:certificate/eb73b64a-f996-4594-bc65-ab638bd7f641"
   },
   {
     "ParameterKey": "FraudHeaderEnabled",

--- a/ci/stack-orchestration/configuration/integration/integration-oidc-cloudfront/parameters.json
+++ b/ci/stack-orchestration/configuration/integration/integration-oidc-cloudfront/parameters.json
@@ -5,7 +5,7 @@
   },
   {
     "ParameterKey": "CloudFrontCertArn",
-    "ParameterValue": "TODO"
+    "ParameterValue": "arn:aws:acm:us-east-1:058264132019:certificate/eb73b64a-f996-4594-bc65-ab638bd7f641"
   },
   {
     "ParameterKey": "FraudHeaderEnabled",


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

### What’s changed:
- Adds parameters for the integration Hosted Zone ID in configuration 
- Adds live integration domain certificate ARN in configuration 

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
