### PR TITLE
BAU: Make signJWT a public method on OrchJwtService

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidJWEException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidJWEException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.orchestration.shared.exceptions;
-
-public class InvalidJWEException extends RuntimeException {
-    public InvalidJWEException(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidJWTException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/InvalidJWTException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class InvalidJWTException extends RuntimeException {
+    public InvalidJWTException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchJwtService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/OrchJwtService.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.MessageType;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.orchestration.shared.exceptions.InvalidJWEException;
+import uk.gov.di.orchestration.shared.exceptions.InvalidJWTException;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -56,6 +56,33 @@ public class OrchJwtService {
             attachLogFieldToLogs(JWT_ID, jwtClaimsSet.getJWTID());
         }
         LOG.info("Generating signed and encrypted JWT");
+        var signedJwt = signJWT(jwtClaimsSet, signingKeyAlias);
+        return encryptJWT(signedJwt, publicEncryptionKey);
+    }
+
+    private EncryptedJWT encryptJWT(SignedJWT signedJWT, RSAPublicKey publicEncryptionKey) {
+        try {
+            LOG.info("Encrypting SignedJWT");
+            var jweObject =
+                    new JWEObject(
+                            new JWEHeader.Builder(
+                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                                    .contentType("JWT")
+                                    .build(),
+                            new Payload(signedJWT));
+            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
+            LOG.info("SignedJWT has been successfully encrypted");
+            return EncryptedJWT.parse(jweObject.serialize());
+        } catch (JOSEException e) {
+            LOG.error("Error when encrypting SignedJWT", e);
+            throw new InvalidJWTException("Error when encrypting SignedJWT", e);
+        } catch (ParseException e) {
+            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
+            throw new InvalidJWTException("Error when parsing JWE object to EncryptedJWT", e);
+        }
+    }
+
+    public SignedJWT signJWT(JWTClaimsSet jwtClaimsSet, String signingKeyAlias) {
         var signingKey = jwksService.getPublicJWKWithKeyId(signingKeyAlias);
         var jwsHeader =
                 new JWSHeader.Builder(SIGNING_ALGORITHM).keyID(signingKey.getKeyID()).build();
@@ -91,32 +118,10 @@ public class OrchJwtService {
                                             signResult.signature().asByteArray(),
                                             ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
                             .toString();
-            return encryptJWT(SignedJWT.parse(message + "." + signature), publicEncryptionKey);
+            return SignedJWT.parse(message + "." + signature);
         } catch (ParseException | JOSEException e) {
             LOG.error("Error when generating SignedJWT", e);
-            throw new InvalidJWEException("Error when generating SignedJWT", e);
-        }
-    }
-
-    private EncryptedJWT encryptJWT(SignedJWT signedJWT, RSAPublicKey publicEncryptionKey) {
-        try {
-            LOG.info("Encrypting SignedJWT");
-            var jweObject =
-                    new JWEObject(
-                            new JWEHeader.Builder(
-                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
-                                    .contentType("JWT")
-                                    .build(),
-                            new Payload(signedJWT));
-            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
-            LOG.info("SignedJWT has been successfully encrypted");
-            return EncryptedJWT.parse(jweObject.serialize());
-        } catch (JOSEException e) {
-            LOG.error("Error when encrypting SignedJWT", e);
-            throw new InvalidJWEException("Error when encrypting SignedJWT", e);
-        } catch (ParseException e) {
-            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
-            throw new InvalidJWEException("Error when parsing JWE object to EncryptedJWT", e);
+            throw new InvalidJWTException("Error when generating SignedJWT", e);
         }
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchJwtServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/OrchJwtServiceTest.java
@@ -87,6 +87,26 @@ class OrchJwtServiceTest {
     }
 
     @Test
+    void shouldSignAJwtWithAGivenKeyAlias() throws Exception {
+        var claim1Value = "JWT claim 1";
+        var jwtClaimsSet = new JWTClaimsSet.Builder().claim("claim1", claim1Value).build();
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(SIGNING_KEY_ID).build();
+        var expectedMessage =
+                jwsHeader.toBase64URL() + "." + Base64URL.encode(jwtClaimsSet.toString());
+        mockKmsSigning(ecSigningKey, jwtClaimsSet);
+
+        var signedJWTResponse = orchJwtService.signJWT(jwtClaimsSet, SIGNING_KEY_ALIAS);
+
+        var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
+        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claim1"), equalTo(claim1Value));
+        verify(kmsConnectionService).sign(signRequestCaptor.capture());
+        assertThat(
+                SdkBytes.fromByteArray(expectedMessage.getBytes(StandardCharsets.UTF_8)),
+                equalTo(signRequestCaptor.getValue().message()));
+        assertThat(MessageType.RAW, equalTo(signRequestCaptor.getValue().messageType()));
+    }
+
+    @Test
     void shouldUseAHashDigestWhenMessageSizeIsMoreThan4095() throws Exception {
         var claim1Value = "JWT claim 1";
         var jwtClaimsSet =
@@ -99,11 +119,9 @@ class OrchJwtServiceTest {
                 jwsHeader.toBase64URL() + "." + Base64URL.encode(jwtClaimsSet.toString());
         mockKmsSigning(ecSigningKey, jwtClaimsSet);
 
-        var encryptedJWT =
-                orchJwtService.signAndEncryptJWT(jwtClaimsSet, SIGNING_KEY_ALIAS, publicEncKey);
+        var signedJWTResponse = orchJwtService.signJWT(jwtClaimsSet, SIGNING_KEY_ALIAS);
 
         var signRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
-        var signedJWTResponse = decryptJWT(encryptedJWT);
         assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claim1"), equalTo(claim1Value));
         assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("state"), equalTo(LONG_CLAIM));
         signedJWTResponse.verify(new ECDSAVerifier(ecSigningKey.toECPublicKey()));


### PR DESCRIPTION
### Wider context of change

Splits up signing and encrypting a JWT into separate methods and makes the signJWT method public. This enables us to call this method separately from signAndEncrypt, which means we can directly invoke it from our tests, cutting down some faff related signing related logic - such as using a message digest.

This requires us to rename an exception to reflect that it can be thrown in multiple contexts - either using a JWS or a JWE. The message from this Exception should be enough to gather the context in which it is thrown. 

This is preparatory work to enable some more refactoring ideas - but is harmless change that can stand by itself.


### What’s changed
- Splits signing code into it's own method, moving it into `signJwt`, and makes this method public
- Renames InvalidJWEException to InvalidJWTException to reflect it's slightly more generic nature

### Manual testing
- N/A this is a pretty simple lift and shift of existing code into it's own method

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

- [ ] Added new endpoints to local running (`LocalOrchestrationApi.java`) or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
