### PR TITLE
AUT-5653: Add Dynamo bulk writes to inactive account data scan Lambda

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -55,12 +55,32 @@ Resources:
               !Ref Environment,
               inactiveAccountExportPauseBetweenInvocationsMs,
             ]
+          INACTIVE_ACCOUNT_EXPORT_TABLE_NAME:
+            - !Sub
+              - "arn:aws:dynamodb:${AWS::Region}:${AccountId}:table/${TableName}"
+              - AccountId:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    inactiveAccountExportTableAccountId,
+                  ]
+                TableName:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    inactiveAccountExportTableName,
+                  ]
+
       Policies:
         - !Ref LambdaBasicExecutionPolicy
         - !Ref DynamoUserReadAccessPolicy
         - !Ref DynamoCredentialReadAccessPolicy
         - !Ref CloudWatchLogsKmsAccessPolicy
         - !Ref InactiveAccountDataExportSelfInvokePolicy
+        - !If
+          - InactiveAccountTrackerCrossAccountWriteEnabled
+          - !Ref InactiveAccountTrackerCrossAccountWritePolicy
+          - !Ref AWS::NoValue
       AutoPublishAlias: live
       LoggingConfig:
         LogGroup: !Ref InactiveAccountDataExportLogGroup

--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -55,7 +55,8 @@ Resources:
               !Ref Environment,
               inactiveAccountExportPauseBetweenInvocationsMs,
             ]
-          INACTIVE_ACCOUNT_EXPORT_TABLE_NAME:
+          INACTIVE_ACCOUNT_EXPORT_TABLE_NAME: !If
+            - InactiveAccountTrackerCrossAccountWriteEnabled
             - !Sub
               - "arn:aws:dynamodb:${AWS::Region}:${AccountId}:table/${TableName}"
               - AccountId:
@@ -70,6 +71,10 @@ Resources:
                     !Ref Environment,
                     inactiveAccountExportTableName,
                   ]
+            - !Sub
+              - ${Env}-stub-inactive-account-tracker
+              - Env:
+                  !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
 
       Policies:
         - !Ref LambdaBasicExecutionPolicy
@@ -80,6 +85,10 @@ Resources:
         - !If
           - InactiveAccountTrackerCrossAccountWriteEnabled
           - !Ref InactiveAccountTrackerCrossAccountWritePolicy
+          - !Ref AWS::NoValue
+        - !If
+          - InactiveAccountTrackerStubEnabled
+          - !Ref InactiveAccountTrackerStubWritePolicy
           - !Ref AWS::NoValue
       AutoPublishAlias: live
       LoggingConfig:

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -74,6 +74,18 @@ Conditions:
               - !Ref SubEnvironment
               - none
 
+  InactiveAccountTrackerCrossAccountWriteEnabled:
+    Fn::Or:
+      - Fn::Equals:
+          - !Ref Environment
+          - staging
+      - Fn::Equals:
+          - !Ref Environment
+          - integration
+      - Fn::Equals:
+          - !Ref Environment
+          - production
+
   AllowBulkTestUsers:
     Fn::Equals:
       - !FindInMap [
@@ -187,6 +199,7 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
+      inactiveAccountExportTableName: "authdev1-stub-inactive-account-tracker"
 
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
@@ -225,6 +238,7 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
+      inactiveAccountExportTableName: "authdev2-stub-inactive-account-tracker"
 
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
@@ -263,6 +277,7 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
+      inactiveAccountExportTableName: "authdev3-stub-inactive-account-tracker"
 
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
@@ -301,6 +316,7 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
+      inactiveAccountExportTableName: "dev-stub-inactive-account-tracker"
 
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
@@ -339,6 +355,7 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "7500"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
+      inactiveAccountExportTableName: "build-stub-inactive-account-tracker"
 
     staging:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
@@ -377,6 +394,9 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "7500"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
+      inactiveAccountExportTableAccountId: "539729775994"
+      inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:539729775994:key/5191526d-1c85-4316-baf7-9fbe373880cf
+      inactiveAccountExportTableName: "inactive_account_tracker_store"
 
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
@@ -415,6 +435,9 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "7500"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
+      inactiveAccountExportTableAccountId: "666500506359"
+      inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:666500506359:key/1ab2a72b-63e0-49b6-b88a-5160a7d27985
+      inactiveAccountExportTableName: "inactive_account_tracker_store"
 
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
@@ -453,6 +476,9 @@ Mappings:
       inactiveAccountExportMaxRetries: "3"
       inactiveAccountExportMaxItemsPerSegment: "7500"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
+      inactiveAccountExportTableAccountId: "026991849909"
+      inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:026991849909:key/5489c67b-2c14-4b76-b6a3-a25148b14311
+      inactiveAccountExportTableName: "inactive_account_tracker_store"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -1233,6 +1259,51 @@ Resources:
                     !Ref Environment,
                     internationalSmsSendCountTableEncryptionKey,
                   ]
+
+  # Policy for cross-account write access to the inactive account tracker table
+  InactiveAccountTrackerCrossAccountWritePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: InactiveAccountTrackerCrossAccountWriteEnabled
+    Properties:
+      Description: "IAM policy for writing to the inactive account tracker table in the home-team account"
+      Path: !Sub
+        - /${Env}/utils/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowBatchWriteToTrackerTable
+            Effect: Allow
+            Action:
+              - dynamodb:BatchWriteItem
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${DataStoreAccountId}:table/${TableName}
+                - DataStoreAccountId:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      inactiveAccountExportTableAccountId,
+                    ]
+                  TableName:
+                    !FindInMap [
+                      EnvironmentConfiguration,
+                      !Ref Environment,
+                      inactiveAccountExportTableName,
+                    ]
+          - Sid: AllowAccessToTrackerTableKms
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  inactiveAccountExportTableEncryptionKey,
+                ]
 
   # ============================================================================
   # S3 Access Policies

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -1760,7 +1760,9 @@ Resources:
     Type: AWS::KMS::Key
     Condition: InactiveAccountTrackerStubEnabled
     Properties:
-      Description: KMS key for the inactive account tracker stub table
+      Description: !Sub
+        - KMS key for the inactive account tracker stub table (${Env})
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       EnableKeyRotation: true
       KeyPolicy:
         Version: 2012-10-17

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -74,18 +74,6 @@ Conditions:
               - !Ref SubEnvironment
               - none
 
-  InactiveAccountTrackerCrossAccountWriteEnabled:
-    Fn::Or:
-      - Fn::Equals:
-          - !Ref Environment
-          - staging
-      - Fn::Equals:
-          - !Ref Environment
-          - integration
-      - Fn::Equals:
-          - !Ref Environment
-          - production
-
   AllowBulkTestUsers:
     Fn::Equals:
       - !FindInMap [
@@ -148,17 +136,21 @@ Conditions:
                 ]
               - "0"
 
-  InactiveAccountTrackerStubEnabled: !Not
-    - !Or
-      - !Equals
-        - !Ref Environment
-        - staging
-      - !Equals
-        - !Ref Environment
-        - integration
-      - !Equals
-        - !Ref Environment
-        - production
+  InactiveAccountTrackerCrossAccountWriteEnabled:
+    Fn::Or:
+      - Fn::Equals:
+          - !Ref Environment
+          - staging
+      - Fn::Equals:
+          - !Ref Environment
+          - integration
+      - Fn::Equals:
+          - !Ref Environment
+          - production
+
+  InactiveAccountTrackerStubEnabled:
+    Fn::Not:
+      - !Condition InactiveAccountTrackerCrossAccountWriteEnabled
 
 Mappings:
   EnvironmentConfiguration:
@@ -1304,6 +1296,41 @@ Resources:
                   !Ref Environment,
                   inactiveAccountExportTableEncryptionKey,
                 ]
+
+  # Policy for write access to the inactive account tracker stub table
+  InactiveAccountTrackerStubWritePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: InactiveAccountTrackerStubEnabled
+    Properties:
+      Description: "IAM policy for writing to the inactive account tracker stub table"
+      Path: !Sub
+        - /${Env}/utils/
+        - Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowBatchWriteToTrackerStubTable
+            Effect: Allow
+            Action:
+              - dynamodb:BatchWriteItem
+            Resource:
+              - !Sub
+                - arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${Env}-stub-inactive-account-tracker
+                - Env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+          - Sid: AllowAccessToTrackerStubTableKms
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource:
+              - !GetAtt InactiveAccountTrackerStubKmsKey.Arn
 
   # ============================================================================
   # S3 Access Policies

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -257,6 +257,10 @@ public class ConfigurationService
                                 "INACTIVE_ACCOUNT_EXPORT_PAUSE_BETWEEN_INVOCATIONS_MS", "60000"));
     }
 
+    public String getInactiveAccountExportTableName() {
+        return System.getenv().getOrDefault("INACTIVE_ACCOUNT_EXPORT_TABLE_NAME", "");
+    }
+
     public String getTicfCRILambdaIdentifier() {
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_IDENTIFIER", "");
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.utils.helpers;
+
+import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InactiveAccountDataExportBatchWriteService {
+
+    private final List<InactiveAccountTrackerItem> buffer = new ArrayList<>();
+
+    public InactiveAccountDataExportBatchWriteService() {}
+
+    public void add(InactiveAccountTrackerItem item) {
+        buffer.add(item);
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
@@ -1,17 +1,94 @@
 package uk.gov.di.authentication.utils.helpers;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class InactiveAccountDataExportBatchWriteService {
 
-    private final List<InactiveAccountTrackerItem> buffer = new ArrayList<>();
+    private static final Logger LOG =
+            LogManager.getLogger(InactiveAccountDataExportBatchWriteService.class);
 
-    public InactiveAccountDataExportBatchWriteService() {}
+    static final int BATCH_WRITE_ITEM_MAX_SIZE = 25;
+
+    private static final TableSchema<InactiveAccountTrackerItem> TRACKER_ITEM_SCHEMA =
+            TableSchema.fromBean(InactiveAccountTrackerItem.class);
+
+    private final DynamoDbClient client;
+    private final String tableName;
+    private final List<InactiveAccountTrackerItem> buffer = new ArrayList<>();
+    private long totalWritten;
+    private long totalBatchesFlushed;
+
+    public InactiveAccountDataExportBatchWriteService(DynamoDbClient client, String tableName) {
+        this.client = client;
+        this.tableName = tableName;
+    }
 
     public void add(InactiveAccountTrackerItem item) {
         buffer.add(item);
+        if (buffer.size() == BATCH_WRITE_ITEM_MAX_SIZE) {
+            flush();
+        }
+    }
+
+    public void flushRemaining() {
+        if (!buffer.isEmpty()) {
+            flush();
+        }
+    }
+
+    public long getTotalWritten() {
+        return totalWritten;
+    }
+
+    public long getTotalBatchesFlushed() {
+        return totalBatchesFlushed;
+    }
+
+    private void flush() {
+        List<WriteRequest> writeRequests = toWriteRequests(buffer);
+
+        BatchWriteItemResponse response =
+                client.batchWriteItem(
+                        BatchWriteItemRequest.builder()
+                                .requestItems(Map.of(tableName, writeRequests))
+                                .build());
+
+        int unprocessedCount = 0;
+        if (response.hasUnprocessedItems() && response.unprocessedItems().containsKey(tableName)) {
+            unprocessedCount = response.unprocessedItems().get(tableName).size();
+        }
+
+        int written = buffer.size() - unprocessedCount;
+        totalWritten += written;
+        totalBatchesFlushed++;
+        buffer.clear();
+
+        if (unprocessedCount > 0) {
+            LOG.warn("BatchWriteItem returned {} unprocessed items", unprocessedCount);
+        }
+    }
+
+    private static List<WriteRequest> toWriteRequests(List<InactiveAccountTrackerItem> items) {
+        List<WriteRequest> writeRequests = new ArrayList<>(items.size());
+
+        for (InactiveAccountTrackerItem item : items) {
+            writeRequests.add(
+                    WriteRequest.builder()
+                            .putRequest(pr -> pr.item(TRACKER_ITEM_SCHEMA.itemToMap(item, true)))
+                            .build());
+        }
+
+        return writeRequests;
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -11,6 +11,8 @@ import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.LambdaPauseHelper;
 import uk.gov.di.authentication.shared.helpers.TableNameHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -19,6 +21,8 @@ import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportRequest;
 import uk.gov.di.authentication.utils.entity.InactiveAccountDataExportResponse;
+import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
+import uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportBatchWriteService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.backoff;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildCredentialKeys;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.buildTrackerItem;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
 
@@ -252,6 +257,8 @@ public class InactiveAccountDataExportHandler
         long itemsScanned = 0;
         long missingCredentialsCount = 0;
         List<Map<String, AttributeValue>> currentBatch = new ArrayList<>();
+        InactiveAccountDataExportBatchWriteService batchWriteService =
+                new InactiveAccountDataExportBatchWriteService();
 
         do {
             if (itemsScanned >= maxItemsPerSegment) {
@@ -288,7 +295,8 @@ public class InactiveAccountDataExportHandler
                 currentBatch.add(item);
 
                 if (currentBatch.size() >= BATCH_GET_ITEM_MAX_SIZE) {
-                    missingCredentialsCount += batchGetUserCredentials(currentBatch, maxRetries);
+                    missingCredentialsCount +=
+                            batchGetUserCredentials(currentBatch, maxRetries, batchWriteService);
                     currentBatch.clear();
                 }
             }
@@ -297,7 +305,8 @@ public class InactiveAccountDataExportHandler
         } while (lastKey != null && !lastKey.isEmpty());
 
         if (!currentBatch.isEmpty()) {
-            missingCredentialsCount += batchGetUserCredentials(currentBatch, maxRetries);
+            missingCredentialsCount +=
+                    batchGetUserCredentials(currentBatch, maxRetries, batchWriteService);
             currentBatch.clear();
         }
 
@@ -315,7 +324,9 @@ public class InactiveAccountDataExportHandler
     }
 
     private long batchGetUserCredentials(
-            List<Map<String, AttributeValue>> userProfileItems, int maxRetries) {
+            List<Map<String, AttributeValue>> userProfileItems,
+            int maxRetries,
+            InactiveAccountDataExportBatchWriteService batchWriteService) {
         if (userProfileItems.isEmpty()) {
             return 0;
         }
@@ -325,9 +336,36 @@ public class InactiveAccountDataExportHandler
             return userProfileItems.size();
         }
 
-        List<Map<String, AttributeValue>> results = fetchWithRetry(keys, maxRetries);
+        List<Map<String, AttributeValue>> credentialResults = fetchWithRetry(keys, maxRetries);
 
-        return countMissingCredentials(keys.size(), results.size());
+        buildAndBufferTrackerItems(userProfileItems, credentialResults, batchWriteService);
+
+        return countMissingCredentials(keys.size(), credentialResults.size());
+    }
+
+    private void buildAndBufferTrackerItems(
+            List<Map<String, AttributeValue>> userProfileItems,
+            List<Map<String, AttributeValue>> credentialResults,
+            InactiveAccountDataExportBatchWriteService batchWriteService) {
+        Map<String, Map<String, AttributeValue>> credentialsByEmail = new HashMap<>();
+        for (Map<String, AttributeValue> credItem : credentialResults) {
+            AttributeValue email = credItem.get(UserCredentials.ATTRIBUTE_EMAIL);
+            if (email != null) {
+                credentialsByEmail.put(email.s(), credItem);
+            }
+        }
+
+        for (Map<String, AttributeValue> profileItem : userProfileItems) {
+            AttributeValue email = profileItem.get(UserProfile.ATTRIBUTE_EMAIL);
+            if (email == null) {
+                continue;
+            }
+            InactiveAccountTrackerItem trackerItem =
+                    buildTrackerItem(profileItem, credentialsByEmail.get(email.s()));
+            if (trackerItem != null) {
+                batchWriteService.add(trackerItem);
+            }
+        }
     }
 
     private List<Map<String, AttributeValue>> fetchWithRetry(

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -60,6 +60,7 @@ public class InactiveAccountDataExportHandler
     private final Json objectMapper = SerializationService.getInstance();
     private final String userProfileTableName;
     private final String userCredentialsTableName;
+    private final String exportTableName;
     private final int parallelism;
     private final int totalSegments;
     private final int maxRetries;
@@ -77,6 +78,7 @@ public class InactiveAccountDataExportHandler
                 TableNameHelper.getFullTableName(USER_PROFILE_TABLE, configurationService);
         this.userCredentialsTableName =
                 TableNameHelper.getFullTableName(USER_CREDENTIALS_TABLE, configurationService);
+        this.exportTableName = configurationService.getInactiveAccountExportTableName();
         this.parallelism = configurationService.getInactiveAccountExportParallelism();
         this.totalSegments = configurationService.getInactiveAccountExportTotalSegments();
         this.maxRetries = configurationService.getInactiveAccountExportMaxRetries();
@@ -143,12 +145,14 @@ public class InactiveAccountDataExportHandler
 
             long totalItemsScanned = 0;
             long totalMissingCredentials = 0;
+            long totalWritten = 0;
             Map<Integer, Map<String, String>> remainingSegmentKeys = new HashMap<>();
 
             for (SegmentTask segmentTask : segmentTasks) {
                 SegmentResult result = segmentTask.task().join();
                 totalItemsScanned += result.itemsScanned();
                 totalMissingCredentials += result.missingCredentialsCount();
+                totalWritten += result.writtenCount();
 
                 if (result.lastEvaluatedKey() != null && !result.lastEvaluatedKey().isEmpty()) {
                     remainingSegmentKeys.put(
@@ -157,13 +161,17 @@ public class InactiveAccountDataExportHandler
             }
 
             processedCount += totalItemsScanned;
+            writtenCount += totalWritten;
 
             LOG.info(
                     "Invocation complete: {} items scanned this invocation, {} missing credentials, "
-                            + "{} total processed, {} segments remaining",
+                            + "{} total processed, {} written this invocation, "
+                            + "{} total written, {} segments remaining",
                     totalItemsScanned,
                     totalMissingCredentials,
                     processedCount,
+                    totalWritten,
+                    writtenCount,
                     remainingSegmentKeys.size());
 
             if (!remainingSegmentKeys.isEmpty()) {
@@ -258,7 +266,7 @@ public class InactiveAccountDataExportHandler
         long missingCredentialsCount = 0;
         List<Map<String, AttributeValue>> currentBatch = new ArrayList<>();
         InactiveAccountDataExportBatchWriteService batchWriteService =
-                new InactiveAccountDataExportBatchWriteService();
+                new InactiveAccountDataExportBatchWriteService(client, exportTableName);
 
         do {
             if (itemsScanned >= maxItemsPerSegment) {
@@ -310,17 +318,26 @@ public class InactiveAccountDataExportHandler
             currentBatch.clear();
         }
 
+        batchWriteService.flushRemaining();
+
         Map<String, AttributeValue> finalKey =
                 (lastKey != null && !lastKey.isEmpty()) ? lastKey : null;
 
         LOG.info(
-                "Segment {} completed: {} items scanned, {} missing credentials, segmentExhausted={}",
+                "Segment {} completed: {} items scanned, {} missing credentials, "
+                        + "{} items written, {} batches flushed, segmentExhausted={}",
                 segment,
                 itemsScanned,
                 missingCredentialsCount,
+                batchWriteService.getTotalWritten(),
+                batchWriteService.getTotalBatchesFlushed(),
                 finalKey == null);
 
-        return new SegmentResult(itemsScanned, missingCredentialsCount, finalKey);
+        return new SegmentResult(
+                itemsScanned,
+                missingCredentialsCount,
+                batchWriteService.getTotalWritten(),
+                finalKey);
     }
 
     private long batchGetUserCredentials(
@@ -422,6 +439,7 @@ public class InactiveAccountDataExportHandler
     record SegmentResult(
             long itemsScanned,
             long missingCredentialsCount,
+            long writtenCount,
             Map<String, AttributeValue> lastEvaluatedKey) {}
 
     private static void gracefulPoolShutdown(ForkJoinPool forkJoinPool) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
@@ -1,23 +1,112 @@
 package uk.gov.di.authentication.utils.helpers;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportBatchWriteService.BATCH_WRITE_ITEM_MAX_SIZE;
 
 class InactiveAccountDataExportBatchWriteServiceTest {
 
-    @Test
-    void shouldAccumulateItemsInBuffer() {
-        int itemCount = 10;
-        var service = new InactiveAccountDataExportBatchWriteService();
+    private static final String TABLE_NAME = "test-tracker-table";
 
-        assertDoesNotThrow(
-                () -> {
-                    for (int i = 0; i < itemCount; i++) {
-                        service.add(createTrackerItem(i));
-                    }
-                });
+    private final DynamoDbClient client = mock(DynamoDbClient.class);
+
+    @BeforeEach
+    void setUp() {
+        when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
+                .thenReturn(BatchWriteItemResponse.builder().build());
+    }
+
+    private InactiveAccountDataExportBatchWriteService createService() {
+        return new InactiveAccountDataExportBatchWriteService(client, TABLE_NAME);
+    }
+
+    @Test
+    void shouldFlushAutomaticallyAtBatchSize() {
+        var service = createService();
+
+        for (int i = 0; i < BATCH_WRITE_ITEM_MAX_SIZE; i++) {
+            service.add(createTrackerItem(i));
+        }
+
+        verify(client, times(1)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(BATCH_WRITE_ITEM_MAX_SIZE, service.getTotalWritten());
+        assertEquals(1, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldNotFlushWhenBelowBatchSize() {
+        var service = createService();
+
+        for (int i = 0; i < BATCH_WRITE_ITEM_MAX_SIZE - 1; i++) {
+            service.add(createTrackerItem(i));
+        }
+
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
+    }
+
+    @Test
+    void shouldFlushRemainingAsPartialBatch() {
+        var service = createService();
+        int itemCount = 10;
+
+        for (int i = 0; i < itemCount; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        verify(client, times(1)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(itemCount, service.getTotalWritten());
+        assertEquals(1, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldNotFlushRemainingWhenBufferIsEmpty() {
+        var service = createService();
+
+        service.flushRemaining();
+
+        verify(client, never()).batchWriteItem(any(BatchWriteItemRequest.class));
+    }
+
+    @Test
+    void shouldFlushMultipleTimesAsItemsAccumulate() {
+        var service = createService();
+        int totalItems = BATCH_WRITE_ITEM_MAX_SIZE * 3;
+
+        for (int i = 0; i < totalItems; i++) {
+            service.add(createTrackerItem(i));
+        }
+
+        verify(client, times(3)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(totalItems, service.getTotalWritten());
+        assertEquals(3, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldFlushFullBatchThenFlushRemainingPartialBatch() {
+        var service = createService();
+        int totalItems = BATCH_WRITE_ITEM_MAX_SIZE + 10;
+
+        for (int i = 0; i < totalItems; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        verify(client, times(2)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(totalItems, service.getTotalWritten());
+        assertEquals(2, service.getTotalBatchesFlushed());
     }
 
     private InactiveAccountTrackerItem createTrackerItem(int index) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
@@ -1,0 +1,30 @@
+package uk.gov.di.authentication.utils.helpers;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class InactiveAccountDataExportBatchWriteServiceTest {
+
+    @Test
+    void shouldAccumulateItemsInBuffer() {
+        int itemCount = 10;
+        var service = new InactiveAccountDataExportBatchWriteService();
+
+        assertDoesNotThrow(
+                () -> {
+                    for (int i = 0; i < itemCount; i++) {
+                        service.add(createTrackerItem(i));
+                    }
+                });
+    }
+
+    private InactiveAccountTrackerItem createTrackerItem(int index) {
+        return new InactiveAccountTrackerItem()
+                .withDateForDeletion("2029-01-15")
+                .withCommonSubjectId("subject-" + index)
+                .withPublicSubjectId("public-subject-" + index)
+                .withEmailAddress("user" + index + "@example.com");
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
@@ -63,6 +65,10 @@ class InactiveAccountDataExportHandlerTest {
                 .thenReturn("test-inactive-account-data-export-lambda");
         when(configurationService.getInactiveAccountExportPauseBetweenInvocationsMs())
                 .thenReturn(0L);
+        when(configurationService.getInactiveAccountExportTableName())
+                .thenReturn("test-tracker-table");
+        when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
+                .thenReturn(BatchWriteItemResponse.builder().build());
     }
 
     private InactiveAccountDataExportHandler createHandler() {
@@ -93,7 +99,7 @@ class InactiveAccountDataExportHandlerTest {
         var response = handler.handleRequest(request, context);
 
         assertEquals(itemCount, response.processedCount());
-        assertEquals(0, response.writtenCount());
+        assertEquals(itemCount, response.writtenCount());
     }
 
     @Test
@@ -399,7 +405,7 @@ class InactiveAccountDataExportHandlerTest {
         var response = handler.handleRequest(request, context);
 
         assertEquals(105, response.processedCount());
-        assertEquals(0, response.writtenCount());
+        assertEquals(5, response.writtenCount());
         verify(client, times(1)).scan(any(ScanRequest.class));
     }
 
@@ -415,7 +421,7 @@ class InactiveAccountDataExportHandlerTest {
         var response = handler.handleRequest(request, context);
 
         assertEquals(505, response.processedCount());
-        assertEquals(0, response.writtenCount());
+        assertEquals(itemCount, response.writtenCount());
     }
 
     @Test
@@ -503,7 +509,7 @@ class InactiveAccountDataExportHandlerTest {
 
         assertNotNull(continuation.segmentKeys());
         assertEquals(105, continuation.processedCount());
-        assertEquals(0, continuation.writtenCount());
+        assertEquals(5, continuation.writtenCount());
     }
 
     @Test


### PR DESCRIPTION
## What

* Added batch write service to buffer and flush inactive account tracker items to DynamoDB in batches of 25.
* Updated the data export Lambda to generate tracker items and use the new batch write service.
* Added cross-account IAM policies to allow the Lambda to write to the home-team managed tracker table in staging, integration, and production.
    * This will be tested fully in a subsequent ticket.

Note: The stub DynamoDB tracker table for dev and build was already present. Write retry functionality may be added in a subsequent PR.

## How to review

1. Code review.
1. Optionally, deploy the utils module to a dev environment, trigger the inactive account data export Lambda with an empty object (`{}`) as the request payload, verify that records are correctly batch-written to the stub DynamoDB table and that the Lambda logs accurately reflect the total records written.
    - [I've done this - see testing section below]

## Testing

I've performed the following steps:

1. Deployed the utils module to authdev1
1. Triggered the inactive account data export Lambda with an empty object (`{}`) as the request payload
1. Verified that records are correctly batch-written to the stub DynamoDB table and that the Lambda logs accurately reflect the total records written.
    - Checked that the stub tracker table had the same item count as the user profile table and that the items looked as expected - 1440 items in each (in authdev1)
    - Checked the counts in the logs were as expected - `Invocation complete: 4 items scanned this invocation, 0 missing credentials, 1440 total processed, 4 written this invocation, 1440 total written, 0 segments remaining`

## Checklist

- [x] Deployment of this PR will not break active user journeys **- Changes are isolated to a background data export job and do not impact active user sessions.**

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**

- [ ] A UCD review has been performed. **- N/A, utils Lambda changes only**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Add stub table - https://github.com/govuk-one-login/authentication-api/pull/8689
- IAD tracker entity (pre- attribute renames) - https://github.com/govuk-one-login/authentication-api/pull/8631
- Self re-invocation - https://github.com/govuk-one-login/authentication-api/pull/8624