### PR TITLE
AUT 5464: Emit passkey prompt skipped audit event

### DIFF
--- a/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyRegistrationPromptSkipped.java
+++ b/audit-events/src/main/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyRegistrationPromptSkipped.java
@@ -1,0 +1,38 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.shared.RestrictedDeviceInformation;
+import uk.gov.di.authentication.auditevents.entity.shared.Users.UserWithoutPhone;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public record AuthPasskeyRegistrationPromptSkipped(
+        String eventName,
+        long timestamp,
+        long eventTimestampMs,
+        String clientId,
+        String componentId,
+        UserWithoutPhone user,
+        RestrictedDeviceInformation restricted,
+        Extensions extensions)
+        implements StructuredAuditEvent {
+
+    public static AuthPasskeyRegistrationPromptSkipped create(
+            AuditContext auditContext, JourneyType journeyType, Clock clock) {
+        Instant now = clock.instant();
+        return new AuthPasskeyRegistrationPromptSkipped(
+                "AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED",
+                now.getEpochSecond(),
+                now.toEpochMilli(),
+                auditContext.clientId(),
+                ComponentId.AUTH.getValue(),
+                UserWithoutPhone.fromAuditContext(auditContext),
+                RestrictedDeviceInformation.from(auditContext),
+                new Extensions(journeyType.getValue()));
+    }
+
+    public record Extensions(@SerializedName("journey-type") String journeyType) {}
+}

--- a/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyRegistrationPromptSkippedTest.java
+++ b/audit-events/src/test/java/uk/gov/di/authentication/auditevents/entity/AuthPasskeyRegistrationPromptSkippedTest.java
@@ -1,0 +1,67 @@
+package uk.gov.di.authentication.auditevents.entity;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
+
+class AuthPasskeyRegistrationPromptSkippedTest {
+
+    @Test
+    void shouldSerialiseAnAuthPasskeyDeleteSuccessfulAuditEvent() {
+        var auditContext =
+                AuditContext.emptyAuditContext()
+                        .withClientId("client-id")
+                        .withEmail("test@example.com")
+                        .withSubjectId("internal-common-subject-id")
+                        .withPersistentSessionId("persistent-session-id")
+                        .withSessionId("session-id")
+                        .withClientSessionId("signin-journey-id")
+                        .withIpAddress("192.0.2.0/24")
+                        .withTxmaAuditEncoded("encoded-device-info");
+
+        var fixedInstant = Instant.parse("2026-06-10T13:13:04.730565Z");
+        var fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
+
+        var event =
+                AuthPasskeyRegistrationPromptSkipped.create(
+                        auditContext, JourneyType.SIGN_IN, fixedClock);
+
+        var actualEvent = event.serialize();
+
+        var expectedEvent =
+                """
+                                {
+                                   "event_name": "AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED",
+                                   "timestamp": 1781097184,
+                                   "event_timestamp_ms": 1781097184730,
+                                   "client_id": "client-id",
+                                   "component_id": "AUTH",
+                                   "user": {
+                                     "email": "test@example.com",
+                                     "govuk_signin_journey_id": "signin-journey-id",
+                                     "ip_address": "192.0.2.0/24",
+                                     "persistent_session_id": "persistent-session-id",
+                                     "session_id": "session-id",
+                                     "user_id": "internal-common-subject-id"
+                                   },
+                                   "restricted": {
+                                     "device_information": {
+                                       "encoded": "encoded-device-info"
+                                     }
+                                   },
+                                   "extensions": {
+                                     "journey-type": "SIGN_IN"
+                                   }
+                                 }
+                        """;
+
+        assertEquals(asJson(expectedEvent), asJson(actualEvent));
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NonNull;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -36,18 +37,21 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     private static final Logger LOG = LogManager.getLogger(UpdateProfileHandler.class);
 
     private final AuditService auditService;
+    private final StructuredAuditService structuredAuditService;
 
     protected UpdateProfileHandler(
             AuthenticationService authenticationService,
             ConfigurationService configurationService,
             AuditService auditService,
-            AuthSessionService authSessionService) {
+            AuthSessionService authSessionService,
+            StructuredAuditService structuredAuditService) {
         super(
                 UpdateProfileRequest.class,
                 configurationService,
                 authenticationService,
                 authSessionService);
         this.auditService = auditService;
+        this.structuredAuditService = structuredAuditService;
     }
 
     public UpdateProfileHandler() {
@@ -57,6 +61,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     public UpdateProfileHandler(ConfigurationService configurationService) {
         super(UpdateProfileRequest.class, configurationService);
         auditService = new AuditService(configurationService);
+        structuredAuditService = new StructuredAuditService(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -8,10 +8,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NonNull;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyRegistrationPromptSkipped;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LogLineHelper;
@@ -22,6 +24,8 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.time.Clock;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
 import static uk.gov.di.audit.AuditContext.emptyAuditContext;
@@ -118,7 +122,10 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             case SKIP_ADDING_PASSKEY -> {
                 authenticationService.renewLastSkippedAddingPasskeyTimestamp(request.getEmail());
                 LOG.info("Renewed lastSkippedAddingPasskey timestamp");
-                // TODO - AUT-5464 - Add the audit event here
+                var auditEvent =
+                        AuthPasskeyRegistrationPromptSkipped.create(
+                                auditContext, JourneyType.SIGN_IN, Clock.systemUTC());
+                structuredAuditService.submitAuditEvent(auditEvent);
             }
             default -> {
                 LOG.error(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -10,7 +10,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.entity.AuthPasskeyRegistrationPromptSkipped;
+import uk.gov.di.authentication.auditevents.entity.shared.Users.UserWithoutPhone;
 import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -26,6 +29,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -174,7 +178,25 @@ class UpdateProfileHandlerTest {
                     .submitAuditEvent(
                             AUTH_UPDATE_PROFILE_REQUEST_RECEIVED,
                             auditContextWithOnlyClientSession);
-            // TODO - AUT-5464 - Verify AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED audit event
+
+            ArgumentCaptor<AuthPasskeyRegistrationPromptSkipped> auditEventCaptor =
+                    ArgumentCaptor.forClass(AuthPasskeyRegistrationPromptSkipped.class);
+            verify(structuredAuditService).submitAuditEvent(auditEventCaptor.capture());
+            var emittedAuditEvent = auditEventCaptor.getValue();
+            assertThat(
+                    emittedAuditEvent.eventName(),
+                    equalTo("AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED"));
+            assertThat(emittedAuditEvent.extensions().journeyType(), equalTo("SIGN_IN"));
+            var expectedUser =
+                    new UserWithoutPhone(
+                            EMAIL,
+                            CLIENT_SESSION_ID,
+                            IP_ADDRESS,
+                            DI_PERSISTENT_SESSION_ID,
+                            SESSION_ID,
+                            INTERNAL_COMMON_SUBJECT_ID,
+                            null);
+            assertThat(emittedAuditEvent.user(), equalTo(expectedUser));
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditContext;
+import uk.gov.di.authentication.auditevents.services.StructuredAuditService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -64,6 +65,8 @@ class UpdateProfileHandlerTest {
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuditService auditService = mock(AuditService.class);
+    private final StructuredAuditService structuredAuditService =
+            mock(StructuredAuditService.class);
 
     private final String TERMS_AND_CONDITIONS_VERSION =
             configurationService.getTermsAndConditionsVersion();
@@ -115,7 +118,8 @@ class UpdateProfileHandlerTest {
                         authenticationService,
                         configurationService,
                         auditService,
-                        authSessionService);
+                        authSessionService,
+                        structuredAuditService);
     }
 
     @Nested

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -67,8 +67,10 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertThat(response, hasStatus(204));
         assertTxmaAuditEventsReceived(
-                txmaAuditQueue, List.of(AUTH_UPDATE_PROFILE_REQUEST_RECEIVED));
-        // TODO - AUT-5464 - Add AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED to List
+                txmaAuditQueue,
+                List.of(
+                        "AUTH_UPDATE_PROFILE_REQUEST_RECEIVED",
+                        "AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED"));
     }
 
     private void setUpTest(String sessionId) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -82,11 +82,14 @@ public class AuditAssertionsHelper {
     }
 
     public static List<String> assertTxmaAuditEventsReceived(
-            SqsQueueExtension queue,
-            Collection<AuditableEvent> events,
-            boolean validateDeviceInformation) {
+            SqsQueueExtension queue, List<String> eventNames) {
+        return assertTxmaAuditEventsReceived(queue, eventNames, true);
+    }
 
-        var expectedTxmaEvents = events.stream().map(Objects::toString).toList();
+    public static List<String> assertTxmaAuditEventsReceived(
+            SqsQueueExtension queue,
+            List<String> expectedTxmaEvents,
+            boolean validateDeviceInformation) {
 
         if (expectedTxmaEvents.isEmpty()) {
             throw new RuntimeException(
@@ -144,6 +147,15 @@ public class AuditAssertionsHelper {
         }
 
         return sentEvents;
+    }
+
+    public static List<String> assertTxmaAuditEventsReceived(
+            SqsQueueExtension queue,
+            Collection<AuditableEvent> events,
+            boolean validateDeviceInformation) {
+
+        var expectedTxmaEvents = events.stream().map(Objects::toString).toList();
+        return assertTxmaAuditEventsReceived(queue, expectedTxmaEvents, validateDeviceInformation);
     }
 
     private static void assertValidAuditEventsHaveDeviceInformationInRestrictedSection(


### PR DESCRIPTION
Emits a new audit event to track when a user has skipped registering a passkey.

Event catalogue link: https://event-catalogue.internal.account.gov.uk/events/AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED/


## How to test

Currently deployed to authdev2. Run through a journey where you're prompted to set up a passkey, click skip, look at the sqs topic for the api and verify you have a AUTH_PASSKEY_REGISTRATION_PROMPT_SKIPPED event.