### PR TITLE
Aut 5050/suppress prompt for recently skipped users

### DIFF
--- a/ci/cloudformation/auth/function/user-exists.yaml
+++ b/ci/cloudformation/auth/function/user-exists.yaml
@@ -78,6 +78,12 @@ Resources:
               !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
               amcClientId,
             ]
+          PASSKEY_PROMPT_SUPPRESSION_IN_MINUTES:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment],
+              passkeyPromptSuppressionInMinutes,
+            ]
       LoggingConfig:
         LogGroup: !Ref UserExistsFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -277,6 +277,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "true"
       relyingPartyId: authdev1.dev.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 5
     authdev2:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ff8d97e6-69d6-4ea1-81c0-0de8d8bcac85
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/a99e39a4-0a63-4816-b222-6e7c6c318b32
@@ -335,6 +336,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "true"
       relyingPartyId: authdev2.dev.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 5
     authdev3:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/8a67ba56-4eb2-4bfb-8254-5cc1c92a5db5
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ce9680d3-953a-4b6a-9098-a0380d0afc70
@@ -397,6 +399,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "true"
       relyingPartyId: authdev3.dev.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 5
     dev:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f5e5d059-1581-4c5c-8d60-e168fd8a9a84
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4b475855-e71a-43a5-a836-c6cb37e9cb22
@@ -464,6 +467,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "true"
       relyingPartyId: dev.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 5
     build:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/e8fdebb6-2d33-4d0c-825c-2b5c874522d8
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/4932c4d3-bf86-4f39-a32c-b82faf9a2574
@@ -536,6 +540,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "false"
       relyingPartyId: build.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 10080
     staging:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/01f3d1a6-e66f-4eb7-a3d7-412437c8f01d
@@ -610,6 +615,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "true"
       relyingPartyId: staging.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 5
     integration:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
@@ -684,6 +690,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "false"
       relyingPartyId: integration.account.gov.uk
+      passkeyPromptSuppressionInMinutes: 10080
     production:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/730472f0-c7ba-4bda-a411-08cdaa65fe8a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/075774c2-b836-452f-9684-dcd742146f81
@@ -758,6 +765,7 @@ Mappings:
       argon2Parallelism: "1"
       passwordRehashOnLoginEnabled: "false"
       relyingPartyId: account.gov.uk
+      passkeyPromptSuppressionInMinutes: 10080
   LambdaConfiguration:
     account-recovery:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelper.java
@@ -35,8 +35,14 @@ public class PasskeyRegistrationPromptHelper {
                                 .minusMinutes(dontPromptAgainInMinutesDuration);
                 var lastSkippedAsLocalDateTime =
                         LocalDateTime.parse(userProfile.getLastSkippedAddingPasskey());
-                return lastSkippedAsLocalDateTime.isAfter(
-                        earliestTimestampAfterWhichWeCanPromptAgain);
+                var shouldSuppress =
+                        lastSkippedAsLocalDateTime.isAfter(
+                                earliestTimestampAfterWhichWeCanPromptAgain);
+                if (shouldSuppress) {
+                    LOG.info(
+                            "suppressing passkey registration prompt as user has recently skipped");
+                }
+                return shouldSuppress;
             } catch (DateTimeParseException e) {
                 LOG.warn(
                         "last skipped adding passkey date on user profile could not be parsed as local date time, not suppressing create passkey prompt");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelper.java
@@ -16,8 +16,33 @@ public class PasskeyRegistrationPromptHelper {
         /* This utility class should not be instantiated */
     }
 
-    public static boolean shouldSuppressPasskeyRegistrationPrompt(UserProfile userProfile) {
-        return accountIsLessThanTwoHoursOld(userProfile);
+    public static boolean shouldSuppressPasskeyRegistrationPrompt(
+            UserProfile userProfile, Long dontPromptAgainIfSkippedInMinutes) {
+        return accountIsLessThanTwoHoursOld(userProfile)
+                || userHasRecentlySkippedPasskeyRegistration(
+                        userProfile, dontPromptAgainIfSkippedInMinutes);
+    }
+
+    private static boolean userHasRecentlySkippedPasskeyRegistration(
+            UserProfile userProfile, Long dontPromptAgainInMinutesDuration) {
+        var lastSkipped = userProfile.getLastSkippedAddingPasskey();
+        if (Objects.isNull(lastSkipped)) {
+            return false;
+        } else {
+            try {
+                var earliestTimestampAfterWhichWeCanPromptAgain =
+                        LocalDateTime.now(ZoneId.of("UTC"))
+                                .minusMinutes(dontPromptAgainInMinutesDuration);
+                var lastSkippedAsLocalDateTime =
+                        LocalDateTime.parse(userProfile.getLastSkippedAddingPasskey());
+                return lastSkippedAsLocalDateTime.isAfter(
+                        earliestTimestampAfterWhichWeCanPromptAgain);
+            } catch (DateTimeParseException e) {
+                LOG.warn(
+                        "last skipped adding passkey date on user profile could not be parsed as local date time, not suppressing create passkey prompt");
+                return false;
+            }
+        }
     }
 
     private static boolean accountIsLessThanTwoHoursOld(UserProfile userProfile) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -214,7 +214,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                 request.isSupportPasskeyUsage());
                 shouldSuppressPasskeyRegistrationPrompt =
                         PasskeyRegistrationPromptHelper.shouldSuppressPasskeyRegistrationPrompt(
-                                userProfile, 5L);
+                                userProfile,
+                                configurationService.getPasskeyPromptSuppressionInMinutes());
                 metadataPairs.add(
                         pair(
                                 AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -214,7 +214,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                 request.isSupportPasskeyUsage());
                 shouldSuppressPasskeyRegistrationPrompt =
                         PasskeyRegistrationPromptHelper.shouldSuppressPasskeyRegistrationPrompt(
-                                userProfile);
+                                userProfile, 5L);
                 metadataPairs.add(
                         pair(
                                 AUDIT_EVENT_EXTENSIONS_HAS_ACTIVE_PASSKEY,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/PasskeyRegistrationPromptHelperTest.java
@@ -16,12 +16,24 @@ import static uk.gov.di.authentication.frontendapi.helpers.PasskeyRegistrationPr
 
 class PasskeyRegistrationPromptHelperTest {
     private static final LocalDateTime NOW = LocalDateTime.now(ZoneId.of("UTC"));
+    private static final String TWO_WEEKS_AGO = NOW.minusWeeks(2).toString();
+    private static final String JUST_LESS_THAN_ONE_WEEK_AGO =
+            NOW.minusWeeks(1).plusMinutes(5).toString();
+    private static final String JUST_OVER_ONE_WEEK_AGO =
+            NOW.minusWeeks(1).minusMinutes(5).toString();
     private static final String YESTERDAY = NOW.minusDays(1).toString();
     private static final String TWO_HOURS_ONE_MINUTE_AGO = NOW.minusMinutes(121).toString();
     private static final String ONE_HOUR_59_AGO = NOW.minusMinutes(119).toString();
     private static final String THIRTY_MINUTES_AGO = NOW.minusMinutes(30).toString();
+    private static final String ONE_MINUTE_AGO = NOW.minusMinutes(1).toString();
+    private static final String JUST_OVER_FIVE_MINUTES_AGO =
+            NOW.minusMinutes(5).minusSeconds(1).toString();
+    private static final String JUST_UNDER_FIVE_MINUTES_AGO =
+            NOW.minusMinutes(5).plusSeconds(1).toString();
+    private static final long ONE_WEEK_DURATION_IN_MINUTES = 60 * 24 * 7;
+    private static final long FIVE_MINUTES = 5;
 
-    private static Stream<Arguments> dateTimesToExpectedShouldSuppressPrompts() {
+    private static Stream<Arguments> accountCreatedDateTimesToExpectedShouldSuppressPrompts() {
         return Stream.of(
                 Arguments.of(YESTERDAY, false),
                 Arguments.of(TWO_HOURS_ONE_MINUTE_AGO, false),
@@ -30,32 +42,73 @@ class PasskeyRegistrationPromptHelperTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dateTimesToExpectedShouldSuppressPrompts")
+    @MethodSource("accountCreatedDateTimesToExpectedShouldSuppressPrompts")
     void shouldSuppressPasskeyRegistrationPromptShouldReturnTrueIfAccountLessThan2HoursOld(
             String createdAtTimestamp, boolean expectedResult) {
         var userProfile = new UserProfile().withCreated(createdAtTimestamp);
 
-        assertEquals(expectedResult, shouldSuppressPasskeyRegistrationPrompt(userProfile));
+        assertEquals(expectedResult, shouldSuppressPasskeyRegistrationPrompt(userProfile, 5L));
     }
 
     @Test
     void shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfAccountTimestampIsNull() {
         var userProfile = new UserProfile();
 
-        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile));
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile, FIVE_MINUTES));
     }
 
     @Test
     void shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfAccountTimestampIsEmpty() {
         var userProfile = new UserProfile().withCreated("");
 
-        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile));
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile, FIVE_MINUTES));
     }
 
     @Test
     void shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfAccountTimestampDoesNotParse() {
         var userProfile = new UserProfile().withCreated("not a parseable local date time");
 
-        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile));
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile, FIVE_MINUTES));
+    }
+
+    private static Stream<Arguments> userSkippedTimestampsToExpectedShouldSuppressPrompt() {
+        return Stream.of(
+                Arguments.of(null, ONE_WEEK_DURATION_IN_MINUTES, false),
+                Arguments.of(null, FIVE_MINUTES, false),
+                Arguments.of(TWO_WEEKS_AGO, ONE_WEEK_DURATION_IN_MINUTES, false),
+                Arguments.of(JUST_LESS_THAN_ONE_WEEK_AGO, ONE_WEEK_DURATION_IN_MINUTES, true),
+                Arguments.of(JUST_OVER_ONE_WEEK_AGO, ONE_WEEK_DURATION_IN_MINUTES, false),
+                Arguments.of(JUST_LESS_THAN_ONE_WEEK_AGO, FIVE_MINUTES, false),
+                Arguments.of(YESTERDAY, ONE_WEEK_DURATION_IN_MINUTES, true),
+                Arguments.of(YESTERDAY, FIVE_MINUTES, false),
+                Arguments.of(JUST_OVER_FIVE_MINUTES_AGO, FIVE_MINUTES, false),
+                Arguments.of(JUST_UNDER_FIVE_MINUTES_AGO, FIVE_MINUTES, true),
+                Arguments.of(ONE_MINUTE_AGO, FIVE_MINUTES, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("userSkippedTimestampsToExpectedShouldSuppressPrompt")
+    void
+            shouldSuppressPasskeyRegistrationPromptShouldReturnTrueIfUserHasRecentlySkippedPasskeyRegistration(
+                    String skippedTimestamp, Long configuredDuration, boolean expectedResult) {
+        var userProfile =
+                new UserProfile()
+                        .withCreated(TWO_WEEKS_AGO)
+                        .withLastSkippedAddingPasskey(skippedTimestamp);
+
+        assertEquals(
+                expectedResult,
+                shouldSuppressPasskeyRegistrationPrompt(userProfile, configuredDuration));
+    }
+
+    @Test
+    void
+            shouldSuppressPasskeyRegistrationPromptShouldReturnFalseIfLastSkippedTimestampDoesNotParse() {
+        var userProfile =
+                new UserProfile()
+                        .withCreated(TWO_WEEKS_AGO)
+                        .withLastSkippedAddingPasskey("not a parseable local date time");
+
+        assertFalse(shouldSuppressPasskeyRegistrationPrompt(userProfile, FIVE_MINUTES));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -119,6 +119,7 @@ class CheckUserExistsHandlerTest {
             new BearerAccessToken("adapi_bearer");
     private static final String YESTERDAY = LocalDateTime.now().minusDays(1).toString();
     private static final String ONE_HOUR_AGO = LocalDateTime.now().minusHours(1).toString();
+    private static final String TWO_WEEKS_AGO = LocalDateTime.now().minusWeeks(2).toString();
 
     private static final AuditContext AUDIT_CONTEXT =
             new AuditContext(
@@ -671,6 +672,37 @@ class CheckUserExistsHandlerTest {
                 String createdAtTimestamp, boolean expectedShouldSuppressPasskeyPrompt)
                 throws Json.JsonException {
             var userProfile = generateUserProfile().withCreated(createdAtTimestamp);
+            setupUserProfileAndClient(Optional.of(userProfile));
+            when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
+                    .thenReturn(new UserCredentials().withMfaMethods(List.of()));
+
+            var result = handler.handleRequest(userExistsRequest(EMAIL_ADDRESS), context);
+
+            assertThat(result, hasStatus(200));
+            var checkUserExistsResponse =
+                    objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
+            assertEquals(
+                    expectedShouldSuppressPasskeyPrompt,
+                    checkUserExistsResponse.shouldSuppressPasskeyRegistrationPrompt());
+        }
+
+        private static Stream<Arguments> skippedDateTimesToExpectedShouldSuppressPrompts() {
+            return Stream.of(Arguments.of(TWO_WEEKS_AGO, false), Arguments.of(YESTERDAY, true));
+        }
+
+        @ParameterizedTest
+        @MethodSource("skippedDateTimesToExpectedShouldSuppressPrompts")
+        void shouldIndicateThatPasskeyPromptShouldBeSuppressedWhenUserHasRecentlySkipped(
+                String skippedAtTimestamp, boolean expectedShouldSuppressPasskeyPrompt)
+                throws Json.JsonException {
+            var oneWeekInMinutes = 10080L;
+            when(configurationService.getPasskeyPromptSuppressionInMinutes())
+                    .thenReturn(oneWeekInMinutes);
+
+            var userProfile =
+                    generateUserProfile()
+                            .withCreated(TWO_WEEKS_AGO)
+                            .withLastSkippedAddingPasskey(skippedAtTimestamp);
             setupUserProfileAndClient(Optional.of(userProfile));
             when(authenticationService.getUserCredentialsFromEmail(EMAIL_ADDRESS))
                     .thenReturn(new UserCredentials().withMfaMethods(List.of()));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -784,6 +784,13 @@ public class ConfigurationService
         }
     }
 
+    public Long getPasskeyPromptSuppressionInMinutes() {
+        var oneWeekInMinutes = "10080";
+        return Long.parseLong(
+                System.getenv()
+                        .getOrDefault("PASSKEY_PROMPT_SUPPRESSION_IN_MINUTES", oneWeekInMinutes));
+    }
+
     // FEATURE SWITCHES
     public boolean isEnhancedAuthCodeProtectionEnabled() {
         return System.getenv()

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -653,6 +653,14 @@ class ConfigurationServiceTest {
         assertTrue(configurationService.isInternationalSmsSendingEnabled());
     }
 
+    @Test
+    void getDontPromptForPasskeysAgainDurationMinutesShouldDefault() {
+        var oneWeekDurationMinutes = (long) 60 * 24 * 7;
+        assertEquals(
+                oneWeekDurationMinutes,
+                configurationService.getPasskeyPromptSuppressionInMinutes());
+    }
+
     private GetParameterRequest parameterRequest(String name) {
         return GetParameterRequest.builder().withDecryption(true).name(name).build();
     }


### PR DESCRIPTION
## What

Add an additional check to the existing logic for sending the shouldSuppressPasskeyPrompt flag back to the backend, which checks if the passkey registration prompt was recently skipped.

If it was, indicate to the frontend that the prompt should be skipped on the current journey. This is to avoid overly prompting users who have already chosen not to set up a passkey.

The duration of time for which we suppress the prompt after a skip varies by environment:

* in testing envs (authdevs, dev, staging) only suppress for 5 minutes to make testing easier
* in prod and prod-like envs (production, integration and build), suppress for a week

## How to test

Currently deployed to dev. Run through a journey where you are prompted to set up a passkey, and click skip (either in auth or amc). See that on a subsequent journey, you are not prompted. See that you are prompted if you start a journey more than 5 minutes after the original skip event.


## Related PRs

* [Related change to the acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/958) (this api PR should be merged first)
* Previous changes to update the user profile with a last skipped at timestamp: [backend changes](https://github.com/govuk-one-login/authentication-api/pull/8644) and [frontend changes](https://github.com/govuk-one-login/authentication-frontend/pull/3596)
