### PR TITLE
AUT-5653: Retry unprocessed items from IAD data export BatchWriteItem requests

### DIFF
--- a/ci/cloudformation/utils/function/inactive-account-data-export.yaml
+++ b/ci/cloudformation/utils/function/inactive-account-data-export.yaml
@@ -75,6 +75,12 @@ Resources:
               - ${Env}-stub-inactive-account-tracker
               - Env:
                   !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          INACTIVE_ACCOUNT_EXPORT_BATCH_WRITE_MAX_RETRIES:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              inactiveAccountExportBatchWriteMaxRetries,
+            ]
 
       Policies:
         - !Ref LambdaBasicExecutionPolicy

--- a/ci/cloudformation/utils/parent.yaml
+++ b/ci/cloudformation/utils/parent.yaml
@@ -192,6 +192,7 @@ Mappings:
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev1-stub-inactive-account-tracker"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     authdev2:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/5159e290-3b74-45c0-9ba8-eaab516ccb9a
@@ -231,6 +232,7 @@ Mappings:
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev2-stub-inactive-account-tracker"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     authdev3:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/754cd07e-794e-4ea2-9c8a-333a03792aa0
@@ -270,6 +272,7 @@ Mappings:
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "authdev3-stub-inactive-account-tracker"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     dev:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/311cb3c3-97fc-465b-8d53-575386fce181
@@ -309,6 +312,7 @@ Mappings:
       inactiveAccountExportMaxItemsPerSegment: "10"
       inactiveAccountExportPauseBetweenInvocationsMs: "15000"
       inactiveAccountExportTableName: "dev-stub-inactive-account-tracker"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     build:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/12f40ae0-84a0-4840-a497-129366eef354
@@ -348,6 +352,7 @@ Mappings:
       inactiveAccountExportMaxItemsPerSegment: "7500"
       inactiveAccountExportPauseBetweenInvocationsMs: "60000"
       inactiveAccountExportTableName: "build-stub-inactive-account-tracker"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     staging:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/a152899b-1c48-4053-b883-74855739fc16
@@ -389,6 +394,7 @@ Mappings:
       inactiveAccountExportTableAccountId: "539729775994"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:539729775994:key/5191526d-1c85-4316-baf7-9fbe373880cf
       inactiveAccountExportTableName: "inactive_account_tracker_store"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     integration:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/7f17084d-14a7-4482-8a7b-e392d1f60d41
@@ -430,6 +436,7 @@ Mappings:
       inactiveAccountExportTableAccountId: "666500506359"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:666500506359:key/1ab2a72b-63e0-49b6-b88a-5160a7d27985
       inactiveAccountExportTableName: "inactive_account_tracker_store"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
     production:
       userProfileTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/365c4de5-6a6d-43db-8569-eca00e889177
@@ -471,6 +478,7 @@ Mappings:
       inactiveAccountExportTableAccountId: "026991849909"
       inactiveAccountExportTableEncryptionKey: arn:aws:kms:eu-west-2:026991849909:key/5489c67b-2c14-4b76-b6a3-a25148b14311
       inactiveAccountExportTableName: "inactive_account_tracker_store"
+      inactiveAccountExportBatchWriteMaxRetries: "3"
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -261,6 +261,12 @@ public class ConfigurationService
         return System.getenv().getOrDefault("INACTIVE_ACCOUNT_EXPORT_TABLE_NAME", "");
     }
 
+    public int getInactiveAccountExportBatchWriteMaxRetries() {
+        return Integer.parseInt(
+                System.getenv()
+                        .getOrDefault("INACTIVE_ACCOUNT_EXPORT_BATCH_WRITE_MAX_RETRIES", "0"));
+    }
+
     public String getTicfCRILambdaIdentifier() {
         return System.getenv().getOrDefault("TICF_CRI_LAMBDA_IDENTIFIER", "");
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteService.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.backoff;
+
 public class InactiveAccountDataExportBatchWriteService {
 
     private static final Logger LOG =
@@ -25,13 +27,17 @@ public class InactiveAccountDataExportBatchWriteService {
 
     private final DynamoDbClient client;
     private final String tableName;
+    private final int maxRetries;
     private final List<InactiveAccountTrackerItem> buffer = new ArrayList<>();
     private long totalWritten;
+    private long totalFailed;
     private long totalBatchesFlushed;
 
-    public InactiveAccountDataExportBatchWriteService(DynamoDbClient client, String tableName) {
+    public InactiveAccountDataExportBatchWriteService(
+            DynamoDbClient client, String tableName, int maxRetries) {
         this.client = client;
         this.tableName = tableName;
+        this.maxRetries = maxRetries;
     }
 
     public void add(InactiveAccountTrackerItem item) {
@@ -51,32 +57,61 @@ public class InactiveAccountDataExportBatchWriteService {
         return totalWritten;
     }
 
+    public long getTotalFailed() {
+        return totalFailed;
+    }
+
     public long getTotalBatchesFlushed() {
         return totalBatchesFlushed;
     }
 
     private void flush() {
         List<WriteRequest> writeRequests = toWriteRequests(buffer);
-
-        BatchWriteItemResponse response =
-                client.batchWriteItem(
-                        BatchWriteItemRequest.builder()
-                                .requestItems(Map.of(tableName, writeRequests))
-                                .build());
-
-        int unprocessedCount = 0;
-        if (response.hasUnprocessedItems() && response.unprocessedItems().containsKey(tableName)) {
-            unprocessedCount = response.unprocessedItems().get(tableName).size();
-        }
-
-        int written = buffer.size() - unprocessedCount;
-        totalWritten += written;
-        totalBatchesFlushed++;
         buffer.clear();
 
-        if (unprocessedCount > 0) {
-            LOG.warn("BatchWriteItem returned {} unprocessed items", unprocessedCount);
+        int retryCount = 0;
+
+        while (!writeRequests.isEmpty()) {
+            BatchWriteItemResponse response =
+                    client.batchWriteItem(
+                            BatchWriteItemRequest.builder()
+                                    .requestItems(Map.of(tableName, writeRequests))
+                                    .build());
+
+            List<WriteRequest> unprocessedItems = extractUnprocessedItems(response);
+
+            int writtenThisCall = writeRequests.size() - unprocessedItems.size();
+            totalWritten += writtenThisCall;
+
+            writeRequests = unprocessedItems;
+
+            if (!writeRequests.isEmpty()) {
+                retryCount++;
+                if (retryCount > maxRetries) {
+                    LOG.error(
+                            "Failed to write {} items after {} retries",
+                            writeRequests.size(),
+                            maxRetries);
+                    totalFailed += writeRequests.size();
+                    break;
+                }
+                LOG.warn(
+                        "{} unprocessed write items (attempt {}/{})",
+                        writeRequests.size(),
+                        retryCount,
+                        maxRetries);
+                backoff(retryCount);
+            }
         }
+
+        totalBatchesFlushed++;
+    }
+
+    private List<WriteRequest> extractUnprocessedItems(BatchWriteItemResponse response) {
+        if (response.hasUnprocessedItems() && response.unprocessedItems().containsKey(tableName)) {
+            return response.unprocessedItems().get(tableName);
+        }
+        return List.of();
     }
 
     private static List<WriteRequest> toWriteRequests(List<InactiveAccountTrackerItem> items) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -64,6 +64,7 @@ public class InactiveAccountDataExportHandler
     private final int parallelism;
     private final int totalSegments;
     private final int maxRetries;
+    private final int batchWriteMaxRetries;
     private final int maxItemsPerSegment;
     private final long pauseBetweenInvocationsMs;
     private final String lambdaName;
@@ -82,6 +83,8 @@ public class InactiveAccountDataExportHandler
         this.parallelism = configurationService.getInactiveAccountExportParallelism();
         this.totalSegments = configurationService.getInactiveAccountExportTotalSegments();
         this.maxRetries = configurationService.getInactiveAccountExportMaxRetries();
+        this.batchWriteMaxRetries =
+                configurationService.getInactiveAccountExportBatchWriteMaxRetries();
         this.maxItemsPerSegment = configurationService.getInactiveAccountExportMaxItemsPerSegment();
         this.pauseBetweenInvocationsMs =
                 configurationService.getInactiveAccountExportPauseBetweenInvocationsMs();
@@ -266,7 +269,8 @@ public class InactiveAccountDataExportHandler
         long missingCredentialsCount = 0;
         List<Map<String, AttributeValue>> currentBatch = new ArrayList<>();
         InactiveAccountDataExportBatchWriteService batchWriteService =
-                new InactiveAccountDataExportBatchWriteService(client, exportTableName);
+                new InactiveAccountDataExportBatchWriteService(
+                        client, exportTableName, batchWriteMaxRetries);
 
         do {
             if (itemsScanned >= maxItemsPerSegment) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportBatchWriteServiceTest.java
@@ -5,7 +5,13 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 import uk.gov.di.authentication.utils.entity.InactiveAccountTrackerItem;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,6 +25,7 @@ import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportBa
 class InactiveAccountDataExportBatchWriteServiceTest {
 
     private static final String TABLE_NAME = "test-tracker-table";
+    private static final int MAX_RETRIES = 3;
 
     private final DynamoDbClient client = mock(DynamoDbClient.class);
 
@@ -29,7 +36,7 @@ class InactiveAccountDataExportBatchWriteServiceTest {
     }
 
     private InactiveAccountDataExportBatchWriteService createService() {
-        return new InactiveAccountDataExportBatchWriteService(client, TABLE_NAME);
+        return new InactiveAccountDataExportBatchWriteService(client, TABLE_NAME, MAX_RETRIES);
     }
 
     @Test
@@ -107,6 +114,79 @@ class InactiveAccountDataExportBatchWriteServiceTest {
         verify(client, times(2)).batchWriteItem(any(BatchWriteItemRequest.class));
         assertEquals(totalItems, service.getTotalWritten());
         assertEquals(2, service.getTotalBatchesFlushed());
+    }
+
+    @Test
+    void shouldRetryUnprocessedItemsSuccessfully() {
+        int itemCount = 10;
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            int call = callCount.getAndIncrement();
+                            if (call == 0) {
+                                return responseWithUnprocessedItems(3);
+                            }
+                            return BatchWriteItemResponse.builder().build();
+                        });
+
+        var service = createService();
+        for (int i = 0; i < itemCount; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        verify(client, times(2)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(itemCount, service.getTotalWritten());
+        assertEquals(0, service.getTotalFailed());
+    }
+
+    @Test
+    void shouldCountFailedItemsAfterRetriesExhausted() {
+        int itemCount = 10;
+        int unprocessedCount = 3;
+
+        when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
+                .thenReturn(responseWithUnprocessedItems(unprocessedCount));
+
+        var service = createService();
+        for (int i = 0; i < itemCount; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        // Initial call + 3 retries = 4 calls
+        verify(client, times(MAX_RETRIES + 1)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(itemCount - unprocessedCount, service.getTotalWritten());
+        assertEquals(unprocessedCount, service.getTotalFailed());
+    }
+
+    @Test
+    void shouldNotRetryWhenNoUnprocessedItems() {
+        var service = createService();
+        int itemCount = 10;
+
+        for (int i = 0; i < itemCount; i++) {
+            service.add(createTrackerItem(i));
+        }
+        service.flushRemaining();
+
+        verify(client, times(1)).batchWriteItem(any(BatchWriteItemRequest.class));
+        assertEquals(0, service.getTotalFailed());
+    }
+
+    private BatchWriteItemResponse responseWithUnprocessedItems(int count) {
+        List<WriteRequest> unprocessed = new java.util.ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            unprocessed.add(
+                    WriteRequest.builder()
+                            .putRequest(PutRequest.builder().item(Map.of()).build())
+                            .build());
+        }
+        return BatchWriteItemResponse.builder()
+                .unprocessedItems(Map.of(TABLE_NAME, unprocessed))
+                .build();
     }
 
     private InactiveAccountTrackerItem createTrackerItem(int index) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandlerTest.java
@@ -67,6 +67,7 @@ class InactiveAccountDataExportHandlerTest {
                 .thenReturn(0L);
         when(configurationService.getInactiveAccountExportTableName())
                 .thenReturn("test-tracker-table");
+        when(configurationService.getInactiveAccountExportBatchWriteMaxRetries()).thenReturn(3);
         when(client.batchWriteItem(any(BatchWriteItemRequest.class)))
                 .thenReturn(BatchWriteItemResponse.builder().build());
     }


### PR DESCRIPTION
## What

* Retries unprocessed items from IAD data export `BatchWriteItem` requests

See description of fdfe159390e55a2770fb38f1bbb02ed731392d20 for more context on this change.

For wider context, see [0006-inactive-account-deletion-data-export.md](https://github.com/govuk-one-login/authentication-api/blob/main/docs/adr/0006-inactive-account-deletion-data-export.md).

## How to review

1. Code review.
1. Check over the unit tests added in `InactiveAccountDataExportBatchWriteServiceTest` around the retry behaviour.
1. Optionally, deploy the utils module to a dev environment, trigger the inactive account data export Lambda with an empty object (`{}`) as the request payload, verify that records are correctly batch-written to the stub DynamoDB table and that the Lambda logs accurately reflect the total records written.
    - [I've done this - see testing section below]

## Testing

I've performed the following steps to confirm writing is still working as expected:

1. Deployed the utils module to authdev1
1. Triggered the inactive account data export Lambda with an empty object (`{}`) as the request payload
1. Verified that records are correctly batch-written to the stub DynamoDB table and that the Lambda logs accurately reflect the total records written.

## Checklist

- [x] Deployment of this PR will not break active user journeys **- Changes are isolated to a background data export job and do not impact active user sessions.**

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**

- [ ] A UCD review has been performed. **- N/A, utils Lambda changes only**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Add Dynamo bulk writes to inactive account data scan Lambda - https://github.com/govuk-one-login/authentication-api/pull/8692