### PR TITLE
AUT-5691: Add hasSetupMfa attribute to IAD tracker item

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/entity/InactiveAccountTrackerItem.java
@@ -18,6 +18,7 @@ public class InactiveAccountTrackerItem {
     private String userLastActive;
     private String status = "pending";
     private String statusLastUpdated;
+    private Boolean hasSetupMfa;
     private String userLastActiveSource = "AUTH_BACKFILL";
     private String userLastActiveSourceId;
     private String userLastActiveUpdated;
@@ -185,6 +186,20 @@ public class InactiveAccountTrackerItem {
 
     public InactiveAccountTrackerItem withUserLastActiveUpdated(String userLastActiveUpdated) {
         this.userLastActiveUpdated = userLastActiveUpdated;
+        return this;
+    }
+
+    @DynamoDbAttribute("hasSetupMfa")
+    public Boolean getHasSetupMfa() {
+        return hasSetupMfa;
+    }
+
+    public void setHasSetupMfa(Boolean hasSetupMfa) {
+        this.hasSetupMfa = hasSetupMfa;
+    }
+
+    public InactiveAccountTrackerItem withHasSetupMfa(Boolean hasSetupMfa) {
+        this.hasSetupMfa = hasSetupMfa;
         return this;
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -182,7 +182,8 @@ public class InactiveAccountDataExportHelper {
                 .withStatusLastUpdated(currentTimestamp)
                 .withUserLastActive(lastActiveTimestamp)
                 .withUserLastActiveSourceId(lastActiveSourceId)
-                .withUserLastActiveUpdated(currentTimestamp);
+                .withUserLastActiveUpdated(currentTimestamp)
+                .withHasSetupMfa(determineHasSetupMfa(userProfileItem, userCredentialsItem));
     }
 
     public static boolean determineHasSetupMfa(

--- a/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelper.java
@@ -185,6 +185,40 @@ public class InactiveAccountDataExportHelper {
                 .withUserLastActiveUpdated(currentTimestamp);
     }
 
+    public static boolean determineHasSetupMfa(
+            Map<String, AttributeValue> userProfileItem,
+            Map<String, AttributeValue> userCredentialsItem) {
+        AttributeValue migratedAttr =
+                userProfileItem.get(UserProfile.ATTRIBUTE_MFA_METHODS_MIGRATED);
+        boolean isMigrated = migratedAttr != null && Boolean.TRUE.equals(migratedAttr.bool());
+
+        if (isMigrated) {
+            return hasMfaMethods(userCredentialsItem);
+        }
+
+        AttributeValue phoneVerifiedAttr =
+                userProfileItem.get(UserProfile.ATTRIBUTE_PHONE_NUMBER_VERIFIED);
+        boolean phoneVerified = phoneVerifiedAttr != null && "1".equals(phoneVerifiedAttr.n());
+
+        if (phoneVerified) {
+            return true;
+        }
+
+        return hasMfaMethods(userCredentialsItem);
+    }
+
+    private static boolean hasMfaMethods(Map<String, AttributeValue> userCredentialsItem) {
+        if (userCredentialsItem == null) {
+            return false;
+        }
+        AttributeValue mfaMethodsAttr =
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_MFA_METHODS);
+        if (mfaMethodsAttr == null || !mfaMethodsAttr.hasL()) {
+            return false;
+        }
+        return !mfaMethodsAttr.l().isEmpty();
+    }
+
     private static String getTermsAndConditionsTimestamp(Map<String, AttributeValue> item) {
         AttributeValue tcMap = item.get(UserProfile.ATTRIBUTE_TERMS_AND_CONDITIONS);
         if (tcMap == null || !tcMap.hasM()) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/InactiveAccountDataExportHandler.java
@@ -49,11 +49,11 @@ public class InactiveAccountDataExportHandler
     private static final int BATCH_GET_ITEM_MAX_SIZE = 100;
 
     private static final String USER_PROFILE_PROJECTION_EXPRESSION =
-            "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt";
+            "Email,Created,Updated,termsAndConditions.#ts,PublicSubjectID,SubjectID,salt,PhoneNumberVerified,mfaMethodsMigrated";
     private static final Map<String, String> USER_PROFILE_EXPRESSION_ATTRIBUTE_NAMES =
             Map.of("#ts", "timestamp");
     private static final String USER_CREDENTIALS_PROJECTION_EXPRESSION =
-            "Email,Created,Updated,MigratedPassword";
+            "Email,Created,Updated,MigratedPassword,MfaMethods";
 
     private final DynamoDbClient client;
     private final LambdaInvokerService lambdaInvokerService;

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -177,6 +177,7 @@ class InactiveAccountDataExportHelperTest {
         assertEquals("UserProfile.Updated", result.getUserLastActiveSourceId());
         assertNotNull(result.getStatusLastUpdated());
         assertNotNull(result.getUserLastActiveUpdated());
+        assertFalse(result.getHasSetupMfa());
     }
 
     @Test

--- a/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/helpers/InactiveAccountDataExportHelperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.utils.helpers;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,6 +23,7 @@ import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHe
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.calculateDateForDeletion;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.calculateLastActiveDate;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.countMissingCredentials;
+import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.determineHasSetupMfa;
 import static uk.gov.di.authentication.utils.helpers.InactiveAccountDataExportHelper.extractUnprocessedKeys;
 
 class InactiveAccountDataExportHelperTest {
@@ -323,5 +326,136 @@ class InactiveAccountDataExportHelperTest {
     @Test
     void calculateDateForDeletionShouldReturnNullForBlankInput() {
         assertNull(calculateDateForDeletion(""));
+    }
+
+    @Nested
+    class DetermineHasSetupMfaTest {
+
+        @Test
+        void shouldReturnTrueForMigratedUserWithMfaMethods() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_MFA_METHODS_MIGRATED,
+                            AttributeValue.builder().bool(true).build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_MFA_METHODS,
+                            AttributeValue.builder()
+                                    .l(
+                                            List.of(
+                                                    AttributeValue.builder()
+                                                            .m(
+                                                                    Map.of(
+                                                                            "MfaMethodType",
+                                                                            AttributeValue.builder()
+                                                                                    .s("AUTH_APP")
+                                                                                    .build()))
+                                                            .build()))
+                                    .build());
+
+            assertTrue(determineHasSetupMfa(profileItem, credentialsItem));
+        }
+
+        @Test
+        void shouldReturnFalseForMigratedUserWithNoMfaMethods() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_MFA_METHODS_MIGRATED,
+                            AttributeValue.builder().bool(true).build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_EMAIL,
+                            AttributeValue.builder().s("test@example.com").build());
+
+            assertFalse(determineHasSetupMfa(profileItem, credentialsItem));
+        }
+
+        @Test
+        void shouldReturnFalseForMigratedUserWithEmptyMfaMethodsList() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_MFA_METHODS_MIGRATED,
+                            AttributeValue.builder().bool(true).build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_MFA_METHODS,
+                            AttributeValue.builder().l(List.of()).build());
+
+            assertFalse(determineHasSetupMfa(profileItem, credentialsItem));
+        }
+
+        @Test
+        void shouldReturnTrueForUnmigratedUserWithPhoneNumberVerified() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_PHONE_NUMBER_VERIFIED,
+                            AttributeValue.builder().n("1").build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_EMAIL,
+                            AttributeValue.builder().s("test@example.com").build());
+
+            assertTrue(determineHasSetupMfa(profileItem, credentialsItem));
+        }
+
+        @Test
+        void shouldReturnTrueForUnmigratedUserWithMfaMethodPresent() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_PHONE_NUMBER_VERIFIED,
+                            AttributeValue.builder().n("0").build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_MFA_METHODS,
+                            AttributeValue.builder()
+                                    .l(
+                                            List.of(
+                                                    AttributeValue.builder()
+                                                            .m(
+                                                                    Map.of(
+                                                                            "MfaMethodType",
+                                                                            AttributeValue.builder()
+                                                                                    .s("AUTH_APP")
+                                                                                    .build()))
+                                                            .build()))
+                                    .build());
+
+            assertTrue(determineHasSetupMfa(profileItem, credentialsItem));
+        }
+
+        @Test
+        void shouldReturnFalseForUnmigratedUserWithPhoneNotVerifiedAndNoMfaMethods() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_PHONE_NUMBER_VERIFIED,
+                            AttributeValue.builder().n("0").build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_EMAIL,
+                            AttributeValue.builder().s("test@example.com").build());
+
+            assertFalse(determineHasSetupMfa(profileItem, credentialsItem));
+        }
+
+        @Test
+        void shouldReturnFalseForUnmigratedUserWithPhoneNotVerifiedAndEmptyMfaMethods() {
+            Map<String, AttributeValue> profileItem =
+                    Map.of(
+                            UserProfile.ATTRIBUTE_PHONE_NUMBER_VERIFIED,
+                            AttributeValue.builder().n("0").build());
+
+            Map<String, AttributeValue> credentialsItem =
+                    Map.of(
+                            UserCredentials.ATTRIBUTE_MFA_METHODS,
+                            AttributeValue.builder().l(List.of()).build());
+
+            assertFalse(determineHasSetupMfa(profileItem, credentialsItem));
+        }
     }
 }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Adds `hasSetupMfa` attribute to IAD tracker item to allow the home-team to determine if an account has been partially created
    - This will be used in home-owned logic to determine whether to send the user notification emails

## How to review

1. Code review.
1. Check over the unit tests added in `InactiveAccountDataExportBatchWriteServiceTest` around the retry behaviour.
1. Optionally, deploy the utils module to a dev environment, trigger the inactive account data export Lambda with an empty object (`{}`) as the request payload, verify that the records written to the stub DynamoDB table include the new `hasSetupMfa` attribute (with expected values) and that the Lambda logs accurately reflect the total records written.
    - [I've done this - see testing section below]

## Testing

I've performed the following steps to confirm writing is still working as expected:

1. Deployed the utils module to authdev1.
1. Triggered the inactive account data export Lambda with an empty object (`{}`) as the request payload.
1. Verified that the records written to the stub DynamoDB table:
    a. Include the new `hasSetupMfa` attribute.
    b. The `hasSetupMfa` attribute is set to `false` for a known partial account.
    c. The `hasSetupMfa` attribute is set to `true` for an account known to have MFA set up.
    d. The total records written count is as expected (1,440 in dev).

## Checklist

- [x] Deployment of this PR will not break active user journeys **- Changes are isolated to a background data export job and do not impact active user sessions.**

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**

- [x] No changes required or changes have been made to stub-orchestration. **- N/A**

- [ ] A UCD review has been performed. **- N/A, utils Lambda changes only**